### PR TITLE
IPC max health and states

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -59,13 +59,11 @@
   - type: MobState
     allowedStates:
     - Alive
-    - Critical
-    - Dead
+    - Dead # why did EE just not remove the state and instead made them crit at 119.999???
   - type: MobThresholds
     thresholds:
       0: Alive
-      119.999: Critical # TO make it almost impossible
-      120: Dead
+      100: Dead # mono
     stateAlertDict:
       Alive: BorgHealth
       Critical: BorgCrit


### PR DESCRIPTION
## About the PR
6 lines changed about ipc max health and states

## Why / Balance
goobstation does it, theres no reason for them to have an additional 20 max health

## How to test
you play ipc

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] total IPC death

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: IPC no longer die at 120 damage, and instead do so at 100 (like in goob)
- fix: Fixed having a very, very, very, very, very rare chance for an IPC to go "crit"
