### PR TITLE
M-10 mass scanner fix

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ussp.yml
@@ -101,7 +101,8 @@
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
   - type: RadarConsole
-    maxRange: 225
+    maxRange: 350
+    followEntity: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true


### PR DESCRIPTION

## About the PR
Makes the Mass scanner in the M-10 helmet less annoying to use, also a little more of radar range.

## Why / Balance
Is annoying to use as its basically one of its gimmick

## How to test
Toggle the scanner when the helmet is equipped by pressing E or right click on it.

## Requirements

- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: M-10 internal mass scanner increased to 350 meters.
