### PR TITLE
Overhaul hypospray obtainment and return unrestricted hypo

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: hypospray
   parent: BaseItem # Frontier: remove BaseGrandTheftContraband
-  description: A sterile injector for rapid administration of drugs to patients.
+  description: The base, unrestricted hypospray. Designed by top Nanotrasen researchers, it features a large chemical storage, along with a next-to-zero injection delay. It has a warning on its side reading "FOR MEDICAL USE ONLY.".
   id: Hypospray
   components:
   - type: Sprite
@@ -23,7 +23,7 @@
     delay: 0.5
   - type: StaticPrice
     price: 1000
-    vendPrice: 10000
+    vendPrice: 20000
   - type: StealTarget
     stealGroup: Hypospray
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -22,10 +22,8 @@
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice
-    price: 750
-  - type: Tag
-    tags:
-    - HighRiskItem
+    price: 1000
+    vendPrice: 10000
   - type: StealTarget
     stealGroup: Hypospray
 

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/civimed.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/civimed.yml
@@ -7,6 +7,7 @@
     Bloodpack: 4294967295 # Infinite
     Gauze: 4294967295 # Infinite
     EmergencyMedipen: 4294967295 # Infinite
+    Hypospray: 10 # limited, because its not supposed to be waved around
     BodyBagFolded: 4294967295 # Infinite
     ClothingEyesHudMedical: 4294967295 # Infinite
     ClothingEyesEyepatchHudMedical: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/civimed.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/civimed.yml
@@ -7,7 +7,9 @@
     Bloodpack: 4294967295 # Infinite
     Gauze: 4294967295 # Infinite
     EmergencyMedipen: 4294967295 # Infinite
-    Hypospray: 10 # limited, because its not supposed to be waved around
+    HypoMini: 4294967295 # Infinite - Mono
+    HypoMiniLimitedEdition: 10 # Limited because its a direct upgrade, and can be found on expeds
+    Hypospray: 5 # limited. its supposed to be really rare to use these, but still findable.
     BodyBagFolded: 4294967295 # Infinite
     ClothingEyesHudMedical: 4294967295 # Infinite
     ClothingEyesEyepatchHudMedical: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/civimed.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/civimed.yml
@@ -9,7 +9,7 @@
     EmergencyMedipen: 4294967295 # Infinite
     HypoMini: 4294967295 # Infinite - Mono
     HypoMiniLimitedEdition: 10 # Limited because its a direct upgrade, and can be found on expeds 
-    Hypospray: 5 # limited. its supposed to be really rare to use these, but still findable. - Mono end
+    Hypospray: 1 # only one in stock. its supposed to be really rare to use these, but still findable. - Mono end
     BodyBagFolded: 4294967295 # Infinite
     ClothingEyesHudMedical: 4294967295 # Infinite
     ClothingEyesEyepatchHudMedical: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/civimed.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/civimed.yml
@@ -8,8 +8,8 @@
     Gauze: 4294967295 # Infinite
     EmergencyMedipen: 4294967295 # Infinite
     HypoMini: 4294967295 # Infinite - Mono
-    HypoMiniLimitedEdition: 10 # Limited because its a direct upgrade, and can be found on expeds
-    Hypospray: 5 # limited. its supposed to be really rare to use these, but still findable.
+    HypoMiniLimitedEdition: 10 # Limited because its a direct upgrade, and can be found on expeds 
+    Hypospray: 5 # limited. its supposed to be really rare to use these, but still findable. - Mono end
     BodyBagFolded: 4294967295 # Infinite
     ClothingEyesHudMedical: 4294967295 # Infinite
     ClothingEyesEyepatchHudMedical: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
@@ -23,6 +23,7 @@
     delay: 2.5
   - type: StaticPrice
     price: 550
+    vendPrice: 5000
   - type: PirateBountyItem # Frontier
     id: HypoMini # Frontier
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
@@ -66,7 +66,7 @@
     sprite: _NF/Objects/Specific/Medical/hypominilimitededition.rsi
   - type: StaticPrice # Mono
     price: 20 # 20 whole dollars
-    vendPrice: 6000
+    vendPrice: 10000
   - type: UseDelay
     delay: 2
   - type: SolutionContainerManager

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
@@ -23,14 +23,14 @@
     delay: 2.5
   - type: StaticPrice
     price: 550
-    vendPrice: 5000
+    vendPrice: 5000 # Mono
   - type: PirateBountyItem # Frontier
     id: HypoMini # Frontier
 
 - type: entity
   name: NTCS-102 hypospray
   parent: [HypoMini, BaseC2ContrabandUnredeemable]
-  description: A commercial hypospray designed by Nanotrasen Chemical Supply. It has two built in safety features for the consumer market, a small chemical reservoir and an injection delay. This one is branded for use by law-enforcement.
+  description: A commercial hypospray designed by Nanotrasen Chemical Supply. It has a larger chemical reservoir compared to its commercial version and a slightly lowered injection delay. # Mono
   id: HypoBrigmedic
   components:
   - type: Sprite
@@ -41,7 +41,7 @@
   - type: SolutionContainerManager # Mono
     solutions:
       hypospray:
-        maxVol: 10
+        maxVol: 15 # why is a lawenforcement version the same as a civilian version?
   - type: RefillableSolution
     solution: hypospray
   - type: ExaminableSolution
@@ -51,12 +51,12 @@
   - type: UseDelay
     delay: 1.5
   - type: StaticPrice
-    price: 550  # Mono end
+    price: 750  # Mono end
 
 - type: entity
   name: NTCS-103 hypospray
   parent: HypoMini
-  description: A commercial hypospray designed by Nanotrasen Chemical Supply. It has two built in safety features for the consumer market, a small chemical reservoir and an injection delay. This one seems to be a limited edition, lucky you!
+  description: A modified, experimental hypospray designed as a limited edition by the Nanotrasen Chemical Supply. It has a lowered injection delay and a slighlty modified chemical reservoir.
   id: HypoMiniLimitedEdition
   components:
   - type: Sprite
@@ -64,7 +64,16 @@
     state: hypo
   - type: Item
     sprite: _NF/Objects/Specific/Medical/hypominilimitededition.rsi
-
+  - type: StaticPrice # Mono
+    price: 20 # 20 whole dollars
+    vendPrice: 6000
+  - type: UseDelay
+    delay: 2
+  - type: SolutionContainerManager
+    solutions:
+      hypospray:
+        maxVol: 12 # Mono end
+    
 - type: entity
   name: empty medipen
   parent: BaseItem


### PR DESCRIPTION
## About the PR
Adds the base, unrestricted hypospray to all civimeds, for a price of course.
Also adds the normal, restricted hyposprays to all civimeds along with the unused, "rare" hypo and giving it a buff with a raised price tag.
Normal hypo has only one stock in every civimed and a hefty, 20 thousand dollar price tag. also had its description changed
NTCS-101 hypospray added to all civimeds with a 10 stock and a 5 thousand dollar price tag, no buffs.
NTCS-102 hypospray (TSF or law enforcement) version) buffed, not added to vendors. with a shortened injection (2.5s to 1.5s) and its capacity raised to 15.
NTCS-103 experimental hypospray buffed, and added to vendors for 10 thousand dollars, shortened injection  (2.5s to 2.0s) and capacity raised to 12.

## Why / Balance
this is just a frontier holdover, someone got killed by a hypo with lead in it and mald pr'd this propably. also we already have a hypopen in uplinks so i dont see the issue

## How to test
civimed vendors

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: The normal, unrestricted hypospray has returned! Every civimed holds only ONE, ever
- add: Commercial hyposprays have been added to all civi-meds for a raised price tag
- add: NTCS-103 has returned and can be obtained easily using civi-meds
- tweak: NTCS-102 has received a buff to speed and capacity, as it was a law enforcement version
- tweak: NTCS-103 has been changed to be an experimental hypospray, with a raised capacity and speed
