### PR TITLE
Those who buff

### DIFF
--- a/Content.Shared/Theta/ShipEvent/Components/CircularShieldComponent.cs
+++ b/Content.Shared/Theta/ShipEvent/Components/CircularShieldComponent.cs
@@ -41,10 +41,10 @@ public sealed partial class CircularShieldComponent : Component
 
     // Power surge mechanics when taking damage
     [DataField("projectileWattPerImpact"), ViewVariables(VVAccess.ReadWrite)]
-    public float ProjectileWattPerImpact = 100f; // 100W per projectile impact
+    public float ProjectileWattPerImpact = 500f; // 500W per projectile impact
 
     [DataField("damageSurgeDuration"), ViewVariables(VVAccess.ReadWrite)]
-    public float DamageSurgeDuration = 30f; // Duration in seconds before surge dissipates
+    public float DamageSurgeDuration = 10f; // Duration in seconds before surge dissipates
 
     [DataField("currentSurgePower"), ViewVariables(VVAccess.ReadWrite)]
     public float CurrentSurgePower; // Additional watts of power usage from damage

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
@@ -116,4 +116,4 @@
     detectionRange: 800
     scanArc: 65
     launchSpeed: 60
-    maxSpeed: 200
+    maxSpeed: 140

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
@@ -113,7 +113,7 @@
   - type: MiningGatheringHard
   - type: TargetSeeking
     acceleration: 20
-    detectionRange: 400
-    scanArc: 45
-    launchSpeed: 25
-    maxSpeed: 80
+    detectionRange: 800
+    scanArc: 65
+    launchSpeed: 60
+    maxSpeed: 200

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/BallisticArtillery.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/BallisticArtillery.yml
@@ -254,7 +254,7 @@
     range: 500
   - type: Gun
     fireRate: 1
-    projectileSpeed: 45
+    projectileSpeed: 80
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
     soundEmpty:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Missile speed is buffed so they shouldnt hit parent ship when launching
Shields will take more power on impact now and less time before power surge decrease

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Shields take more power on impact, but take less time to dissipate power surges.
- tweak: Missile speeds have been tweaked.