### PR TITLE
USSP medpen and weapon adding

### DIFF
--- a/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/ussp.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/ussp.yml
@@ -20,3 +20,5 @@
     ClothingHeadHelmetHeavyUSSP: 4294967295 # Infinite
     MagazineLightRifleLowCapacityEmpty: 4294967295 # Infinite
     SpeedLoaderLightRifle: 4294967295 # Infinite
+    EmergencyMedipen: 4294967295 # Infinite
+    WeaponRifleAK502: 4294967295 # Infinite

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -123,3 +123,6 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+  - type: StaticPrice
+    price: 100
+    vendPrice: 9000


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds emergency medipen to the USSP vendor alongside with the AK-502 to said vendor.

## Why / Balance
Ussp have it extremely rough in ground combat.

## How to test
Check vendor

## Media
![2025-6-08_00 03 28](https://github.com/user-attachments/assets/2c8dbbdf-67c9-4da3-a67b-d5493ad573aa)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- add: Emergency medipen to the ussp vendor
- add: AK-502 to the ussp vendor

