### PR TITLE
Iapetus Directional Fan

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/iapetus.yml
+++ b/Resources/Maps/_Mono/Shuttles/iapetus.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/15/2025 23:27:41
-  entityCount: 414
+  time: 04/07/2025 16:16:20
+  entityCount: 415
 maps: []
 grids:
 - 1
@@ -634,6 +634,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,1.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a directional fan to the Iapetus artifact chamber.

## Why / Balance
All good artifact chambers have directional fans. All safe ones, too.

## How to test
Buy it, open arti chamber room door. Boom, tested.

## Media
![Screenshot 2025-04-07 121500](https://github.com/user-attachments/assets/6f65abbb-e9b2-4613-8959-a2daa1323ae2)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nope.

**Changelog**
:cl:
- tweak: Iapetus now has a directional fan in the door to the arti chamber.
