### PR TITLE
Turns off Rogue Suit Sensors

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/Jumpsuit/jumpsuits.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Jumpsuit/jumpsuits.yml
@@ -38,7 +38,7 @@
     sprite: _Mono/Clothing/Uniforms/Jumpsuit/rogue/tactical.rsi
   - type: SuitSensor
     randomMode: false
-    mode: SensorVitals
+    mode: SensorOff
 
 - type: entity
   parent: ClothingUniformBase
@@ -52,7 +52,7 @@
     sprite: _Mono/Clothing/Uniforms/Jumpsuit/rogue/shirtless.rsi
   - type: SuitSensor
     randomMode: false
-    mode: SensorVitals
+    mode: SensorOff
 
 - type: entity
   parent: ClothingUniformBase
@@ -66,7 +66,7 @@
     sprite: _Mono/Clothing/Uniforms/Jumpsuit/rogue/tactical_jeans.rsi
   - type: SuitSensor
     randomMode: false
-    mode: SensorVitals
+    mode: SensorOff
 
 - type: entity
   parent: ClothingUniformBase
@@ -80,7 +80,7 @@
     sprite: _Mono/Clothing/Uniforms/Jumpsuit/rogue/tactical_cargo.rsi
   - type: SuitSensor
     randomMode: false
-    mode: SensorVitals
+    mode: SensorOff
 
 - type: entity
   parent: ClothingUniformBase
@@ -94,4 +94,4 @@
     sprite: _Mono/Clothing/Uniforms/Jumpsuit/rogue/warm.rsi
   - type: SuitSensor
     randomMode: false
-    mode: SensorVitals
+    mode: SensorOff


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Forgot to turn them off

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Rogue Suit sensors starting on Vitals

