### PR TITLE
Fix Chitinid and Resomi Loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -18,8 +18,6 @@
     - Human
     - Moth
     - Reptilian
-    - Chitinid # DeltaV
-    - Resomi
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox

--- a/Resources/Prototypes/_NF/Loadouts/loadout_effects.yml
+++ b/Resources/Prototypes/_NF/Loadouts/loadout_effects.yml
@@ -24,6 +24,8 @@
     - Vulpkanin
     - Harpy
     - Rodentia
+    - Chitinid # DeltaV
+    - Resomi # Goob
 
 - type: loadoutEffectGroup
   id: ShoesCapableNF
@@ -43,6 +45,8 @@
     - Vulpkanin
     - Harpy
     - Rodentia
+    - Chitinid # DeltaV
+    - Resomi # Goob
 
 - type: loadoutEffectGroup
   id: NFNotDocOrStc


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Ark
- fix: Chitinid and Resomi now have shoes and survival boxes in their loadouts. Thanks to SuperJoelDood for reporting this bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Adjusted species capabilities: The update rebalances the available loadout effects for species "Chitinid" and "Resomi". They no longer use the legacy oxygen management ability and now benefit from enhanced oxygen handling along with improved footwear functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->