### PR TITLE
Increase the map zoom radius from 512m to 4096m (and double the scroll sensitivity)

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -78,7 +78,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
     private readonly Dictionary<Color, List<(Vector2, string)>> _strings = new();
     private readonly List<ShuttleExclusionObject> _viewportExclusions = new();
 
-    public ShuttleMapControl() : base(256f, 512f, 512f)
+    public ShuttleMapControl() : base(256f, 4096f, 512f)
     {
         RobustXamlLoader.Load(this);
         _shuttles = EntManager.System<ShuttleSystem>();

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -33,6 +33,8 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
     protected override bool Draggable => true;
 
+    protected override float ScrollSensitivity => 4f;
+
     public bool ShowBeacons = true;
     public MapId ViewingMap = MapId.Nullspace;
 

--- a/Content.Client/UserInterface/Controls/MapGridControl.xaml.cs
+++ b/Content.Client/UserInterface/Controls/MapGridControl.xaml.cs
@@ -41,7 +41,7 @@ public partial class MapGridControl : LayoutContainer
     protected Vector2 StartDragPosition;
     protected bool Recentering;
 
-    protected const float ScrollSensitivity = 8f;
+    protected virtual float ScrollSensitivity => 8f;
 
     protected float RecenterMinimum = 0.05f;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Increases the map zoom radius by 8 times. (512m -> 4096m)
It's literally just a number change. I still tested it though.
Also I had to increase the sensitivity a bit to accommodate the new size.
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
I want it and others want it too according to the suggestions channel at least. It's a nice QoL improvement that reduces the amount of dragging you have to deal with.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
Just zoom in and out on the shuttle console's map menu.
<!-- Describe the way it can be tested -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The maximum size of the map viewport on shuttle consoles is now 8 times larger. (512m -> 4096m)
- tweak: The scroll sensitivity of the map viewport on shuttle consoles is now twice as high. (1/8 -> 1/4)
