### PR TITLE
Getting rid of the lame ghostrole rule

### DIFF
--- a/Resources/Locale/en-US/_NF/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_NF/ghost/roles/ghost-role-component.ftl
@@ -66,11 +66,9 @@ ghost-role-information-punk-boss-dungeon-description = Defend the expedition dun
 ghost-role-information-dungeon-boss-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all dungeon mobs.
                                         Fight players within the dungeon, defend your dungeon.
                                         Please note that [color=yellow]all server rules still apply.[/color] Additionally:
-                                        - [color=red]DO NOT[/color] damage player shuttles or their contents.
                                         - [color=red]DO NOT[/color] hide from players to run down the expedition timer.
                                         - [color=red]DO NOT[/color] gib players. Once they're dead, leave them be.
                                         - [color=red]DO NOT[/color] destroy or hide valuable loot in the dungeon.
-                                        - [color=red]DO NOT[/color] leave the planet.
 
 nf-ghost-role-information-derelict-cyborg-description = You are a cyborg that's been stranded on a wreck for years, exposed to countless ion storms.
 


### PR DESCRIPTION
Got rid of the dumb rules here, exped bosses should be allowed to do as they would in reality (without ruining rp, hence the rules I left behind)

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed dumb rules for dungeon bosses

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed rules preventing dungeon bosses from boarding shuttles and leaving their dungeons
