### PR TITLE
Pirate Requirement Fixes

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/stc.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/stc.yml
@@ -7,7 +7,7 @@
   alwaysUseSpawner: true
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 10800 # 20 hrs # mono - change to 3 hr
+      time: 18000 # 20 hrs # mono - change to 5 hr
     - !type:RoleTimeRequirement
       role: JobSecurityGuard
       time: 3600 # 3 hrs as security guard # mono - change to 1 hr

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
@@ -6,9 +6,9 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 10800 # 3 hrs - mono
-  #  - !type:DepartmentTimeRequirement # mono - comments it out
-  #    department: Security
-  #    time: 10800 # 3 hrs
+    - !type:DepartmentTimeRequirement # mono - comments it out
+      department: Security
+      time: 10800 # 3 hrs
   startingGear: PirateNFGear
   alwaysUseSpawner: true
   hideConsoleVisibility: true

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
@@ -9,7 +9,7 @@
     - !type:RoleTimeRequirement
       role: JobPirateFirstMate # mono
       time: 10800 # 3 hours
-  #whitelisted: true # mono - comment out
+  whitelisted: true 
   startingGear: PirateCaptainNFGear
   alwaysUseSpawner: true
   hideConsoleVisibility: true

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_first_mate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_first_mate.yml
@@ -9,7 +9,7 @@
     - !type:RoleTimeRequirement # mono
       role: JobPirate # mono
       time: 10800 # 3 hours
-  #whitelisted: true # mono - comment out
+  whitelisted: true # mono - comment out
   startingGear: PirateFirstMateNFGear
   alwaysUseSpawner: true
   hideConsoleVisibility: true

--- a/Resources/ServerInfo/_NF/Guidebook/Rules/3_Escalation.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Rules/3_Escalation.xml
@@ -5,9 +5,9 @@ A fistfight does not suddenly escalate into a gunfight. Use common sense.
 
     - Antagonistic ghost roles and pest ghost roles like mice are always fair game for attack. 
     - As a non-antagonist, don't attack Nanotrasen and NGC-aligned ghost roles like familiars, drones, or pets without provocation.
-    - Antags listed in [textlink="Antagonism Rules"link="FrontierRule7"] do not require escalation to attack.
     - Do not attack another player without a legitimate, explainable roleplay reason that could be applied in a similar, real-life scenario.
-    - If a fight results with being critically injured or killed, seek medical help for them. This does not apply to fights between Antags and Non-Antags.
+    - If a fight results in someone being critically injured or killed, seek medical help for them.
     - If a fight ends and both parties leave the area, you cannot skip escalation and plunge back into a fight. What's done is done.
     - A 15 minute non-aggression period is required after respawning, so you can't immediately get in a ship and try to go kill whoever killed you.
+    - NFSD and command roles must resolve situations with non-lethal force and de-escalate IC confrontation except in cases where there is a reasonable chance of harm/death.
 </Document>

--- a/Resources/Textures/_NF/Structures/Decoration/banner.rsi/meta.json
+++ b/Resources/Textures/_NF/Structures/Decoration/banner.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-4.0",
-  "copyright": "taken from Paradise Station, https://github.com/ParadiseSS13/Paradise/commit/0deaf46e1a080baabf1753662051c8f3fbf1be0a; nfsd-banner and nfsd-flag Created by Ghost Prince for Frontier Station; banner_goblin sprited by erhardsteinhauer (discord/github) for Frontier Station, based on https://github.com/tgstation/tgstation/commit/fa9e44d937026d5a2ba72615afccf2f18a87c485"; ngc-banner Created by LukeZurg22 for Monolith based on the banner from Frontier,
+  "copyright": "taken from Paradise Station, https://github.com/ParadiseSS13/Paradise/commit/0deaf46e1a080baabf1753662051c8f3fbf1be0a; nfsd-banner and nfsd-flag Created by Ghost Prince for Frontier Station; banner_goblin sprited by erhardsteinhauer (discord/github) for Frontier Station, based on https://github.com/tgstation/tgstation/commit/fa9e44d937026d5a2ba72615afccf2f18a87c485; ngc-banner Created by LukeZurg22 for Monolith based on the banner from Frontier"
   "size": {
     "x": 32,
     "y": 32

--- a/Resources/Textures/_NF/Structures/Decoration/banner.rsi/meta.json
+++ b/Resources/Textures/_NF/Structures/Decoration/banner.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-4.0",
-  "copyright": "taken from Paradise Station, https://github.com/ParadiseSS13/Paradise/commit/0deaf46e1a080baabf1753662051c8f3fbf1be0a; nfsd-banner and nfsd-flag Created by Ghost Prince for Frontier Station; banner_goblin sprited by erhardsteinhauer (discord/github) for Frontier Station, based on https://github.com/tgstation/tgstation/commit/fa9e44d937026d5a2ba72615afccf2f18a87c485; ngc-banner Created by LukeZurg22 for Monolith based on the banner from Frontier"
+  "copyright": "taken from Paradise Station, https://github.com/ParadiseSS13/Paradise/commit/0deaf46e1a080baabf1753662051c8f3fbf1be0a; nfsd-banner and nfsd-flag Created by Ghost Prince for Frontier Station; banner_goblin sprited by erhardsteinhauer (discord/github) for Frontier Station, based on https://github.com/tgstation/tgstation/commit/fa9e44d937026d5a2ba72615afccf2f18a87c485; ngc-banner Created by LukeZurg22 for Monolith based on the banner from Frontier",
   "size": {
     "x": 32,
     "y": 32


### PR DESCRIPTION
As of prior round, everyone played pirates. This fixes the requirements for Pirates, though Ark will need to resolve the actual time requirement's disabling in the server's config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Mga Bagong Tampok**
	- Na-activate na ang karagdagang oras para sa trabahong "Pirate" at na-enable na ang whitelisting sa "Pirate Captain" at "Pirate First Mate" roles.

- **Mga Gawain**
	- In-adjust ang playtime sa ilang trabaho: tumaas ang pangkalahatang kinakailangang oras mula 3 hanggang 5 oras at inayos ang tagal ng oras para sa security role.
	- In-update ang attribution ng banner.

- **Dokumentasyon**
	- Pinalinaw ang escalation guidelines kasama ang bagong patakarang hindi nakamamatay para sa mga partikular na role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->