### PR TITLE
Ammo addings for USSP

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -64,6 +64,7 @@
   - MagazineDMR # mono
   - MagazineDMREmpty # mono
   - MagazineBoxDMR # mono
+  - MagazineLightRifleLowCapacity # mono
 
 - type: latheRecipePack
   id: SecurityWeaponsStatic

--- a/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/ussp.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/ussp.yml
@@ -18,3 +18,5 @@
     WeaponSniperMosin: 4294967295 # Infinite
     WeaponRifleSVS: 4294967295 # Infinite
     ClothingHeadHelmetHeavyUSSP: 4294967295 # Infinite
+    MagazineLightRifleLowCapacityEmpty: 4294967295 # Infinite
+    SpeedLoaderLightRifle: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/weaponryworks.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/weaponryworks.yml
@@ -81,3 +81,5 @@
     MagazineBoxMagnum: 4294967295
     BoxShotgunSlug: 4294967295
     BoxLethalshot: 4294967295
+    MagazineLightRifleLowCapacityEmpty: 4294967295
+    SpeedLoaderLightRifle: 4294967295


### PR DESCRIPTION


## About the PR
Made the .30 speedloader obtainable, and the .30 low cap magazine easier to obtain for the USSP and the mercs

**Changelog**
:cl:
- tweak: .30 low cap magazine and .30 speedloader are obtainable via vendors and ammotechfab

