### PR TITLE
NCMCO color fixes

### DIFF
--- a/Resources/Prototypes/_NF/PointsOfInterest/courthouse.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/courthouse.yml
@@ -18,7 +18,7 @@
   gridPath: /Maps/_NF/POI/courthouse.yml
   addComponents:
   - type: IFF
-    color: "#ae7d57"
+    color: "#047abd
 
 - type: gameMap
   id: Courthouse

--- a/Resources/Prototypes/_NF/PointsOfInterest/courthouse.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/courthouse.yml
@@ -18,7 +18,7 @@
   gridPath: /Maps/_NF/POI/courthouse.yml
   addComponents:
   - type: IFF
-    color: "#047abd
+    color: "#047abd"
 
 - type: gameMap
   id: Courthouse

--- a/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
@@ -1,12 +1,12 @@
 # Author Info
-# GitHub:
-# Discord: Tjsip
+# GitHub: SuperJoelD00D
+# Discord: Super_Joel_Dood
 
 # Maintainer Info
 # GitHub: ???
 # Discord: ???
 
-# Notes:
+# Notes: Wow.
 #
 - type: pointOfInterest
   id: Nfsd
@@ -18,7 +18,7 @@
   gridPath: /Maps/_NF/POI/nfsd.yml
   addComponents:
   - type: IFF
-    color: "#ae7d57"
+    color: "#407780"
   - type: ProtectedGrid
     preventEmpEvents: true
 

--- a/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
@@ -18,7 +18,7 @@
   gridPath: /Maps/_NF/POI/nfsd.yml
   addComponents:
   - type: IFF
-    color: "#407780"
+    color: "#047abd"
   - type: ProtectedGrid
     preventEmpEvents: true
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes NCMCO (plus Courthouse as a bonus) proper NGC colors. Bye bye brown.

## Why / Balance
Who wants a POI that isn't the branded color.

## How to test
Just go fly over to them.

## Media
![Screenshot 2025-04-22 171348](https://github.com/user-attachments/assets/bb5e8562-fed9-4426-93fa-e49518a1cd3c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Made NCMCO (and Courthouse) proper colors, that being blue. Yay!
