### PR TITLE
Instant prying with tools for airlocks and such [PORT]

### DIFF
--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -97,7 +97,7 @@ public abstract class SharedAirlockSystem : EntitySystem
 
         if (DoorSystem.IsBolted(uid))
             args.PryTimeModifier *= component.BoltedPryModifier;
-        else if (!component.powered && args.InstaPry) // Goobstation - Monolith
+        else if (!component.Powered && args.InstaPry) // Goobstation - Monolith
             args.PryTimeModifier = 0f;
     }
 

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -97,6 +97,8 @@ public abstract class SharedAirlockSystem : EntitySystem
 
         if (DoorSystem.IsBolted(uid))
             args.PryTimeModifier *= component.BoltedPryModifier;
+        else if (!component.powered && args.InstaPry) // Goobstation - Monolith
+            args.PryTimeModifier = 0f;
     }
 
     /// <summary>

--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -97,7 +97,7 @@ public abstract class SharedAirlockSystem : EntitySystem
 
         if (DoorSystem.IsBolted(uid))
             args.PryTimeModifier *= component.BoltedPryModifier;
-        else if (!component.Powered && args.InstaPry) // Goobstation - Monolith
+        else if (!component.Powered && args.Instapry) // Goobstation - Monolith
             args.PryTimeModifier = 0f;
     }
 

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -71,7 +71,7 @@ public abstract class SharedFirelockSystem : EntitySystem
 
     private void OnDoorGetPryTimeModifier(EntityUid uid, FirelockComponent component, ref GetPryTimeModifierEvent args)
     {
-        if (args.InstaPry) // monolith
+        if (args.Instapry) // monolith
         {
             args.PryTimeModifier = 0f;
             return;

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -71,6 +71,12 @@ public abstract class SharedFirelockSystem : EntitySystem
 
     private void OnDoorGetPryTimeModifier(EntityUid uid, FirelockComponent component, ref GetPryTimeModifierEvent args)
     {
+        if (args.InstaPry) // monolith
+        {
+            args.PryTimeModifier = 0f;
+            return;
+        }
+        
         WarnPlayer((uid, component), args.User);
 
         if (component.IsLocked)

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -48,6 +48,11 @@ namespace Content.Shared.Maps
         [DataField]
         public PrototypeFlags<ToolQualityPrototype> DeconstructTools { get; set; } = new();
 
+        /// Monolith - Goobstation
+        /// Tile deconstruct do-after time multiplier
+        [DataField]
+        public float DeconstructTimeMultiplier { get; private set; }
+
         // Delta V
         // [DataField("canShovel")] public bool CanShovel { get; private set; }
         //Delta V

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -96,10 +96,10 @@ public record struct GetPryTimeModifierEvent
     public float PryTimeModifier = 1.0f;
     public float BaseTime = 5.0f;
 
-    public GetPryTimeModifierEvent(EntityUid user, bool Instapry) // Goobstation
+    public GetPryTimeModifierEvent(EntityUid user, bool instapry) // Goobstation
     {
         User = user;
-        InstaPry = instaPry; // Goobstation
+        InstaPry = instapry; // Goobstation
     }
 }
 

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -36,6 +36,13 @@ public sealed partial class PryingComponent : Component
     /// </summary>
     [DataField]
     public bool Enabled = true;
+
+    /// <summary>
+    /// Goobstation
+    /// Whether the tool is able to instantly pry unpowered unbolted doors and firelocks
+    /// </summary>
+    [DataField]
+    public bool InstaPry = true;
 }
 
 /// <summary>
@@ -85,10 +92,11 @@ public readonly record struct PriedEvent(EntityUid User)
 public record struct GetPryTimeModifierEvent
 {
     public readonly EntityUid User;
+    public readonly bool Instapry; // Goobstation
     public float PryTimeModifier = 1.0f;
     public float BaseTime = 5.0f;
 
-    public GetPryTimeModifierEvent(EntityUid user)
+    public GetPryTimeModifierEvent(EntityUid user, bool instaPry) // Goobstation
     {
         User = user;
     }

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -99,7 +99,6 @@ public record struct GetPryTimeModifierEvent
     public GetPryTimeModifierEvent(EntityUid user, bool instapry) // Goobstation
     {
         User = user;
-        InstaPry = instapry; // Goobstation
+        Instapry = instapry;
     }
 }
-

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -96,7 +96,7 @@ public record struct GetPryTimeModifierEvent
     public float PryTimeModifier = 1.0f;
     public float BaseTime = 5.0f;
 
-    public GetPryTimeModifierEvent(EntityUid user, bool instaPry) // Goobstation
+    public GetPryTimeModifierEvent(EntityUid user, bool Instapry) // Goobstation
     {
         User = user;
         InstaPry = instaPry; // Goobstation

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -99,6 +99,7 @@ public record struct GetPryTimeModifierEvent
     public GetPryTimeModifierEvent(EntityUid user, bool instaPry) // Goobstation
     {
         User = user;
+        InstaPry = instaPry; // Goobstation
     }
 }
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Doors.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Prying.Components;
+using Content.Shared.Timing;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
@@ -22,6 +23,7 @@ public sealed class PryingSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly UseDelaySystem _delay = default!; // Goobstation
 
     public override void Initialize()
     {

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -66,6 +66,9 @@ public sealed class PryingSystem : EntitySystem
     {
         id = null;
 
+        if (TryComp(tool, out UseDelayComponent? delay) && _delay.IsDelayed((tool, delay))) // Goobstation
+            return false;
+
         PryingComponent? comp = null;
         if (!Resolve(tool, ref comp, false))
             return false;
@@ -94,6 +97,9 @@ public sealed class PryingSystem : EntitySystem
     {
         id = null;
 
+        if (TryComp(user, out UseDelayComponent? delay) && _delay.IsDelayed((user, delay))) // Goobstation
+            return false;
+
         // We don't care about displaying a message if no tool was used.
         if (!TryComp<PryUnpoweredComponent>(target, out var unpoweredComp) || !CanPry(target, user, out _, unpoweredComp: unpoweredComp))
             // If we have reached this point we want the event that caused this
@@ -102,7 +108,7 @@ public sealed class PryingSystem : EntitySystem
 
         // hand-prying is much slower
         var modifier = CompOrNull<PryingComponent>(user)?.SpeedModifier ?? unpoweredComp.PryModifier;
-        return StartPry(target, user, null, modifier, out id);
+        return StartPry(target, user, user, modifier, out id); // Goob edit
     }
 
     private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null, PryUnpoweredComponent? unpoweredComp = null)
@@ -133,7 +139,9 @@ public sealed class PryingSystem : EntitySystem
 
     private bool StartPry(EntityUid target, EntityUid user, EntityUid? tool, float toolModifier, [NotNullWhen(true)] out DoAfterId? id)
     {
-        var modEv = new GetPryTimeModifierEvent(user);
+        var instaPry = TryComp(tool, out PryingComponent? prying) && prying.InstaPry; // Goobstation
+
+        var modEv = new GetPryTimeModifierEvent(user, instaPry); // Goob edit
 
         RaiseLocalEvent(target, ref modEv);
         var doAfterArgs = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(modEv.BaseTime * modEv.PryTimeModifier / toolModifier), new DoorPryDoAfterEvent(), target, target, tool)
@@ -177,6 +185,9 @@ public sealed class PryingSystem : EntitySystem
 
         var ev = new PriedEvent(args.User);
         RaiseLocalEvent(uid, ref ev);
+
+        if (TryComp(args.Used, out UseDelayComponent? delay)) // Goobstation
+            _delay.TryResetDelay((args.Used.Value, delay));
     }
 }
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
@@ -3,6 +3,7 @@ using Content.Shared.Fluids.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
+using Content.Shared.Timing;
 using Content.Shared.Tools.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -65,6 +66,9 @@ public abstract partial class SharedToolSystem
         if (!Resolve(ent, ref ent.Comp1, ref ent.Comp2, false))
             return false;
 
+        if (TryComp(ent, out UseDelayComponent? delay) && _delay.IsDelayed((ent.Owner, delay))) // Goobstation
+            return false;
+
         var comp = ent.Comp1!;
         var tool = ent.Comp2!;
 
@@ -88,7 +92,7 @@ public abstract partial class SharedToolSystem
             return false;
 
         var args = new TileToolDoAfterEvent(GetNetEntity(gridUid), tileRef.GridIndices);
-        UseTool(ent, user, ent, comp.Delay, tool.Qualities, args, out _, toolComponent: tool);
+        UseTool(ent, user, ent, comp.Delay * tileDef.DeconstructTimeMultiplier, tool.Qualities, args, out _, toolComponent: tool); // Goob edit
         return true;
     }
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
+using Content.Shared.Timing;
 using Content.Shared.Tools.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
@@ -32,6 +33,7 @@ public abstract partial class SharedToolSystem : EntitySystem
     [Dependency] private   readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private   readonly TileSystem _tiles = default!;
     [Dependency] private   readonly TurfSystem _turfs = default!;
+    [Dependency] private   readonly UseDelaySystem _delay = default!; // Goobstation
 
     public const string CutQuality = "Cutting";
     public const string PulseQuality = "Pulsing";
@@ -57,6 +59,9 @@ public abstract partial class SharedToolSystem : EntitySystem
             RaiseLocalEvent(GetEntity(args.OriginalTarget.Value), (object) ev);
         else
             RaiseLocalEvent((object) ev);
+            
+        if (TryComp(uid, out UseDelayComponent? delay)) // Goobstation
+            _delay.TryResetDelay((uid, delay));
     }
 
     private void OnExamine(Entity<ToolComponent> ent, ref ExaminedEvent args)

--- a/Resources/Prototypes/Entities/Debugging/spanisharmyknife.yml
+++ b/Resources/Prototypes/Entities/Debugging/spanisharmyknife.yml
@@ -23,6 +23,8 @@
   - type: ToolTileCompatible
   - type: Tool
   - type: Prying
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: MultipleTool
     statusShowBehavior: true
     entries:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2542,6 +2542,8 @@
     speedModifier: 1.5
     useSound:
       path: /Audio/Items/crowbar.ogg
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute from base.yml.
     allowedStates:
     - Alive

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -28,6 +28,8 @@
     speedModifier: 3 # 1.5-> 3 Mono
     useSound:
       path: /Audio/Items/crowbar.ogg
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: Reactive
     groups:
       Flammable: [Touch]

--- a/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
@@ -95,6 +95,8 @@
     delay: 10
   - type: Prying
     speedModifier: 0.05
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 3 # slow because mooooooooooooo
 
 - type: entity
   name: mooltitool

--- a/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
@@ -29,6 +29,8 @@
   - type: StaticPrice
     price: 22
   - type: Prying
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: Sprite
     sprite: _NF/Objects/Tools/crowbar.rsi # Frontier: _NF prefix
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -27,6 +27,8 @@
     speedModifier: 1.5
     pryPowered: true
     useSound: /Audio/Items/jaws_pry.ogg
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: MultipleTool
     statusShowBehavior: true
     entries:

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -437,6 +437,8 @@
     - Multitool
   - type: Prying
     enabled: false
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: Tool
     qualities:
     - Screwing

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -5,6 +5,7 @@
   baseTurf: Lattice
   isSubfloor: true
   deconstructTools: [ Axing ] # DeltaV - The return of fireaxe prying
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -22,6 +23,7 @@
   baseTurf: Lattice
   isSubfloor: true
   deconstructTools: [ Axing ] # DeltaV - The return of fireaxe prying
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -34,6 +36,7 @@
   baseTurf: Lattice
   isSubfloor: true
   deconstructTools: [ Axing ] # DeltaV - The return of fireaxe prying
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -46,6 +49,7 @@
   baseTurf: Lattice
   isSubfloor: true
   deconstructTools: [ Axing ] # DeltaV - The return of fireaxe prying
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -58,6 +62,7 @@
   baseTurf: Lattice
   isSubfloor: true
   deconstructTools: [ Axing ] # DeltaV - The return of fireaxe prying
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.15 #a little less then actual snow
@@ -70,6 +75,7 @@
   baseTurf: Space
   isSubfloor: true
   deconstructTools: [ Cutting ]
+  deconstructTimeMultiplier: 1 # Goobstation
   weather: true
   footstepSounds:
     collection: FootstepCatwalk
@@ -86,6 +92,7 @@
   baseTurf: Space
   isSubfloor: true
   deconstructTools: [ Cutting ]
+  deconstructTimeMultiplier: 1 # Goobstation
   weather: true
   footstepSounds:
     collection: FootstepPlating

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -110,7 +110,7 @@
       speedModifier: 1.5
       pryPowered: true
     - type: UseDelay # For insta prying
-      delay: 1
+      delay: 1 # whoever ported the hands didnt see this part so theyre technically already insta prying, lmao
 
 - type: entity
   parent: RightArmCyberneticBase


### PR DESCRIPTION
## About the PR
you can now pry open airlocks and firelocks along with tiles instantly, because its just so convenient.
also a little note, whoever ported the cybernetic arms (that allow you to pry open doors with your hands) forgot to remove the instant pry, so we are technically already implemented with this system, lmao

## Why / Balance
QOL

## How to test
<!-- Describe the way it can be tested -->
pry open door

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
none, modified prying comp's

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Instant prying! You can now open airlocks, firelocks and pry tiles and such with a tool, without a do-after!
