### PR TITLE
Lower whitelist role requirements, raise DoC requirements

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/sr.yml
@@ -8,7 +8,7 @@
       time: 72000 # 20 hrs
     - !type:RoleTimeRequirement
       role: JobSecurityGuard
-      time: 10800 # 3 hrs as security guard
+      time: 7200 # 2 hrs as security guard - mono
   whitelisted: true
   startingGear: SrGear
   alwaysUseSpawner: true

--- a/Resources/Prototypes/_NF/Roles/Jobs/Medical/doc.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Medical/doc.yml
@@ -5,10 +5,10 @@
   playTimeTracker: JobDirectorOfCare
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 144000 # 20 hrs # mono - change to 40hr
+      time: 162000 # mono - 45 hours
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 72000 # mono - 10 hours
+      time: 72000 # mono - 20 hours
   alternateRequirementSets: # mono
     longerPlaytimeLessSec: # mono
     - !type:OverallPlaytimeRequirement # mono

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
@@ -5,26 +5,23 @@
   playTimeTracker: JobHeadOfSecurity
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 180000 # 50 hours # mono
-    - !type:DepartmentTimeRequirement
-      department: Security
       time: 108000 # 30 hours # mono
-    - !type:RoleTimeRequirement
-      role: JobWarden
-      time: 36000 # 10 hours # mono
-    - !type:RoleTimeRequirement
-      role: JobSeniorOfficer
-      time: 10800 # 3 hours # mono
-  alternateRequirementSets:
-    longerPlaytimeLessSec:
-    - !type:OverallPlaytimeRequirement
-      time: 270000 # 75 hours # mono
     - !type:DepartmentTimeRequirement
       department: Security
       time: 72000 # 20 hours # mono
     - !type:RoleTimeRequirement
       role: JobWarden
       time: 21600 # 6 hours # mono
+  alternateRequirementSets:
+    longerPlaytimeLessSec:
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hours # mono
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10 hours # mono
+    - !type:RoleTimeRequirement
+      role: JobWarden
+      time: 10800 # 3 hours # mono
   whitelisted: true
   startingGear: SheriffGear
   alwaysUseSpawner: true

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
@@ -4,14 +4,14 @@
   description: job-description-pirate-captain
   playTimeTracker: JobPirateCaptain
   requirements:
-    - !type:OverallPlaytimeRequirement
-      time: 234000 # 65 hours - mono
+    - !type:OverallPlaytimeRequirement # mono start
+      time: 108000 # 65 hours
     - !type:RoleTimeRequirement
-      role: JobPirateFirstMate # mono
-      time: 54000 # 3 hours
+      role: JobPirateFirstMate
+      time: 3600 # 1 hour
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 36000 # 10 hours # mono
+      time: 36000 # 10 hours # mono end
   whitelisted: true
   startingGear: PirateCaptainNFGear
   alwaysUseSpawner: true


### PR DESCRIPTION
## About the PR
Lowers the requirements to play CL from 3 hours to 2 hours as security guard
Raises DoC requirements from 40 hours general playtime to 45 also fixes an error in the comments
Essentially halves Colonel requirements, now being: 30 hours general playtime, 20 hours in TSF, 6 hours as captain. OR 50 hours general playtime, 10 hours in TSF and 3 hours in captain.
Lowers the INSANE amount of playtime needed to play rogue commander. Seriously, whoever set these requirements needs to be taken out back and shot.
Now being: 30 hours general playtime, 1 hour in rogue commandant and 10 hours in TSF.

## Why / Balance
People who play these roles have to be whitelisted, which shows they haven't broken any rules in a large time span. This is also to encourage people to play CL and Colonel more often. The rogue commander and commandant requirements are just insane, being 65 hours (?????) of playtime to play a role like this, while the literal colonel before this PR being lower. DoC requirements are raised because recently, people who have been playing the role are simply incompetent.

## How to test
role timers

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Almost every, if not all whitelist-only roles have had their time requirements lowered
- tweak: DoC requirements have been raised because of general incompetence
