### PR TITLE
AI ships tuning (hopefully) and 100% free lag

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/ghost_roles.yml
@@ -5,7 +5,7 @@
   components:
   - type: ConditionalSpawner
     prototypes:
-    - PlayerBorgRedacted
+    - PlayerBorgRedactedGhostRole
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/ghost_roles.yml
@@ -5,7 +5,7 @@
   components:
   - type: ConditionalSpawner
     prototypes:
-    - PlayerBorgRedactedGhostRole
+    - PlayerBorgRedacted
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -103,4 +103,5 @@
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
+    prototype: RedactedBorg
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
@@ -24,7 +24,7 @@
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
-    lifetime: 10
+    lifetime: 5
   - type: PointLight
     color: "#FB00FF"
   - type: ExplodeOnTrigger

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/Ammo/90mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/Ammo/90mm.yml
@@ -8,7 +8,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: TimedDespawn
-    lifetime: 60
+    lifetime: 5
   - type: PointLight
     radius: 3.5
     energy: 0.5

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/Ammo/autocannon.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/Ammo/autocannon.yml
@@ -15,7 +15,7 @@
     ignoreWeaponGrid: true
   - type: ShipWeaponProjectile
   - type: TimedDespawn
-    lifetime: 60
+    lifetime: 3
   - type: PointLight
     radius: 3.5
     energy: 0.5

--- a/Resources/Prototypes/_Mono/GameRules/Shuttles/ship_spawns.yml
+++ b/Resources/Prototypes/_Mono/GameRules/Shuttles/ship_spawns.yml
@@ -1,9 +1,9 @@
 - type: preloadedGrid
   id: AIZenith
   path: /Maps/_Mono/ShuttleEvent/zenith.yml
-  copies: 4
+  copies: 3
 
 - type: preloadedGrid
   id: AIRazor
   path: /Maps/_Mono/ShuttleEvent/razor.yml
-  copies: 8
+  copies: 5

--- a/Resources/Prototypes/_Mono/GameRules/base.yml
+++ b/Resources/Prototypes/_Mono/GameRules/base.yml
@@ -5,10 +5,10 @@
     - type: BasicStationEventScheduler
       scheduledGameRules: !type:NestedSelector
         tableId: MonoAISTCEventsTable
-      minimumTimeUntilFirstEvent: 5400 # 90 minutes
+      minimumTimeUntilFirstEvent: 10800 # 180 minutes
       minMaxEventTiming:
-        min: 3600 # 60 minutes between events
-        max: 5400 # 90 minutes between events
+        min: 5400 # 90 minutes between events
+        max: 9000 # 150 minutes between events
 
 - type: entityTable
   id: MonoAISTCEventsTable

--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -14,7 +14,9 @@
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
-    maxOccurrences: 4
+    maxOccurrences: 3
+    requiredJobs:
+      Sheriff: 1
   - type: LoadMapRule
     preloadedGrid: AIZenith
 
@@ -27,6 +29,8 @@
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 3
-    maxOccurrences: 8
+    maxOccurrences: 5
+    requiredJobs:
+      Sheriff: 1
   - type: LoadMapRule
     preloadedGrid: AIRazor

--- a/Resources/Prototypes/_Mono/Roles/Ghostroles/whitelisted.yml
+++ b/Resources/Prototypes/_Mono/Roles/Ghostroles/whitelisted.yml
@@ -1,0 +1,7 @@
+- type: ghostRole
+  id: RedactedBorg
+  name: ghost-role-information-redacted-borg
+  description: ghost-role-information-redacted-borg-description
+  rules: ghost-role-information-silicon-rules
+  entityPrototype: PlayerBorgRedacted
+  whitelisted: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Derelict AI ships now need more time to spawn in (and have higher cooldowns for spawning), now (should) need whitelist when whitelist is enabled, and now require a sheriff to spawn. Additionally, Zenith can only spawn 3 times now (was 4), and Razor can only spawn 5 times now (was 8).
- fix: Ship projectile lifetimes have been lowered again. I accidentally left it on one minute for 20mms. Sorry. 100% FREE LAG
