### PR TITLE
Adds the Twilight class light freighter

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/twilight.yml
+++ b/Resources/Maps/_Mono/Shuttles/twilight.yml
@@ -1,0 +1,3754 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 247.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 05/19/2025 17:43:35
+  entityCount: 513
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  4: FloorBrokenWood
+  5: FloorDark
+  8: FloorDarkDiagonal
+  9: FloorDarkMini
+  10: FloorDarkPlastic
+  12: FloorKitchen
+  11: FloorTechMaint3
+  7: FloorWhite
+  6: FloorWhiteDiagonalMini
+  3: FloorWood
+  2: Lattice
+  1: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: 3.5123887,0.97567177
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAwAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAAAQAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAAAQAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAQAAAAAACQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAACgAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACgAAAAAACgAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAAQAAAAAACgAAAAAACgAAAAAACgAAAAAABQAAAAAABQAAAAAAAAAAAAAAAQAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACgAAAAAACgAAAAAACgAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACgAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAACwAAAAAAAQAAAAAAAQAAAAAADAAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAADAAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            42: -12,8
+            43: -12,7
+        - node:
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            41: -1,4
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            0: -9,7
+            1: -10,7
+            2: -11,7
+            3: -11,8
+            4: -10,8
+            5: -9,8
+            6: -8,8
+            7: -8,7
+        - node:
+            color: '#0A6AB6FF'
+            id: BoxGreyscale
+          decals:
+            24: -7,5
+            25: -14,7
+            26: -10,5
+            27: -9,5
+            28: -1,2
+            29: -5,4
+            30: 1,4
+            31: 0,7
+            32: 4,9
+        - node:
+            color: '#A91409FF'
+            id: BoxGreyscale
+          decals:
+            16: -3,9
+            17: 2,10
+            18: 2,4
+            19: -2,2
+            20: -4,6
+            21: -7,7
+            22: -14,8
+            23: -12,4
+        - node:
+            color: '#0A5C34A7'
+            id: CheckerNWSE
+          decals:
+            33: 0,6
+            34: 1,7
+            35: 1,6
+            36: 0,7
+            37: 2,7
+            38: 2,6
+        - node:
+            color: '#FFFFFFFF'
+            id: burnt2
+          decals:
+            39: -4,4
+            40: -5,6
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 224
+            1: 57344
+          -1,0:
+            1: 40064
+            0: 16
+          0,1:
+            1: 30479
+          -1,1:
+            1: 52733
+          0,2:
+            1: 40432
+          -1,2:
+            1: 65535
+          0,3:
+            0: 112
+          -1,3:
+            1: 14
+            0: 16
+          1,0:
+            1: 4096
+            0: 512
+          1,1:
+            1: 4369
+            0: 4
+            2: 17472
+          1,2:
+            1: 4368
+            0: 4
+          1,3:
+            0: 32
+          -4,1:
+            0: 34
+            2: 68
+            1: 57344
+          -4,2:
+            1: 14
+            0: 3584
+          -3,1:
+            2: 3
+            1: 65472
+          -3,2:
+            1: 15
+            0: 3840
+          -3,0:
+            2: 32768
+          -2,0:
+            0: 12416
+          -2,1:
+            1: 15288
+          -2,2:
+            1: 2191
+            0: 8960
+          -2,3:
+            0: 132
+        uniqueMixes:
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: BecomesStation
+      id: twilight
+- proto: AirAlarm
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -11.5,9.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 22
+      - 312
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 315
+      - 21
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 20
+      - 316
+  - uid: 6
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 18
+      - 314
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 19
+      - 317
+- proto: Airlock
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+- proto: AirlockCargo
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,8.5
+      parent: 1
+- proto: AirlockCommand
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,9.5
+      parent: 1
+- proto: AirlockExternal
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -12.5,7.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -12.5,8.5
+      parent: 1
+- proto: AirlockShuttle
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,7.5
+      parent: 1
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
+    - type: Door
+      secondsUntilStateChange: -5767.535
+      state: Opening
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,8.5
+      parent: 1
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
+    - type: Door
+      secondsUntilStateChange: -5767.835
+      state: Opening
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -11.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+- proto: AlwaysPoweredStrobeLight
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,10.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+- proto: AppraisalCartridge
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: AppraisalTool
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,8.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,7.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,9.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,9.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -13.5,10.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -10.5,10.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -12.5,10.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -11.5,10.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -9.5,10.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -14.5,10.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -10.5,4.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -12.5,4.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -13.5,4.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -14.5,4.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -14.5,5.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -13.5,5.5
+      parent: 1
+- proto: Bed
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+- proto: BedsheetSpawner
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+- proto: BoxDispenserFlare
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 1.5094571,7.7286415
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -11.5,6.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -12.5,6.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -13.5,6.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -13.5,7.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -13.5,8.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -9.5,10.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -10.5,10.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -11.5,10.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -12.5,10.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -13.5,10.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -14.5,10.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,4.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,4.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -10.5,4.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+- proto: ChairOfficeLight
+  entities:
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -1.3637304,12.402018
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.3637304,11.464518
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 0.51126957,11.487955
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,10.5
+      parent: 1
+- proto: ChairWood
+  entities:
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 3.6069574,4.9264784
+      parent: 1
+- proto: ClosetWallO2Filled
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -10.5,9.5
+      parent: 1
+- proto: ClosetWallO2N2Filled
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+- proto: ClothingBackpackMessengerCargo
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingBackpackSatchelCargo
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingMaskBreath
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 188
+    components:
+    - type: Transform
+      parent: 187
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingOuterHardsuitSpatio
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 189
+    components:
+    - type: Transform
+      parent: 187
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingShoesBootsMag
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 190
+    components:
+    - type: Transform
+      parent: 187
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpskirtCargo
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitCargo
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ComputerGunneryConsole
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerRadar
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerShuttle
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+    - type: ShuttleConsoleLock
+      locked: False
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+    - type: DeviceLinkSource
+      linkedPorts: {}
+      lastSignals: {}
+      ports:
+      - device-button-1
+      - device-button-2
+      - device-button-3
+      - device-button-4
+      - device-button-5
+      - device-button-6
+      - device-button-7
+      - device-button-8
+- proto: ComputerWallmountStationRecords
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,8.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: CrateEmptySpawner
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 1
+- proto: CrowbarRed
+  entities:
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 1.4860196,7.5880165
+      parent: 1
+- proto: CurtainsOrange
+  entities:
+  - uid: 202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+- proto: DoubleEmergencyAirTankFilled
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 191
+    components:
+    - type: Transform
+      parent: 187
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: DrinkGlass
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+  - uid: 206
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+  - uid: 207
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: EmergencyMedipen
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 2.5055432,6.7631636
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 2.5055432,6.5287886
+      parent: 1
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+- proto: FaxMachineShip
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+- proto: FireAlarm
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,6.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: Firelock
+  entities:
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -14.5,8.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -14.5,7.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+- proto: FirelockEdge
+  entities:
+  - uid: 238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+- proto: FoodBowlBig
+  entities:
+  - uid: 208
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: FoodContainerEgg
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      parent: 240
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: FoodMeat
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      parent: 240
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 243
+    components:
+    - type: Transform
+      parent: 240
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: FoodPlate
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+  - uid: 210
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: FoodPlateTin
+  entities:
+  - uid: 211
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: FoodShakerPepper
+  entities:
+  - uid: 212
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: FoodShakerSalt
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: Fork
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: GasMixerOn
+  entities:
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,6.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.20999998
+      inletOneConcentration: 0.79
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,4.5
+      parent: 1
+- proto: GasPipeBend
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,5.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 253
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 254
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 257
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 258
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 259
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -11.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 267
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 275
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 278
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 281
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 283
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 284
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 288
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 289
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 290
+    components:
+    - type: Transform
+      pos: -11.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 291
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 293
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 299
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPort
+  entities:
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,5.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,5.5
+      parent: 1
+- proto: GasPressurePumpOn
+  entities:
+  - uid: 303
+    components:
+    - type: Transform
+      pos: -11.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasVentPump
+  entities:
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 305
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 306
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 307
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 313
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 317
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: Gauze
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 2.3394246,7.8412886
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 2.7144246,7.8881636
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 320
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,5.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,12.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 336
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,4.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 1
+- proto: GunneryServer
+  entities:
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: Gyroscope
+  entities:
+  - uid: 341
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+- proto: JetpackMiniFilled
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 192
+    components:
+    - type: Transform
+      parent: 187
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: KitchenElectricRange
+  entities:
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+- proto: KitchenKnife
+  entities:
+  - uid: 215
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+  - uid: 216
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: LockerFreezerBase
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+    - type: Lock
+      locked: False
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 242
+          - 243
+          - 241
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: LockerSalvageSpecialistFilledHardsuit
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 31
+          - 36
+          - 32
+          - 33
+          - 38
+          - 27
+          - 40
+          - 37
+          - 28
+          - 39
+          - 29
+          - 34
+          - 30
+          - 35
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: Pullable
+      prevFixedRotation: True
+- proto: LockerWallMaterialsFuelUraniumFilled
+  entities:
+  - uid: 343
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+- proto: MachineFTLDrive
+  entities:
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: NapkinDrum5
+  entities:
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+- proto: NitrogenCanister
+  entities:
+  - uid: 346
+    components:
+    - type: Transform
+      anchored: True
+      pos: -9.5,5.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: NitrogenTankFilled
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 193
+    components:
+    - type: Transform
+      parent: 187
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: NoticeBoardNF
+  entities:
+  - uid: 347
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+- proto: Ointment
+  entities:
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 2.4800496,7.395976
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 2.831612,7.3725386
+      parent: 1
+- proto: OxygenCanister
+  entities:
+  - uid: 350
+    components:
+    - type: Transform
+      anchored: True
+      pos: -8.5,5.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: OxygenTankFilled
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 194
+    components:
+    - type: Transform
+      parent: 187
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: PaperBin20
+  entities:
+  - uid: 351
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+- proto: Pen
+  entities:
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -0.4314146,11.083664
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -0.6892271,10.989914
+      parent: 1
+- proto: Plunger
+  entities:
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 4.7062287,6.475134
+      parent: 1
+- proto: PortableGeneratorSuperPacmanShuttle
+  entities:
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+- proto: PoweredlightBlue
+  entities:
+  - uid: 356
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,9.5
+      parent: 1
+- proto: PoweredlightExterior
+  entities:
+  - uid: 357
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,10.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,5.5
+      parent: 1
+- proto: PoweredlightLED
+  entities:
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: -11.5,8.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+- proto: PoweredlightOrange
+  entities:
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+- proto: PoweredlightRed
+  entities:
+  - uid: 371
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,7.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,10.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,10.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,10.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,10.5
+      parent: 1
+- proto: RailingCorner
+  entities:
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,10.5
+      parent: 1
+- proto: ReinforcedWindow
+  entities:
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 1
+- proto: ReinforcedWindowDiagonal
+  entities:
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+- proto: RubberStampApproved
+  entities:
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -0.7089424,12.049763
+      parent: 1
+- proto: RubberStampDenied
+  entities:
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -0.3573799,11.909138
+      parent: 1
+- proto: ShelfKitchen
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,9.5
+      parent: 1
+    - type: Storage
+      storedItems:
+        215:
+          position: 0,0
+          _rotation: North
+        216:
+          position: 1,0
+          _rotation: South
+        208:
+          position: 2,1
+          _rotation: East
+        209:
+          position: 2,0
+          _rotation: North
+        217:
+          position: 5,3
+          _rotation: North
+        205:
+          position: 0,3
+          _rotation: North
+        206:
+          position: 1,3
+          _rotation: North
+        207:
+          position: 2,3
+          _rotation: North
+        214:
+          position: 3,3
+          _rotation: South
+        212:
+          position: 4,3
+          _rotation: South
+        213:
+          position: 4,4
+          _rotation: South
+        210:
+          position: 4,0
+          _rotation: South
+        211:
+          position: 4,1
+          _rotation: South
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 215
+          - 216
+          - 208
+          - 217
+          - 205
+          - 206
+          - 207
+          - 214
+          - 212
+          - 213
+          - 209
+          - 210
+          - 211
+- proto: ShuttersWindow
+  entities:
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 4
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 4
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 4
+- proto: SignalButton
+  entities:
+  - uid: 511
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        398:
+        - Pressed: Toggle
+        399:
+        - Pressed: Toggle
+        397:
+        - Pressed: Toggle
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,5.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        13:
+        - Pressed: DoorBolt
+        14:
+        - Pressed: DoorBolt
+        15:
+        - Pressed: DoorBolt
+        16:
+        - Pressed: DoorBolt
+  - uid: 513
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        12:
+        - Pressed: DoorBolt
+        17:
+        - Pressed: DoorBolt
+- proto: SinkStemlessWater
+  entities:
+  - uid: 400
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 401
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+- proto: SoapDeluxe
+  entities:
+  - uid: 402
+    components:
+    - type: Transform
+      pos: 4.7006373,7.4829464
+      parent: 1
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 403
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+- proto: Spoon
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      parent: 204
+    - type: Physics
+      canCollide: False
+- proto: SubstationWallBasic
+  entities:
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+- proto: SuitStorageEVASalvage
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 194
+          - 192
+          - 191
+          - 189
+          - 193
+          - 190
+          - 188
+- proto: TableReinforced
+  entities:
+  - uid: 405
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 409
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 412
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,5.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+    - type: Thruster
+      enabled: False
+    - type: ApcPowerReceiver
+      powerLoad: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,4.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: Thruster
+      enabled: False
+    - type: ApcPowerReceiver
+      powerLoad: 1
+  - uid: 419
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+- proto: ToiletEmpty
+  entities:
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+- proto: TowelColorWhite
+  entities:
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 2.2955427,7.178259
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 4.238794,6.7329464
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+- proto: WallReinforced
+  entities:
+  - uid: 429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,9.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,6.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,5.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,5.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,5.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,4.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,6.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,9.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,9.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,9.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,9.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,6.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+- proto: WallReinforcedDiagonal
+  entities:
+  - uid: 475
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,4.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+- proto: WallSolid
+  entities:
+  - uid: 484
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,6.5
+      parent: 1
+- proto: WardrobeCargoFilled
+  entities:
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 507
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 1
+- proto: WeaponProtoKineticAccelerator
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      parent: 26
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: WeaponTurretL85Autocannon
+  entities:
+  - uid: 508
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      pos: -12.5,4.5
+      parent: 1
+- proto: WelderMini
+  entities:
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 1.6159158,7.3116493
+      parent: 1
+...

--- a/Resources/Maps/_Mono/Shuttles/twilight.yml
+++ b/Resources/Maps/_Mono/Shuttles/twilight.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 05/19/2025 17:43:35
-  entityCount: 513
+  time: 05/19/2025 18:29:46
+  entityCount: 519
 maps: []
 grids:
 - 1
@@ -18,8 +18,11 @@ tilemap:
   5: FloorDark
   8: FloorDarkDiagonal
   9: FloorDarkMini
+  14: FloorDarkMono
   10: FloorDarkPlastic
   12: FloorKitchen
+  15: FloorMetalDiamond
+  13: FloorTechMaint2
   11: FloorTechMaint3
   7: FloorWhite
   6: FloorWhiteDiagonalMini
@@ -44,7 +47,7 @@ entities:
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAACgAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACgAAAAAACgAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAAQAAAAAACgAAAAAACgAAAAAACgAAAAAABQAAAAAABQAAAAAAAAAAAAAAAQAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACgAAAAAACgAAAAAACgAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACwAAAAAACgAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAACwAAAAAAAQAAAAAAAQAAAAAADAAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAADAAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAACwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAACgAAAAAAAQAAAAAABQAAAAAACwAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACgAAAAAACgAAAAAACgAAAAAABQAAAAAABQAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAADQAAAAAADQAAAAAADQAAAAAADQAAAAAAAQAAAAAACgAAAAAACgAAAAAACgAAAAAABQAAAAAABQAAAAAAAAAAAAAAAQAAAAAACwAAAAAACwAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAACgAAAAAACgAAAAAACgAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAACwAAAAAACwAAAAAACwAAAAAADgAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABQAAAAAABQAAAAAAAAAAAAAACwAAAAAACwAAAAAACwAAAAAADgAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADgAAAAAACgAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACwAAAAAACwAAAAAACwAAAAAAAQAAAAAAAQAAAAAADAAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAADAAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAADAAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAADAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
     - type: Broadphase
     - type: Physics
@@ -100,7 +103,6 @@ entities:
             27: -9,5
             28: -1,2
             29: -5,4
-            30: 1,4
             31: 0,7
             32: 4,9
         - node:
@@ -109,7 +111,6 @@ entities:
           decals:
             16: -3,9
             17: 2,10
-            18: 2,4
             19: -2,2
             20: -4,6
             21: -7,7
@@ -144,7 +145,8 @@ entities:
           0,1:
             1: 30479
           -1,1:
-            1: 52733
+            1: 52477
+            2: 256
           0,2:
             1: 40432
           -1,2:
@@ -160,7 +162,7 @@ entities:
           1,1:
             1: 4369
             0: 4
-            2: 17472
+            3: 17472
           1,2:
             1: 4368
             0: 4
@@ -168,19 +170,19 @@ entities:
             0: 32
           -4,1:
             0: 34
-            2: 68
+            3: 68
             1: 57344
           -4,2:
             1: 14
             0: 3584
           -3,1:
-            2: 3
+            3: 3
             1: 65472
           -3,2:
             1: 15
             0: 3840
           -3,0:
-            2: 32768
+            3: 32768
           -2,0:
             0: 12416
           -2,1:
@@ -208,6 +210,21 @@ entities:
           - 0
         - volume: 2500
           temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
           moles:
           - 21.824879
           - 82.10312
@@ -309,9 +326,14 @@ entities:
   - uid: 9
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,5.5
+      pos: -1.5,5.5
       parent: 1
+    - type: Door
+      secondsUntilStateChange: -66.85656
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
   - uid: 10
     components:
     - type: Transform
@@ -355,7 +377,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -5767.535
+      secondsUntilStateChange: -6726.66
       state: Opening
   - uid: 16
     components:
@@ -367,7 +389,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -5767.835
+      secondsUntilStateChange: -6726.96
       state: Opening
   - uid: 17
     components:
@@ -387,9 +409,12 @@ entities:
   - uid: 19
     components:
     - type: Transform
-      pos: -3.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
       parent: 1
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 7
   - uid: 20
@@ -431,11 +456,11 @@ entities:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 25
+  - uid: 504
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
       parent: 1
 - proto: AppraisalCartridge
   entities:
@@ -735,25 +760,25 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
   - uid: 93
     components:
     - type: Transform
-      pos: -2.5,4.5
+      pos: -4.5,3.5
       parent: 1
   - uid: 94
     components:
     - type: Transform
-      pos: -3.5,4.5
+      pos: -3.5,6.5
       parent: 1
   - uid: 95
     components:
     - type: Transform
       pos: -3.5,5.5
-      parent: 1
-  - uid: 96
-    components:
-    - type: Transform
-      pos: -2.5,5.5
       parent: 1
   - uid: 97
     components:
@@ -1025,6 +1050,16 @@ entities:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
 - proto: CableHV
   entities:
   - uid: 151
@@ -1045,12 +1080,22 @@ entities:
   - uid: 154
     components:
     - type: Transform
-      pos: -3.5,5.5
+      pos: -2.5,5.5
       parent: 1
   - uid: 155
     components:
     - type: Transform
       pos: -3.5,6.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      pos: -2.5,4.5
       parent: 1
 - proto: CableMV
   entities:
@@ -1069,15 +1114,28 @@ entities:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 159
+  - uid: 266
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 160
+  - uid: 514
     components:
     - type: Transform
-      pos: -2.5,4.5
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 517
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
       parent: 1
 - proto: Catwalk
   entities:
@@ -1508,11 +1566,6 @@ entities:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 228
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 1
   - uid: 229
     components:
     - type: Transform
@@ -1558,6 +1611,11 @@ entities:
     - type: Transform
       pos: -7.5,9.5
       parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
 - proto: FirelockEdge
   entities:
   - uid: 238
@@ -1566,6 +1624,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
+    - type: Door
+      secondsUntilStateChange: -69.85655
+      state: Closing
   - uid: 239
     components:
     - type: Transform
@@ -1829,14 +1890,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 266
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 267
     components:
     - type: Transform
@@ -2009,6 +2062,12 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 519
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
 - proto: GasPipeTJunction
   entities:
   - uid: 289
@@ -2501,14 +2560,6 @@ entities:
           ent: null
     - type: Pullable
       prevFixedRotation: True
-- proto: LockerWallMaterialsFuelUraniumFilled
-  entities:
-  - uid: 343
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,6.5
-      parent: 1
 - proto: MachineFTLDrive
   entities:
   - uid: 344
@@ -2683,6 +2734,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -13.5,5.5
       parent: 1
+- proto: PoweredlightGreen
+  entities:
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
 - proto: PoweredlightLED
   entities:
   - uid: 365
@@ -2712,8 +2771,8 @@ entities:
   - uid: 369
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,6.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
       parent: 1
   - uid: 370
     components:
@@ -2723,12 +2782,6 @@ entities:
       parent: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 371
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,4.5
-      parent: 1
   - uid: 372
     components:
     - type: Transform
@@ -2981,7 +3034,7 @@ entities:
       invokeCounter: 4
 - proto: SignalButton
   entities:
-  - uid: 511
+  - uid: 400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2997,7 +3050,7 @@ entities:
         - Pressed: Toggle
 - proto: SignalButtonDirectional
   entities:
-  - uid: 512
+  - uid: 401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3013,7 +3066,7 @@ entities:
         - Pressed: DoorBolt
         16:
         - Pressed: DoorBolt
-  - uid: 513
+  - uid: 402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3027,7 +3080,7 @@ entities:
         - Pressed: DoorBolt
 - proto: SinkStemlessWater
   entities:
-  - uid: 400
+  - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3035,22 +3088,29 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 401
+  - uid: 404
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,12.5
       parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
 - proto: SoapDeluxe
   entities:
-  - uid: 402
+  - uid: 405
     components:
     - type: Transform
       pos: 4.7006373,7.4829464
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 403
+  - uid: 406
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3066,7 +3126,7 @@ entities:
       canCollide: False
 - proto: SubstationWallBasic
   entities:
-  - uid: 404
+  - uid: 407
     components:
     - type: Transform
       pos: -3.5,7.5
@@ -3093,25 +3153,25 @@ entities:
           - 188
 - proto: TableReinforced
   entities:
-  - uid: 405
+  - uid: 408
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
-  - uid: 406
+  - uid: 409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,9.5
       parent: 1
-  - uid: 407
+  - uid: 410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 408
+  - uid: 411
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3119,19 +3179,19 @@ entities:
       parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 409
+  - uid: 412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 1
-  - uid: 410
+  - uid: 413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 411
+  - uid: 414
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3139,13 +3199,13 @@ entities:
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 412
+  - uid: 415
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,5.5
       parent: 1
-  - uid: 413
+  - uid: 416
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3155,29 +3215,29 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 414
+  - uid: 417
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 415
+  - uid: 418
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 1
-  - uid: 416
+  - uid: 419
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,12.5
       parent: 1
-  - uid: 417
+  - uid: 420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,4.5
       parent: 1
-  - uid: 418
+  - uid: 421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3187,338 +3247,331 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 419
+  - uid: 422
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,3.5
       parent: 1
-  - uid: 420
+  - uid: 423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,3.5
       parent: 1
-  - uid: 421
+  - uid: 424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 422
+  - uid: 425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
-  - uid: 423
+  - uid: 426
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,5.5
       parent: 1
-  - uid: 424
+  - uid: 427
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
 - proto: ToiletEmpty
   entities:
-  - uid: 425
+  - uid: 428
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
 - proto: TowelColorWhite
   entities:
-  - uid: 426
+  - uid: 429
     components:
     - type: Transform
       pos: 2.2955427,7.178259
       parent: 1
-  - uid: 427
+  - uid: 430
     components:
     - type: Transform
       pos: 4.238794,6.7329464
       parent: 1
-- proto: VendingMachineTankDispenserEVA
-  entities:
-  - uid: 428
-    components:
-    - type: Transform
-      pos: -1.5,4.5
-      parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 429
+  - uid: 432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,9.5
       parent: 1
-  - uid: 430
+  - uid: 433
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,6.5
       parent: 1
-  - uid: 431
+  - uid: 434
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,5.5
       parent: 1
-  - uid: 432
+  - uid: 435
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 1
-  - uid: 433
+  - uid: 436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,5.5
       parent: 1
-  - uid: 434
+  - uid: 437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,4.5
       parent: 1
-  - uid: 435
+  - uid: 438
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,4.5
       parent: 1
-  - uid: 436
+  - uid: 439
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,4.5
       parent: 1
-  - uid: 437
+  - uid: 440
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,4.5
       parent: 1
-  - uid: 438
+  - uid: 441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,4.5
       parent: 1
-  - uid: 439
+  - uid: 442
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 440
+  - uid: 443
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 441
+  - uid: 444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 442
+  - uid: 445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 443
+  - uid: 446
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 1
-  - uid: 444
+  - uid: 447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 445
+  - uid: 448
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 446
+  - uid: 449
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 447
+  - uid: 450
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 448
+  - uid: 451
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 449
+  - uid: 452
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 450
+  - uid: 453
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 1
-  - uid: 451
+  - uid: 454
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 1
-  - uid: 452
+  - uid: 455
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,7.5
       parent: 1
-  - uid: 453
+  - uid: 456
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,8.5
       parent: 1
-  - uid: 454
+  - uid: 457
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,9.5
       parent: 1
-  - uid: 455
+  - uid: 458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,6.5
       parent: 1
-  - uid: 456
+  - uid: 459
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,9.5
       parent: 1
-  - uid: 457
+  - uid: 460
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 458
+  - uid: 461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,12.5
       parent: 1
-  - uid: 459
+  - uid: 462
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,12.5
       parent: 1
-  - uid: 460
+  - uid: 463
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,12.5
       parent: 1
-  - uid: 461
+  - uid: 464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,11.5
       parent: 1
-  - uid: 462
+  - uid: 465
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,11.5
       parent: 1
-  - uid: 463
+  - uid: 466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,10.5
       parent: 1
-  - uid: 464
+  - uid: 467
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,9.5
       parent: 1
-  - uid: 465
+  - uid: 468
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,9.5
       parent: 1
-  - uid: 466
+  - uid: 469
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,9.5
       parent: 1
-  - uid: 467
+  - uid: 470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,9.5
       parent: 1
-  - uid: 468
+  - uid: 471
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 469
+  - uid: 472
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 470
+  - uid: 473
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 471
+  - uid: 474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,6.5
       parent: 1
-  - uid: 472
+  - uid: 475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-  - uid: 473
+  - uid: 476
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 474
+  - uid: 477
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3526,183 +3579,188 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 475
+  - uid: 478
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 476
+  - uid: 479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,13.5
       parent: 1
-  - uid: 477
+  - uid: 480
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 1
-  - uid: 478
+  - uid: 481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 479
+  - uid: 482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 480
+  - uid: 483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,3.5
       parent: 1
-  - uid: 481
+  - uid: 484
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 1
-  - uid: 482
+  - uid: 485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,4.5
       parent: 1
-  - uid: 483
+  - uid: 486
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
 - proto: WallSolid
   entities:
-  - uid: 484
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 487
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 485
+  - uid: 488
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 486
+  - uid: 489
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 1
-  - uid: 487
+  - uid: 490
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 1
-  - uid: 488
-    components:
-    - type: Transform
-      pos: -5.5,5.5
-      parent: 1
-  - uid: 489
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,10.5
-      parent: 1
-  - uid: 490
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,8.5
-      parent: 1
   - uid: 491
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,3.5
+      pos: -5.5,5.5
       parent: 1
   - uid: 492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,8.5
+      pos: 1.5,10.5
       parent: 1
   - uid: 493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,8.5
+      pos: 1.5,8.5
       parent: 1
   - uid: 494
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
       parent: 1
   - uid: 495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,5.5
+      pos: 4.5,8.5
       parent: 1
   - uid: 496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,5.5
+      pos: 3.5,8.5
       parent: 1
   - uid: 497
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,5.5
+      pos: 2.5,8.5
       parent: 1
   - uid: 498
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: 1.5,5.5
       parent: 1
   - uid: 499
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
       parent: 1
   - uid: 500
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,7.5
+      pos: 3.5,5.5
       parent: 1
   - uid: 501
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,6.5
+      pos: -4.5,7.5
       parent: 1
   - uid: 502
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,4.5
+      pos: -3.5,7.5
       parent: 1
   - uid: 503
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 506
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 3.5,7.5
       parent: 1
-  - uid: 504
+  - uid: 507
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 1
-  - uid: 505
+  - uid: 508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3710,14 +3768,14 @@ entities:
       parent: 1
 - proto: WardrobeCargoFilled
   entities:
-  - uid: 506
+  - uid: 509
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 507
+  - uid: 510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3734,19 +3792,19 @@ entities:
     - type: InsideEntityStorage
 - proto: WeaponTurretL85Autocannon
   entities:
-  - uid: 508
+  - uid: 511
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 1
-  - uid: 509
+  - uid: 512
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 1
 - proto: WelderMini
   entities:
-  - uid: 510
+  - uid: 513
     components:
     - type: Transform
       pos: 1.6159158,7.3116493

--- a/Resources/Prototypes/_Mono/Shipyard/twilight.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/twilight.yml
@@ -1,0 +1,40 @@
+# Author Info
+# GitHub: kyres1
+# Discord: kyres1
+
+# Shuttle Notes:
+#
+- type: vessel
+  id: Twilight
+  parent: BaseVessel
+  name: SKR Twilight
+  description: A small, fast jump-capable cargo transport with light rear-facing defensive armament.
+  price: 25500
+  category: Small
+  group: Shipyard
+  shuttlePath: /Maps/_Mono/Shuttles/twilight.yml
+  guidebookPage: Null
+  class:
+  - Cargo
+  engine:
+  - Uranium
+
+- type: gameMap
+  id: Twilight
+  mapName: 'SKR Twilight'
+  mapPath: /Maps/_Mono/Shuttles/twilight.yml
+  minPlayers: 0
+  stations:
+    Twilight:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'Twilight CIV{1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          availableJobs:
+            Contractor: [ 0, 0 ]
+            Pilot: [ 0, 0 ]
+            Mercenary: [ 0, 0 ]


### PR DESCRIPTION
Adds a new low-end cargo ship to the civilian shipyard. It costs 25500 credits, only a little pricier than the Sabine.

It features similar or worse salvaging features, but a less capable rear-facing armament and more cargo space inside. It's also flimsier due to some scarily-large windows and weak inner walls. It also has bolt toggles on the doors inside because I'm tired of linking signalers every round, damnit, and it just makes sense. Besides that, a cruddy kitchen, commons area, a living quarter and a bathroom are all pretty nice for a ship you're gonna be stuck in for multiple hours. We like roleplay.

Also it has FTL.

## Why / Balance
There was no low-grade civilian freighter. The Sabine is the closest equivalent and it's very much less roomy. This has similar capabilities but is geared specifically towards cargo, given its clunky configuration, rearward facing armament, and larger interior.

## Media
![image](https://github.com/user-attachments/assets/78eaa82f-abb1-410a-b53e-d163269ae9bf)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the Twilight-class light freighter to the shipyard. It costs 25500 credits.
