### PR TITLE
Updates burst shipgun method and Fixes half burst shots

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
@@ -226,9 +226,9 @@
         - MachineLayer
   - type: Gun
     projectileSpeed: 105
-    fireRate: 0.125
+    fireRate: 0.2
     burstCooldown: 10
-    burstFireRate: 1.5
+    burstFireRate: 2
     shotsPerBurst: 2
     selectedMode: Burst
     availableModes: Burst

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/launcher.yml
@@ -226,7 +226,12 @@
         - MachineLayer
   - type: Gun
     projectileSpeed: 105
-    fireRate: 1.5
+    fireRate: 0.125
+    burstCooldown: 10
+    burstFireRate: 1.5
+    shotsPerBurst: 2
+    selectedMode: Burst
+    availableModes: Burst
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/cannon.ogg
     soundEmpty:
@@ -234,8 +239,6 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 12000
-    autoRechargePause: true
-    autoRechargePauseTime: 10
   - type: SpaceArtillery
     powerChargeRate: 12000
     powerUsePassive: 1500


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
So before this I was doing burst by using a delayed recharging mechanic on the weapon, but after the delay ran out due to being empty, it tried reloading the 2 shots instantly which didn't always work leaving player shooting just once and then listening to empty clicking.

This method uses `- type: Gun` burst mode as if it were a normal gun to configure a better and more detailed way to do the same burst mode without the issues previous had.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Cyrexa burst firing only once instead of twice

