### PR TITLE
[Bounty] Adds Mass Scanners to Mechs

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Mech.Components;
 using Content.Shared.Mech.EntitySystems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
+using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Tools.Components;
 using Content.Shared.Verbs;
 using Content.Shared.Wires;
@@ -53,6 +54,7 @@ public sealed partial class MechSystem : SharedMechSystem
         SubscribeLocalEvent<MechComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<MechComponent, GetVerbsEvent<AlternativeVerb>>(OnAlternativeVerb);
         SubscribeLocalEvent<MechComponent, MechOpenUiEvent>(OnOpenUi);
+        SubscribeLocalEvent<MechComponent, MechOpenRadarEvent>(OnOpenRadar);
         SubscribeLocalEvent<MechComponent, RemoveBatteryEvent>(OnRemoveBattery);
         SubscribeLocalEvent<MechComponent, MechEntryEvent>(OnMechEntry);
         SubscribeLocalEvent<MechComponent, MechExitEvent>(OnMechExit);
@@ -165,6 +167,15 @@ public sealed partial class MechSystem : SharedMechSystem
     {
         args.Handled = true;
         ToggleMechUi(uid, component);
+    }
+
+    private void OnOpenRadar(EntityUid uid, MechComponent component, MechOpenRadarEvent args)
+    {
+        var pilot = GetEntity(args.Pilot);
+        if (!TryComp<ActorComponent>(pilot, out var actor))
+            return;
+
+        _ui.TryToggleUi(uid, RadarConsoleUiKey.Key, actor.PlayerSession);
     }
 
     private void OnToolUseAttempt(EntityUid uid, MechPilotComponent component, ref ToolUserAttemptUseEvent args)

--- a/Content.Shared/Mech/Components/MechComponent.cs
+++ b/Content.Shared/Mech/Components/MechComponent.cs
@@ -148,11 +148,13 @@ public sealed partial class MechComponent : Component
     [DataField]
     public EntProtoId MechCycleAction = "ActionMechCycleEquipment";
     [DataField]
-    public EntProtoId ToggleAction = "ActionToggleLight"; //Goobstation Mech Lights toggle action 
+    public EntProtoId ToggleAction = "ActionToggleLight"; //Goobstation Mech Lights toggle action
     [DataField]
     public EntProtoId MechUiAction = "ActionMechOpenUI";
     [DataField]
     public EntProtoId MechEjectAction = "ActionMechEject";
+    [DataField]
+    public EntProtoId MechRadarUiAction = "ActionRadarUiButton";
     #endregion
 
     #region Visualizer States
@@ -167,5 +169,6 @@ public sealed partial class MechComponent : Component
     [DataField] public EntityUid? MechCycleActionEntity;
     [DataField] public EntityUid? MechUiActionEntity;
     [DataField] public EntityUid? MechEjectActionEntity;
-    [DataField, AutoNetworkedField] public EntityUid? ToggleActionEntity; //Goobstation Mech Lights toggle action 
+    [DataField, AutoNetworkedField] public EntityUid? ToggleActionEntity; //Goobstation Mech Lights toggle action
+    [DataField] public EntityUid? MechRadarUiActionEntity;
 }

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Mech.Equipment.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
@@ -62,6 +63,7 @@ public abstract class SharedMechSystem : EntitySystem
     {
         SubscribeLocalEvent<MechComponent, MechToggleEquipmentEvent>(OnToggleEquipmentAction);
         SubscribeLocalEvent<MechComponent, MechEjectPilotEvent>(OnEjectPilotEvent);
+        SubscribeLocalEvent<MechComponent, MechRadarUiEvent>(OnOpenRadarUiEvent);
         SubscribeLocalEvent<MechComponent, UserActivateInWorldEvent>(RelayInteractionEvent);
         SubscribeLocalEvent<MechComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<MechComponent, DestructionEventArgs>(OnDestruction);
@@ -98,6 +100,24 @@ public abstract class SharedMechSystem : EntitySystem
             return;
         args.Handled = true;
         TryEject(uid, component);
+    }
+
+    private void OnOpenRadarUiEvent(EntityUid uid, MechComponent component, MechRadarUiEvent args)
+    {
+        if (args.Handled)
+            return;
+        args.Handled = true;
+
+        // Mass scanner logic - open radar console UI
+        var pilot = component.PilotSlot.ContainedEntity;
+        if (pilot == null)
+            return;
+
+        // Raise server event to open radar UI
+        if (_net.IsServer)
+        {
+            RaiseLocalEvent(uid, new MechOpenRadarEvent(EntityManager.GetNetEntity(pilot.Value)));
+        }
     }
 
     private void RelayInteractionEvent(EntityUid uid, MechComponent component, UserActivateInWorldEvent args)
@@ -160,6 +180,7 @@ public abstract class SharedMechSystem : EntitySystem
         _actions.AddAction(pilot, ref component.MechUiActionEntity, component.MechUiAction, mech);
         _actions.AddAction(pilot, ref component.MechEjectActionEntity, component.MechEjectAction, mech);
         _actions.AddAction(pilot, ref component.ToggleActionEntity, component.ToggleAction, mech); //Goobstation Mech Lights toggle action
+        _actions.AddAction(pilot, ref component.MechRadarUiActionEntity, component.MechRadarUiAction, mech);
     }
 
     private void RemoveUser(EntityUid mech, EntityUid pilot)
@@ -585,4 +606,15 @@ public sealed partial class MechEntryEvent : SimpleDoAfterEvent
 [Serializable, NetSerializable]
 public sealed partial class HandleMechEquipmentBatteryEvent : EntityEventArgs
 {
+}
+
+[Serializable, NetSerializable]
+public sealed partial class MechOpenRadarEvent : EntityEventArgs
+{
+    public NetEntity Pilot { get; }
+
+    public MechOpenRadarEvent(NetEntity pilot)
+    {
+        Pilot = pilot;
+    }
 }

--- a/Content.Shared/Mech/SharedMech.cs
+++ b/Content.Shared/Mech/SharedMech.cs
@@ -60,3 +60,7 @@ public sealed partial class MechOpenUiEvent : InstantActionEvent
 public sealed partial class MechEjectPilotEvent : InstantActionEvent
 {
 }
+
+public sealed partial class MechRadarUiEvent : InstantActionEvent
+{
+}

--- a/Resources/Locale/en-US/mech/mech.ftl
+++ b/Resources/Locale/en-US/mech/mech.ftl
@@ -19,3 +19,5 @@ mech-slot-display = Open Slots: {$amount}
 mech-no-enter = You cannot pilot this.
 
 mech-eject-pilot-alert = {$user} is pulling the pilot out of the {$item}!
+
+mech-custom-action-popup = Mass scanner activated! Opening radar display...

--- a/Resources/Prototypes/Actions/mech.yml
+++ b/Resources/Prototypes/Actions/mech.yml
@@ -35,3 +35,16 @@
       sprite: Interface/Actions/actions_mecha.rsi
       state: mech_eject
     event: !type:MechEjectPilotEvent
+
+- type: entity
+  id: ActionRadarUiButton
+  name: Mass Scanner
+  description: Scans the surrounding area for mass signatures
+  components:
+  - type: InstantAction
+    itemIconStyle: NoItem
+    icon:
+      sprite: Objects/Tools/handheld_mass_scanner.rsi
+      state: icon
+    event: !type:MechRadarUiEvent
+    useDelay: 0.5

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -42,6 +42,8 @@
     interfaces:
       enum.MechUiKey.Key:
         type: MechBoundUserInterface
+      enum.RadarConsoleUiKey.Key:
+        type: RadarConsoleBoundUserInterface
   - type: MeleeWeapon
     canWideSwing: false
     hidden: true
@@ -144,6 +146,9 @@
   - type: StaticPrice
     price: 450
   # Goobstation Change End
+  - type: RadarConsole
+    maxRange: 256
+    followEntity: true
 
 - type: entity
   id: MechRipley


### PR DESCRIPTION
## About the PR
Add's a mass scanner to Mechs

## Why / Balance
Bounty, helps with space-faring mechs

## How to test
Open Dev Enviroment
Spawns any mech (applies to base so every mech gets it)
Get in
Check for Mass Scanner Button

## Media

https://github.com/user-attachments/assets/80451f56-32d3-4515-a350-4862defa5638



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes

**Changelog**

:cl:

- tweak: Mechs now have access to Mass Scanners


