### PR TITLE
Supplement for companies

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -417,9 +417,12 @@ namespace Content.Client.Lobby.UI
             // Clear any existing items
             CompanyButton.Clear();
 
+            var username = _playerManager.LocalPlayer?.Session?.Name; //Lua modified - company login support
+
             // Add all companies from prototypes - use consistent sorting with UpdateCompanyControls
             var companies = _prototypeManager.EnumeratePrototypes<CompanyPrototype>()
-                .Where(c => !c.Disabled) // Filter out disabled companies
+                //.Where(c => !c.Disabled) // Filter out disabled companies
+                .Where(c => !c.Disabled || (username != null && c.Logins.Contains(username))) //Lua modified - company login support
                 .ToList();
             companies.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
 
@@ -1869,8 +1872,11 @@ namespace Content.Client.Lobby.UI
             if (Profile is null)
                 return;
 
+            var username = _playerManager.LocalPlayer?.Session?.Name; //Lua modified - company login support
+
             var companies = _prototypeManager.EnumeratePrototypes<CompanyPrototype>()
-                .Where(c => !c.Disabled) // Filter out disabled companies
+                //.Where(c => !c.Disabled) // Filter out disabled companies
+                .Where(c => !c.Disabled || (username != null && c.Logins.Contains(username))) //Lua modified - company login support
                 .ToList();
             companies.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
 

--- a/Content.Server/Company/CompanySystem.cs
+++ b/Content.Server/Company/CompanySystem.cs
@@ -67,6 +67,18 @@ public sealed class CompanySystem : EntitySystem
         var playerId = args.Player.UserId.ToString();
         var profileCompany = args.Profile.Company;
 
+        //Lua start: Login support
+        foreach (var companyProto in _prototypeManager.EnumeratePrototypes<CompanyPrototype>())
+        {
+            if (companyProto.Logins.Contains(args.Player.Name))
+            {
+                companyComp.CompanyName = companyProto.ID;
+                Dirty(args.Mob, companyComp);
+                return;
+            }
+        }
+        //Lua end
+
         // Use "None" as fallback for empty company
         if (string.IsNullOrEmpty(profileCompany))
             profileCompany = "None";

--- a/Content.Shared/Company/CompanyPrototype.cs
+++ b/Content.Shared/Company/CompanyPrototype.cs
@@ -38,4 +38,10 @@ public sealed class CompanyPrototype : IPrototype
     /// </summary>
     [DataField("disabled")]
     public bool Disabled { get; private set; } = false;
+
+    /// <summary>
+    /// Access for login in closed company
+    /// </summary>
+    [DataField("logins", required: false)]
+    public List<string> Logins { get; private set; } = new();
 }

--- a/Resources/Locale/en-US/_Mono/companies/companies.ftl
+++ b/Resources/Locale/en-US/_Mono/companies/companies.ftl
@@ -7,3 +7,5 @@ armadan-exiles-description = A miscellaneous group of individuals whom have been
 union-j-description = A group of hard working men and women who make and break things; contractually neutral but often favours the NGC and law enforcement affairs in practice.
 
 # aetherion-dynamics-description = A large corporation hellbent on bulding the best ships and weaponry money can buy. Their agents in the Rogue Frontier specialize in making money and testing the limits of any technology they can get their hands on.
+
+lua-technologies-description = A technocratic corporation developing revolutionary technologies based on the principles of Purspace. A strictly isolated society of scientists where decisions are made solely on the basis of scientific data.

--- a/Resources/Prototypes/companies.yml
+++ b/Resources/Prototypes/companies.yml
@@ -46,3 +46,16 @@
   color: "#8B0000"
   disabled: true
 # DO NOT TOUCH
+
+# TEST remove after (or no)
+- type: company
+  id: LuaTech
+  name: Lua Technologies
+  color: "#407dc4"
+  description: lua-technologies-description
+  disabled: true
+  logins:
+    - HacksLua
+    - localhost@HacksLua
+    - hqdishka
+# TEST


### PR DESCRIPTION
## About the PR

Adds support for hidden (`disabled: true`) companies that are only visible and selectable if the player's login is listed in `logins`. These companies will now appear in the UI if the login matches.

## Why

Allows for restricted or secret factions available only to specific players.

## How to test

- Add a company with `disabled: true` and your login in `logins`.
- Log in with that username - the company should be visible and selectable.
- Other usernames should not see it.

## Requirements

- [X] I have read the PR guidelines.
- [X] No media required for this change.

**Changelog**
```yaml
:cl:
add: Hidden companies can now be made visible to whitelisted logins.
```