### PR TITLE
lower smuggling note pop requirements

### DIFF
--- a/Resources/Prototypes/_NF/Events/nf_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_events.yml
@@ -64,7 +64,7 @@
     weight: 8 # Fairly common.
     duration: 35
     earliestStart: 50
-    minimumPlayers: 20
+    minimumPlayers: 2
     reoccurrenceDelay: 50
   - type: RandomFaxRule
     minFaxes: 1


### PR DESCRIPTION
lowers smuggling pop requirements

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Loweres the pop requirements for smuggling notes

## Why / Balance
These events cannot spawn until there are 20 pop, and thus it would be impossible to see how they would work balancewise with FTL
## How to test
Go in game, buy ship, wait, see if you get fax

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Lowered smuggling note pop requirements


