### PR TITLE
add weapon range to guidebook

### DIFF
--- a/Resources/ServerInfo/_Mono/Guidebook/Specifications/AK570.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Specifications/AK570.xml
@@ -12,6 +12,7 @@ A [color=gold]ballistic[/color] 90mm heavy autocannon, firing general-purpose ro
 - Firerate: [color=crimson] 120 RPM [/color]/[color=deepskyblue] 2 RPS [/color]
 - Sell Value: [color=greenyellow][bold]750 Spesos[/bold][/color]
 - Muzzle Velocity: [color=orange]80 m/s[/color]
+- Range: [color=orange]400m[/color]
 - Capacitor Storage: [color=orange]40000u[/color]
 - Capacitor Recharge: [color=turquoise]95u/s[/color]
 - Capacitor Fire Cost: [color=turquoise]50u[/color]

--- a/Resources/ServerInfo/_Mono/Guidebook/Specifications/ASM302.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Specifications/ASM302.xml
@@ -26,5 +26,6 @@ A basic combat-rated [color=GreenYellow]missile[/color] pod turret.
 - Scanning Arc: [color=teal]15 degrees[/color]
 - Launch Speed: [color=darkorange]60 m/s[/color]
 - Max Speed: [color=darkorange]140 m/s[/color]
+- Range: [color=orange]2046m[/color]
 
 </Document>

--- a/Resources/ServerInfo/_Mono/Guidebook/Specifications/CHARON.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Specifications/CHARON.xml
@@ -12,6 +12,7 @@ A [color=gold]ballistic[/color] mass driver, firing a large slug hard enough to 
 - Firerate: [color=crimson] 3 RPM [/color]/[color=deepskyblue] 0.05 RPS [/color]
 - Sell Value: [color=greenyellow][bold]15000 Spesos[/bold][/color]
 - Muzzle Velocity: [color=orange]300 m/s[/color]
+- Range: [color=orange]13500m[/color]
 - Capacitor Storage: [color=orange]40000u[/color]
 - Capacitor Recharge: [color=turquoise]350u/s[/color]
 - Capacitor Fire Cost: [color=turquoise]1500u[/color]

--- a/Resources/ServerInfo/_Mono/Guidebook/Specifications/CYREXA.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Specifications/CYREXA.xml
@@ -12,6 +12,7 @@ A [color=gold]ballistic[/color] capital-class turret, firing a 220mm shell with 
 - Firerate: [color=crimson] 7.5 RPM [/color]/[color=deepskyblue] 0.125 RPS [/color]
 - Sell Value: [color=greenyellow][bold]5000 Spesos[/bold][/color]
 - Muzzle Velocity: [color=orange]105 m/s[/color]
+- Range: [color=orange]2625m[/color]
 - Capacitor Storage: [color=orange]1000u[/color]
 - Capacitor Recharge: [color=turquoise]60u/s[/color]
 - Capacitor Fire Cost: [color=turquoise]350u[/color]

--- a/Resources/ServerInfo/_Mono/Guidebook/Specifications/DYMERE.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Specifications/DYMERE.xml
@@ -12,6 +12,7 @@ An [color=MediumVioletRed]energy[/color]-based capital-class turret capable of s
 - Firerate: [color=crimson] 45 RPM [/color]/[color=deepskyblue] 0.75 RPS [/color]
 - Sell Value: [color=greenyellow][bold]60000 Spesos[/bold][/color]
 - Muzzle Velocity: [color=orange]95 m/s[/color]
+- Range: [color=orange]1900m[/color]
 - Capacitor Storage: [color=orange]40000 J[/color]
 - Capacitor Recharge: [color=turquoise]67 J/s[/color]
 - Capacitor Fire Cost: [color=turquoise]2400 J[/color]

--- a/Resources/ServerInfo/_Mono/Guidebook/Specifications/L85.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Specifications/L85.xml
@@ -12,6 +12,7 @@ A light 20mm [color=gold]ballistic[/color] weapon.
 - Firerate: [color=crimson] 720 RPM [/color]/[color=deepskyblue] 12 RPS [/color]
 - Sell Value: [color=greenyellow][bold]250 Spesos[/bold][/color]
 - Muzzle Velocity: [color=orange]60 m/s[/color]
+- Range: [color=orange]180m[/color]
 - Capacitor Storage: [color=turquoise]20000u[/color]
 - Capacitor Recharge: [color=turquoise]500u/s[/color]
 - Capacitor Fire Cost: [color=turquoise]15u[/color]

--- a/Resources/ServerInfo/_Mono/Guidebook/Specifications/MARAUDER.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Specifications/MARAUDER.xml
@@ -12,6 +12,7 @@ A abandoned concept for a [color=MediumVioletRed]energy[/color]-based launcher, 
 - Firerate: [color=crimson] 15 RPM [/color]/[color=deepskyblue] 0.25 RPS [/color]
 - Sell Value: [color=greenyellow][bold]2500 Spesos[/bold][/color]
 - Muzzle Velocity: [color=orange]40 m/s[/color]
+- Range: [color=orange]400m[/color]
 - Capacitor Storage: [color=orange]40000u[/color]
 - Capacitor Recharge: [color=turquoise]350u/s[/color]
 - Capacitor Fire Cost: [color=turquoise]500u[/color]

--- a/Resources/ServerInfo/_Mono/Guidebook/Specifications/RUBICON.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Specifications/RUBICON.xml
@@ -12,6 +12,7 @@ A heavy [color=MediumVioletRed]energy[/color]-based launcher, firing EMP project
 - Firerate: [color=crimson] 12 RPM [/color]/[color=deepskyblue] 0.2 RPS [/color]
 - Sell Value: [color=greenyellow][bold]2500 Spesos[/bold][/color]
 - Muzzle Velocity: [color=orange]40 m/s[/color]
+- Range: [color=orange]400m[/color]
 - Capacitor Storage: [color=orange]40000u[/color]
 - Capacitor Recharge: [color=turquoise]350u/s[/color]
 - Capacitor Fire Cost: [color=turquoise]500u[/color]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
adds weapon ranges of batteries to guidebook. All the range is calculated by lifetime * speed. Data are from xml files in /Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery

## Why / Balance
its good

## How to test
open guidebook

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![屏幕截图 2025-05-16 202404](https://github.com/user-attachments/assets/909baf42-439d-4d34-b18e-8a71c1ea301b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: added weapon ranges of batteries to guidebook
-->
:cl:
- add: added weapon ranges of batteries to guidebook
