### PR TITLE
Made cryo just tell where you cryo'd, instead of telling your coords

### DIFF
--- a/Content.Server/_NF/CryoSleep/CryoSleepSystem.cs
+++ b/Content.Server/_NF/CryoSleep/CryoSleepSystem.cs
@@ -377,9 +377,7 @@ public sealed partial class CryoSleepSystem : SharedCryoSleepSystem
         {
             message = Loc.GetString("cryopod-radio-location",
                 ("character", characterName),
-                ("location", gridMetadata.EntityName),
-                ("x", Math.Round(mapPos.Position.X)),
-                ("y", Math.Round(mapPos.Position.Y)));
+                ("location", gridMetadata.EntityName));
         }
         else
         {

--- a/Content.Server/_NF/CryoSleep/CryoSleepSystem.cs
+++ b/Content.Server/_NF/CryoSleep/CryoSleepSystem.cs
@@ -377,7 +377,7 @@ public sealed partial class CryoSleepSystem : SharedCryoSleepSystem
         {
             message = Loc.GetString("cryopod-radio-location",
                 ("character", characterName),
-                ("location", gridMetadata.EntityName));
+                ("location", gridMetadata.EntityName)); // Mono: They don't tell coords now
         }
         else
         {

--- a/Resources/Locale/en-US/_NF/cryosleep/cryosleep-component.ftl
+++ b/Resources/Locale/en-US/_NF/cryosleep/cryosleep-component.ftl
@@ -22,5 +22,5 @@ cryopod-refuse-organic = The {$cryopod} detected multiple sentients! Remove {$na
 cryopod-wake-up = {$entity} returns from cryosleep!
 
 # Mono
-cryopod-radio-location = {$character} has entered cryosleep at {$location} ({$x}, {$y}).
+cryopod-radio-location = {$character} has entered cryosleep at {$location}.
 cryopod-radio-coordinates = {$character} has entered cryosleep at coordinates ({$x}, {$y}).


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title says for itself

## Why / Balance
No more revealing anything

## How to test
- Go into the game
- Go cryo

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Cryo doesn't tell your coordinates anymore.