### PR TITLE
Smart-Equip to Back (Suit Storage) [Port]

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -73,6 +73,7 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.OpenInventoryMenu);
             human.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
+            human.AddFunction(ContentKeyFunctions.SmartEquipBack); // Goobstation - Smart equip to back
             human.AddFunction(ContentKeyFunctions.OpenBackpack);
             human.AddFunction(ContentKeyFunctions.OpenBelt);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -197,6 +197,7 @@ namespace Content.Client.Options.UI.Tabs
             AddHeader("ui-options-header-interaction-adv");
             AddButton(ContentKeyFunctions.SmartEquipBackpack);
             AddButton(ContentKeyFunctions.SmartEquipBelt);
+            AddButton(ContentKeyFunctions.SmartEquipBack); // Goobstation - Equip To Back
             AddButton(ContentKeyFunctions.OpenBackpack);
             AddButton(ContentKeyFunctions.OpenBelt);
             AddButton(ContentKeyFunctions.ThrowItemInHand);

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -31,6 +31,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction OpenInventoryMenu = "OpenInventoryMenu";
         public static readonly BoundKeyFunction SmartEquipBackpack = "SmartEquipBackpack";
         public static readonly BoundKeyFunction SmartEquipBelt = "SmartEquipBelt";
+        public static readonly BoundKeyFunction SmartEquipBack = "SmartEquipBack"; // Goobstation - Smart equip to back
         public static readonly BoundKeyFunction OpenBackpack = "OpenBackpack";
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";

--- a/Content.Shared/_Goobstation/Interaction/BackEquipSystem.cs
+++ b/Content.Shared/_Goobstation/Interaction/BackEquipSystem.cs
@@ -1,0 +1,107 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Input;
+using Content.Shared.Interaction;
+using Content.Shared.Inventory;
+using Content.Shared.Popups;
+using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Whitelist;
+using Robust.Shared.Containers;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+
+namespace Content.Shared._Goobstation.Interaction;
+
+public sealed class BackEquipSystem : EntitySystem
+{
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+
+    public override void Initialize()
+    {
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.SmartEquipBack,
+                InputCmdHandler.FromDelegate(HandleEquipToBack,
+                    handle: false,
+                    outsidePrediction: false)) // Goobstation - Smart equip to back
+            .Register<BackEquipSystem>();
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        CommandBinds.Unregister<BackEquipSystem>();
+    }
+
+    private void HandleEquipToBack(ICommonSession? session)
+    {
+        HandleEquipToSlot(session, "suitstorage");
+    }
+
+    private void HandleEquipToSlot(ICommonSession? session, string equipmentSlot)
+    {
+        if (session is not { } playerSession)
+            return;
+
+        if (playerSession.AttachedEntity is not { Valid: true } uid || !Exists(uid))
+            return;
+
+        if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHand == null)
+            return;
+
+        var handItem = hands.ActiveHand.HeldEntity;
+
+        if (!_actionBlocker.CanInteract(uid, handItem))
+            return;
+
+        if (!TryComp<InventoryComponent>(uid, out var inventory) || !_inventory.HasSlot(uid, equipmentSlot, inventory))
+        {
+            _popup.PopupClient(Loc.GetString("smart-equip-missing-equipment-slot", ("slotName", equipmentSlot)),
+                uid,
+                uid);
+            return;
+        }
+
+        if (handItem != null && !_hands.CanDropHeld(uid, hands.ActiveHand))
+        {
+            _popup.PopupClient(Loc.GetString("smart-equip-cant-drop"), uid, uid);
+            return;
+        }
+
+        _inventory.TryGetSlotEntity(uid, equipmentSlot, out var slotEntity);
+        var emptyEquipmentSlotString = Loc.GetString("smart-equip-empty-equipment-slot", ("slotName", equipmentSlot));
+        if (slotEntity is not { } slotItem)
+        {
+            if (handItem == null)
+            {
+                _popup.PopupClient(emptyEquipmentSlotString, uid, uid);
+                return;
+            }
+
+            if (!_inventory.CanEquip(uid, handItem.Value, equipmentSlot, out var reason))
+            {
+                _popup.PopupClient(Loc.GetString(reason), uid, uid);
+                return;
+            }
+
+            _hands.TryDrop(uid, hands.ActiveHand, handsComp: hands);
+            _inventory.TryEquip(uid, handItem.Value, equipmentSlot, predicted: true, checkDoafter: true);
+            return;
+        }
+        if (handItem != null)
+            return;
+
+        if (!_inventory.CanUnequip(uid, equipmentSlot, out var inventoryReason))
+        {
+            _popup.PopupClient(Loc.GetString(inventoryReason), uid, uid);
+            return;
+        }
+        _inventory.TryUnequip(uid, equipmentSlot, inventory: inventory, predicted: true, checkDoafter: true);
+        _hands.TryPickup(uid, slotItem, handsComp: hands);
+    }
+}

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -156,6 +156,7 @@ ui-options-static-storage-ui = Lock storage window to hotbar
 
 ui-options-function-smart-equip-backpack = Smart-equip to backpack
 ui-options-function-smart-equip-belt = Smart-equip to belt
+ui-options-function-smart-equip-back = Smart-equip to back slot
 ui-options-function-open-backpack = Open backpack
 ui-options-function-open-belt = Open belt
 ui-options-function-throw-item-in-hand = Throw item

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -253,6 +253,9 @@ binds:
   type: State
   key: E
   mod1: Shift
+- function: SmartEquipBack # Goobstation - Smart equip to back
+  type: State # Goobstation - Smart equip to back
+  key: F # Goobstation - Smart equip to back
 - function: OpenBackpack
   type: State
   key: V


### PR DESCRIPTION
* Goobbackequip

* :trollface:

---------


(cherry picked from commit cf478f991530b68c56bfd2aa7fc3abcea704469a)

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Ark
- add: Smart equip to your back slot is now available and is default bound to F. Ported from Goob.
