### PR TITLE
Adds floor drains to the Victoria

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/Victoria.yml
+++ b/Resources/Maps/_Mono/Shuttles/Victoria.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 05/18/2025 22:17:51
-  entityCount: 371
+  time: 05/25/2025 21:05:39
+  entityCount: 373
 maps: []
 grids:
 - 1
@@ -227,25 +227,25 @@ entities:
       id: IHR Victoria
 - proto: AirAlarm
   entities:
-  - uid: 304
+  - uid: 2
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
     - type: DeviceList
       devices:
-      - 344
-      - 319
-      - 321
-      - 303
-      - 318
-      - 317
-      - 356
-      - 355
-      - 283
+      - 212
+      - 210
+      - 211
+      - 207
+      - 209
+      - 208
+      - 165
+      - 164
+      - 163
 - proto: AirCanister
   entities:
-  - uid: 296
+  - uid: 3
     components:
     - type: Transform
       anchored: True
@@ -255,7 +255,7 @@ entities:
       bodyType: Static
 - proto: AirlockCommandGlass
   entities:
-  - uid: 220
+  - uid: 4
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -263,7 +263,7 @@ entities:
       parent: 1
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 97
+  - uid: 5
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -271,7 +271,7 @@ entities:
       parent: 1
 - proto: AirlockMaintGlass
   entities:
-  - uid: 276
+  - uid: 6
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -279,25 +279,25 @@ entities:
       parent: 1
 - proto: AirlockScienceGlass
   entities:
-  - uid: 40
+  - uid: 7
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 42
+  - uid: 8
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
 - proto: APCHyperCapacity
   entities:
-  - uid: 119
+  - uid: 9
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-8.5
       parent: 1
-  - uid: 169
+  - uid: 10
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -305,25 +305,25 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 111
+  - uid: 11
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 184
+  - uid: 12
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 185
+  - uid: 13
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 186
+  - uid: 14
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -331,27 +331,27 @@ entities:
       parent: 1
 - proto: Autolathe
   entities:
-  - uid: 112
+  - uid: 15
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
 - proto: Beaker
   entities:
-  - uid: 369
+  - uid: 16
     components:
     - type: Transform
       pos: 2.2942958,-2.8637948
       parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 3
+  - uid: 17
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 19
+  - uid: 18
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -359,7 +359,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 99
+  - uid: 19
     components:
     - type: Transform
       pos: 3.5,2.5
@@ -368,663 +368,663 @@ entities:
       invokeCounter: 1
 - proto: ButtonFrameCaution
   entities:
-  - uid: 350
+  - uid: 20
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
-  - uid: 351
+  - uid: 21
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 1
-  - uid: 354
+  - uid: 22
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 90
+  - uid: 23
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 122
+  - uid: 24
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 127
+  - uid: 25
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 128
+  - uid: 26
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 129
+  - uid: 27
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 133
+  - uid: 28
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 134
+  - uid: 29
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 136
+  - uid: 30
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 137
+  - uid: 31
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 138
+  - uid: 32
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 139
+  - uid: 33
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 140
+  - uid: 34
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 144
+  - uid: 35
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 145
+  - uid: 36
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 146
+  - uid: 37
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 149
+  - uid: 38
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 153
+  - uid: 39
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 154
+  - uid: 40
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 155
+  - uid: 41
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 156
+  - uid: 42
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 160
+  - uid: 43
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 161
+  - uid: 44
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 162
+  - uid: 45
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 163
+  - uid: 46
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 165
+  - uid: 47
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 166
+  - uid: 48
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 167
+  - uid: 49
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 168
+  - uid: 50
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 170
+  - uid: 51
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 171
+  - uid: 52
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 172
+  - uid: 53
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 173
+  - uid: 54
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 174
+  - uid: 55
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 175
+  - uid: 56
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 176
+  - uid: 57
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 177
+  - uid: 58
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 178
+  - uid: 59
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 179
+  - uid: 60
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 180
+  - uid: 61
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 181
+  - uid: 62
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 182
+  - uid: 63
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 183
+  - uid: 64
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 189
+  - uid: 65
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 197
+  - uid: 66
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 199
+  - uid: 67
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 202
+  - uid: 68
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 203
+  - uid: 69
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 204
+  - uid: 70
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 205
+  - uid: 71
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 206
+  - uid: 72
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 207
+  - uid: 73
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 208
+  - uid: 74
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 209
+  - uid: 75
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 210
+  - uid: 76
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 211
+  - uid: 77
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 212
+  - uid: 78
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 213
+  - uid: 79
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 214
+  - uid: 80
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 236
+  - uid: 81
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 260
+  - uid: 82
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 261
+  - uid: 83
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 262
+  - uid: 84
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 263
+  - uid: 85
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 1
-  - uid: 264
+  - uid: 86
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
-  - uid: 265
+  - uid: 87
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 266
+  - uid: 88
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 267
+  - uid: 89
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 268
+  - uid: 90
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
-  - uid: 269
+  - uid: 91
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 270
+  - uid: 92
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 271
+  - uid: 93
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 272
+  - uid: 94
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 273
+  - uid: 95
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 286
+  - uid: 96
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 287
+  - uid: 97
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 114
+  - uid: 98
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 117
+  - uid: 99
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 118
+  - uid: 100
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 125
+  - uid: 101
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 193
+  - uid: 102
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 223
+  - uid: 103
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 305
+  - uid: 104
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 29
+  - uid: 105
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 120
+  - uid: 106
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 121
+  - uid: 107
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 126
+  - uid: 108
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 130
+  - uid: 109
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 132
+  - uid: 110
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 143
+  - uid: 111
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 150
+  - uid: 112
     components:
     - type: Transform
       pos: 1.5,-2.5
-      parent: 1
-  - uid: 151
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 164
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 198
-    components:
-    - type: Transform
-      pos: -0.5,-9.5
-      parent: 1
-  - uid: 201
-    components:
-    - type: Transform
-      pos: -0.5,-10.5
-      parent: 1
-  - uid: 226
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 1
-  - uid: 229
-    components:
-    - type: Transform
-      pos: 1.5,-8.5
-      parent: 1
-  - uid: 230
-    components:
-    - type: Transform
-      pos: 1.5,-9.5
-      parent: 1
-  - uid: 231
-    components:
-    - type: Transform
-      pos: 0.5,-9.5
-      parent: 1
-  - uid: 241
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 1
-- proto: CableTerminal
-  entities:
-  - uid: 195
-    components:
-    - type: Transform
-      pos: 0.5,-10.5
-      parent: 1
-- proto: Catwalk
-  entities:
-  - uid: 89
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
       parent: 1
   - uid: 113
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
   - uid: 116
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 121
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 131
+- proto: CableTerminal
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 126
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 135
+  - uid: 127
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 142
+  - uid: 128
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 147
+  - uid: 129
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 152
+  - uid: 130
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 157
+  - uid: 131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
-  - uid: 158
+  - uid: 132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-10.5
       parent: 1
-  - uid: 190
+  - uid: 133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
-  - uid: 191
+  - uid: 134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 194
+  - uid: 135
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 215
+  - uid: 136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 216
+  - uid: 137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 224
+  - uid: 138
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 227
+  - uid: 139
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 228
+  - uid: 140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-9.5
       parent: 1
-  - uid: 232
+  - uid: 141
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 233
+  - uid: 142
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 234
+  - uid: 143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-9.5
       parent: 1
-  - uid: 235
+  - uid: 144
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 239
+  - uid: 145
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 285
+  - uid: 146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-9.5
       parent: 1
-  - uid: 288
+  - uid: 147
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1032,7 +1032,7 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 361
+  - uid: 148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1040,14 +1040,14 @@ entities:
       parent: 1
 - proto: CircuitImprinter
   entities:
-  - uid: 159
+  - uid: 149
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 346
+  - uid: 150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1055,14 +1055,14 @@ entities:
       parent: 1
 - proto: ClothingBeltUtilityFilled
   entities:
-  - uid: 360
+  - uid: 151
     components:
     - type: Transform
       pos: 2.6986322,-3.498808
       parent: 1
 - proto: ComputerAnalysisConsole
   entities:
-  - uid: 237
+  - uid: 152
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1070,13 +1070,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        248:
+        235:
         - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 348
+  - uid: 153
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1084,7 +1084,7 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        249:
+        236:
         - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
     - type: ApcPowerReceiver
       powerLoad: 5
@@ -1092,7 +1092,7 @@ entities:
       startingCharge: 0
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 93
+  - uid: 154
     components:
     - type: Transform
       pos: -0.5,5.5
@@ -1103,7 +1103,7 @@ entities:
       startingCharge: 0
 - proto: ComputerResearchAndDevelopment
   entities:
-  - uid: 222
+  - uid: 155
     components:
     - type: Transform
       pos: 1.5,5.5
@@ -1114,7 +1114,7 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 277
+  - uid: 156
     components:
     - type: Transform
       pos: 0.5,5.5
@@ -1139,7 +1139,7 @@ entities:
       - device-button-8
 - proto: ComputerStationRecords
   entities:
-  - uid: 371
+  - uid: 157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1151,84 +1151,100 @@ entities:
       startingCharge: 0
 - proto: CrateArtifactContainer
   entities:
-  - uid: 336
+  - uid: 158
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 337
+  - uid: 159
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 340
+  - uid: 160
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
 - proto: FaxMachineBase
   entities:
-  - uid: 370
+  - uid: 161
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 373
+  - uid: 162
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
     - type: DeviceList
       devices:
-      - 318
-      - 303
-      - 321
-      - 319
-      - 344
-      - 317
-      - 356
-      - 355
-      - 283
+      - 209
+      - 207
+      - 211
+      - 210
+      - 212
+      - 208
+      - 165
+      - 164
+      - 163
 - proto: FirelockGlass
   entities:
-  - uid: 283
+  - uid: 163
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
-  - uid: 355
+      - 2
+      - 162
+  - uid: 164
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
-  - uid: 356
+      - 2
+      - 162
+  - uid: 165
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
+      - 2
+      - 162
+- proto: FloorDrain
+  entities:
+  - uid: 372
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: GasOutletInjector
   entities:
-  - uid: 4
+  - uid: 166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 217
+  - uid: 167
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1236,7 +1252,7 @@ entities:
       parent: 1
 - proto: GasPassiveVent
   entities:
-  - uid: 333
+  - uid: 168
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1246,7 +1262,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 312
+  - uid: 169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1254,31 +1270,31 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 322
+  - uid: 170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 323
+  - uid: 171
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-7.5
       parent: 1
-  - uid: 328
+  - uid: 172
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 343
+  - uid: 173
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 45
+  - uid: 174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1286,7 +1302,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 196
+  - uid: 175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1294,7 +1310,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 221
+  - uid: 176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1302,7 +1318,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 297
+  - uid: 177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1310,7 +1326,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 299
+  - uid: 178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1318,7 +1334,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 300
+  - uid: 179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1326,7 +1342,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 301
+  - uid: 180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1334,7 +1350,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 307
+  - uid: 181
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1342,7 +1358,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 308
+  - uid: 182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1350,7 +1366,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 309
+  - uid: 183
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1358,7 +1374,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 310
+  - uid: 184
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1366,70 +1382,70 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 313
+  - uid: 185
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 314
+  - uid: 186
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 315
+  - uid: 187
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 316
+  - uid: 188
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 324
+  - uid: 189
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 325
+  - uid: 190
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 326
+  - uid: 191
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 327
+  - uid: 192
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 330
+  - uid: 193
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 335
+  - uid: 194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1437,7 +1453,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 345
+  - uid: 195
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1447,7 +1463,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 302
+  - uid: 196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1455,7 +1471,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 311
+  - uid: 197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1463,7 +1479,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 331
+  - uid: 198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1471,7 +1487,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 332
+  - uid: 199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1481,19 +1497,19 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 284
+  - uid: 200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 1
-  - uid: 339
+  - uid: 201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 1
-  - uid: 341
+  - uid: 202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1501,13 +1517,13 @@ entities:
       parent: 1
 - proto: GasPressurePump
   entities:
-  - uid: 18
+  - uid: 203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-4.5
       parent: 1
-  - uid: 298
+  - uid: 204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1515,7 +1531,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 329
+  - uid: 205
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1523,7 +1539,7 @@ entities:
       parent: 1
 - proto: GasValve
   entities:
-  - uid: 334
+  - uid: 206
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1533,7 +1549,7 @@ entities:
       color: '#990000FF'
 - proto: GasVentPump
   entities:
-  - uid: 303
+  - uid: 207
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1541,22 +1557,22 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
+      - 2
+      - 162
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 317
+  - uid: 208
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
+      - 2
+      - 162
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 318
+  - uid: 209
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1564,13 +1580,13 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
+      - 2
+      - 162
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 319
+  - uid: 210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1578,22 +1594,22 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
+      - 2
+      - 162
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 321
+  - uid: 211
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
+      - 2
+      - 162
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 344
+  - uid: 212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1601,110 +1617,110 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 304
-      - 373
+      - 2
+      - 162
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 290
+  - uid: 213
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 35
+  - uid: 214
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,6.5
       parent: 1
-  - uid: 36
+  - uid: 215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,6.5
       parent: 1
-  - uid: 37
+  - uid: 216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 46
+  - uid: 217
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 47
+  - uid: 218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 101
+  - uid: 219
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 102
+  - uid: 220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 103
+  - uid: 221
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 104
+  - uid: 222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 105
+  - uid: 223
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 106
+  - uid: 224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 107
+  - uid: 225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-12.5
       parent: 1
-  - uid: 108
+  - uid: 226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 109
+  - uid: 227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-12.5
       parent: 1
-  - uid: 238
+  - uid: 228
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
       parent: 1
-  - uid: 240
+  - uid: 229
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1712,7 +1728,7 @@ entities:
       parent: 1
 - proto: GunneryServer
   entities:
-  - uid: 243
+  - uid: 230
     components:
     - type: Transform
       pos: -0.5,4.5
@@ -1723,7 +1739,7 @@ entities:
       startingCharge: 0
 - proto: Gyroscope
   entities:
-  - uid: 289
+  - uid: 231
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1731,75 +1747,75 @@ entities:
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 295
+  - uid: 232
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
 - proto: LockerSalvageSpecialistFilledHardsuit
   entities:
-  - uid: 219
+  - uid: 233
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
 - proto: LockerWallMaterialsFuelUraniumFilled2
   entities:
-  - uid: 347
+  - uid: 234
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
 - proto: MachineArtifactAnalyzer
   entities:
-  - uid: 248
+  - uid: 235
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 249
+  - uid: 236
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
 - proto: MonkeyCubeBox
   entities:
-  - uid: 362
+  - uid: 237
     components:
     - type: Transform
       pos: 2.5413134,-2.6501322
       parent: 1
 - proto: Multitool
   entities:
-  - uid: 357
+  - uid: 238
     components:
     - type: Transform
       pos: -0.43888736,-9.486454
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 320
+  - uid: 239
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
 - proto: OreProcessor
   entities:
-  - uid: 188
+  - uid: 240
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
 - proto: PlushieRainbowLizard
   entities:
-  - uid: 292
+  - uid: 241
     components:
     - type: Transform
       pos: 2.5725634,-2.9938822
       parent: 1
 - proto: PortableGeneratorSuperPacman
   entities:
-  - uid: 279
+  - uid: 242
     components:
     - type: Transform
       anchored: True
@@ -1815,7 +1831,7 @@ entities:
     - type: Anchorable
       currentDelay: 2
     - type: InsertingMaterialStorage
-  - uid: 280
+  - uid: 243
     components:
     - type: Transform
       anchored: True
@@ -1833,7 +1849,7 @@ entities:
     - type: InsertingMaterialStorage
 - proto: PosterContrabandBustyBackdoorExoBabes6
   entities:
-  - uid: 365
+  - uid: 244
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1841,7 +1857,7 @@ entities:
       parent: 1
 - proto: PosterContrabandEAT
   entities:
-  - uid: 367
+  - uid: 245
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1849,7 +1865,7 @@ entities:
       parent: 1
 - proto: PosterLegit50thAnniversaryVintageReprint
   entities:
-  - uid: 366
+  - uid: 246
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1857,7 +1873,7 @@ entities:
       parent: 1
 - proto: PosterLegitSafetyMothSSD
   entities:
-  - uid: 364
+  - uid: 247
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1865,7 +1881,7 @@ entities:
       parent: 1
 - proto: PosterLegitSMBoH
   entities:
-  - uid: 363
+  - uid: 248
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1873,30 +1889,30 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 242
+  - uid: 249
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
-  - uid: 244
+  - uid: 250
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 245
+  - uid: 251
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 1
-  - uid: 246
+  - uid: 252
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 247
+  - uid: 253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1904,20 +1920,20 @@ entities:
       parent: 1
 - proto: Protolathe
   entities:
-  - uid: 13
+  - uid: 254
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
 - proto: ReinforcedUraniumWindow
   entities:
-  - uid: 9
+  - uid: 255
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 23
+  - uid: 256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1925,82 +1941,82 @@ entities:
       parent: 1
 - proto: ReinforcedWindow
   entities:
-  - uid: 2
+  - uid: 257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-12.5
       parent: 1
-  - uid: 10
+  - uid: 258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 26
+  - uid: 259
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 27
+  - uid: 260
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 28
+  - uid: 261
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 32
+  - uid: 262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 43
+  - uid: 263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 44
+  - uid: 264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 49
+  - uid: 265
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 50
+  - uid: 266
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 55
+  - uid: 267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 63
+  - uid: 268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 64
+  - uid: 269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-12.5
       parent: 1
-  - uid: 78
+  - uid: 270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2008,21 +2024,21 @@ entities:
       parent: 1
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 218
+  - uid: 271
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
 - proto: SalvageTechfabNF
   entities:
-  - uid: 192
+  - uid: 272
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 353
+  - uid: 273
     components:
     - type: Transform
       pos: 2.5,2.5
@@ -2031,11 +2047,11 @@ entities:
       state: True
     - type: DeviceLinkSource
       linkedPorts:
-        99:
+        19:
         - Pressed: Toggle
 - proto: SignalButtonBridge
   entities:
-  - uid: 141
+  - uid: 274
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2043,11 +2059,11 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        19:
+        18:
         - Pressed: Toggle
-        40:
+        7:
         - Pressed: DoorBolt
-  - uid: 349
+  - uid: 275
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2055,13 +2071,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        3:
+        17:
         - Pressed: Toggle
-        42:
+        8:
         - Pressed: DoorBolt
 - proto: SinkStemlessWater
   entities:
-  - uid: 306
+  - uid: 276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2069,82 +2085,82 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 200
+  - uid: 277
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 374
+  - uid: 278
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: SprayBottle
   entities:
-  - uid: 293
+  - uid: 279
     components:
     - type: Transform
       pos: 2.3069384,-3.5229287
       parent: 1
 - proto: StairStage
   entities:
-  - uid: 187
+  - uid: 280
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 148
+  - uid: 281
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
 - proto: SuitStorageRD
   entities:
-  - uid: 110
+  - uid: 282
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 291
+  - uid: 283
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 294
+  - uid: 284
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 8
+  - uid: 285
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 24
+  - uid: 286
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 25
+  - uid: 287
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 30
+  - uid: 288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-13.5
       parent: 1
-  - uid: 56
+  - uid: 289
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2152,55 +2168,55 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 59
+  - uid: 290
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 66
+  - uid: 291
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-13.5
       parent: 1
-  - uid: 67
+  - uid: 292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-13.5
       parent: 1
-  - uid: 70
+  - uid: 293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
-  - uid: 71
+  - uid: 294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 72
+  - uid: 295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 75
+  - uid: 296
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 250
+  - uid: 297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 251
+  - uid: 298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2208,13 +2224,13 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 258
+  - uid: 299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-12.5
       parent: 1
-  - uid: 259
+  - uid: 300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2222,305 +2238,305 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 5
+  - uid: 301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 6
+  - uid: 302
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-  - uid: 7
+  - uid: 303
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
       parent: 1
-  - uid: 11
+  - uid: 304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-7.5
       parent: 1
-  - uid: 12
+  - uid: 305
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 15
+  - uid: 306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-5.5
       parent: 1
-  - uid: 16
+  - uid: 307
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-5.5
       parent: 1
-  - uid: 20
+  - uid: 308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 21
+  - uid: 309
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 22
+  - uid: 310
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-  - uid: 31
+  - uid: 311
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 33
+  - uid: 312
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-  - uid: 34
+  - uid: 313
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 1
-  - uid: 38
+  - uid: 314
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 39
+  - uid: 315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-  - uid: 41
+  - uid: 316
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-8.5
       parent: 1
-  - uid: 51
+  - uid: 317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 52
+  - uid: 318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 1
-  - uid: 53
+  - uid: 319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 54
+  - uid: 320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 57
+  - uid: 321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 58
+  - uid: 322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 61
+  - uid: 323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,5.5
       parent: 1
-  - uid: 62
+  - uid: 324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 65
+  - uid: 325
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 1
-  - uid: 69
+  - uid: 326
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-0.5
       parent: 1
-  - uid: 73
+  - uid: 327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 1
-  - uid: 77
+  - uid: 328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-6.5
       parent: 1
-  - uid: 80
+  - uid: 329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 81
+  - uid: 330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 83
+  - uid: 331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-8.5
       parent: 1
-  - uid: 84
+  - uid: 332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-9.5
       parent: 1
-  - uid: 85
+  - uid: 333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-10.5
       parent: 1
-  - uid: 87
+  - uid: 334
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-11.5
       parent: 1
-  - uid: 88
+  - uid: 335
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 91
+  - uid: 336
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-12.5
       parent: 1
-  - uid: 92
+  - uid: 337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
       parent: 1
-  - uid: 94
+  - uid: 338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-10.5
       parent: 1
-  - uid: 96
+  - uid: 339
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-11.5
       parent: 1
-  - uid: 98
+  - uid: 340
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 100
+  - uid: 341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 115
+  - uid: 342
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 123
+  - uid: 343
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-8.5
       parent: 1
-  - uid: 124
+  - uid: 344
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-11.5
       parent: 1
-  - uid: 225
+  - uid: 345
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-8.5
       parent: 1
-  - uid: 254
+  - uid: 346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-8.5
       parent: 1
-  - uid: 256
+  - uid: 347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 1
-  - uid: 274
+  - uid: 348
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 275
+  - uid: 349
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-9.5
       parent: 1
-  - uid: 338
+  - uid: 350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 1
-  - uid: 342
+  - uid: 351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2528,76 +2544,76 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 48
+  - uid: 352
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 60
+  - uid: 353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 68
+  - uid: 354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 74
+  - uid: 355
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-8.5
       parent: 1
-  - uid: 76
+  - uid: 356
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,3.5
       parent: 1
-  - uid: 79
+  - uid: 357
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 82
+  - uid: 358
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
-  - uid: 86
+  - uid: 359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-13.5
       parent: 1
-  - uid: 95
+  - uid: 360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-13.5
       parent: 1
-  - uid: 252
+  - uid: 361
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 253
+  - uid: 362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-7.5
       parent: 1
-  - uid: 255
+  - uid: 363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-10.5
       parent: 1
-  - uid: 257
+  - uid: 364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2605,13 +2621,13 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonalOutpost
   entities:
-  - uid: 14
+  - uid: 365
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 17
+  - uid: 366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2619,7 +2635,7 @@ entities:
       parent: 1
 - proto: WarningWaste
   entities:
-  - uid: 282
+  - uid: 367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2627,7 +2643,7 @@ entities:
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 372
+  - uid: 368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2635,7 +2651,7 @@ entities:
       parent: 1
 - proto: WeaponTurretL85Autocannon
   entities:
-  - uid: 278
+  - uid: 369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2643,7 +2659,7 @@ entities:
       parent: 1
 - proto: WindoorSecureUranium
   entities:
-  - uid: 281
+  - uid: 370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2651,7 +2667,7 @@ entities:
       parent: 1
 - proto: Wrench
   entities:
-  - uid: 352
+  - uid: 371
     components:
     - type: Transform
       pos: -0.6060772,-9.55229


### PR DESCRIPTION
title. Artifacts send out fluids very very often and it's extremely annoying the tenth go-around to have to use a syringe on a lake of potassium into a bucket. 

## About the PR
I added drains to the victoria

## Why / Balance
because the artifacts keep leaking

## How to test
spawn the victoria

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Added floor drains to the Victoria class.
-->
