### PR TITLE
Smart FTL drive fetching

### DIFF
--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -156,35 +156,53 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     {
         // Return the default FTL range if no powered drive was found
         // In the future, we could return a different range if an unpowered drive was found
-        if(!TryGetFTLDrive(shuttleUid, out var drive, out var driveComp, true))
+        if (!TryGetFTLDrive(shuttleUid, out var drive, out var driveComp) || !_powerReceiverSystem.IsPowered(drive.Value))
             return FTLRange;
 
         return driveComp.Range;
     }
 
-    public bool TryGetFTLDrive(EntityUid shuttleUid, [NotNullWhen(true)] out EntityUid? driveUid, [NotNullWhen(true)] out FTLDriveComponent? drive, bool poweredOnly = false)
+    /// <summary>
+    /// Tries to get the highest range FTL drive on the shuttle. Prioritizes powered drives.
+    /// </summary>
+    public bool TryGetFTLDrive(EntityUid shuttleUid, [NotNullWhen(true)] out EntityUid? driveUid, [NotNullWhen(true)] out FTLDriveComponent? drive)
     {
-        float highestRange = 0;
+        var highestRange = 0f;
 
         driveUid = null;
         drive = null;
 
-        // Look for any powered FTL drives on the shuttle's grid
-        // FTL drive is now optional and only enhances range if present
+        // Okay so, this is fucking stupid, but it works.
+        // When making this method smarter I needed to do two things.
+        // 1. Maintain parity between TryGetFTLDrive results regardless of what they're used for. (so I don't cause weird bugs)
+        // 2. Get a powered drive if one exists since those are the only ones you can actually jump with.
+        // So instead of only getting powered drives we prioritize powered drives.
+        var poweredDriveFound = false;
+
         var query = AllEntityQuery<FTLDriveComponent>();
 
         while (query.MoveNext(out var uid, out var comp))
         {
             if (Transform(uid).GridUid != shuttleUid)
                 continue;
-            if (poweredOnly && !_powerReceiverSystem.IsPowered(uid))
+
+            var isPowered = _powerReceiverSystem.IsPowered(uid);
+
+            // If we've already found an powered drive, ignore unpowered ones.
+            if (poweredDriveFound && !isPowered)
                 continue;
-            if (highestRange > 0 && comp.Range <= highestRange)
+
+            var isBetterCandidate = (comp.Range > highestRange) || (isPowered && !poweredDriveFound);
+
+            if (!isBetterCandidate)
                 continue;
 
             highestRange = comp.Range;
+
             driveUid = uid;
             drive = comp;
+
+            poweredDriveFound = _powerReceiverSystem.IsPowered(uid);
         }
 
         return driveUid != null;

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -202,7 +202,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
             driveUid = uid;
             drive = comp;
 
-            poweredDriveFound = _powerReceiverSystem.IsPowered(uid);
+            poweredDriveFound = isPowered;
         }
 
         return driveUid != null;

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -156,15 +156,16 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     {
         // Return the default FTL range if no powered drive was found
         // In the future, we could return a different range if an unpowered drive was found
-        if(!TryGetFTLDrive(shuttleUid, out var drive, out var driveComp)
-           || !_powerReceiverSystem.IsPowered(drive.Value))
+        if(!TryGetFTLDrive(shuttleUid, out var drive, out var driveComp, true))
             return FTLRange;
 
         return driveComp.Range;
     }
 
-    public bool TryGetFTLDrive(EntityUid shuttleUid, [NotNullWhen(true)] out EntityUid? driveUid, [NotNullWhen(true)] out FTLDriveComponent? drive)
+    public bool TryGetFTLDrive(EntityUid shuttleUid, [NotNullWhen(true)] out EntityUid? driveUid, [NotNullWhen(true)] out FTLDriveComponent? drive, bool poweredOnly = false)
     {
+        float highestRange = 0;
+
         driveUid = null;
         drive = null;
 
@@ -176,13 +177,17 @@ public abstract partial class SharedShuttleSystem : EntitySystem
         {
             if (Transform(uid).GridUid != shuttleUid)
                 continue;
+            if (poweredOnly && !_powerReceiverSystem.IsPowered(uid))
+                continue;
+            if (highestRange > 0 && comp.Range <= highestRange)
+                continue;
 
+            highestRange = comp.Range;
             driveUid = uid;
             drive = comp;
-            return true;
         }
 
-        return false;
+        return driveUid != null;
     }
 
     public float GetFTLBufferRange(EntityUid shuttleUid, MapGridComponent? grid = null)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes TryGetFTLDrive less stupid.
It now prioritizes the highest range powered drive.
I did retain parity between TryGetFTLDrive calls at the very least, so it shouldn't break anything.
It'll still return an unpowered drive if no powered one was found.

Tested in game, should work fine.
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
Having to throw your old drive out of your ship is annoying as hell.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
Unwrench and wrench a bunch of FTL drives of varying ranges on a ship.
<!-- Describe the way it can be tested -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You no longer have to throw out your old FTL drive to get the benefits of your new one.
