### PR TITLE
expedition glass change

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -25,7 +25,7 @@
   - type: Prying
     pryPowered: true
     force: true
-    speedModifier: 1.5
+    speedModifier: 3 # 1.5-> 3 Mono
     useSound:
       path: /Audio/Items/crowbar.ogg
   - type: Reactive

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
@@ -153,13 +153,13 @@
 #    - type: Pullable # TODO: This makes the mob stuck to your hand if it dies when you pull it
     - type: Carriable # Carrying system from nyanotrasen.
     - type: Tool
-      speedModifier: 1.5
+      speedModifier: 3 # 1.5->3 Mono
       qualities:
         - Prying
     - type: Prying # Open door from xeno.yml.
       pryPowered: true
       force: true
-      speedModifier: 1.5
+      speedModifier: 3 # 1.5->3 - Mono
       useSound:
         path: /Audio/Items/crowbar.ogg
     - type: MovementIgnoreGravity
@@ -234,14 +234,14 @@
   - type: ProtectedFromStepTriggers
   - type: Climbing
   - type: Tool
-    speedModifier: 1.5
+    speedModifier: 3 # 1.5->3 Mono
     qualities:
       - Prying
     hideQualities: true
   - type: Prying
     pryPowered: true
     force: true
-    speedModifier: 1.5
+    speedModifier: 3 # 1.5->3 Mono
     useSound:
       path: /Audio/Items/crowbar.ogg
 #  - type: Access

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/crowbars.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/crowbars.yml
@@ -2,7 +2,7 @@
   parent: BaseCrowbar
   id: CrowbarPocket
   name: pocket crowbar
-  description: 
+  description:
   components:
   - type: EmitSoundOnLand
     sound:
@@ -15,7 +15,7 @@
       types:
         Blunt: 6
   - type: Tool
-    speedModifier: 0.5
+    speedModifier: 1 # 0.5->1 - Mono
   - type: PhysicalComposition
     materialComposition:
       Steel: 50

--- a/Resources/Prototypes/_NF/Entities/Structures/Dungeon/airlocks.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Dungeon/airlocks.yml
@@ -6,18 +6,18 @@
   suffix: Dungeon only, DO NOT MAP
   # categories: [ DoNotMap ] # FIXME - shouldn't be mapped on shuttles/POIs, bluespace events might be fine
   description: An airlock with murky glass windows, it's hard to see what's on the other side.
-  components:
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49"
-        density: 100
-        mask:
-        - FullTileMask
-        layer:
-        - AirlockLayer # Blocks lasers, but not LoS
+#  components: # Mono - No longer blocks lasers
+#  - type: Fixtures
+#    fixtures:
+#      fix1:
+#        shape:
+#          !type:PhysShapeAabb
+#          bounds: "-0.49,-0.49,0.49,0.49"
+#        density: 100
+#        mask:
+#        - FullTileMask
+#        layer:
+#        - AirlockLayer # Blocks lasers, but not LoS
 
 # Basic airlock
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Structures/Dungeon/grille.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Dungeon/grille.yml
@@ -28,11 +28,11 @@
         state: grille
       - sprite: Decals/dirty.rsi
         state: rust
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape:
-            !type:PhysShapeAabb
-            bounds: "-0.5,-0.5,0.5,0.5"
-          layer:
-          - WallLayer # Blocks lasers, but not LoS
+#    - type: Fixtures # Mono - No longer blocks lasers
+#      fixtures:
+#        fix1:
+#          shape:
+#            !type:PhysShapeAabb
+#            bounds: "-0.5,-0.5,0.5,0.5"
+#          layer:
+#          - WallLayer # Blocks lasers, but not LoS

--- a/Resources/Prototypes/_NF/Entities/Structures/Dungeon/windows.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Dungeon/windows.yml
@@ -6,16 +6,16 @@
   suffix: Dungeon only, DO NOT MAP
   # categories: [ DoNotMap ] # FIXME - shouldn't be mapped on shuttles/POIs, bluespace events might be fine
   description: A murky glass window, it's hard to see what's on the other side.
-  components:
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb {}
-        mask:
-        - FullTileMask
-        layer:
-        - WallLayer # Blocks lasers, but not LoS
+#  components: # Mono - No longer blocks lasers
+#  - type: Fixtures
+#    fixtures:
+#      fix1:
+#        shape:
+#          !type:PhysShapeAabb {}
+#        mask:
+#        - FullTileMask
+#        layer:
+#        - WallLayer # Blocks lasers, but not LoS
 
 - type: entity
   id: WindowDirectionalMurkyDungeon
@@ -23,18 +23,18 @@
   suffix: Dungeon only, DO NOT MAP
   # categories: [ DoNotMap ] # FIXME - shouldn't be mapped on shuttles/POIs, bluespace events might be fine
   description: A murky glass window, it's hard to see what's on the other side.
-  components:
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,-0.36"
-        density: 1500
-        mask:
-        - FullTileMask
-        layer:
-        - WallLayer # Blocks lasers, but not LoS
+#  components: # Mono - No longer blocks lasers
+#  - type: Fixtures
+#    fixtures:
+#      fix1:
+#        shape:
+#          !type:PhysShapeAabb
+#          bounds: "-0.49,-0.49,0.49,-0.36"
+#        density: 1500
+#        mask:
+#        - FullTileMask
+#        layer:
+#        - WallLayer # Blocks lasers, but not LoS
 
 # Common window
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Expedition windows/glass airlocks no longer block lasers

Expedition Mobs+Xenos prying speed doubled.

The starting mini-crowbar you can have now is the same speed as a normal crowbar instead of half

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Wizden and Frontier holdovers. Prying speed buffed because half the time mobs get stuck and fail to pry windoors anyways for a good few seconds and to make fighting behind glass airlocks not super free.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Expedition windows no longer block laser
- tweak: Expeditions mob prying speed doubled
- tweak: Starting crowbar in loadout now the same speed as normal crowbars.


