### PR TITLE
Marauder buff

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -10,7 +10,7 @@
     damage:
       types:
         Radiation: 1250
-        Structural: 4250
+        Structural: 4750
         Heat: 350
         Ion: 350
   - type: Sprite
@@ -32,10 +32,10 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    maxIntensity: 125
-    intensitySlope: 3
-    totalIntensity: 95
-    maxTileBreak: 1
+    maxIntensity: 135
+    intensitySlope: 4
+    totalIntensity: 100
+    maxTileBreak: 3
 
 # RUBICON
 


### PR DESCRIPTION
Plasma cannon that is wildly underperforming in practice compared to every other option in its weight class. Requires multiple to be effective in its current state, however this buffs them to be more generally effective.

This makes the marauder hit a bit harder than it typically would. Depending on how it performs in the game (not in a test enviroment) I will decrease the fire rate to balance it.

:cl:
- tweak: TheyHeldMeDownAndForcedMeToType Buff of Marauder to be less shit more good.