### PR TITLE
Add radar blips for vehicles

### DIFF
--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -1,7 +1,28 @@
+using Content.Server._Mono.Radar; //Lua mod
+using Content.Shared.Buckle.Components; //Lua mod
 using Content.Shared.Vehicle;
+using Content.Shared.Vehicle.Components; //Lua mod
 
 namespace Content.Server.Vehicle;
 
 public sealed class VehicleSystem : SharedVehicleSystem
 {
+    //Lua start
+    protected override void OnStrapped(EntityUid uid, VehicleComponent component, ref StrappedEvent args)
+    {
+        base.OnStrapped(uid, component, ref args);
+
+        var blip = EnsureComp<RadarBlipComponent>(uid);
+        blip.RadarColor = Color.Cyan;
+        blip.Scale = 0.5f;
+        blip.VisibleFromOtherGrids = true;
+    }
+
+    protected override void OnUnstrapped(EntityUid uid, VehicleComponent component, ref UnstrappedEvent args)
+    {
+        RemComp<RadarBlipComponent>(uid);
+
+        base.OnUnstrapped(uid, component, ref args);
+    }
+    //Lua end
 }

--- a/Content.Shared/Vehicle/SharedVehicleSystem.cs
+++ b/Content.Shared/Vehicle/SharedVehicleSystem.cs
@@ -108,7 +108,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     }
 
     // Umbra: vehicle changes
-    private void OnUnstrapped(EntityUid uid, VehicleComponent component, ref UnstrappedEvent args)
+    protected virtual void OnUnstrapped(EntityUid uid, VehicleComponent component, ref UnstrappedEvent args) //Lua: private void<protected virtual void
     {
         // Remove rider
         var riderUid = args.Buckle.Owner;
@@ -157,7 +157,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         }
     }
 
-    private void OnStrapped(EntityUid uid, VehicleComponent component, ref StrappedEvent args)
+    protected virtual void OnStrapped(EntityUid uid, VehicleComponent component, ref StrappedEvent args) //Lua: private void<protected virtual void
     {
         var riderUid = args.Buckle.Owner;
 


### PR DESCRIPTION
# Add radar blips for vehicles

## About the PR
This PR adds radar blip visualization for vehicles similar to jetpacks:
- Adds cyan radar blip when someone enters a vehicle
- Removes the blip when exiting
- Uses same parameters as jetpacks (0.5 scale, visible from other grids)

## Why / Balance
- Provides consistent visibility for all moving entities (jetpacks and vehicles)
- Helps players track vehicle movement
- Matches existing game balance for radar visibility

## How to test
1. Spawn any vehicle (e.g. with `spawn bike`)
2. Enter the vehicle - should see cyan blip on radar
3. Exit vehicle - blip should disappear

## Media
https://github.com/user-attachments/assets/34b1cd88-6134-4797-ba69-88e18371b625

## Requirements
- [X] I have read and am following the Pull Request and Changelog Guidelines
- [X] I have added media to this PR or it does not require an ingame showcase

## Breaking changes
None - this is purely additive functionality

**Changelog**
```yaml
:cl:
- add: Vehicles now show up as radar blips when occupied, similar to jetpacks
```