### PR TITLE
Give marine privates an uplink

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/cadet.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/cadet.yml
@@ -39,3 +39,4 @@
     back:
     - MagazinePistol
     - FrontierUplinkCoin10
+    - BaseSecurityUplinkRadio # Give them FUC but no uplink?


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Gives the marine private an uplink, since they are given coins, yet no uplink to use them with.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Its just QoL, right now they have to borrow other marines uplinks, seems unneeded.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Marine privates now get an uplink
