### PR TITLE
Bluespace bags can now contain big people

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -249,7 +249,7 @@
   - type: Storage
     maxItemSize: Huge
     grid:
-    - 0,0,11,4
+    - 0,0,19,9 # Mono Revert
   - type: ClothingSpeedModifier
     sprintModifier: 1 # makes its stats identical to other variants of bag of holding
   - type: HeldSpeedModifier

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -293,8 +293,8 @@
   - type: PseudoItem # Mono - Everyone bluespace baggable
     storedOffset: -10,0
     shape:
-      - 0, 0, 4, 3
-      - 0, 3, 6, 7
+      - 0, 0, 4, 4
+      - 0, 3, 6, 5
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -290,6 +290,11 @@
   - type: Carriable # Goobstation
   - type: LayingDown # WD EDIT
   - type: CPRTraining # Goobstation
+  - type: PseudoItem # Mono - Everyone bluespace baggable
+    storedOffset: -10,0
+    shape:
+      - 0, 0, 4, 3
+      - 0, 3, 6, 7
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -325,5 +325,5 @@
   - type: PseudoItem # Mono - Everyone bluespace baggable
     storedOffset: -10,0
     shape:
-      - 0, 0, 4, 3
-      - 0, 3, 6, 7
+      - 0, 0, 4, 4
+      - 0, 3, 6, 5

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -322,3 +322,8 @@
   - type: CanEnterCryostorage # Goobstation
   - type: StatusIcon # Goobstation
     bounds: -0.5,-0.5,0.5,0.5
+  - type: PseudoItem # Mono - Everyone bluespace baggable
+    storedOffset: -10,0
+    shape:
+      - 0, 0, 4, 3
+      - 0, 3, 6, 7


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Only bluespace bags work for bigger species, smaller "duffelable" species still smaller and can fit in normal duffels

also de-frontiers the bluespace duffelbag of holding to be inline with the other ones.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Intuitive and makes sense

also frontier holdover

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


![Math](https://github.com/user-attachments/assets/e7fa205b-a56d-4c98-84bf-10b58930f75d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Bigger species can fit into bluespace bags
- fix: Bluespace duffelbags are now full bag of holding sized
