### PR TITLE
Adds a new brawler ship for the rogues.

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/Onslaught.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/Onslaught.yml
@@ -1,0 +1,6026 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 247.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 05/27/2025 19:27:28
+  entityCount: 936
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  3: Space
+  0: FloorBrassFilled
+  5: FloorDark
+  8: FloorDarkAlt
+  4: FloorDarkMono
+  9: FloorDarkPlastic
+  6: FloorMetalDiamond
+  7: FloorMiningDark
+  2: Lattice
+  1: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.375,-0.6875
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: CAAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAACQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAABgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAACQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACQAAAAAACQAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAABgAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAACAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAACAAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: AwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FED83DFF'
+            id: BotGreyscale
+          decals:
+            250: 0,7
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            311: -5,7
+            312: -4,7
+        - node:
+            color: '#FED83DFF'
+            id: WarnCornerGreyscaleNE
+          decals:
+            252: 1,9
+            266: 1,2
+        - node:
+            color: '#FED83DFF'
+            id: WarnCornerGreyscaleNW
+          decals:
+            253: -1,9
+            265: -1,2
+        - node:
+            color: '#FED83DFF'
+            id: WarnCornerGreyscaleSE
+          decals:
+            264: 1,4
+        - node:
+            color: '#FED83DFF'
+            id: WarnCornerGreyscaleSW
+          decals:
+            269: -1,4
+        - node:
+            color: '#FED83DFF'
+            id: WarnCornerSmallGreyscaleNE
+          decals:
+            251: 1,0
+            268: 0,2
+        - node:
+            color: '#FED83DFF'
+            id: WarnCornerSmallGreyscaleNW
+          decals:
+            179: -1,0
+            267: 0,2
+        - node:
+            color: '#FED83DFF'
+            id: WarnCornerSmallGreyscaleSE
+          decals:
+            271: 0,4
+        - node:
+            color: '#FED83DFF'
+            id: WarnCornerSmallGreyscaleSW
+          decals:
+            270: 0,4
+        - node:
+            color: '#FED83DFF'
+            id: WarnLineGreyscaleE
+          decals:
+            128: 1,1
+            260: 1,7
+            261: 1,6
+            262: 1,5
+            307: 1,8
+            308: 0,3
+        - node:
+            color: '#FED83DFF'
+            id: WarnLineGreyscaleN
+          decals:
+            176: -2,0
+            177: 2,0
+        - node:
+            color: '#FED83DFF'
+            id: WarnLineGreyscaleW
+          decals:
+            130: -1,1
+            254: -1,8
+            255: -1,7
+            256: -1,6
+            257: -1,5
+            309: 0,3
+        - node:
+            cleanable: True
+            color: '#FED83DFF'
+            id: electricdanger
+          decals:
+            154: -0.030890346,-0.014304757
+        - node:
+            color: '#C85353FF'
+            id: tile_diagonal
+          decals:
+            289: -1,-5
+            291: 1,-2
+        - node:
+            color: '#C85353FF'
+            id: tile_diagonal_corner
+          decals:
+            294: -1,-3
+        - node:
+            color: '#C85353FF'
+            id: tile_diagonal_corner_180
+          decals:
+            292: 1,-4
+        - node:
+            color: '#C85353FF'
+            id: tile_diagonal_corner_270
+          decals:
+            293: -1,-4
+        - node:
+            color: '#C85353FF'
+            id: tile_diagonal_flipped
+          decals:
+            288: 1,-5
+            290: -1,-2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 5111
+            1: 1024
+          0,-1:
+            0: 4881
+            2: 34
+            3: 8
+          -1,0:
+            0: 2557
+            4: 1024
+          0,1:
+            0: 30711
+          -1,1:
+            0: 56829
+          0,2:
+            0: 5495
+            4: 512
+          -1,2:
+            0: 3276
+            3: 4368
+          0,3:
+            0: 819
+            3: 128
+          -1,3:
+            0: 2184
+            3: 32
+          1,0:
+            0: 817
+          1,1:
+            0: 13107
+          1,2:
+            3: 4912
+          1,3:
+            3: 43680
+          2,0:
+            3: 8242
+          1,4:
+            3: 19673
+          2,-1:
+            3: 4096
+          2,1:
+            3: 26178
+          2,2:
+            3: 18020
+          2,3:
+            3: 9318
+          2,4:
+            3: 18
+          -3,1:
+            3: 52296
+          -3,2:
+            3: 19652
+          -3,3:
+            3: 33996
+          -3,0:
+            3: 32904
+          -2,0:
+            3: 16
+            0: 2176
+          -3,4:
+            3: 8
+          -2,-1:
+            3: 7404
+          -2,3:
+            3: 43680
+          -2,4:
+            3: 17970
+          -2,1:
+            0: 34952
+          -2,2:
+            3: 2176
+          0,-2:
+            0: 12560
+            3: 34880
+          -1,-2:
+            0: 32768
+            3: 12864
+          -1,-1:
+            2: 8
+            0: 2176
+            3: 275
+          1,-2:
+            3: 12288
+          1,-1:
+            3: 2039
+          -2,-2:
+            3: 32768
+          0,4:
+            3: 33616
+            0: 32
+          -1,4:
+            3: 10449
+          0,5:
+            3: 8
+          1,5:
+            3: 294
+          0,6:
+            3: 128
+          -2,5:
+            3: 140
+          -1,5:
+            3: 258
+          -1,6:
+            3: 32
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14984
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.1499
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+  - uid: 10
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.5005525,7.8903847
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 64
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50471276,7.7008395
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 75
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055236,7.902877
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 186
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 193
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 305
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.57329744,7.808267
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 384
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 414
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.5005525,7.8903847
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 683
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 690
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.49844703,7.903583
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 703
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 711
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.49858224,7.750133
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 731
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.5005525,7.8903847
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 747
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 748
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 789
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.5005574,7.8118997
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 861
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 920
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+  - uid: 938
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.50055975,7.731757
+      parent: 1
+    - type: RadarBlip
+      enabled: False
+      visibleFromOtherGrids: True
+      shape: Ring
+      scale: 0
+      radarColor: '#00DEFEFF'
+    - type: CircularShieldRadar
+- proto: AirAlarm
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 677
+      - 569
+      - 563
+      - 442
+      - 250
+      - 566
+      - 567
+      - 655
+      - 78
+      - 594
+      - 593
+      - 490
+      - 671
+      - 555
+- proto: AirlockHatchRogueLocked
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+- proto: AirlockMiningGlassRogueLocked
+  entities:
+  - uid: 148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 926
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+- proto: AirlockShuttleSyndicateRogueLocked
+  entities:
+  - uid: 746
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+- proto: AmeController
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+- proto: AmeShielding
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+- proto: APCHyperCapacity
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 939
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+- proto: BlastDoorOpen
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 699
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 718
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 719
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 720
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 721
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 722
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+- proto: Bucket
+  entities:
+  - uid: 936
+    components:
+    - type: Transform
+      pos: 1.447768,7.66825
+      parent: 1
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 728
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 7.5,14.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 9.5,13.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 7.5,13.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 7.5,17.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -6.5,17.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -8.5,7.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -8.5,12.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -8.5,13.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 751
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 755
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 756
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 758
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 759
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 760
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 761
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 762
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 765
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 766
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 767
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 768
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 769
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 770
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 771
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 772
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 774
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 775
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 776
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 794
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 796
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 797
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 798
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 799
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 800
+    components:
+    - type: Transform
+      pos: -2.5,19.5
+      parent: 1
+  - uid: 801
+    components:
+    - type: Transform
+      pos: -3.5,19.5
+      parent: 1
+  - uid: 802
+    components:
+    - type: Transform
+      pos: -3.5,18.5
+      parent: 1
+  - uid: 803
+    components:
+    - type: Transform
+      pos: -3.5,17.5
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      pos: -4.5,17.5
+      parent: 1
+  - uid: 805
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 806
+    components:
+    - type: Transform
+      pos: -4.5,15.5
+      parent: 1
+  - uid: 807
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      pos: 4.5,18.5
+      parent: 1
+  - uid: 810
+    components:
+    - type: Transform
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 811
+    components:
+    - type: Transform
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 812
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 813
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 814
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 818
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 819
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 820
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 821
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 826
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 827
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 828
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 928
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 929
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 930
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 931
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 932
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 10.5,13.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      pos: -9.5,13.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: -9.5,12.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -8.5,12.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 538
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 783
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 784
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 785
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 835
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 836
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 837
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 838
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 839
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 840
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 841
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 842
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 918
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 919
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 907
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 910
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 911
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 913
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 914
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,15.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,10.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,18.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,17.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,13.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,14.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,17.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,18.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,9.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 626
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 627
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 628
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 629
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 630
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 631
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 632
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 633
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 636
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 637
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 638
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 639
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 640
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 641
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 642
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 643
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 646
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 678
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 679
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 680
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 681
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 709
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,9.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,9.5
+      parent: 1
+  - uid: 742
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 782
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,10.5
+      parent: 1
+  - uid: 790
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,18.5
+      parent: 1
+  - uid: 795
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 822
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 830
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,21.5
+      parent: 1
+  - uid: 831
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,18.5
+      parent: 1
+  - uid: 833
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,21.5
+      parent: 1
+  - uid: 843
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 853
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,13.5
+      parent: 1
+  - uid: 857
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,15.5
+      parent: 1
+  - uid: 858
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 862
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 863
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,17.5
+      parent: 1
+  - uid: 877
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,7.5
+      parent: 1
+  - uid: 887
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,12.5
+      parent: 1
+  - uid: 888
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,13.5
+      parent: 1
+  - uid: 889
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 890
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 891
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 893
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,19.5
+      parent: 1
+  - uid: 894
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 896
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 897
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 898
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,20.5
+      parent: 1
+  - uid: 899
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,20.5
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,17.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 687
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+- proto: CircularShieldBase
+  entities:
+  - uid: 689
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+    - type: CircularShield
+      width: 6.283185307179586 rad
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PolygonShape
+            radius: 0.01
+            vertices:
+            - -0.45,-0.45
+            - 0.45,-0.45
+            - 0.45,0.45
+            - -0.45,0.45
+          mask:
+          - Impassable
+          - TableLayer
+          - LowImpassable
+          layer:
+          - TableLayer
+          - LowImpassable
+          density: 60
+          hard: True
+          restitution: 0
+          friction: 0.4
+        ShieldFixture:
+          shape: !type:PhysShapeCircle
+            radius: 0
+            position: 0.50055975,7.731757
+          mask: []
+          layer:
+          - BulletImpassable
+          density: 1
+          hard: False
+          restitution: 0
+          friction: 0.4
+    - type: ApcPowerReceiver
+      powerLoad: 0
+- proto: CircularShieldConsole
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        689:
+        - CircularShieldConsoleSender: CircularShieldConsoleReceiver
+    - type: ApcPowerReceiver
+      powerLoad: 5
+  - uid: 867
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        689:
+        - CircularShieldConsoleSender: CircularShieldConsoleReceiver
+    - type: ApcPowerReceiver
+      powerLoad: 5
+- proto: ClosetWallO2N2Filled
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 1
+- proto: ComputerGunneryConsole
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+  - uid: 686
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerIFF
+  entities:
+  - uid: 927
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerRadar
+  entities:
+  - uid: 684
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerShuttle
+  entities:
+  - uid: 733
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: ShuttleConsoleLock
+      locked: False
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+    - type: DeviceLinkSource
+      linkedPorts: {}
+      lastSignals: {}
+      ports:
+      - device-button-1
+      - device-button-2
+      - device-button-3
+      - device-button-4
+      - device-button-5
+      - device-button-6
+      - device-button-7
+      - device-button-8
+- proto: ComputerStationRecords
+  entities:
+  - uid: 921
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: CurtainsBlackOpen
+  entities:
+  - uid: 935
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+- proto: DebugThruster
+  entities:
+  - uid: 275
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 825
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,13.5
+      parent: 1
+- proto: FaxMachineShip
+  entities:
+  - uid: 717
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+- proto: GasMixer
+  entities:
+  - uid: 560
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.22000003
+      inletOneConcentration: 0.78
+- proto: GasPassiveVent
+  entities:
+  - uid: 587
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+- proto: GasPipeBend
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 591
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 668
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+- proto: GasPipeFourway
+  entities:
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 865
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: GasPipeStraight
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 617
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 618
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 622
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 667
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 672
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 692
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+- proto: GasPipeTJunction
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+- proto: GasPort
+  entities:
+  - uid: 558
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+- proto: GasVentPump
+  entities:
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 442
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 563
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 566
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 569
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 677
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+- proto: GasVentScrubber
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 490
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 555
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 593
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 594
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 655
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 4
+  - uid: 671
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 791
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 81
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,13.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,7.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,12.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,13.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 647
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 673
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 779
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 780
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 781
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 845
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 847
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 848
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-4.5
+      parent: 1
+- proto: GunneryServer
+  entities:
+  - uid: 685
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: Gyroscope
+  entities:
+  - uid: 884
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+- proto: LockerWallColorL1FireFilled
+  entities:
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+- proto: LockerWallMaterialsFuelAmeJarFilled
+  entities:
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+- proto: MachineFTLDrive
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+- proto: NFHolopadShip
+  entities:
+  - uid: 851
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+- proto: NitrogenCanister
+  entities:
+  - uid: 624
+    components:
+    - type: Transform
+      anchored: True
+      pos: -3.5,7.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: OxygenCanister
+  entities:
+  - uid: 623
+    components:
+    - type: Transform
+      anchored: True
+      pos: -4.5,7.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: PaperOffice
+  entities:
+  - uid: 937
+    components:
+    - type: Transform
+      pos: 1.0047555,8.067015
+      parent: 1
+    - type: Paper
+      content: >-
+        ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓███████▓▒░  
+
+        ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ 
+
+        ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ 
+
+        ░▒▓█▓▒░▒▓████████▓▒░▒▓███████▓▒░  
+
+        ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ 
+
+        ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ 
+
+        ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░
+                    INTERSTELLAR HULL REWORKS
+         _____________________________________________________________
+
+        IHR Premium battle tested blue "Shit Bucket":
+
+        $30,000
+
+        Onslaught Hull:
+
+        $130,000
+         _____________________________________________________________
+        Total: 160,000
+- proto: PosterContrabandBustyBackdoorExoBabes6
+  entities:
+  - uid: 625
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+- proto: PosterContrabandRebelsUnite
+  entities:
+  - uid: 933
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+- proto: PosterContrabandRevolt
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+- proto: PoweredlightLED
+  entities:
+  - uid: 707
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 712
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 713
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 715
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 716
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 864
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: ReinforcedUraniumWindow
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 634
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 649
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 669
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 670
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+- proto: SignalButtonBridge
+  entities:
+  - uid: 727
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        149:
+        - Pressed: Toggle
+        30:
+        - Pressed: Toggle
+        699:
+        - Pressed: Toggle
+        718:
+        - Pressed: Toggle
+        720:
+        - Pressed: Toggle
+        719:
+        - Pressed: Toggle
+        721:
+        - Pressed: Toggle
+        722:
+        - Pressed: Toggle
+        723:
+        - Pressed: Toggle
+        724:
+        - Pressed: Toggle
+        725:
+        - Pressed: Toggle
+        726:
+        - Pressed: Toggle
+- proto: SignElectricalMed
+  entities:
+  - uid: 564
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 706
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: StairStageDark
+  entities:
+  - uid: 902
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,18.5
+      parent: 1
+  - uid: 903
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,18.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 905
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 917
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+- proto: SuitStorageEVAPirate
+  entities:
+  - uid: 674
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 866
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,13.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,7.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,12.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,13.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 792
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 793
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 860
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,19.5
+      parent: 1
+- proto: ToiletDirtyWater
+  entities:
+  - uid: 934
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,18.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,19.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,23.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,20.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -3.5,19.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 6.5,17.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -3.5,18.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -4.5,17.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -5.5,17.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 4.5,18.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 4.5,20.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -2.5,21.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -4.5,20.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,12.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 9.5,14.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -3.5,21.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -7.5,14.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -8.5,14.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,23.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,12.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,11.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -8.5,11.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,15.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,16.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,16.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -2.5,24.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,15.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,13.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 3.5,21.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,13.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,22.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,22.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,2.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 4.5,21.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,17.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 3.5,24.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,15.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,11.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,18.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,19.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,18.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,19.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,19.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,13.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,14.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 654
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 698
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 739
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 773
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 815
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 824
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 832
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 834
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 849
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 854
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 855
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 856
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 868
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 869
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 870
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,17.5
+      parent: 1
+  - uid: 872
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 876
+    components:
+    - type: Transform
+      pos: 5.5,20.5
+      parent: 1
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,20.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,22.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -2.5,25.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,20.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,14.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -9.5,14.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,17.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,11.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,25.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,11.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -8.5,16.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,0.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -5.5,20.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -3.5,22.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,16.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -7.5,17.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,20.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      pos: -1.5,17.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 676
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 682
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 829
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 850
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,17.5
+      parent: 1
+  - uid: 852
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+- proto: WallReinforced
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,11.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 651
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 675
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 694
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 695
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 696
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 922
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 923
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 924
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 925
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+- proto: WallReinforcedDiagonal
+  entities:
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 816
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+- proto: WarpPointAdmin
+  entities:
+  - uid: 705
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+- proto: WeaponTurretAK570
+  entities:
+  - uid: 700
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 701
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 702
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,21.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,21.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 874
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,9.5
+      parent: 1
+- proto: WeaponTurretCyrexa
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,17.5
+      parent: 1
+  - uid: 817
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,17.5
+      parent: 1
+- proto: WeaponTurretDravon
+  entities:
+  - uid: 871
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,18.5
+      parent: 1
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,18.5
+      parent: 1
+- proto: WeaponTurretL85Autocannon
+  entities:
+  - uid: 823
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 859
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+...

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/Onslaught.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/Onslaught.yml
@@ -1,0 +1,32 @@
+- type: vessel
+  id: Onslaught
+  parent: BaseVesselAntag
+  name: RG Onslaught
+  description: Brawler ship specialized in combat with 2 build in Cyrexas and a thick coat of plastitanium. Manufactured by [redacted], Salvaged and restored by IHR in the [redacted] sector.
+  price: 160000
+  category: Medium
+  group: BlackMarket
+  shuttlePath: /Maps/_Mono/Shuttles/BlackMarket/Onslaught.yml
+  guidebookPage: Null
+  class:
+  - Pirate
+  engine:
+  - AME
+
+- type: gameMap
+  id: Onslaught
+  mapName: 'Onslaught'
+  mapPath: /Maps/_Mono/Shuttles/BlackMarket/Onslaught.yml
+  minPlayers: 0
+  stations:
+    Tethys:
+      stationProto: StandardFrontierVessel
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: 'Onslaught RG{1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '14'
+        - type: StationJobs
+          availableJobs:
+            Pirate: [ 0, 0 ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
It add a new brawler ship the Onslaught for the rogues starting at 160,000 that includes 2 cyrexas, 2 dravons and 6 90mm

## Why / Balance
The rogues have been asking for a new ship so here is my shot at it and since the TFS got a new one a few days ago I think they need some extra "tools"

## How to test
spawn one using /loadgrid 1 [path of the .yml] (Onslaught.yml)

## Media
![image](https://github.com/user-attachments/assets/455f58dc-a0ca-4428-b36d-f843210ef9aa)
![image](https://github.com/user-attachments/assets/0f13c36b-f467-4baf-a70c-94f4de16c5eb)
![image](https://github.com/user-attachments/assets/3eadedcd-da99-464b-88aa-1c33cd7455ab)
![image](https://github.com/user-attachments/assets/e09b7d07-b03f-4a83-bcc5-7f1f4aaa70ca)
![image](https://github.com/user-attachments/assets/5a1981f4-51d9-487a-bb84-aa80bc322379)
![image](https://github.com/user-attachments/assets/36a3961f-fb19-46d3-8ed3-56cca9f92cc3)


**Changelog**
<!-- 
<!--
:cl:
-Adds the Onslaught to the blackmarket (Rogues)
-->
