### PR TITLE
Modifies civilian EVA suits + Voidsuit and CMO armors

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -426,15 +426,18 @@
   - type: Armor
     modifiers:
       coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
         Caustic: 0.1
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.95
+    walkModifier: 1 # 0.9-> 1 - Mono
+    sprintModifier: 1 # 0.95-> 1 - Mono
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMedical
   - type: StaminaDamageResistance # Mono - Stamres
-    coefficient: 0.8
+    coefficient: 0.7
 
 #Research Director's Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -119,8 +119,11 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Heat: 0.90
+      coefficients: # Added Blunt, Slash, and Pierce - Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
+        Heat: 0.9
         Radiation: 0.75
         Caustic: 0.5
   - type: GroupExamine
@@ -155,3 +158,5 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+  - type: StaminaDamageResistance # Mono - Stamres
+    coefficient: 0.8

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
@@ -10,6 +10,14 @@
   - type: Item
     shape:
     - 0,0,3,2
+  - type: Armor
+    modifiers:
+      coefficients: # Made to have no protection - Mono
+        Blunt: 1
+        Slash: 1
+        Piercing: 1
+        Heat: 1
+        Radiation: 1
   - type: ClothingSpeedModifier # Changed to 5% because the suit doesn't provide any protection other than from low pressure
     walkModifier: 0.95
     sprintModifier: 0.95
@@ -84,6 +92,10 @@
       - state: equipped-breathing-gear
       - state: equipped-unshaded
         shader: unshaded
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Caustic: 0.75
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadEVAHelmetHydro
 
@@ -255,6 +267,13 @@
       - state: equipped-breathing-gear
       - state: equipped-unshaded
         shader: unshaded
+  - type: Armor
+    modifiers:
+      coefficients: # CL suit, seems fine to have something - Mono
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadEVAHelmetSr
 
@@ -312,6 +331,12 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+  - type: Armor
+    modifiers:
+      coefficients: # Cap suit, seems fine to have something - Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
     clothingPrototype: ClothingHeadEVAHelmetCaptain
 
 ## ENGINEERING
@@ -333,6 +358,12 @@
     - state: icon-breathing-gear
     - state: icon-unshaded
       shader: unshaded
+  - type: Armor
+    modifiers:
+      coefficients: # Engie suit gets something - Mono
+        Blunt: 0.95
+        Radiation: 0.75
+
   - type: Item
     inhandVisuals:
       left:
@@ -426,6 +457,11 @@
         shader: unshaded
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadEVAHelmetAtmosTech
+  - type: Armor
+    modifiers:
+      coefficients: # Engie suit gets something - Mono
+        Blunt: 0.95
+        Radiation: 0.75
 
 ## SUPPLY
 - type: entity
@@ -538,6 +574,12 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+  - type: Armor
+    modifiers:
+      coefficients: # Salv suit, seems fine to have something - Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
     clothingPrototype: ClothingHeadEVAHelmetSalvage
 
 ## MEDICAL
@@ -595,6 +637,10 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+  - type: Armor
+    modifiers:
+      coefficients: # Med suit, seems fine to have something - Mono
+        Caustic: 0.75
     clothingPrototype: ClothingHeadEVAHelmetMedic
 
 ## SCIENCE
@@ -651,6 +697,10 @@
       - state: equipped-breathing-gear
       - state: equipped-unshaded
         shader: unshaded
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Caustic: 0.75
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadEVAHelmetScientist
 
@@ -708,6 +758,10 @@
       - state: equipped-breathing-gear
       - state: equipped-unshaded
         shader: unshaded
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Caustic: 0.75
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadEVAHelmetJanitor
 
@@ -1222,6 +1276,12 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
     clothingPrototype: ClothingHeadEVAHelmetMercenary
 
 - type: entity
@@ -1278,6 +1338,12 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
     clothingPrototype: ClothingHeadEVAHelmetPrivateSec
 
 ## NFSD
@@ -1335,6 +1401,12 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
     clothingPrototype: ClothingHeadEVAHelmetNfsd
 
 ## PLAYER FACTIONS
@@ -1398,6 +1470,12 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
     clothingPrototype: ClothingHeadEVAHelmetLvhi
 
 - type: entity
@@ -1466,6 +1544,12 @@
         state: decor_base_OuterClothing_armor_05
         color: "#8f1717"
   - type: ToggleableClothing
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
     clothingPrototype: ClothingHeadEVAHelmetArcadia
 
 #FSB suit
@@ -1484,6 +1568,12 @@
     sprite: _NF/Clothing/OuterClothing/Suits/fsb_voidsuit.rsi
   - type: Clothing
     sprite: _NF/Clothing/OuterClothing/Suits/fsb_voidsuit.rsi
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Blunt: 0.95
+        Slash: 0.95
+        Piercing: 0.95
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitFSB
     slot: head

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
@@ -1401,13 +1401,13 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+    clothingPrototype: ClothingHeadEVAHelmetNfsd
   - type: Armor
     modifiers:
       coefficients: # Mono
         Blunt: 0.95
         Slash: 0.95
         Piercing: 0.95
-    clothingPrototype: ClothingHeadEVAHelmetNfsd
 
 ## PLAYER FACTIONS
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
@@ -331,13 +331,13 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+    clothingPrototype: ClothingHeadEVAHelmetCaptain
   - type: Armor
     modifiers:
       coefficients: # Cap suit, seems fine to have something - Mono
         Blunt: 0.95
         Slash: 0.95
         Piercing: 0.95
-    clothingPrototype: ClothingHeadEVAHelmetCaptain
 
 ## ENGINEERING
 - type: entity
@@ -574,13 +574,14 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+    clothingPrototype: ClothingHeadEVAHelmetSalvage
   - type: Armor
     modifiers:
       coefficients: # Salv suit, seems fine to have something - Mono
         Blunt: 0.95
         Slash: 0.95
         Piercing: 0.95
-    clothingPrototype: ClothingHeadEVAHelmetSalvage
+
 
 ## MEDICAL
 - type: entity
@@ -637,11 +638,12 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+    clothingPrototype: ClothingHeadEVAHelmetMedic
   - type: Armor
     modifiers:
       coefficients: # Med suit, seems fine to have something - Mono
         Caustic: 0.75
-    clothingPrototype: ClothingHeadEVAHelmetMedic
+
 
 ## SCIENCE
 - type: entity
@@ -1276,13 +1278,14 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+    clothingPrototype: ClothingHeadEVAHelmetMercenary
   - type: Armor
     modifiers:
       coefficients: # Mono
         Blunt: 0.95
         Slash: 0.95
         Piercing: 0.95
-    clothingPrototype: ClothingHeadEVAHelmetMercenary
+
 
 - type: entity
   parent: NFClothingOuterEVASuitBase
@@ -1338,13 +1341,14 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+    clothingPrototype: ClothingHeadEVAHelmetPrivateSec
   - type: Armor
     modifiers:
       coefficients: # Mono
         Blunt: 0.95
         Slash: 0.95
         Piercing: 0.95
-    clothingPrototype: ClothingHeadEVAHelmetPrivateSec
+
 
 ## NFSD
 - type: entity
@@ -1470,13 +1474,14 @@
       - state: equipped-unshaded
         shader: unshaded
   - type: ToggleableClothing
+    clothingPrototype: ClothingHeadEVAHelmetLvhi
   - type: Armor
     modifiers:
       coefficients: # Mono
         Blunt: 0.95
         Slash: 0.95
         Piercing: 0.95
-    clothingPrototype: ClothingHeadEVAHelmetLvhi
+
 
 - type: entity
   parent: NFClothingOuterEVASuitBase
@@ -1544,13 +1549,14 @@
         state: decor_base_OuterClothing_armor_05
         color: "#8f1717"
   - type: ToggleableClothing
+    clothingPrototype: ClothingHeadEVAHelmetArcadia
   - type: Armor
     modifiers:
       coefficients: # Mono
         Blunt: 0.95
         Slash: 0.95
         Piercing: 0.95
-    clothingPrototype: ClothingHeadEVAHelmetArcadia
+
 
 #FSB suit
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The EVA suits weren't meant to be armored at all in exchange for 5% slowdown, but instead parented the base hardsuit for 10% resists and 75% radiation resist instead. Removes armor on EVA suits, instead adds specialized armor to individual EVA suits (medical suits get 25% caustic, military suits get 5% resists, engineering suits get 25% radiation, CL suit gets 10% resists as CL is special)

Also gives the the Paramedic suit 5% resists so its not a strict downgrade to the normal hardsuit.

CMO hardsuit also has all slowdown removed and gets some 15% resists, as fitting for a TSF command member.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- remove: EVA suits having hardsuit armor
- add: Individual armor values for EVA suits depending on their specialty
- tweak: Paramedic Voidsuit has minor 5% resistances
- tweak: CMO Hardsuit has no slowdown and 15% resistances
