### PR TITLE
Minor error fix for a few ships

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/Expedition/flashpoint.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/flashpoint.yml
@@ -2107,8 +2107,6 @@ entities:
       pos: 8.5,-14.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 25
   - uid: 67
@@ -2197,8 +2195,6 @@ entities:
       pos: 12.5,-4.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 19
   - uid: 78
@@ -7273,8 +7269,6 @@ entities:
       pos: 5.5,-14.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 25
       - 903
@@ -9083,8 +9077,6 @@ entities:
       pos: 10.5,-21.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1171
@@ -9094,8 +9086,6 @@ entities:
       pos: 10.5,-16.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1172
@@ -9138,8 +9128,6 @@ entities:
       pos: 10.5,-22.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 25
     - type: AtmosPipeColor
@@ -9205,8 +9193,6 @@ entities:
       pos: 12.5,-6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 19
     - type: AtmosPipeColor
@@ -9247,8 +9233,6 @@ entities:
       pos: 10.5,-15.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 25
     - type: AtmosPipeColor

--- a/Resources/Maps/_Mono/Shuttles/Expedition/judiciary.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/judiciary.yml
@@ -751,8 +751,6 @@ entities:
       pos: -1.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 594
@@ -762,8 +760,6 @@ entities:
       pos: -0.5,-3.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 595
@@ -773,8 +769,6 @@ entities:
       pos: -4.5,-2.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 596
@@ -784,8 +778,6 @@ entities:
       pos: -1.5,3.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 597
@@ -795,8 +787,6 @@ entities:
       pos: -1.5,11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 598
@@ -812,8 +802,6 @@ entities:
       pos: -5.5,7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 600
@@ -823,8 +811,6 @@ entities:
       pos: 2.5,7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 609
@@ -833,8 +819,6 @@ entities:
       pos: 1.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: AmeController
@@ -2404,8 +2388,6 @@ entities:
       pos: -2.5,8.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: FirelockGlass
@@ -2416,8 +2398,6 @@ entities:
       pos: -4.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 602
@@ -2426,8 +2406,6 @@ entities:
       pos: -0.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 603
@@ -2436,8 +2414,6 @@ entities:
       pos: 0.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 604
@@ -2446,8 +2422,6 @@ entities:
       pos: -1.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 605
@@ -2456,8 +2430,6 @@ entities:
       pos: -1.5,5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 606
@@ -2466,8 +2438,6 @@ entities:
       pos: -3.5,7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 607
@@ -2476,8 +2446,6 @@ entities:
       pos: 0.5,7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 608
@@ -2486,8 +2454,6 @@ entities:
       pos: 2.5,10.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: GasOutletInjector
@@ -2925,8 +2891,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 280
@@ -2937,8 +2901,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 299
@@ -2950,8 +2912,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: GasVentScrubber
@@ -2965,8 +2925,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 279
@@ -2977,8 +2935,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 323
@@ -2989,8 +2945,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: GravityGeneratorMini

--- a/Resources/Maps/_Mono/Shuttles/Expedition/magus.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/magus.yml
@@ -725,8 +725,6 @@ entities:
       pos: 3.5,6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 538
@@ -736,8 +734,6 @@ entities:
       pos: 5.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 539
@@ -747,8 +743,6 @@ entities:
       pos: -1.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 540
@@ -758,8 +752,6 @@ entities:
       pos: 2.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 541
@@ -769,8 +761,6 @@ entities:
       pos: -0.5,5.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 543
@@ -780,8 +770,6 @@ entities:
       pos: 2.5,9.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 544
@@ -791,8 +779,6 @@ entities:
       pos: 5.5,9.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 545
@@ -802,8 +788,6 @@ entities:
       pos: 3.5,12.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
 - proto: AmeController
@@ -2277,8 +2261,6 @@ entities:
       pos: 4.5,7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 232
@@ -2288,8 +2270,6 @@ entities:
       pos: 6.5,7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 233
@@ -2299,8 +2279,6 @@ entities:
       pos: 5.5,7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
 - proto: FirelockGlass
@@ -2311,8 +2289,6 @@ entities:
       pos: 2.5,2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 565
@@ -2321,8 +2297,6 @@ entities:
       pos: 1.5,5.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 566
@@ -2331,8 +2305,6 @@ entities:
       pos: 2.5,7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 567
@@ -2341,8 +2313,6 @@ entities:
       pos: 2.5,10.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 568
@@ -2351,8 +2321,6 @@ entities:
       pos: 0.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 569
@@ -2361,8 +2329,6 @@ entities:
       pos: 4.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
 - proto: GasMixerFlipped
@@ -2861,8 +2827,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 471
@@ -2873,8 +2837,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 473
@@ -2886,8 +2848,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 475
@@ -2899,8 +2859,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
 - proto: GasVentScrubber
@@ -2914,8 +2872,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 474
@@ -2927,8 +2883,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 511
@@ -2939,8 +2893,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
   - uid: 515
@@ -2951,8 +2903,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 536
 - proto: GravityGeneratorMini

--- a/Resources/Maps/_Mono/Shuttles/Nfsd/tarantula.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/tarantula.yml
@@ -3589,8 +3589,6 @@ entities:
       pos: 3.5,-2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 513
       - 514
@@ -4246,8 +4244,6 @@ entities:
       pos: 5.5,-1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 18
     - type: AtmosPipeColor
@@ -4315,8 +4311,6 @@ entities:
       pos: 5.5,-2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 18
     - type: AtmosPipeColor

--- a/Resources/Maps/_Mono/Shuttles/letterbox.yml
+++ b/Resources/Maps/_Mono/Shuttles/letterbox.yml
@@ -166,8 +166,6 @@ entities:
       pos: 1.5,-2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 2
 - proto: AlwaysPoweredLightExterior
@@ -527,8 +525,6 @@ entities:
       pos: 1.5,-1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 2
 - proto: GasVentScrubber
@@ -540,8 +536,6 @@ entities:
       pos: -0.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 2
 - proto: GravityGeneratorMini

--- a/Resources/Maps/_Mono/Shuttles/twilight.yml
+++ b/Resources/Maps/_Mono/Shuttles/twilight.yml
@@ -413,8 +413,6 @@ entities:
       pos: -2.5,5.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 7
   - uid: 20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes invalid entries in ship .yml files that cause errors.

## How to test
To reproduce the error during mapping, place an air alarm, link it to an air sensor. Delete and replace the air alarm, re-link it to the air sensor. Now when you save or load this grid the entity_deserializer will report the error in the server console. For the disposal unit version of the error, just place an item inside and eject it before saving.

## Media
When buying an affected ship there will be errors from the entity_deserializer.
![magus_buyingerror](https://github.com/user-attachments/assets/489f7623-0535-425c-bd65-f1b4988ffd9a)

When selling that ship you get an error for each invalid entry.
![magus_sellingerror](https://github.com/user-attachments/assets/a3b10ae6-5400-40ad-9525-0743b36395d2)

I tested my changes by buying and selling each ship once on Dev Station.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Mapping error cleaned up on 6 ships.