### PR TITLE
Remove the brigmed's insane FMC amount

### DIFF
--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/brigmedic.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/brigmedic.yml
@@ -43,6 +43,5 @@
     back:
     - EncryptionKeyMedical
     - Magazine9x19mmPistolFMJ
-    - FederationMilitaryCredit10
     - BaseSecurityUplinkRadioDeputy #Mono: Added Deputy uplink
     - RadioHandheldNF # Mono

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/brigmedic.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/brigmedic.yml
@@ -43,5 +43,5 @@
     back:
     - EncryptionKeyMedical
     - Magazine9x19mmPistolFMJ
-    - BaseSecurityUplinkRadioDeputy #Mono: Added Deputy uplink
+    - BaseSecurityUplinkRadioOfficer #Mono: Changed to officer uplink
     - RadioHandheldNF # Mono


### PR DESCRIPTION
## About the PR
Removes the 10 FMC the brigmed gets round start.

## Why / Balance
They get 10 FMC in their uplink by default. Why do they get 20 FMC. a captian gets less.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl:
- fix: TSF Brig medics no longer get 20 FMC round start. Sorry brig-colonels.