### PR TITLE
shipturret on IFF + other things

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -53,7 +53,7 @@
           collection: MetalBreak
   - type: RadarBlip
     radarColor: "#C92BCC"
-    scale: 1
+    scale: 2
   - type: ShipGunType
     shipType: Energy
 
@@ -112,7 +112,7 @@
           collection: MetalBreak
   - type: RadarBlip
     radarColor: "#035EFC"
-    scale: 1
+    scale: 2
   - type: ShipGunType
     shipType: Energy
 
@@ -161,7 +161,7 @@
     proto: ShipDymereProjectile
     fireCost: 2400
   - type: RadarBlip
-    radarColor: "#FA4E5C"
+    radarColor: "#C92BCC"
+    scale: 3
   - type: ShipGunType
     shipType: Energy
-

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -56,7 +56,7 @@
           collection: MetalBreak
   - type: RadarBlip
     radarColor: "#C92BCC"
-    scale: 1
+    scale: 2
   - type: ShipGunType
     shipType: Energy
 
@@ -118,7 +118,7 @@
           collection: MetalBreak
   - type: RadarBlip
     radarColor: "#035EFC"
-    scale: 1
+    scale: 2
   - type: ShipGunType
     shipType: Energy
 
@@ -171,7 +171,8 @@
     proto: ShipDymereProjectile
     fireCost: 2400 # Adjusted from 1600 to achieve 17 total shots
   - type: RadarBlip
-    radarColor: "#FA4E5C"
+    radarColor: "#C92BCC"
+    scale: 3
   - type: ShipGunType
     shipType: Energy
-    
+

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -21,6 +21,7 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
+    radarColor: "#C92BCC"
     scale: 2.5
     requireNoGrid: true
     shape: triangle
@@ -58,8 +59,8 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    radarColor: "#00FFAA"
-    scale: 1.5
+    radarColor: "#035EFC"
+    scale: 2
     requireNoGrid: true
     shape: circle
   - type: TimedDespawn
@@ -93,8 +94,8 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    radarColor: "#6BC1FF"
-    scale: 2
+    radarColor: "#C92BCC"
+    scale: 3.5
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -27,7 +27,7 @@
   - type: TimedDespawn
     lifetime: 10
   - type: PointLight
-    color: "#FB00FF"
+    radarColor: "#C92BCC"
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
@@ -58,8 +58,8 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    radarColor: "#00FFAA"
-    scale: 1.5
+    radarColor: "#035EFC"
+    scale: 2
     requireNoGrid: true
     shape: circle
   - type: TimedDespawn
@@ -93,8 +93,8 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    radarColor: "#6BC1FF"
-    scale: 2
+    radarColor: "#C92BCC"
+    scale: 3.5
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
@@ -1,4 +1,4 @@
-# 20mm
+# L85 20mm
 
 - type: entity
   id: WeaponTurretL85Autocannon
@@ -49,7 +49,7 @@
   - type: ShipGunType
     shipType: Ballistic
 
-# DRAVON
+# DRAVON 57mm
 
 - type: entity
   id: WeaponTurretDravon
@@ -91,7 +91,7 @@
   - type: ShipGunType
     shipType: Ballistic
 
-# 90mm
+# AK570 90mm
 
 - type: entity
   id: WeaponTurretAK570
@@ -133,7 +133,7 @@
   - type: ShipGunType
     shipType: Ballistic
 
-# TARNYX
+# TARNYX EMP 150mm
 
 - type: entity
   id: WeaponTurretTarnyx

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
@@ -87,7 +87,7 @@
     fireCost: 28
   - type: RadarBlip
     radarColor: "#FF0000"
-    scale: 1
+    scale: 1.5
   - type: ShipGunType
     shipType: Ballistic
 
@@ -171,7 +171,7 @@
     fireCost: 8000
   - type: RadarBlip
     radarColor: "#035EFC"
-    scale: 1
+    scale: 2.5
   - type: ShipGunType
     shipType: Ballistic
 

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
@@ -86,7 +86,7 @@
     proto: ShipDravonProjectile
     fireCost: 28
   - type: RadarBlip
-    radarColor: "#FF9100"
+    radarColor: "#FF0000"
     scale: 1
   - type: ShipGunType
     shipType: Ballistic
@@ -170,7 +170,7 @@
     proto: ShipTarnyxProjectile
     fireCost: 8000
   - type: RadarBlip
-    radarColor: "#FF9100"
+    radarColor: "#035EFC"
     scale: 1
   - type: ShipGunType
     shipType: Ballistic

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
@@ -47,7 +47,7 @@
   - type: RadiationBlocker
     resistance: 8
   - type: RadarBlip
-    radarColor: "#00A6FF"
+    radarColor: "#FF0000"
     scale: 1
   - type: ShipGunType
     shipType: Ballistic
@@ -92,8 +92,8 @@
     proto: 90mmBulletArmorPiercing
     fireCost: 50
   - type: RadarBlip
-    radarColor: "#FF9100"
-    scale: 1
+    radarColor: "#FF0000"
+    scale: 1.5
   - type: ShipGunType
     shipType: Ballistic
 
@@ -149,7 +149,8 @@
     proto: ShipCyrexaProjectile
     fireCost: 350
   - type: RadarBlip
-    radarColor: "#03FC9D"
+    radarColor: "#FF0000"
+    scale: 2
   - type: ShipGunType
     shipType: Ballistic
 
@@ -222,6 +223,6 @@
           collection: MetalBreak
   - type: RadarBlip
     radarColor: "#CF0E0E"
-    scale: 1
+    scale: 3
   - type: ShipGunType
     shipType: Ballistic

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -139,6 +139,8 @@
     requireNoGrid: true
     shape: triangle
 
+# 90mm AP
+
 - type: entity
   id: 90mmBulletArmorPiercing
   parent: 90mmBulletExplosiveBase
@@ -159,6 +161,8 @@
     maxTileBreak: 1
   - type: PointLight
     color: orange
+
+# 90mm HE
 
 - type: entity
   id: 90mmBulletExplosiveBase

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -191,7 +191,7 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    radarColor: "#00FFAA"
+    radarColor: "#035EFC"
     scale: 1.5
     requireNoGrid: true
     shape: circle

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -20,7 +20,8 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    scale: 3
+    radarColor: "#CF0E0E"
+    scale: 4
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
@@ -59,7 +60,7 @@
     radius: 3.5
     energy: 0.5
   - type: RadarBlip
-    scale: 0.35
+    scale: 0.5
     requireNoGrid: true
     shape: triangle
 
@@ -97,7 +98,7 @@
     energy: 0.5
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    scale: 1
+    scale: 1.5
     requireNoGrid: true
     shape: triangle
 
@@ -155,7 +156,7 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    scale: 2.5
+    scale: 3
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -231,7 +231,7 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    scale: 3
+    scale: 3.25
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
@@ -1,4 +1,4 @@
-# VESPERA
+# ADMP-27 VESPERA
 
 - type: entity
   id: WeaponTurretVespera
@@ -36,7 +36,7 @@
     fireCost: 867
   - type: RadarBlip
     radarColor: "#FCBA03"
-    scale: 1
+    scale: 2
   - type: ShipGunType
     shipType: Missile
 
@@ -143,7 +143,7 @@
   - type: ShipGunType
     shipType: Missile
 
-# TOVEK
+# ADMX-23 TOVEK
 
 - type: entity
   id: WeaponTurretTovek
@@ -180,7 +180,7 @@
     proto: ShipMissileASM557
     fireCost: 17500
   - type: RadarBlip
-    radarColor: "#FB00FF"
-    scale: 1.5
+    radarColor: "#035EFC"
+    scale: 2
   - type: ShipGunType
     shipType: Missile

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
@@ -119,7 +119,24 @@
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM302
-    fireCost: 35
+    fireCost: 300
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 800
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
   - type: RadarBlip
     radarColor: "#FCBA03"
     scale: 1.5

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
@@ -163,49 +163,7 @@
     proto: ShipMissileASM557
     fireCost: 17500
   - type: RadarBlip
-    radarColor: "#FCBA03"
+    radarColor: "#FB00FF"
     scale: 1.5
-  - type: ShipGunType
-    shipType: Missile
-
-# TOVEK
-
-- type: entity
-  id: WeaponTurretTovek
-  name: ADMX-23 TOVEK Hybrid EMP Pod
-  parent: BallisticArtillery
-  description: A hybrid EMP missile pod manufactured by Aetherion Dynamics. Deals both physical and EMP damage. Can be remotely activated, or linked up to a GCS.
-  components:
-  - type: StaticPrice
-    price: 3000
-  - type: Sprite
-    sprite: _Mono/Objects/ShuttleWeapons/tovek.rsi
-    layers:
-    - state: space_artillery
-  - type: Appearance
-  - type: AmmoCounter
-  - type: Battery
-    maxCharge: 40000
-    startingCharge: 40000
-  - type: ExaminableBattery
-  - type: WirelessNetworkConnection
-    range: 500
-  - type: Gun
-    fireRate: 1.5
-    projectileSpeed: 40
-    soundGunshot:
-      path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
-    soundEmpty:
-      path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 500
-  - type: Actions
-  - type: ProjectileBatteryAmmoProvider
-    proto: ShipMissileASM557
-    fireCost: 17500
-  - type: RadarBlip
-    radarColor: "#FCBA03"
-    scale: 1
   - type: ShipGunType
     shipType: Missile

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
@@ -1,13 +1,14 @@
-# Vanyk
+
+# ASM-501 Smerchs
 
 - type: entity
-  id: WeaponTurretVanyk
-  name: ASM-302 pod
+  id: WeaponTurretASM501
+  name: ASM-501 pod
   parent: BallisticArtillery
-  description: A basic guided missile pod. Can be remotely activated, or linked up to a GCS.
+  description: ASM-501 Smerchs heavy torpedo launcher. Can be remotely activated, or linked up to a GCS.
   components:
   - type: StaticPrice
-    price: 2250
+    price: 7500
   - type: Sprite
     sprite: _Mono/Objects/ShuttleWeapons/vanyk.rsi
     layers:
@@ -21,8 +22,7 @@
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
-    fireRate: 1
-    projectileSpeed: 80
+    fireRate: 0.1
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
     soundEmpty:
@@ -32,30 +32,57 @@
     powerUsePassive: 200
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 350
+    autoRechargeRate: 60
+  - type: Actions
+  - type: ProjectileBatteryAmmoProvider
+    proto: ShipMissileASM501
+    fireCost: 350
+  - type: RadarBlip
+    radarColor: "#FCBA03"
+    scale: 2.5
+  - type: ShipGunType
+    shipType: Missile
+
+# ASM-302 Vanyk
+
+- type: entity
+  id: WeaponTurretVanyk
+  name: ASM-302 pod
+  parent: BallisticArtillery
+  description: ASM-302 Vanyk basic guided missile pod. Can be remotely activated, or linked up to a GCS.
+  components:
+  - type: StaticPrice
+    price: 5000
+  - type: Sprite
+    sprite: _Mono/Objects/ShuttleWeapons/vanyk.rsi
+    layers:
+    - state: space_artillery
+  - type: Appearance
+  - type: AmmoCounter
+  - type: Battery
+    maxCharge: 40000
+    startingCharge: 40000
+  - type: ExaminableBattery
+  - type: WirelessNetworkConnection
+    range: 500
+  - type: Gun
+    fireRate: 0.8
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg
+    soundEmpty:
+      path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
+  - type: SpaceArtillery
+    powerChargeRate: 250
+    powerUsePassive: 200
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 60
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM302
-    fireCost: 300
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 1200
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 800
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
+    fireCost: 35
   - type: RadarBlip
     radarColor: "#FCBA03"
-    scale: 1
+    scale: 1.5
   - type: ShipGunType
     shipType: Missile

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -20,7 +20,8 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    scale: 1
+    radarColor: "#FCBA03"
+    scale: 1.5
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
@@ -44,3 +45,48 @@
     scanArc: 15
     launchSpeed: 60
     maxSpeed: 140
+
+# ASM-501
+
+- type: entity
+  id: ShipMissileASM501
+  name: ASM-501 missile
+  parent: BaseBulletTrigger
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Structural: 15000
+        Blunt: 2000
+        Heat: 500
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    layers:
+    - state: frag
+  - type: Ammo
+    muzzleFlash: null
+  - type: ShipWeaponProjectile
+  - type: RadarBlip
+    radarColor: "#FCBA03"
+    scale: 4
+    requireNoGrid: true
+    shape: triangle
+  - type: TimedDespawn
+    lifetime: 30
+  - type: PointLight
+    radius: 5
+    color: orange
+    energy: 2
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 6000
+    intensitySlope: 30
+    totalIntensity: 6000
+  - type: GatheringProjectile
+  - type: MiningGatheringSoft
+  - type: MiningGatheringHard
+  - type: TargetSeeking
+    launchSpeed: 20
+    maxSpeed: 20

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -143,3 +143,48 @@
     scanArc: 25
     launchSpeed: 40
     maxSpeed: 200
+
+# ASM-501
+
+- type: entity
+  id: ShipMissileASM501
+  name: ASM-501 missile
+  parent: BaseBulletTrigger
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Structural: 15000
+        Blunt: 2000
+        Heat: 500
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    layers:
+    - state: frag
+  - type: Ammo
+    muzzleFlash: null
+  - type: ShipWeaponProjectile
+  - type: RadarBlip
+    radarColor: "#FCBA03"
+    scale: 4
+    requireNoGrid: true
+    shape: triangle
+  - type: TimedDespawn
+    lifetime: 30
+  - type: PointLight
+    radius: 5
+    color: orange
+    energy: 2
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 6000
+    intensitySlope: 30
+    totalIntensity: 6000
+  - type: GatheringProjectile
+  - type: MiningGatheringSoft
+  - type: MiningGatheringHard
+  - type: TargetSeeking
+    launchSpeed: 20
+    maxSpeed: 20

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -20,6 +20,7 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
+    radarColor: "#FCBA03"
     scale: 1
     requireNoGrid: true
     shape: triangle
@@ -160,6 +161,7 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
+    radarColor: "#FCBA03"
     scale: 1
     requireNoGrid: true
     shape: triangle

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -161,7 +161,7 @@
     muzzleFlash: null
   - type: ShipWeaponProjectile
   - type: RadarBlip
-    radarColor: "#FCBA03"
+    radarColor: "#FB00FF"
     scale: 1
     requireNoGrid: true
     shape: triangle


### PR DESCRIPTION
cannons color on IFF is now sorted by class of weapon and the size of the dot on the gun's power

Red for ballistics
Orange for missiles
Purple for plasma and ionized gas
Blue for EMP
Dark red for railgun

![clideo_editor_e5f2204516354be29881ab48d0af5d56](https://github.com/user-attachments/assets/6959109a-cdf1-47ee-bb7d-120e7b2f22e6)

the projectiles are tweaked too with their color being same as the gun and their size tweaked too

New ship gun:
ASM-501 torpedo
non guided heavy damage torpedo with slow speed (20 or 25) as well as huge dot on IFF 
its the big orange missile and launcher

*also fixes missiles launcher ignoring firerate components and being able to shoot without ammo
(not sure about this one anymore)