### PR TITLE
Re-enable content drop on Restock box destruction

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -370,7 +370,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockSalvageEquipment
   name: Salvage Vendor restock box
-  description: "Strike the earth ere the space carp nip your behind! Slam into a salvage vendor to begin. Or break it, the choice is yours!"" #Monolith: no angry label
+  description: "Strike the earth ere the space carp nip your behind! Slam into a salvage vendor to begin. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -43,8 +43,6 @@
       - !type:DumpRestockInventory # Monolith
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-      - type: StaticPrice # Frontier
-      - price: 400 # Frontier
 
 - type: entity
   parent: BaseVendingMachineRestock

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -40,17 +40,15 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
-#      - !type:DumpRestockInventory # Frontier
+      - !type:DumpRestockInventory # Monolith
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: StaticPrice # Frontier
-    price: 400 # Frontier
 
 - type: entity
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockBooze
   name: Booze-O-Mat restock box
-  description: Slot into your Booze-O-Mat to start the party! Not for sale to passengers below the legal age. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "Slot into your Booze-O-Mat to start the party! Not for sale to passengers below the legal age. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -66,7 +64,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockChang
   name: Mr. Chang's restock box
-  description: A box covered in white labels with bold red Chinese characters, ready to be loaded into the nearest Mr. Chang's vending machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A box covered in white labels with bold red Chinese characters, ready to be loaded into the nearest Mr. Chang's vending machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -114,7 +112,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockClothes
   name: wardrobe restock box
-  description: It's time to step up your fashion! Place inside any clothes vendor restock slot to begin. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "It's time to step up your fashion! Place inside any clothes vendor restock slot to begin. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -154,7 +152,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockCostumes
   name: AutoDrobe restock box
-  description: A panoply of NanoTrasen employees are prancing about a colorful theater in a tragicomedy. You can join them too! Load this into your nearest AutoDrobe vending machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A panoply of NanoTrasen employees are prancing about a colorful theater in a tragicomedy. You can join them too! Load this into your nearest AutoDrobe vending machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -170,7 +168,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockDinnerware
   name: Plasteel Chef's restock box
-  description: It's never raw in this kitchen! Drop into the restock slot on the Plasteel Chef to begin. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "It's never raw in this kitchen! Drop into the restock slot on the Plasteel Chef to begin. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -186,7 +184,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockDiscountDans
   name: Discount Dan's restock box
-  description: A box full of salt and starch. Why suffer Quality when you can have Quantity? Discount Dan's! A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A box full of salt and starch. Why suffer Quality when you can have Quantity? Discount Dan's! Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -202,7 +200,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockDonut
   name: Robust Donuts restock box
-  description: A box full of toroidal bundles of fried dough for restocking a vending machine. Use only as directed by Robust Industries, LLC. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A box full of toroidal bundles of fried dough for restocking a vending machine. Use only as directed by Robust Industries, LLC. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -218,7 +216,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockEngineering
   name: EngiVend restock box
-  description: Only to be used by certified professionals. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "Only to be used by certified professionals. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -235,7 +233,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockGames
   name: Good Clean Fun restock box
-  description: It's time to roll for initiative, dice dragons! Load up at the Good Clean Fun vending machine! A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "It's time to roll for initiative, dice dragons! Load up at the Good Clean Fun vending machine! Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -251,7 +249,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockGetmoreChocolateCorp
   name: GetMore Chocolate restock box
-  description: A box loaded with the finest ersatz cacao. Only to be used in official Getmore Chocolate vending machines. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A box loaded with the finest ersatz cacao. Only to be used in official Getmore Chocolate vending machines. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -267,7 +265,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockHotDrinks
   name: Solar's Best restock box
-  description: Toasty! For use in Solar's Best Hot Drinks or other affiliate vending machines. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "Toasty! For use in Solar's Best Hot Drinks or other affiliate vending machines. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -283,7 +281,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockMedical
   name: NanoMed restock box
-  description: Slot into your department's NanoMed or NanoMedPlus to dispense. Handle with care. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "Slot into your department's NanoMed or NanoMedPlus to dispense. Handle with care. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -300,7 +298,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockNutriMax
   name: NutriMax restock box
-  description: We'll make your thumbs green with our tools. Let's get to harvesting! Load into a NutriMax vending machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "We'll make your thumbs green with our tools. Let's get to harvesting! Load into a NutriMax vending machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -316,7 +314,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockPTech
   name: PTech restock box
-  description: All the bureaucracy you can handle, and more! Load into the PTech vending machine to get started. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "All the bureaucracy you can handle, and more! Load into the PTech vending machine to get started. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -332,7 +330,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockRobustSoftdrinks
   name: beverage restock box
-  description: A cold, clunky container of colliding chilly cylinders. Use only as directed by Robust Industries, LLC. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A cold, clunky container of colliding chilly cylinders. Use only as directed by Robust Industries, LLC. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -355,7 +353,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockSecTech
   name: SecTech restock box
-  description: "Communists beware: the reinforcements have arrived! A label reads \"THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM.\"" # Frontier: add angry label
+  description: "Communists beware: the reinforcements have arrived! Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -372,7 +370,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockSalvageEquipment
   name: Salvage Vendor restock box
-  description: Strike the earth ere the space carp nip your behind! Slam into a salvage vendor to begin. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "Strike the earth ere the space carp nip your behind! Slam into a salvage vendor to begin. Or break it, the choice is yours!"" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -388,7 +386,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockSeeds
   name: MegaSeed restock box
-  description: "A label says they're heirloom seeds, passed down from our ancestors. Pack it into the MegaSeed Servitor! A label reads \"THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM.\"" # Frontier: add angry label
+  description: "A label says they're heirloom seeds, passed down from our ancestors. Pack it into the MegaSeed Servitor! Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -404,7 +402,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockSmokes
   name: ShadyCigs restock box
-  description: It's hard to see anything under all the Surgeon General warnings, but it mentions loading it into a vending machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "It's hard to see anything under all the Surgeon General warnings, but it mentions loading it into a vending machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -420,7 +418,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockTankDispenser
   name: tank dispenser restock box
-  description: Capable of replacing tanks in a gas tank dispenser. Handle with care. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "Capable of replacing tanks in a gas tank dispenser. Handle with care. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -437,7 +435,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockVendomat
   name: Vendomat restock box
-  description: A box full of parts for various machinery. Load it into a Vendomat to begin. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A box full of parts for various machinery. Load it into a Vendomat to begin. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -453,7 +451,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockRobotics
   name: Robotech Deluxe restock box
-  description: A box full of tools for creating borgs. Load it into a Robotech Deluxe to begin. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A box full of tools for creating borgs. Load it into a Robotech Deluxe to begin. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -469,7 +467,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockHappyHonk
   name: Happy Honk restock box
-  description: Place this box full of fun into the restock slot on the Happy Honk Dispenser to begin. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "Place this box full of fun into the restock slot on the Happy Honk Dispenser to begin. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -485,7 +483,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockChemVend
   name: ChemVend restock box
-  description: A box filled with chemicals and covered in dangerous-looking NFPA diamonds. Load it into a ChemVend to begin. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM." # Frontier: add angry label
+  description: "A box filled with chemicals and covered in dangerous-looking NFPA diamonds. Load it into a ChemVend to begin. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -43,8 +43,8 @@
       - !type:DumpRestockInventory # Monolith
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-        - type: StaticPrice # Frontier
-        - price: 400 # Frontier
+      - type: StaticPrice # Frontier
+      - price: 400 # Frontier
 
 - type: entity
   parent: BaseVendingMachineRestock

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -43,6 +43,8 @@
       - !type:DumpRestockInventory # Monolith
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+      - type: StaticPrice # Frontier
+      - price: 400 # Frontier
 
 - type: entity
   parent: BaseVendingMachineRestock

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -43,6 +43,8 @@
       - !type:DumpRestockInventory # Monolith
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+        - type: StaticPrice # Frontier
+        - price: 400 # Frontier
 
 - type: entity
   parent: BaseVendingMachineRestock

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -2,7 +2,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockPride
   name: Pride-O-Mat restock box
-  description: The station needs more plushie sharks and you know it. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM."
+  description: The station needs more plushie sharks and you know it. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -2,7 +2,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockAstroVend
   name: AstroVend restock box
-  description: Rock and stone! A restock for the AstroVend. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM."
+  description: "Rock and stone! A restock for the AstroVend. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -19,7 +19,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockAmmo
   name: Liberation Station restock box
-  description: A box full of ammo and guns for the Liberation Station. 2TH AMENDMENT. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM."
+  description: "A box full of ammo and guns for the Liberation Station. 2TH AMENDMENT. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -35,7 +35,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockCuddlyCritterVend
   name: CuddlyCritterVend restock box
-  description: A box containing toys and plushies for the CuddlyCritterVend machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM."
+  description: "A box containing toys and plushies for the CuddlyCritterVend machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -51,7 +51,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockLessLethalVend
   name: LessLethalVend restock box
-  description: A box containing rubber bullets and disruptors for the LessLethalVend machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM."
+  description: "A box containing rubber bullets and disruptors for the LessLethalVend machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -68,7 +68,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockNonLethalVend
   name: NonLethalVend restock box
-  description: A box containing practice bullets for the NonLethalVend machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM."
+  description: "A box containing practice bullets for the NonLethalVend machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -85,7 +85,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockAutoTuneVend
   name: AutoTuneVend restock box
-  description: A box containing music and stuff for the AutoTuneVend machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM."
+  description: "A box containing music and stuff for the AutoTuneVend machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:
@@ -102,7 +102,7 @@
   parent: BaseVendingMachineRestock
   id: VendingMachineRestockPottedPlantVend
   name: Plant-O-Matic restock box
-  description: A box containing potted plants for the Plant-O-Matic vending machine. A label reads "THE BOX IS TAMPER-PROOF AND WILL DESTROY ITS CONTENT ON HARM."
+  description: A box containing potted plants for the Plant-O-Matic vending machine. Or break it, the choice is yours!" #Monolith: no angry label
   components:
   - type: VendingMachineRestock
     canRestock:

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -7,7 +7,7 @@
   - type: VendingMachineRestock
     canRestock:
     - AstroVendInventory
-    - AstroVendPOIInventory # Infinite stock apart from clothing.
+    #- AstroVendPOIInventory # Infinite stock apart from clothing. DISABLED on Monolith
   - type: Sprite
     layers:
     - state: base


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made restock boxes drop their contents on destroying them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
These boxes are basically useless, you need the corresponding vend in order to properly use them, and their potential on the loot tables are wasted.

## How to test
<!-- Describe the way it can be tested -->
>Spawn a restock box
>Break it

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Restock Box Price has been set to $0, but made restock boxes drop loot on breaking them instead of having their contents destroyed.
