### PR TITLE
Viper group company whitelist

### DIFF
--- a/Resources/Prototypes/_Mono/companies.yml
+++ b/Resources/Prototypes/_Mono/companies.yml
@@ -77,4 +77,18 @@
   description: viper-group-description
   color: "#D82918"
   image: /Textures/_Mono/Companies/thevipergroup.png # Example
+  logins: 
+  - Schizm1253
+  - Archylle
+  - bubz_bs
+  - capslfern
+  - DrOktober
+  - Ghost581
+  - hellcat76
+  - HungryCuban
+  - Kiterny
+  - plazmasniper_2005
+  - Redrover1760
+  - SwadianSupremacy
+  - Traildog
 


### PR DESCRIPTION
Makes the Viper group company whitelisted.

## Why / Balance
Prevents new players from picking them since they're openly hostile to the TSF which can get them involuntarily killed.

## How to test
good question

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).

reading is hard....

**Changelog**
:cl: Ghost581
- add: the Viper Group is now whitelisted. 
