### PR TITLE
reworked IPC low energy state

### DIFF
--- a/Content.Server/_EinsteinEngines/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Death/Systems/SiliconChargeDeathSystem.cs
@@ -5,6 +5,8 @@ using Content.Server._EinsteinEngines.Silicon.Charge;
 using Content.Server._EinsteinEngines.Power.Components;
 using Content.Server.Humanoid;
 using Content.Shared.Humanoid;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems; //Monolith IPC rework
 
 namespace Content.Server._EinsteinEngines.Silicon.Death;
 
@@ -13,6 +15,7 @@ public sealed class SiliconDeathSystem : EntitySystem
     [Dependency] private readonly SleepingSystem _sleep = default!;
     [Dependency] private readonly SiliconChargeSystem _silicon = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearanceSystem = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!; //Monolith IPC rework
 
     public override void Initialize()
     {
@@ -46,8 +49,13 @@ public sealed class SiliconDeathSystem : EntitySystem
         if (deadEvent.Cancelled)
             return;
 
-        EntityManager.EnsureComponent<SleepingComponent>(uid);
-        EntityManager.EnsureComponent<ForcedSleepingComponent>(uid);
+        /*EntityManager.EnsureComponent<SleepingComponent>(uid); Monolith IPC rework edit start
+        EntityManager.EnsureComponent<ForcedSleepingComponent>(uid);*/
+
+        if(!TryComp<HandsComponent>(uid, out var handsComp))
+            return;
+        _hands.RemoveHands(uid, handsComp); // edit end
+
 
         if (TryComp(uid, out HumanoidAppearanceComponent? humanoidAppearanceComponent))
         {
@@ -62,8 +70,11 @@ public sealed class SiliconDeathSystem : EntitySystem
 
     private void SiliconUnDead(EntityUid uid, SiliconDownOnDeadComponent siliconDeadComp, BatteryComponent? batteryComp, EntityUid batteryUid)
     {
-        RemComp<ForcedSleepingComponent>(uid);
-        _sleep.TryWaking(uid, true, null);
+        /*RemComp<ForcedSleepingComponent>(uid); Monolith IPC rework edit start
+        _sleep.TryWaking(uid, true, null);*/
+
+        _hands.AddHand(uid, "right hand", HandLocation.Right);
+        _hands.AddHand(uid, "left hand", HandLocation.Left); // edit end
 
         siliconDeadComp.Dead = false;
 

--- a/Content.Shared/_EinsteinEngines/Silicon/SharedSiliconSystem.cs
+++ b/Content.Shared/_EinsteinEngines/Silicon/SharedSiliconSystem.cs
@@ -21,12 +21,12 @@ public sealed class SharedSiliconChargeSystem : EntitySystem
         SubscribeLocalEvent<SiliconComponent, ComponentInit>(OnSiliconInit);
         SubscribeLocalEvent<SiliconComponent, SiliconChargeStateUpdateEvent>(OnSiliconChargeStateUpdate);
         SubscribeLocalEvent<SiliconComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
-        SubscribeLocalEvent<SiliconComponent, ItemSlotInsertAttemptEvent>(OnItemSlotInsertAttempt);
-        SubscribeLocalEvent<SiliconComponent, ItemSlotEjectAttemptEvent>(OnItemSlotEjectAttempt);
-        SubscribeLocalEvent<SiliconComponent, TryingToSleepEvent>(OnTryingToSleep);    
+        /*SubscribeLocalEvent<SiliconComponent, ItemSlotInsertAttemptEvent>(OnItemSlotInsertAttempt); Monolith IPC rework
+        SubscribeLocalEvent<SiliconComponent, ItemSlotEjectAttemptEvent>(OnItemSlotEjectAttempt);*/
+        SubscribeLocalEvent<SiliconComponent, TryingToSleepEvent>(OnTryingToSleep);
     }
-
-    private void OnItemSlotInsertAttempt(EntityUid uid, SiliconComponent component, ref ItemSlotInsertAttemptEvent args)
+/*
+    private void OnItemSlotInsertAttempt(EntityUid uid, SiliconComponent component, ref ItemSlotInsertAttemptEvent args) Monolith IPC rework
     {
         if (args.Cancelled
             || !TryComp<PowerCellSlotComponent>(uid, out var cellSlotComp)
@@ -47,7 +47,7 @@ public sealed class SharedSiliconChargeSystem : EntitySystem
 
         args.Cancelled = true;
     }
-
+*/
     private void OnSiliconInit(EntityUid uid, SiliconComponent component, ComponentInit args)
     {
         if (!component.BatteryPowered)
@@ -66,7 +66,7 @@ public sealed class SharedSiliconChargeSystem : EntitySystem
         if (!component.BatteryPowered)
             return;
 
-        var closest = 0;
+        var closest = 1; //Monolith IPC rework
 
         foreach (var state in component.SpeedModifierThresholds)
             if (component.ChargeState >= state.Key && state.Key > closest)


### PR DESCRIPTION
## About the PR
Reworked IPCs so they no longer die at low energy, instead they lose their hands and get a very heavy movement penalty which gives them a chance to run/recharge/ask for help/surrender instead of simply being dead with no way for anyone to tell or know. Theyre also capable of changing their own cells by switching it now.

## Why / Balance
Regular IPCs due to the conditions and the balance of the server are way too weak. EMP weaponry , hardsuits with low movement speed penalty and high resistances compared to regular clothing are both very common. IPCs upsides are made insignificant by the fact IPCs also have to wear hardsuits for their protections. Organ modifications are very common and viable for combat, and IPCs are locked out of most modifications.

**Changelog**
<!--
:cl:
- tweak: Reworked IPC low energy state
-->
