### PR TITLE
Trying to go outside of your FTL range will now go as close to the target position as possible

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -144,7 +144,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
                     var range = _shuttles.GetFTLRange(shuttleUid);
 
-                    // If the target position is outside of the shuttle's FTL range, then try to FTL as close as possible.
+                    // If the target position is outside of the shuttle's FTL range, then try to FTL as close as possible to save the player some hassle.
                     if (shuttleToTarget.Length() > range)
                     {
                         mapCoords = new(shuttlePosition + shuttleToTarget.Normalized() * range, ViewingMap);

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -132,6 +132,24 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
                 {
                     // We'll send the "adjusted" position and server will adjust it back when relevant.
                     var mapCoords = new MapCoordinates(InverseMapPosition(args.RelativePosition), ViewingMap);
+
+                    if (!_physicsQuery.TryGetComponent(_shuttleEntity, out var shuttlePhysics) || !EntManager.TryGetComponent(_shuttleEntity, out TransformComponent? shuttleTransform))
+                        return;
+
+                    var shuttleUid = _shuttleEntity.Value;
+
+                    var shuttlePosition = Maps.GetGridPosition((shuttleUid, shuttlePhysics, shuttleTransform));
+                    var targetPosition = mapCoords.Position;
+                    var shuttleToTarget = targetPosition - shuttlePosition;
+
+                    var range = _shuttles.GetFTLRange(shuttleUid);
+
+                    // If the target position is outside of the shuttle's FTL range, then try to FTL as close as possible.
+                    if (shuttleToTarget.Length() > range)
+                    {
+                        mapCoords = new(shuttlePosition + shuttleToTarget.Normalized() * range, ViewingMap);
+                    }
+
                     RequestFTL?.Invoke(mapCoords, _ftlAngle);
                 }
             }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes it so that if you're trying to FTL outside of your shuttle's maximum FTL range, it'll instead try to FTL the maximum possible distance towards the target position. This is done via a client-side check.

There is no UI indicator for this, this is literally my first SS14 PR ever, so this is the best I could do without a major headache. Please be sure to review the code extra carefully.

I tested it in-game, everything seems to work fine, both inside of FTL range and outside of FTL range.

<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
I got tired of the FTL jank on my first round, having to constantly drag your view is annoying.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
Spawn a ship and try to FTL inside and outside of your FTL range. (the orange circle)
<!-- Describe the way it can be tested -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Trying to FTL outside of your shuttle's FTL range will now try to FTL as close to the target as possible.
