### PR TITLE
Remove gatherDestructionWhitelist from NFAsteroidRockOre

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Walls/asteroid.yml
@@ -4,9 +4,6 @@
   abstract: true
   components: &softRockComps
   - type: OreVein
-    gatherDestructionWhitelist:
-      components:
-      - MiningGatheringHard
 
 - type: entity
   parent: IronRock


### PR DESCRIPTION
The current value in the `gatherDestructionWhitelist` field of `NFAsteroidRockOre` prevents ore veins from spawning ore when mined with the PTK-1500e.

Assuming this is an unintentional holdover from Frontier, since the PTK-1500e description was changed to remove the "overpowered for softer rock" comment. #22 

This PR removes the `gatherDestructionWhitelist` values from `NFAsteroidRockOre` but doesn't change or remove the system for whitelisting entities as "too strong" or "not strong enough" to gather ore. See: [GatherableSystem.Projectile.cs](https://github.com/Monolith-Station/Monolith/blob/main/Content.Server/Gatherable/GatherableSystem.Projectile.cs)

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes the `gatherDestructionWhitelist` values from `NFAsteroidRockOre`, allowing ore veins to be mined with ship-based weapons.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix for unintended behavior.

## How to test
<!-- Describe the way it can be tested -->
Fire the PTK-1500e at an ordinary ore vein.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: All ore veins should now drop ore when mined with the PTK-1500e