### PR TITLE
Remove Mob Spawns from Wrecks

### DIFF
--- a/Resources/Prototypes/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/Entities/World/Debris/wrecks.yml
@@ -43,8 +43,8 @@
             prob: 1
           - id: SalvageCanisterSpawner
             prob: 0.2
-          - id: SalvageMobSpawner
-            prob: 0.7
+          # - id: SalvageMobSpawner # Potential lag causing issue, also gives people super easy carp organs anyway. Exped, nerds.
+          #   prob: 0.7
     - type: IFF
       flags: HideLabel
       color: "#88b0d1"

--- a/Resources/Prototypes/_Mono/Loadouts/TSFMC/role_loadouts_tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/TSFMC/role_loadouts_tsfmc.yml
@@ -44,6 +44,7 @@
   - DeputyPDA
   - ContractorWallet
   - ContractorCartridge
+# - ContractorImplanter # Mono - TSF has a skill issue sometimes
   - ContractorEncryptionKey
   - ContractorFun
   - ContractorTrinkets
@@ -70,6 +71,7 @@
   - BrigmedicPDA
   - ContractorWallet
   - ContractorCartridge
+# - ContractorImplanter # Mono - TSF has a skill issue sometimes
   - ContractorEncryptionKey
   - ContractorFun
   - ContractorTrinkets
@@ -96,6 +98,7 @@
   - BailiffPDA
   - ContractorWallet
   - ContractorCartridge
+# - ContractorImplanter # Mono - TSF has a skill issue sometimes
   - ContractorEncryptionKey
   - ContractorFun
   - SeniorOfficerTrinkets
@@ -122,6 +125,7 @@
   - SeniorOfficerPDA
   - ContractorWallet
   - ContractorCartridge
+# - ContractorImplanter # Mono - TSF has a skill issue sometimes
   - ContractorEncryptionKey
   - ContractorFun
   - SeniorOfficerTrinkets
@@ -148,6 +152,7 @@
   - SheriffPDA
   - ContractorWallet
   - ContractorCartridge
+# - ContractorImplanter # Mono - TSF has a skill issue sometimes
   - ContractorFun
   - SeniorOfficerTrinkets
   - NfsdSpeciesSpecific

--- a/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
+++ b/Resources/Prototypes/_NF/Entities/World/Debris/wrecks.yml
@@ -81,8 +81,8 @@
         - id: MedicalPodFilled # Medical bounties
           prob: 0.03
         # Mobs
-        - id: NFSalvageMobSpawner
-          prob: 0.03
+        # - id: NFSalvageMobSpawner # Potential lag causing issue, also gives people super easy carp organs anyway. Exped, nerds.
+        #   prob: 0.03
         # Room
         - id: NFWreckRoomMarker
           prob: 0.01


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes mob spawns from wrecks.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. Potential cause of lag.
2. This is how most people get carp organs. Too free. Go exped, nerds.

Ore mobs will spawn as normal. If this PR is not merged, I will purposefully go wreck exploring and kill carps to get organs.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Carps and such no longer spawn on wrecks. They probably went into space, or something.