### PR TITLE
Arachnid whitelists the web nest and web cocoon

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/web.yml
+++ b/Resources/Prototypes/Recipes/Construction/web.yml
@@ -133,5 +133,8 @@
   placementMode: SnapgridCenter
   canRotate: false
   canBuildInImpassable: false
+  entityWhitelist:
+    tags:
+    - SpiderCraft
   conditions:
     - !type:TileNotBlocked

--- a/Resources/Prototypes/Recipes/Crafting/web.yml
+++ b/Resources/Prototypes/Recipes/Crafting/web.yml
@@ -118,6 +118,9 @@
   targetNode: cocoon
   category: construction-category-clothing
   description: "Strong web cocoon used to restrain criminal or preys, its also prevent rotting."
+  entityWhitelist:
+    tags:
+    - SpiderCraft
   icon:
     sprite: Clothing/OuterClothing/Misc/webcocoon.rsi
     state: cocoon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Web nests and web cocoons can now only be made by arachnids

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Brings them in line with all other spidercraft items

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- fix: Web nests and web cocoons are now properly arachnid-whitelisted