### PR TITLE
Add tank dispenser to Camelot Station tool room

### DIFF
--- a/Resources/Maps/_Mono/POI/camelot.yml
+++ b/Resources/Maps/_Mono/POI/camelot.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 05/19/2025 22:21:17
-  entityCount: 8101
+  time: 05/25/2025 23:50:02
+  entityCount: 8098
 maps: []
 grids:
 - 1
@@ -35757,11 +35757,6 @@ entities:
     - type: Transform
       pos: -15.5,0.5
       parent: 1
-  - uid: 5584
-    components:
-    - type: Transform
-      pos: -17.5,3.5
-      parent: 1
   - uid: 5585
     components:
     - type: Transform
@@ -35783,11 +35778,6 @@ entities:
     components:
     - type: Transform
       pos: -15.5,0.5
-      parent: 1
-  - uid: 5589
-    components:
-    - type: Transform
-      pos: -17.5,3.5
       parent: 1
   - uid: 5590
     components:
@@ -35838,11 +35828,6 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-18.5
-      parent: 1
-  - uid: 5600
-    components:
-    - type: Transform
-      pos: -17.5,3.5
       parent: 1
 - proto: LootSpawnerMaterials
   entities:
@@ -40594,11 +40579,6 @@ entities:
     - type: Transform
       pos: -13.5,0.5
       parent: 1
-  - uid: 6440
-    components:
-    - type: Transform
-      pos: -17.5,3.5
-      parent: 1
   - uid: 6441
     components:
     - type: Transform
@@ -40966,6 +40946,11 @@ entities:
       parent: 1
 - proto: VendingMachineTankDispenserEVAPOI
   entities:
+  - uid: 5584
+    components:
+    - type: Transform
+      pos: -17.5,3.5
+      parent: 1
   - uid: 6505
     components:
     - type: Transform


### PR DESCRIPTION
Camelot Station lacks a tank dispenser that isn't locked behind high-level USSP roles. This change removes three random industrial item spawners from the tool room and puts a tank dispenser in place.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Removes three random item spawners and adds a tank dispenser to the Camelot Station tool room.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Civilian roles and USSP Riflemen can't get gas tanks without breaking into locked engineering or atmospherics areas.

## How to test
<!-- Describe the way it can be tested -->

Load the grid.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![CamelotToolRoom](https://github.com/user-attachments/assets/4113ebe6-6e07-4bb9-878b-2c28605171ad)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Adds a tank dispenser to the Camelot Station tool room.
