### PR TITLE
Hopefully fixes FTL not working sometimes after #622

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -131,23 +131,6 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
                     // We'll send the "adjusted" position and server will adjust it back when relevant.
                     var mapCoords = new MapCoordinates(InverseMapPosition(args.RelativePosition), ViewingMap);
 
-                    if (!_physicsQuery.TryGetComponent(_shuttleEntity, out var shuttlePhysics) || !EntManager.TryGetComponent(_shuttleEntity, out TransformComponent? shuttleTransform))
-                        return;
-
-                    var shuttleUid = _shuttleEntity.Value;
-
-                    var shuttlePosition = Maps.GetGridPosition((shuttleUid, shuttlePhysics, shuttleTransform));
-                    var targetPosition = mapCoords.Position;
-                    var shuttleToTarget = targetPosition - shuttlePosition;
-
-                    var range = _shuttles.GetFTLRange(shuttleUid);
-
-                    // If the target position is outside of the shuttle's FTL range, then try to FTL as close as possible to save the player some hassle.
-                    if (shuttleToTarget.Length() > range)
-                    {
-                        mapCoords = new(shuttlePosition + shuttleToTarget.Normalized() * range, ViewingMap);
-                    }
-
                     RequestFTL?.Invoke(mapCoords, _ftlAngle);
                 }
             }

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -149,6 +149,8 @@ public sealed partial class ShuttleConsoleSystem
             return;
         }
 
+        targetCoordinates = _shuttle.ClampCoordinatesToFTLRange(shuttleUid.Value, targetCoordinates);
+
         List<ShuttleExclusionObject>? exclusions = null;
         GetExclusions(ref exclusions);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Moves the FTL range clamp to the server side and adds a "range <= 0" check so you don't FTL in place if you don't have a drive.
I did my best to test the changes, but I might have missed some edge cases. Hopefully not.
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
Buggy FTLs are annoying.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
Try to FTL with and without a drive.
Make sure any unpowered FTLs are off of the shuttle's grid, they will interfere if you spawn in a new drive.
<!-- Describe the way it can be tested -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You shouldn't FTL in place anymore.
