### PR TITLE
Make encryption key names match their channel names

### DIFF
--- a/Resources/Locale/en-US/_Mono/store/pirate-uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Mono/store/pirate-uplink-catalog.ftl
@@ -54,7 +54,7 @@ uplink-pirate-hypopen-name = Hypopen
 uplink-pirate-hypopen-desc = A chemical hypospray disguised as a pen, capable of instantly injecting up to 10u of reagents. Starts empty.
 
 uplink-pirate-implanter-freelance-name = Insurgency Implanter
-uplink-pirate-implanter-freelance-desc = Implants a Insurgency radio, allowing covert communication without a headset.
+uplink-pirate-implanter-freelance-desc = Implants an Insurgency radio, allowing covert communication without a headset.
 
 uplink-pirate-emag-name = Cryptographic Sequencer
 uplink-pirate-emag-desc = A multipurpose hacking device that can configure the ways some machines work.

--- a/Resources/Locale/en-US/_Mono/store/pirate-uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Mono/store/pirate-uplink-catalog.ftl
@@ -53,8 +53,8 @@ uplink-pirate-agent-id-card-desc = A modified ID card that can copy accesses fro
 uplink-pirate-hypopen-name = Hypopen
 uplink-pirate-hypopen-desc = A chemical hypospray disguised as a pen, capable of instantly injecting up to 10u of reagents. Starts empty.
 
-uplink-pirate-implanter-freelance-name = Freelance Implanter
-uplink-pirate-implanter-freelance-desc = Implants a Freelance radio, allowing covert communication without a headset.
+uplink-pirate-implanter-freelance-name = Insurgency Implanter
+uplink-pirate-implanter-freelance-desc = Implants a Insurgency radio, allowing covert communication without a headset.
 
 uplink-pirate-emag-name = Cryptographic Sequencer
 uplink-pirate-emag-desc = A multipurpose hacking device that can configure the ways some machines work.

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -90,7 +90,7 @@
 - type: entity
   parent: [EncryptionKey, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
   id: EncryptionKeyCommand
-  name: command encryption key
+  name: TSF command encryption key # mono
   categories: [ DoNotMap ] # Frontier
   description: An encryption key used by crew's bosses.
   components:
@@ -186,7 +186,7 @@
 - type: entity
   parent: [ EncryptionKey, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityLawyerContraband<BaseC2ContrabandUnredeemable
   id: EncryptionKeySecurity
-  name: security encryption key
+  name: colonial security encryption key # mono
   categories: [ DoNotMap ] # Frontier
   description: An encryption key used by Frontier security forces. # Frontier
   components:
@@ -265,7 +265,7 @@
 - type: entity
   parent: [EncryptionKey, BaseC3PirateContrabandHighValue] # Frontier: added BaseC3PirateContraband - Mono: Changed to HighValue
   id: EncryptionKeyFreelance
-  name: freelancer encryption key
+  name: insurgency encryption key # mono
   description: An encryption key used by freelancers, who may or may not have an affiliation. It looks like it's worn out.
   components:
     - type: EncryptionKey

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -92,7 +92,7 @@
   id: EncryptionKeyCommand
   name: TSF command encryption key # mono
   categories: [ DoNotMap ] # Frontier
-  description: An encryption key used by crew's bosses.
+  description: An encryption key used by TSF Command.
   components:
   - type: EncryptionKey
     channels:
@@ -188,7 +188,7 @@
   id: EncryptionKeySecurity
   name: colonial security encryption key # mono
   categories: [ DoNotMap ] # Frontier
-  description: An encryption key used by Frontier security forces. # Frontier
+  description: An encryption key used by Colonial security. # Mono
   components:
   - type: EncryptionKey
     channels:
@@ -266,7 +266,7 @@
   parent: [EncryptionKey, BaseC3PirateContrabandHighValue] # Frontier: added BaseC3PirateContraband - Mono: Changed to HighValue
   id: EncryptionKeyFreelance
   name: insurgency encryption key # mono
-  description: An encryption key used by freelancers, who may or may not have an affiliation. It looks like it's worn out.
+  description: An encryption key used by insurgents. # Mono
   components:
     - type: EncryptionKey
       channels:


### PR DESCRIPTION
## About the PR
title


## Why / Balance
its supposed to be this way

## How to test

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Encryption keys now match the radio channels they allow access to
- fix: Freelance implanter isn't false advertising anymore and is named the insurgency implanter appropriately
