### PR TITLE
Zenith Redundant APCs, ADS Manipulator Buff

### DIFF
--- a/Resources/Maps/_Mono/ShuttleEvent/zenith.yml
+++ b/Resources/Maps/_Mono/ShuttleEvent/zenith.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 04/23/2025 01:23:04
-  entityCount: 604
+  time: 05/19/2025 23:11:27
+  entityCount: 615
 maps: []
 grids:
 - 1
@@ -282,7 +282,20 @@ entities:
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
-  - uid: 298
+  - uid: 8
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: -0.5008474,-1.2371682
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 314
     components:
     - type: MetaData
     - type: Transform
@@ -297,1291 +310,1341 @@ entities:
     - type: CircularShieldRadar
 - proto: AirlockHatch
   entities:
-  - uid: 8
+  - uid: 9
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 9
+  - uid: 10
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 10
+  - uid: 11
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
-  - uid: 600
+  - uid: 12
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 11
+  - uid: 13
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 12
+  - uid: 14
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 13
+  - uid: 15
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 14
+  - uid: 16
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 15
+  - uid: 17
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 16
+  - uid: 18
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 17
+  - uid: 19
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
-  - uid: 18
+  - uid: 20
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-  - uid: 19
+  - uid: 21
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 20
+  - uid: 22
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 21
+  - uid: 23
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 22
+  - uid: 24
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 1
-  - uid: 23
+  - uid: 25
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
-  - uid: 24
+  - uid: 26
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 25
+  - uid: 27
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
-  - uid: 26
+  - uid: 28
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 1
-  - uid: 27
+  - uid: 29
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 28
+  - uid: 30
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 29
+  - uid: 31
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 30
+  - uid: 32
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 31
+  - uid: 33
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 32
+  - uid: 34
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 33
+  - uid: 35
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 34
+  - uid: 36
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 35
+  - uid: 37
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 36
+  - uid: 38
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 1
-  - uid: 37
+  - uid: 39
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 1
-  - uid: 38
+  - uid: 40
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 39
+  - uid: 41
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 40
+  - uid: 42
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 41
+  - uid: 43
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 42
+  - uid: 44
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 43
+  - uid: 45
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 44
+  - uid: 46
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 45
+  - uid: 47
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 1
-  - uid: 46
+  - uid: 48
     components:
     - type: Transform
       pos: -7.5,-10.5
       parent: 1
-  - uid: 47
+  - uid: 49
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 1
-  - uid: 48
+  - uid: 50
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 1
-  - uid: 49
+  - uid: 51
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 1
-  - uid: 50
+  - uid: 52
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 1
-  - uid: 51
+  - uid: 53
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 52
+  - uid: 54
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 1
-  - uid: 53
+  - uid: 55
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 1
-  - uid: 54
+  - uid: 56
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 55
+  - uid: 57
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 1
-  - uid: 56
+  - uid: 58
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 57
+  - uid: 59
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 58
+  - uid: 60
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 59
+  - uid: 61
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 60
+  - uid: 62
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 61
+  - uid: 63
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 62
+  - uid: 64
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 63
+  - uid: 65
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 64
+  - uid: 66
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 65
+  - uid: 67
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 66
+  - uid: 68
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 67
+  - uid: 69
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 68
+  - uid: 70
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 69
+  - uid: 71
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 70
+  - uid: 72
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 71
+  - uid: 73
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 72
+  - uid: 74
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 73
+  - uid: 75
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 74
+  - uid: 76
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 75
+  - uid: 77
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 76
+  - uid: 78
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 77
+  - uid: 79
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 78
+  - uid: 80
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 79
+  - uid: 81
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 80
+  - uid: 82
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 81
+  - uid: 83
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 82
+  - uid: 84
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 83
+  - uid: 85
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 84
+  - uid: 86
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 85
+  - uid: 87
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 86
+  - uid: 88
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 87
+  - uid: 89
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 88
+  - uid: 90
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 89
+  - uid: 91
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 90
+  - uid: 92
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 91
+  - uid: 93
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 92
+  - uid: 94
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 93
+  - uid: 95
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 94
+  - uid: 96
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 95
+  - uid: 97
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 96
+  - uid: 98
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 97
+  - uid: 99
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 98
+  - uid: 100
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 99
+  - uid: 101
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 100
+  - uid: 102
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 101
+  - uid: 103
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 102
+  - uid: 104
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 103
+  - uid: 105
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 104
+  - uid: 106
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 105
+  - uid: 107
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 106
+  - uid: 108
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 107
+  - uid: 109
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 108
+  - uid: 110
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 109
+  - uid: 111
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 110
+  - uid: 112
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 111
+  - uid: 113
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 112
+  - uid: 114
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
-  - uid: 113
+  - uid: 115
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 1
-  - uid: 114
+  - uid: 116
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 115
+  - uid: 117
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 116
+  - uid: 118
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 117
+  - uid: 119
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 118
+  - uid: 120
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 119
+  - uid: 121
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 120
+  - uid: 122
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 181
+  - uid: 123
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 121
+  - uid: 124
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 122
+  - uid: 125
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 123
+  - uid: 126
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 124
+  - uid: 127
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 125
+  - uid: 128
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 126
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 127
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 128
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
   - uid: 129
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: -2.5,-1.5
       parent: 1
   - uid: 130
     components:
     - type: Transform
-      pos: 1.5,-1.5
+      pos: 2.5,-1.5
       parent: 1
   - uid: 131
     components:
     - type: Transform
-      pos: -3.5,-2.5
+      pos: -0.5,-3.5
       parent: 1
   - uid: 132
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: -0.5,-6.5
       parent: 1
   - uid: 133
     components:
     - type: Transform
-      pos: -0.5,-4.5
+      pos: 1.5,-1.5
       parent: 1
   - uid: 134
     components:
     - type: Transform
-      pos: 0.5,-0.5
+      pos: -3.5,-2.5
       parent: 1
   - uid: 135
     components:
     - type: Transform
-      pos: -1.5,-0.5
+      pos: -1.5,-1.5
       parent: 1
   - uid: 136
     components:
     - type: Transform
-      pos: -0.5,-0.5
+      pos: -0.5,-4.5
       parent: 1
   - uid: 137
     components:
     - type: Transform
-      pos: -0.5,-5.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 138
     components:
     - type: Transform
-      pos: 3.5,-1.5
+      pos: -1.5,-0.5
       parent: 1
   - uid: 139
     components:
     - type: Transform
-      pos: -2.5,-2.5
+      pos: -0.5,-0.5
       parent: 1
   - uid: 140
     components:
     - type: Transform
-      pos: -0.5,-7.5
+      pos: -0.5,-5.5
       parent: 1
   - uid: 141
     components:
     - type: Transform
-      pos: 0.5,-1.5
+      pos: 3.5,-1.5
       parent: 1
   - uid: 142
     components:
     - type: Transform
-      pos: 5.5,-4.5
+      pos: -2.5,-2.5
       parent: 1
   - uid: 143
     components:
     - type: Transform
-      pos: 1.5,-2.5
+      pos: -0.5,-7.5
       parent: 1
   - uid: 144
     components:
     - type: Transform
-      pos: 0.5,-2.5
+      pos: 0.5,-1.5
       parent: 1
   - uid: 145
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: 5.5,-4.5
       parent: 1
   - uid: 146
     components:
     - type: Transform
-      pos: 5.5,-5.5
+      pos: 1.5,-2.5
       parent: 1
   - uid: 147
     components:
     - type: Transform
-      pos: 2.5,-3.5
+      pos: 0.5,-2.5
       parent: 1
   - uid: 148
     components:
     - type: Transform
-      pos: 2.5,-2.5
+      pos: -1.5,-2.5
       parent: 1
   - uid: 149
     components:
     - type: Transform
-      pos: -3.5,-3.5
+      pos: 5.5,-5.5
       parent: 1
   - uid: 150
     components:
     - type: Transform
-      pos: 6.5,-3.5
+      pos: 2.5,-3.5
       parent: 1
   - uid: 151
     components:
     - type: Transform
-      pos: 2.5,-4.5
+      pos: 2.5,-2.5
       parent: 1
   - uid: 152
     components:
     - type: Transform
-      pos: -3.5,-4.5
+      pos: -3.5,-3.5
       parent: 1
   - uid: 153
     components:
     - type: Transform
-      pos: -6.5,-1.5
+      pos: 6.5,-3.5
       parent: 1
   - uid: 154
     components:
     - type: Transform
-      pos: 5.5,-3.5
+      pos: 2.5,-4.5
       parent: 1
   - uid: 155
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      pos: -3.5,-4.5
       parent: 1
   - uid: 156
     components:
     - type: Transform
-      pos: 5.5,-2.5
+      pos: -6.5,-1.5
       parent: 1
   - uid: 157
     components:
     - type: Transform
-      pos: 5.5,-1.5
+      pos: 5.5,-3.5
       parent: 1
   - uid: 158
     components:
     - type: Transform
-      pos: -6.5,-2.5
+      pos: 4.5,-1.5
       parent: 1
   - uid: 159
     components:
     - type: Transform
-      pos: -6.5,-3.5
+      pos: 5.5,-2.5
       parent: 1
   - uid: 160
     components:
     - type: Transform
-      pos: -6.5,-4.5
+      pos: 5.5,-1.5
       parent: 1
   - uid: 161
     components:
     - type: Transform
-      pos: -6.5,-5.5
+      pos: -6.5,-2.5
       parent: 1
   - uid: 162
     components:
     - type: Transform
-      pos: -7.5,-3.5
+      pos: -6.5,-3.5
       parent: 1
   - uid: 163
     components:
     - type: Transform
-      pos: -0.5,-8.5
+      pos: -6.5,-4.5
       parent: 1
   - uid: 164
     components:
     - type: Transform
-      pos: -0.5,-9.5
+      pos: -6.5,-5.5
       parent: 1
   - uid: 165
     components:
     - type: Transform
-      pos: -0.5,-10.5
+      pos: -7.5,-3.5
       parent: 1
   - uid: 166
     components:
     - type: Transform
-      pos: -0.5,-11.5
+      pos: -0.5,-8.5
       parent: 1
   - uid: 167
     components:
     - type: Transform
-      pos: 3.5,-0.5
+      pos: -0.5,-9.5
       parent: 1
   - uid: 168
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: -0.5,-10.5
       parent: 1
   - uid: 169
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: -0.5,-11.5
       parent: 1
   - uid: 170
     components:
     - type: Transform
-      pos: -4.5,-0.5
+      pos: 3.5,-0.5
       parent: 1
   - uid: 171
     components:
     - type: Transform
-      pos: -4.5,0.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 172
     components:
     - type: Transform
-      pos: -4.5,1.5
+      pos: 3.5,1.5
       parent: 1
   - uid: 173
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 174
     components:
     - type: Transform
-      pos: -0.5,1.5
+      pos: -4.5,0.5
       parent: 1
   - uid: 175
     components:
     - type: Transform
-      pos: -0.5,2.5
+      pos: -4.5,1.5
       parent: 1
   - uid: 176
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: -0.5,0.5
       parent: 1
   - uid: 177
     components:
     - type: Transform
-      pos: -0.5,4.5
+      pos: -0.5,1.5
       parent: 1
-  - uid: 182
-    components:
-    - type: Transform
-      pos: -0.5,9.5
-      parent: 1
-  - uid: 183
-    components:
-    - type: Transform
-      pos: -0.5,10.5
-      parent: 1
-  - uid: 184
-    components:
-    - type: Transform
-      pos: -0.5,11.5
-      parent: 1
-  - uid: 187
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 1
-  - uid: 188
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 1
-  - uid: 189
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 1
-  - uid: 190
-    components:
-    - type: Transform
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 191
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 192
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 1
-  - uid: 193
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
-  - uid: 194
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 195
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 196
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 197
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-  - uid: 198
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
-  - uid: 199
-    components:
-    - type: Transform
-      pos: -3.5,2.5
-      parent: 1
-  - uid: 200
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 1
-  - uid: 201
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
-  - uid: 202
-    components:
-    - type: Transform
-      pos: 2.5,1.5
-      parent: 1
-  - uid: 597
-    components:
-    - type: Transform
-      pos: -0.5,8.5
-      parent: 1
-  - uid: 598
-    components:
-    - type: Transform
-      pos: -0.5,7.5
-      parent: 1
-  - uid: 599
-    components:
-    - type: Transform
-      pos: -0.5,6.5
-      parent: 1
-- proto: CableHV
-  entities:
   - uid: 178
-    components:
-    - type: Transform
-      pos: -0.5,4.5
-      parent: 1
-  - uid: 179
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 1
-  - uid: 185
-    components:
-    - type: Transform
-      pos: -0.5,6.5
-      parent: 1
-  - uid: 203
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 204
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 1
-  - uid: 205
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-  - uid: 206
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 207
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 1
-  - uid: 208
-    components:
-    - type: Transform
-      pos: -1.5,-6.5
-      parent: 1
-  - uid: 209
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
-  - uid: 210
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 1
-  - uid: 211
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-  - uid: 212
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 1
-  - uid: 213
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 214
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 215
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 216
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 217
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 1
-  - uid: 218
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 1
-  - uid: 219
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 220
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 221
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 222
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 223
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 224
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 225
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
-  - uid: 226
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 227
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 228
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 1
-  - uid: 229
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 1
-  - uid: 347
-    components:
-    - type: Transform
-      pos: -1.5,6.5
-      parent: 1
-  - uid: 417
-    components:
-    - type: Transform
-      pos: -0.5,3.5
-      parent: 1
-  - uid: 589
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 590
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 236
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 591
+  - uid: 237
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 592
+  - uid: 238
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 593
+  - uid: 239
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 230
+  - uid: 240
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 231
+  - uid: 241
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 232
+  - uid: 242
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 233
+  - uid: 243
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 234
+  - uid: 244
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 235
+  - uid: 245
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 236
+  - uid: 246
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 237
+  - uid: 247
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 238
+  - uid: 248
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 239
+  - uid: 249
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 240
+  - uid: 250
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 241
+  - uid: 251
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 242
+  - uid: 252
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 594
+  - uid: 253
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 595
+  - uid: 254
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 596
+  - uid: 255
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 601
+  - uid: 256
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 602
+  - uid: 257
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 180
+  - uid: 258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 243
+  - uid: 259
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-2.5
       parent: 1
-  - uid: 244
+  - uid: 260
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-2.5
       parent: 1
-  - uid: 245
+  - uid: 261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 246
+  - uid: 262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1589,263 +1652,265 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 247
+  - uid: 263
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 248
+  - uid: 264
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 249
+  - uid: 265
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 250
+  - uid: 266
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 251
+  - uid: 267
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 252
+  - uid: 268
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 253
+  - uid: 269
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 254
+  - uid: 270
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 255
+  - uid: 271
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 256
+  - uid: 272
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 257
+  - uid: 273
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 258
+  - uid: 274
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 259
+  - uid: 275
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 260
+  - uid: 276
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 261
+  - uid: 277
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 262
+  - uid: 278
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 263
+  - uid: 279
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 264
+  - uid: 280
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
-  - uid: 265
+  - uid: 281
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 266
+  - uid: 282
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 267
+  - uid: 283
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 268
+  - uid: 284
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 1
-  - uid: 269
+  - uid: 285
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 270
+  - uid: 286
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 271
+  - uid: 287
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 272
+  - uid: 288
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 273
+  - uid: 289
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 274
+  - uid: 290
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 275
+  - uid: 291
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 1
-  - uid: 276
+  - uid: 292
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 277
+  - uid: 293
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 278
+  - uid: 294
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 279
+  - uid: 295
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 280
+  - uid: 296
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 281
+  - uid: 297
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 282
+  - uid: 298
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 283
+  - uid: 299
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 1
-  - uid: 284
+  - uid: 300
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
-  - uid: 285
+  - uid: 301
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
-  - uid: 286
+  - uid: 302
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 287
+  - uid: 303
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 288
+  - uid: 304
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 289
+  - uid: 305
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 290
+  - uid: 306
     components:
     - type: Transform
       pos: -7.5,-10.5
       parent: 1
-  - uid: 291
+  - uid: 307
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 292
+  - uid: 308
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 1
-  - uid: 293
+  - uid: 309
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 294
+  - uid: 310
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 295
+  - uid: 311
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 296
+  - uid: 312
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
 - proto: CircularShieldBase
   entities:
-  - uid: 297
+  - uid: 313
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 0
     - type: CircularShield
       width: 6.283185307179586 rad
     - type: Fixtures
@@ -1882,7 +1947,7 @@ entities:
           friction: 0.4
 - proto: CircularShieldConsole
   entities:
-  - uid: 299
+  - uid: 315
     components:
     - type: Transform
       pos: -1.5,4.5
@@ -1891,11 +1956,11 @@ entities:
       powerLoad: 5
     - type: DeviceLinkSource
       linkedPorts:
-        297:
+        313:
         - CircularShieldConsoleSender: CircularShieldConsoleReceiver
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 300
+  - uid: 316
     components:
     - type: Transform
       pos: 0.5,4.5
@@ -1906,11 +1971,13 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 301
+  - uid: 317
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
+    - type: ShuttleConsoleLock
+      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
@@ -1929,160 +1996,160 @@ entities:
       - device-button-8
 - proto: GeneratorRTG
   entities:
-  - uid: 302
+  - uid: 318
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 303
+  - uid: 319
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 304
+  - uid: 320
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 305
+  - uid: 321
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 306
+  - uid: 322
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 307
+  - uid: 323
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 308
+  - uid: 324
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 309
+  - uid: 325
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 310
+  - uid: 326
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 311
+  - uid: 327
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 312
+  - uid: 328
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 313
+  - uid: 329
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 314
+  - uid: 330
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 1
-  - uid: 315
+  - uid: 331
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 1
-  - uid: 316
+  - uid: 332
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 317
+  - uid: 333
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 1
-  - uid: 318
+  - uid: 334
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 319
+  - uid: 335
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 320
+  - uid: 336
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 322
+  - uid: 337
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 323
+  - uid: 338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 324
+  - uid: 339
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 325
+  - uid: 340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-10.5
       parent: 1
-  - uid: 326
+  - uid: 341
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-10.5
       parent: 1
-  - uid: 327
+  - uid: 342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 328
+  - uid: 343
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-8.5
       parent: 1
-  - uid: 329
+  - uid: 344
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 1
-  - uid: 330
+  - uid: 345
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-13.5
       parent: 1
-  - uid: 331
+  - uid: 346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2090,26 +2157,34 @@ entities:
       parent: 1
 - proto: GunneryServer
   entities:
-  - uid: 332
+  - uid: 347
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 333
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+  - uid: 348
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
 - proto: GyroscopeSecurity
   entities:
-  - uid: 334
+  - uid: 349
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
     - type: Thruster
       baseThrust: 4000
-  - uid: 335
+  - uid: 350
     components:
     - type: Transform
       pos: 0.5,0.5
@@ -2118,77 +2193,77 @@ entities:
       baseThrust: 4000
 - proto: MachineFTLDrive
   entities:
-  - uid: 336
+  - uid: 351
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 186
+  - uid: 352
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 337
+  - uid: 353
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-9.5
       parent: 1
-  - uid: 338
+  - uid: 354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 339
+  - uid: 355
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-9.5
       parent: 1
-  - uid: 340
+  - uid: 356
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 1
-  - uid: 341
+  - uid: 357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 342
+  - uid: 358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-7.5
       parent: 1
-  - uid: 343
+  - uid: 359
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 344
+  - uid: 360
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
-  - uid: 345
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 346
+  - uid: 362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-7.5
       parent: 1
-  - uid: 440
+  - uid: 363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2196,90 +2271,90 @@ entities:
       parent: 1
 - proto: PlayerStationAiRedacted
   entities:
-  - uid: 348
+  - uid: 364
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 349
+  - uid: 365
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 350
+  - uid: 366
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 1
-  - uid: 351
+  - uid: 367
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 352
+  - uid: 368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 353
+  - uid: 369
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 354
+  - uid: 370
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 355
+  - uid: 371
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 356
+  - uid: 372
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 357
+  - uid: 373
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 358
+  - uid: 374
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
 - proto: SpawnMobWeaponTurretLaserSyndicateNF
   entities:
-  - uid: 359
+  - uid: 375
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-7.5
       parent: 1
-  - uid: 360
+  - uid: 376
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 361
+  - uid: 377
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 362
+  - uid: 378
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2287,26 +2362,26 @@ entities:
       parent: 1
 - proto: SpawnRedactedBorg
   entities:
-  - uid: 363
+  - uid: 379
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 364
+  - uid: 380
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 365
+  - uid: 381
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 604
+  - uid: 382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2314,127 +2389,207 @@ entities:
       parent: 1
 - proto: SurveillanceCameraGeneral
   entities:
-  - uid: 366
+  - uid: 383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 367
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 384
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 368
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 385
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 369
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 370
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 387
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
-  - uid: 371
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 372
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
-  - uid: 373
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 390
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-3.5
       parent: 1
-  - uid: 374
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 391
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 375
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 392
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 376
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-7.5
       parent: 1
-  - uid: 377
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-7.5
       parent: 1
-  - uid: 378
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 395
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-5.5
       parent: 1
-  - uid: 379
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 396
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-  - uid: 380
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-11.5
       parent: 1
-  - uid: 381
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-4.5
       parent: 1
-  - uid: 382
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 383
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 1
-  - uid: 384
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 401
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,10.5
       parent: 1
-  - uid: 385
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 1
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
 - proto: ThrusterSecurity
   entities:
-  - uid: 386
+  - uid: 403
     components:
     - type: Transform
       pos: 4.5,1.5
@@ -2443,94 +2598,94 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 387
+  - uid: 404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 388
+  - uid: 405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 389
+  - uid: 406
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-9.5
       parent: 1
-  - uid: 390
+  - uid: 407
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 391
+  - uid: 408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-11.5
       parent: 1
-  - uid: 392
+  - uid: 409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-5.5
       parent: 1
-  - uid: 393
+  - uid: 410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-9.5
       parent: 1
-  - uid: 394
+  - uid: 411
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
-  - uid: 395
+  - uid: 412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-3.5
       parent: 1
-  - uid: 396
+  - uid: 413
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 397
+  - uid: 414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-4.5
       parent: 1
-  - uid: 398
+  - uid: 415
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-  - uid: 399
+  - uid: 416
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 400
+  - uid: 417
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 401
+  - uid: 418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-7.5
       parent: 1
-  - uid: 402
+  - uid: 419
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2538,907 +2693,907 @@ entities:
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 321
+  - uid: 420
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 403
+  - uid: 421
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 404
+  - uid: 422
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 405
+  - uid: 423
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 406
+  - uid: 424
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 407
+  - uid: 425
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 408
+  - uid: 426
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 409
+  - uid: 427
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 410
+  - uid: 428
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 411
+  - uid: 429
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 412
+  - uid: 430
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 413
+  - uid: 431
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 414
+  - uid: 432
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 415
+  - uid: 433
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 416
+  - uid: 434
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 418
+  - uid: 435
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 419
+  - uid: 436
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 420
+  - uid: 437
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 421
+  - uid: 438
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 422
+  - uid: 439
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 423
+  - uid: 440
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 424
+  - uid: 441
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 425
+  - uid: 442
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 426
+  - uid: 443
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 427
+  - uid: 444
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 428
+  - uid: 445
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 429
+  - uid: 446
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 430
+  - uid: 447
     components:
     - type: Transform
       pos: -7.5,-6.5
       parent: 1
-  - uid: 431
+  - uid: 448
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 1
-  - uid: 432
+  - uid: 449
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 433
+  - uid: 450
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 434
+  - uid: 451
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 435
+  - uid: 452
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 436
+  - uid: 453
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 437
+  - uid: 454
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 438
+  - uid: 455
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 439
+  - uid: 456
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 441
+  - uid: 457
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 442
+  - uid: 458
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 443
+  - uid: 459
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 444
+  - uid: 460
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 445
+  - uid: 461
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 446
+  - uid: 462
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 447
+  - uid: 463
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 448
+  - uid: 464
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 449
+  - uid: 465
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 450
+  - uid: 466
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 451
+  - uid: 467
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 452
+  - uid: 468
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 453
+  - uid: 469
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 454
+  - uid: 470
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
-  - uid: 455
+  - uid: 471
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-  - uid: 456
+  - uid: 472
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 457
+  - uid: 473
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 458
+  - uid: 474
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 459
+  - uid: 475
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 460
+  - uid: 476
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 461
+  - uid: 477
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 1
-  - uid: 462
+  - uid: 478
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 463
+  - uid: 479
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 464
+  - uid: 480
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 465
+  - uid: 481
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 466
+  - uid: 482
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 467
+  - uid: 483
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 468
+  - uid: 484
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 469
+  - uid: 485
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 470
+  - uid: 486
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-  - uid: 471
+  - uid: 487
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 1
-  - uid: 472
+  - uid: 488
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 473
+  - uid: 489
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 474
+  - uid: 490
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 475
+  - uid: 491
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 476
+  - uid: 492
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 477
+  - uid: 493
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 1
-  - uid: 478
+  - uid: 494
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 479
+  - uid: 495
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 480
+  - uid: 496
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 481
+  - uid: 497
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 482
+  - uid: 498
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 483
+  - uid: 499
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 484
+  - uid: 500
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 485
+  - uid: 501
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 486
+  - uid: 502
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 487
+  - uid: 503
     components:
     - type: Transform
       pos: 6.5,-8.5
       parent: 1
-  - uid: 488
+  - uid: 504
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 489
+  - uid: 505
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 490
+  - uid: 506
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 491
+  - uid: 507
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 492
+  - uid: 508
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 493
+  - uid: 509
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 494
+  - uid: 510
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 495
+  - uid: 511
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 496
+  - uid: 512
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 497
+  - uid: 513
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 498
+  - uid: 514
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 499
+  - uid: 515
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 500
+  - uid: 516
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 501
+  - uid: 517
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 502
+  - uid: 518
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 503
+  - uid: 519
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 504
+  - uid: 520
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 505
+  - uid: 521
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 506
+  - uid: 522
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 507
+  - uid: 523
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 508
+  - uid: 524
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 509
+  - uid: 525
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 510
+  - uid: 526
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 511
+  - uid: 527
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 512
+  - uid: 528
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 513
+  - uid: 529
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 514
+  - uid: 530
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 515
+  - uid: 531
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 516
+  - uid: 532
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 517
+  - uid: 533
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 518
+  - uid: 534
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 519
+  - uid: 535
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 520
+  - uid: 536
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 521
+  - uid: 537
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 522
+  - uid: 538
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 523
+  - uid: 539
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 524
+  - uid: 540
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 525
+  - uid: 541
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
-  - uid: 526
+  - uid: 542
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 527
+  - uid: 543
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 528
+  - uid: 544
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 529
+  - uid: 545
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 530
+  - uid: 546
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 531
+  - uid: 547
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 532
+  - uid: 548
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 533
+  - uid: 549
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 534
+  - uid: 550
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 535
+  - uid: 551
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 536
+  - uid: 552
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 537
+  - uid: 553
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 538
+  - uid: 554
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 539
+  - uid: 555
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 540
+  - uid: 556
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 541
+  - uid: 557
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 542
+  - uid: 558
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 543
+  - uid: 559
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 544
+  - uid: 560
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 545
+  - uid: 561
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 546
+  - uid: 562
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 547
+  - uid: 563
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 548
+  - uid: 564
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 549
+  - uid: 565
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 550
+  - uid: 566
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 551
+  - uid: 567
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 552
+  - uid: 568
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 553
+  - uid: 569
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 603
+  - uid: 570
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 554
+  - uid: 571
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 555
+  - uid: 572
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-4.5
       parent: 1
-  - uid: 556
+  - uid: 573
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 557
+  - uid: 574
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 558
+  - uid: 575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,13.5
       parent: 1
-  - uid: 559
+  - uid: 576
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-6.5
       parent: 1
-  - uid: 560
+  - uid: 577
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 561
+  - uid: 578
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 562
+  - uid: 579
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-1.5
       parent: 1
-  - uid: 563
+  - uid: 580
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-2.5
       parent: 1
-  - uid: 564
+  - uid: 581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-6.5
       parent: 1
-  - uid: 565
+  - uid: 582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-2.5
       parent: 1
-  - uid: 566
+  - uid: 583
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 567
+  - uid: 584
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 568
+  - uid: 585
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-9.5
       parent: 1
-  - uid: 569
+  - uid: 586
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 570
+  - uid: 587
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 1
-  - uid: 571
+  - uid: 588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 1
-  - uid: 572
+  - uid: 589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-6.5
       parent: 1
-  - uid: 573
+  - uid: 590
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 574
+  - uid: 591
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 575
+  - uid: 592
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-4.5
       parent: 1
-  - uid: 576
+  - uid: 593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-9.5
       parent: 1
-  - uid: 577
+  - uid: 594
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 578
+  - uid: 595
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 579
+  - uid: 596
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3446,7 +3601,7 @@ entities:
       parent: 1
 - proto: WeaponTurretCharon
   entities:
-  - uid: 580
+  - uid: 597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3454,37 +3609,37 @@ entities:
       parent: 1
 - proto: WeaponTurretL85Autocannon
   entities:
-  - uid: 581
+  - uid: 598
     components:
     - type: Transform
       pos: -7.5,-10.5
       parent: 1
-  - uid: 582
+  - uid: 599
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
 - proto: WeaponTurretType35
   entities:
-  - uid: 583
+  - uid: 600
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,10.5
       parent: 1
-  - uid: 584
+  - uid: 601
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 585
+  - uid: 602
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,10.5
       parent: 1
-  - uid: 586
+  - uid: 603
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3492,13 +3647,13 @@ entities:
       parent: 1
 - proto: WeaponTurretVanyk
   entities:
-  - uid: 587
+  - uid: 604
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-2.5
       parent: 1
-  - uid: 588
+  - uid: 605
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -129,10 +129,11 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    maxModules: 6
+    maxModules: 8
     moduleWhitelist:
       tags:
       - BorgModuleGeneric
+      - BorgModuleEngineering
       - BorgModuleSyndicate
       - BorgModuleSyndicateAssault
     hasMindState: derelict_e
@@ -158,6 +159,10 @@
       - BorgModuleOperative
       - BorgModuleSyndicateWeapon
       - BorgModuleJetpack
+      - BorgModuleTool
+      - BorgModuleConstruction
+      - BorgModuleCable
+      - BorgModuleRCD
       - BorgModuleGPS
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -61,7 +61,7 @@
   - type: DroppableBorgModule
     moduleId: NFJetpack
     items:
-    - id: JetpackMiniFilled
+    - id: JetpackBlackFilled # JetpackMiniFilled -> JetpackBlackFilled Mono
       whitelist:
         components:
         - Jetpack

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -61,7 +61,7 @@
   - type: DroppableBorgModule
     moduleId: NFJetpack
     items:
-    - id: JetpackBlackFilled # JetpackMiniFilled -> JetpackBlackFilled Mono
+    - id: JetpackBlueFilled # JetpackMiniFilled -> JetpackBlueFilled Mono
       whitelist:
         components:
         - Jetpack


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Zeniths get Redundant APCs by the substations in the SMES room in order to buff internal power durability, so they just don't have the power network die completely sometimes randomly despite not being breached in yet.

Borg Manipulators now get a full set of engineering borg tools, including an RCD, and the BorgJetpackModule is now is a 5L blue jetpack instead of a mini jetpack.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

ADS Manipulators are supposed to tend to the ship, but only get guns.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->


:cl:
- add: Extra Zenith APCs
- tweak: ADS Manipulator get engineering borg modules.

