### PR TITLE
PMC Prices and Stock Adjustments.

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/registered.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/registered.yml
@@ -1,103 +1,131 @@
-# SMGs
+# All Static Prices are multiplied by 12
 
-- type: entity
-  parent:
-  - BaseC2ContrabandMercenary
-  - WeaponSubMachineGunWt550
-  name: PMC WT-550
-  id: WeaponSubMachineGunWt550PMC
-  description: A WT-550 that has been properly registered for private security and mercenary use.
+# Sidearms
 
-- type: entity
-  parent:
-  - BaseC2ContrabandMercenary
-  - WeaponSubMachineGunDrozd
-  name: PMC Drozd
-  id: WeaponSubMachineGunDrozdPMC
-  description: A Drozd that has been properly registered for private security and mercenary use.
-
-- type: entity
-  parent:
-  - BaseC2ContrabandMercenary
-  - WeaponSubMachineGunC20r
-  name: PMC C-20r
-  id: WeaponSubMachineGunC20rPMC
-  description: A C-20r that has been properly registered for private security and mercenary use.
-  components:
-  - type: PirateBountyItem
-    id: StandardTSFLongarm
-
-# Rifles
-
-- type: entity
-  parent:
-  - BaseC2ContrabandMercenary
-  - WeaponRifleLecter
-  name: PMC Lecter
-  id: WeaponRifleLecterPMC
-  description: A Lecter that has been properly registered for private security and mercenary use.
-
-# Shotguns
-
-- type: entity
-  parent:
-  - BaseC2ContrabandMercenary
-  - WeaponShotgunEnforcer
-  name: PMC Enforcer
-  id: WeaponShotgunEnforcerPMC
-  description: An Enforcer that has been properly registered for private security and mercenary use.
-
-# Pistols
-
-- type: entity
+- type: entity #Viper
   parent:
   - BaseC2ContrabandMercenary
   - WeaponPistolViper
   name: PMC Viper
   id: WeaponPistolViperPMC
-  description: A Viper that has been properly registered for private security and mercenary use.
-#  components:
-#  - type: PirateBountyItem
-#    id: PMCGun
+  description: A Viper that has been properly registered for private security and mercenary use. A small underpowered gun retrofitted with a fully automatic receiver. It is favored by Syndicate agents for being easily concealable. Uses .35 auto ammo.
+  components:
+  - type: StaticPrice
+    price: 200
+
+- type: entity # Knife
+  parent:
+  - BaseC2ContrabandMercenary
+  - SurvivalKnife
+  name: PMC Survival Knife
+  id: SurvivalKnifePMC
+  description: A Knife that has been properly registered for private security and mercenary use. Why did you register you knife?
+
+# SMGs
+
+- type: entity #WT-550
+  parent:
+  - BaseC2ContrabandMercenary
+  - WeaponSubMachineGunWt550
+  name: PMC WT-550
+  id: WeaponSubMachineGunWt550PMC
+  description: A WT-550 that has been properly registered for private security and mercenary use. A compact personal defense sub-machine gun. Lightweight build allows for ease of use without wielding a grip. Uses .35 auto ammo.'
+  components:
+  - type: StaticPrice
+    price: 2200
+
+- type: entity #Drozd
+  parent:
+  - BaseC2ContrabandMercenary
+  - WeaponSubMachineGunDrozd
+  name: PMC Drozd
+  id: WeaponSubMachineGunDrozdPMC
+  description: A Drozd that has been properly registered for private security and mercenary use. An old and cheap fully automatic Heavy SMG. Beloved by Mercenaries for it's affordability. Uses .35 auto ammo.
+  components:
+  - type: StaticPrice
+    price: 1350
+
+- type: entity #C-20r
+  parent:
+  - BaseC2ContrabandMercenary
+  - WeaponSubMachineGunC20r
+  name: PMC C-20r
+  id: WeaponSubMachineGunC20rPMC
+  description: A C-20r that has been properly registered for private security and mercenary use. A fast firing sub-machine gun that is often used by the infamous rogue insurgency. Uses .35 auto ammo.
+  components:
+  - type: PirateBountyItem
+    id: StandardTSFLongarm
+  - type: StaticPrice
+    price: 2500
+
+# Rifles
+
+- type: entity #Lecter
+  parent:
+  - BaseC2ContrabandMercenary
+  - WeaponRifleLecter
+  name: PMC Lecter
+  id: WeaponRifleLecterPMC
+  description: A Lecter that has been properly registered for private security and mercenary use. A high end military grade assault rifle. Is a common primary carried by Trans-Solar Federation Marines due to it's high accuracy and cheap manufacturing costs. Uses .20 rifle ammo.
+  components:
+  - type: StaticPrice
+    price: 1500
+
+# Shotguns
+
+- type: entity #Kammerer
+  parent:
+  - BaseC2ContrabandMercenary
+  - WeaponShotgunKammerer
+  name: PMC Kammerer
+  id: WeaponShotgunKammererPMC
+  description: A Kammerer that has been properly registered for private security and mercenary use. An old yet faithfully designed shotgun. Is a favorite among Mercenaries of many worlds. Uses .50 shotgun shells.
+  components:
+  - type: StaticPrice
+    price: 800
 
 # Energy
 
-- type: entity
+- type: entity #Energy Gun
   parent:
   - BaseC2ContrabandMercenary
   - WeaponEnergyGun
   name: PMC Energy Gun
   id: WeaponEnergyGunPMC
-  description: An Energy Gun that has been properly registered for private security and mercenary use.
+  description: An Energy Gun that has been properly registered for private security and mercenary use. A Shellguard EG-7 model. It is beloved by NanoTrasen Private Security for being a versatile weapon that merges disabler and laser.
+  components:
+  - type: StaticPrice
+    price: 1100
 
-- type: entity
+- type: entity #Laser Rifle
   parent:
   - BaseC2ContrabandMercenary
   - WeaponLaserCarbine
   name: PMC Laser Rifle
   id: WeaponLaserCarbinePMC
-  description: A Laser Rifle that has been properly registered for private security and mercenary use.
+  description: A Laser Rifle that has been properly registered for private security and mercenary use. A Shellguard LG-6 model. It is a simple laser carbine and the workhorse of many Private Security organizations.
+  components:
+  - type: StaticPrice
+    price: 750
 
-- type: entity
+- type: entity #Laser Cannon
   parent:
   - BaseC2ContrabandMercenary
   - WeaponLaserCannon
   name: PMC Laser Cannon
   id: WeaponLaserCannonPMC
-  description: A Laser Cannon that has been properly registered for private security and mercenary use.
+  description: A Laser Cannon that has been properly registered for private security and mercenary use. An offering from local R&D. It is a heavy duty accelerated laser cannon.
+  components:
+  - type: StaticPrice
+    price: 1400
 
-- type: entity
+- type: entity #Disabler SMG
   parent:
   - BaseC2ContrabandMercenary
   - WeaponDisablerSMG
   name: PMC Disabler SMG
   id: WeaponDisablerSMGPMC
-  description: An Energy Gun that has been properly registered for private security and mercenary use.
-
-- type: entity
-  parent:
-  - BaseC2ContrabandMercenary
-  - WeaponEnergyShotgun
-  name: PMC Energy Shotgun
-  id: WeaponEnergyShotgunPMC
-  description: An Energy Shotgun that has been properly registered for private security and mercenary use.
+  description: A Disabler SMG that has been properly registered for private security and mercenary use. An upscaled version of Shellguard disabler. Featuring the ability to pepper a large area with incapacitating shots for crowd suppression and riot control.
+  components:
+  - type: StaticPrice
+    price: 420

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/weaponryworks.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/weaponryworks.yml
@@ -61,31 +61,38 @@
 - type: vendingMachineInventory # Mono - this entire thing is mono
   id: WeaponryWorksVendPOIMercInventory
   startingInventory:
+# SMGs
+    WeaponSubMachineGunC20rPMC: 4294967295
     WeaponSubMachineGunWt550PMC: 4294967295
     WeaponRifleLecterPMC: 4294967295
-    WeaponSubMachineGunC20rPMC: 4294967295
     WeaponSubMachineGunDrozdPMC: 4294967295
-    WeaponShotgunEnforcerPMC: 4294967295
-    WeaponEnergyShotgunPMC: 4294967295
-    WeaponEnergyGunPMC: 4294967295
+# Shotguns
+    WeaponShotgunKammererPMC: 4294967295
+# Energy
     WeaponLaserCannonPMC: 4294967295
+    WeaponEnergyGunPMC: 4294967295
     WeaponLaserCarbinePMC: 4294967295
     WeaponDisablerSMGPMC: 4294967295
+# Sidearms
+    WeaponShotgunSawn: 4294967295
     WeaponPistolViperPMC: 4294967295
     WeaponPistolUniversal: 4294967295
-    SurvivalKnife: 4294967295
-    MagazinePistolSubMachineGun: 4294967295
-    MagazinePistolSubMachineGunTopMounted: 4294967295
-    MagazineRifle: 4294967295
-    MagazinePistol: 4294967295
-    MagazineBoxRifle: 4294967295
-    MagazineBoxRifleBig: 4294967295
-    MagazineBoxLightRifle: 4294967295
-    MagazineBoxLightRifleBig: 4294967295
-    MagazineBoxPistol: 4294967295
-    MagazineBoxPistolBig: 4294967295
-    MagazineBoxMagnum: 4294967295
+    Machete: 4294967295
+    KukriKnife: 4294967295
+    CombatKnife: 4294968295
+    SurvivalKnifePMC: 4294967295
+# Magazines
+    MagazinePistol: 4294967295 # .35 Pistol
+    MagazinePistolSubMachineGun: 4294967295 # .35 SMG
+    MagazinePistolSubMachineGunTopMounted: 4294967295 # .35 WT
+    MagazineRifle: 4294967295 # .20 Rifle
+    MagazineLightRifleLowCapacity: 4294967295 # .30 SVS
+    SpeedLoaderLightRifle: 4294967295 # .30 Mosin
+# Ammo
+    MagazineBoxRifleBig: 4294967295 # .20
+    MagazineBoxCaselessRifleBig: 4294967295 # .25
+    MagazineBoxLightRifleBig: 4294967295 # .30
+    MagazineBoxPistolBig: 4294967295 # .35
+    MagazineBoxMagnum: 4294967295 # .45
     BoxShotgunSlug: 4294967295
     BoxLethalshot: 4294967295
-    MagazineLightRifleLowCapacityEmpty: 4294967295
-    SpeedLoaderLightRifle: 4294967295

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/weaponryworks.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/weaponryworks.yml
@@ -79,7 +79,7 @@
     WeaponPistolUniversal: 4294967295
     Machete: 4294967295
     KukriKnife: 4294967295
-    CombatKnife: 4294968295
+    CombatKnife: 4294967295
     SurvivalKnifePMC: 4294967295
 # Magazines
     MagazinePistol: 4294967295 # .35 Pistol


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adjusted prices of weapons with help of contributor team on discord.
Replaces Enforcer with Kammerer in PMC.
Removes Energy Shotgun from PMC.
Adds more knife types, and sawn, off shotgun.
Sorts the vendomat items by type then price.
Added more comments to PMC stuff.

## Why
I heard complains and suggestions from community about adjusting gun prices and adjusting weapons to be less powerful.

 ## Balance
People more experienced than me know more about guns, ask in discord dev discussions if more information is needed.

## Media
![image](https://github.com/user-attachments/assets/8fae5078-c645-47d5-af3e-8494de1a4dd2)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Danchi299 (Daniel Lenrd), BlueHNT
- tweak: Most PMC Weapon prices were increased.
- tweak: Replaced Enforcer with Kammerer in PMC Liberty Station
- remove: Removed Energy Shotgun from PMC Liberty Station. May be re-added later as expeditionary loot.
