### PR TITLE
Makes CYREXA double barrelled and Re-Adds `SpaceArtilleryComp` with better explanation

### DIFF
--- a/Content.Server/_Mono/SpaceArtillery/Components/SpaceArtilleryComponent.cs
+++ b/Content.Server/_Mono/SpaceArtillery/Components/SpaceArtilleryComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class SpaceArtilleryComponent : Component
     public int PowerUsePassive = 600;
 
     /// <summary>
-    /// Maximum rate at which the battery can recharge per second when connected to a powernet.
+    /// Maximum rate at which the battery can recharge when connected to a powernet.
     /// Functions as a throttle for battery regeneration, consistent with BatterySelfRechargerComponent behavior.
     /// </summary>
     [DataField("powerChargeRate"), ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/_Mono/SpaceArtillery/Components/SpaceArtilleryComponent.cs
+++ b/Content.Server/_Mono/SpaceArtillery/Components/SpaceArtilleryComponent.cs
@@ -8,19 +8,23 @@ public sealed partial class SpaceArtilleryComponent : Component
 {
 
     /// <summary>
-    /// Amount of power being used when operating
+    /// Passive power consumption drawn continuously from the powernet while the gun is operational.
+    /// This represents baseline energy upkeep and is not tied to active firing.
     /// </summary>
     [DataField("powerUsePassive"), ViewVariables(VVAccess.ReadWrite)]
     public int PowerUsePassive = 600;
 
     /// <summary>
-    /// Rate of charging the battery
+    /// Maximum rate at which the battery can recharge per second when connected to a powernet.
+    /// Functions as a throttle for battery regeneration, consistent with BatterySelfRechargerComponent behavior.
     /// </summary>
     [DataField("powerChargeRate"), ViewVariables(VVAccess.ReadWrite)]
     public int PowerChargeRate = 3000;
 
     /// <summary>
-    /// Amount of power used when firing
+    /// Additional power consumed per shot beyond the configured fire cost.
+    /// This value is drained from the internal battery (or from the powernet if battery is insufficient).
+    /// Used to simulate power-intensive firing beyond base projectile energy requirements.
     /// </summary>
     [DataField("powerUseActive"), ViewVariables(VVAccess.ReadWrite)]
     public int PowerUseActive = 6000;

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -30,6 +30,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 350
+  - type: SpaceArtillery
+    powerChargeRate: 350
+    powerUsePassive: 500
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMediumPlasmaProjectile
@@ -89,6 +93,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 350
+  - type: SpaceArtillery
+    powerChargeRate: 350
+    powerUsePassive: 1250
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipRubiconProjectile
@@ -156,6 +164,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 67
+  - type: SpaceArtillery
+    powerChargeRate: 67
+    powerUsePassive: 5750
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipDymereProjectile

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
@@ -33,7 +33,10 @@
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 500
+    autoRechargeRate: 100
+  - type: SpaceArtillery
+    powerChargeRate: 100
+    powerUsePassive: 100
   - type: Actions
   - type: CombatMode
     isInCombatMode: true
@@ -81,6 +84,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 220
+  - type: SpaceArtillery
+    powerChargeRate: 220
+    powerUsePassive: 750
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipDravonProjectile
@@ -123,6 +130,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 125
+  - type: SpaceArtillery
+    powerChargeRate: 125
+    powerUsePassive: 600
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: 90mmBulletArmorPiercing
@@ -165,10 +176,14 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 214
+  - type: SpaceArtillery
+    powerChargeRate: 214
+    powerUsePassive: 3500
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipTarnyxProjectile
-    fireCost: 8000
+    fireCost: 17500 # low shot weapon moved back to the original spot
   - type: RadarBlip
     radarColor: "#FF9100"
     scale: 1
@@ -193,8 +208,8 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
+    maxCharge: 12000
+    startingCharge: 12000
   - type: ExaminableBattery
   - type: WirelessNetworkConnection
     range: 500
@@ -211,18 +226,24 @@
         - MachineLayer
   - type: Gun
     projectileSpeed: 105
-    fireRate: 0.125
+    fireRate: 1.5
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/cannon.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 60
+    autoRechargeRate: 12000
+    autoRechargePause: true
+    autoRechargePauseTime: 10
+  - type: SpaceArtillery
+    powerChargeRate: 12000
+    powerUsePassive: 1500
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipCyrexaProjectile
-    fireCost: 350
+    fireCost: 6000
   - type: RadarBlip
     radarColor: "#03FC9D"
   - type: ShipGunType
@@ -260,6 +281,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 350
+  - type: SpaceArtillery
+    powerChargeRate: 350
+    powerUsePassive: 1000
+    powerUseActive: 7500
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipRailgunProjectile

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -214,9 +214,9 @@
   - type: Projectile
     damage:
       types:
-        Structural: 7750
-        Blunt: 15000
-        Ion: 22500
+        Structural: 6500
+        Blunt: 10000
+        Ion: 17500
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/630_armorpiercing_shell_casing.rsi
     layers:

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
@@ -30,6 +30,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 200
+  - type: SpaceArtillery
+    powerChargeRate: 200
+    powerUsePassive: 750
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM417
@@ -76,6 +80,10 @@
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM302
     fireCost: 300
+  - type: SpaceArtillery
+    powerChargeRate: 350
+    powerUsePassive: 600
+    powerUseActive: 0
   - type: Destructible
     thresholds:
     - trigger:
@@ -131,6 +139,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 500
+  - type: SpaceArtillery
+    powerChargeRate: 500
+    powerUsePassive: 2500
+    powerUseActive: 0
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM557


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Cyrexa now shoots twice before going on cooldown.
SpaceArtillery component wasnt as entirely useless as I thought and it has SOME working parts even if they are ancient magic. So I took the liberty of updating the documentation on it to explain it for others a little better and re-added the comp to existing guns in correct setting.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2d668032-50c5-4818-8419-7097c4e22ff0


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Fixed Cyrexa's secondary barrel (now shoots twice before delay).
- fix: Fixed guns having less ammo than they should.

