### PR TITLE
Updates the Dram Minorly. Replaces Its Generator.

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/dram.yml
+++ b/Resources/Maps/_Mono/Shuttles/dram.yml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: 2023 Cheackraze
+# SPDX-FileCopyrightText: 2023 Kennedy
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 dustylens
+# SPDX-FileCopyrightText: 2025 Junerisms
+# SPDX-FileCopyrightText: 2025 KM-Catman
+# SPDX-FileCopyrightText: 2025 RikuTheKiller
+# SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 revoemagcoconut
+# SPDX-FileCopyrightText: 2025 significant harassment
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 meta:
   format: 7
   category: Grid

--- a/Resources/Maps/_Mono/Shuttles/dram.yml
+++ b/Resources/Maps/_Mono/Shuttles/dram.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/12/2025 09:10:34
-  entityCount: 439
+  time: 06/26/2025 21:57:08
+  entityCount: 434
 maps: []
 grids:
 - 1
@@ -176,7 +176,9 @@ entities:
             0: 16
             1: 4096
           1,-1:
-            0: 29235
+            0: 12849
+            2: 2
+            3: 16384
           0,-2:
             1: 238
             0: 57344
@@ -235,6 +237,21 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 20.078888
+          - 75.53487
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
@@ -242,14 +259,14 @@ entities:
       id: Dram
 - proto: AcousticGuitarInstrument
   entities:
-  - uid: 438
+  - uid: 2
     components:
     - type: Transform
       pos: 1.428431,6.6214933
       parent: 1
 - proto: AirAlarm
   entities:
-  - uid: 312
+  - uid: 3
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -257,25 +274,25 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 148
-      - 149
-      - 313
-      - 318
-      - 319
-      - 317
-      - 316
-      - 315
-      - 146
-      - 314
-      - 151
-      - 150
-      - 169
-      - 170
-      - 410
-      - 399
+      - 260
+      - 263
+      - 217
+      - 216
+      - 219
+      - 215
+      - 214
+      - 213
+      - 262
+      - 218
+      - 261
+      - 264
+      - 11
+      - 12
+      - 14
+      - 13
 - proto: AirCanister
   entities:
-  - uid: 134
+  - uid: 4
     components:
     - type: Transform
       anchored: True
@@ -285,7 +302,7 @@ entities:
       bodyType: Static
 - proto: AirlockCaptainLocked
   entities:
-  - uid: 44
+  - uid: 5
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -293,7 +310,7 @@ entities:
       parent: 1
 - proto: AirlockEngineering
   entities:
-  - uid: 131
+  - uid: 6
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -301,13 +318,13 @@ entities:
       parent: 1
 - proto: AirlockExternalGlass
   entities:
-  - uid: 127
+  - uid: 7
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 128
+  - uid: 8
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -315,13 +332,13 @@ entities:
       parent: 1
 - proto: AirlockShuttle
   entities:
-  - uid: 89
+  - uid: 9
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 90
+  - uid: 10
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -329,7 +346,7 @@ entities:
       parent: 1
 - proto: AirSensor
   entities:
-  - uid: 169
+  - uid: 11
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -337,8 +354,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 170
+      - 3
+  - uid: 12
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -346,8 +363,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 399
+      - 3
+  - uid: 13
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -355,8 +372,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 410
+      - 3
+  - uid: 14
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -364,36 +381,43 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
+      - 3
+- proto: AmmoBox12_gaugeBeanbag
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 1.5062017,-3.258247
+      parent: 1
 - proto: APCBasic
   entities:
-  - uid: 143
+  - uid: 15
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-1.5
       parent: 1
-  - uid: 145
+  - uid: 16
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
 - proto: Ash
   entities:
-  - uid: 347
+  - uid: 17
     components:
     - type: Transform
       pos: 2.3285303,-7.52881
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 411
+  - uid: 18
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 412
+  - uid: 19
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -401,166 +425,166 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 358
+  - uid: 20
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 359
+  - uid: 21
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 360
+  - uid: 22
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 361
+  - uid: 23
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 362
+  - uid: 24
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 363
+  - uid: 25
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 364
+  - uid: 26
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 365
+  - uid: 27
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 366
+  - uid: 28
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 367
+  - uid: 29
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 368
+  - uid: 30
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 369
+  - uid: 31
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 370
+  - uid: 32
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 371
+  - uid: 33
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 372
+  - uid: 34
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 373
+  - uid: 35
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 374
+  - uid: 36
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 375
+  - uid: 37
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 376
+  - uid: 38
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 377
+  - uid: 39
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 378
+  - uid: 40
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 379
+  - uid: 41
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 380
+  - uid: 42
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 381
+  - uid: 43
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 382
+  - uid: 44
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 383
+  - uid: 45
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 384
+  - uid: 46
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 385
+  - uid: 47
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 386
+  - uid: 48
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 387
+  - uid: 49
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
 - proto: BarSign
   entities:
-  - uid: 136
+  - uid: 50
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
 - proto: BarSpoon
   entities:
-  - uid: 81
+  - uid: 51
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -568,547 +592,540 @@ entities:
       parent: 1
 - proto: BedsheetSpawner
   entities:
-  - uid: 342
+  - uid: 52
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
 - proto: BoozeDispenser
   entities:
-  - uid: 80
+  - uid: 53
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
-- proto: AmmoBox12_gaugeBeanbag
-  entities:
-  - uid: 351
-    components:
-    - type: Transform
-      pos: 1.5062017,-3.258247
-      parent: 1
 - proto: Bucket
   entities:
-  - uid: 432
+  - uid: 55
     components:
     - type: Transform
       pos: 4.252865,-0.6509013
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 217
+  - uid: 56
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 218
+  - uid: 57
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 219
+  - uid: 58
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 220
+  - uid: 59
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 221
+  - uid: 60
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 222
+  - uid: 61
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 223
+  - uid: 62
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 224
+  - uid: 63
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 225
+  - uid: 64
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 226
+  - uid: 65
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 227
+  - uid: 66
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 228
+  - uid: 67
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 229
+  - uid: 68
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 230
+  - uid: 69
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 231
+  - uid: 70
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 232
+  - uid: 71
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 233
+  - uid: 72
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 234
+  - uid: 73
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 235
+  - uid: 74
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 236
+  - uid: 75
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 237
+  - uid: 76
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 238
+  - uid: 77
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 239
+  - uid: 78
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 240
+  - uid: 79
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 241
+  - uid: 80
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 242
+  - uid: 81
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 243
+  - uid: 82
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 244
+  - uid: 83
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 245
+  - uid: 84
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 246
+  - uid: 85
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 247
+  - uid: 86
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 248
+  - uid: 87
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 249
+  - uid: 88
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 250
+  - uid: 89
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 251
+  - uid: 90
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 252
+  - uid: 91
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 253
+  - uid: 92
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 255
+  - uid: 93
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 256
+  - uid: 94
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 257
+  - uid: 95
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 258
+  - uid: 96
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 259
+  - uid: 97
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 261
+  - uid: 98
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 262
+  - uid: 99
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 263
+  - uid: 100
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 264
+  - uid: 101
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 265
+  - uid: 102
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 266
+  - uid: 103
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 267
+  - uid: 104
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 268
+  - uid: 105
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 269
+  - uid: 106
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 270
+  - uid: 107
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 271
+  - uid: 108
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 272
+  - uid: 109
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 273
+  - uid: 110
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 274
+  - uid: 111
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-  - uid: 275
+  - uid: 112
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 276
+  - uid: 113
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 277
+  - uid: 114
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 278
+  - uid: 115
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 279
+  - uid: 116
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 280
+  - uid: 117
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 281
+  - uid: 118
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 282
+  - uid: 119
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 283
+  - uid: 120
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 284
+  - uid: 121
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 285
+  - uid: 122
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 298
+  - uid: 123
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 304
+  - uid: 124
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 332
+  - uid: 125
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 333
+  - uid: 126
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 187
+  - uid: 127
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 188
+  - uid: 128
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 189
+  - uid: 129
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 190
+  - uid: 130
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 191
+  - uid: 131
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 192
+  - uid: 132
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 193
+  - uid: 133
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 194
+  - uid: 134
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 195
+  - uid: 135
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 196
+  - uid: 136
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 197
+  - uid: 137
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 198
+  - uid: 138
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 199
+  - uid: 139
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 200
+  - uid: 140
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 201
+  - uid: 141
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 202
+  - uid: 142
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 203
+  - uid: 143
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 204
+  - uid: 144
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 205
+  - uid: 145
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 206
+  - uid: 146
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 208
+  - uid: 147
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 209
+  - uid: 148
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 210
+  - uid: 149
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 211
+  - uid: 150
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 212
+  - uid: 151
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 213
+  - uid: 152
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 214
+  - uid: 153
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 215
+  - uid: 154
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 216
+  - uid: 155
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 401
+  - uid: 156
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 186
+  - uid: 157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1116,125 +1133,125 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 207
+  - uid: 158
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 289
+  - uid: 159
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 290
+  - uid: 160
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 291
+  - uid: 161
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 292
+  - uid: 162
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 293
+  - uid: 163
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 294
+  - uid: 164
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 295
+  - uid: 165
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 299
+  - uid: 166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 341
+  - uid: 167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 395
+  - uid: 168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,1.5
       parent: 1
-  - uid: 396
+  - uid: 169
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 397
+  - uid: 170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
-  - uid: 398
+  - uid: 171
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 400
+  - uid: 172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 402
+  - uid: 173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 403
+  - uid: 174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 404
+  - uid: 175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 405
+  - uid: 176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 407
+  - uid: 177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,4.5
       parent: 1
-  - uid: 408
+  - uid: 178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 409
+  - uid: 179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1242,7 +1259,7 @@ entities:
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 93
+  - uid: 180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1250,7 +1267,7 @@ entities:
       parent: 1
 - proto: ChairWood
   entities:
-  - uid: 76
+  - uid: 181
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1258,7 +1275,7 @@ entities:
       parent: 1
 - proto: ClosetWallO2N2Filled
   entities:
-  - uid: 353
+  - uid: 182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1266,7 +1283,7 @@ entities:
       parent: 1
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 88
+  - uid: 183
     components:
     - type: Transform
       pos: 3.5,10.5
@@ -1277,7 +1294,7 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 91
+  - uid: 184
     components:
     - type: Transform
       pos: 2.5,10.5
@@ -1302,7 +1319,7 @@ entities:
       - device-button-8
 - proto: ComputerTabletopStationRecords
   entities:
-  - uid: 92
+  - uid: 185
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1314,10 +1331,11 @@ entities:
       startingCharge: 0
 - proto: ComputerWallmountRadar
   entities:
-  - uid: 352
+  - uid: 186
     components:
     - type: Transform
-      pos: 4.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,4.5
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 5
@@ -1325,7 +1343,7 @@ entities:
       startingCharge: 0
 - proto: ComputerWallmountWithdrawBankATM
   entities:
-  - uid: 135
+  - uid: 187
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1337,14 +1355,14 @@ entities:
       startingCharge: 0
 - proto: CurtainSpawner
   entities:
-  - uid: 343
+  - uid: 188
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 354
+  - uid: 189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1352,77 +1370,77 @@ entities:
       parent: 1
 - proto: DrinkBottleBeer
   entities:
-  - uid: 434
+  - uid: 190
     components:
     - type: Transform
       pos: 3.5653648,-0.12891054
       parent: 1
 - proto: DrinkGlass
   entities:
-  - uid: 94
+  - uid: 191
     components:
     - type: Transform
       pos: 4.5754147,0.80420196
       parent: 1
-  - uid: 95
+  - uid: 192
     components:
     - type: Transform
       pos: 4.6899986,0.9187852
       parent: 1
 - proto: DrinkShaker
   entities:
-  - uid: 96
+  - uid: 193
     components:
     - type: Transform
       pos: 6.2733316,1.2375925
       parent: 1
-  - uid: 421
+  - uid: 195
     components:
     - type: Transform
-      parent: 415
+      parent: 194
     - type: Physics
       canCollide: False
-  - uid: 423
+  - uid: 196
     components:
     - type: Transform
-      parent: 415
+      parent: 194
     - type: Physics
       canCollide: False
 - proto: DrinkShotGlass
   entities:
-  - uid: 308
+  - uid: 197
+    components:
+    - type: Transform
+      parent: 194
+    - type: Physics
+      canCollide: False
+  - uid: 198
+    components:
+    - type: Transform
+      parent: 194
+    - type: Physics
+      canCollide: False
+  - uid: 208
     components:
     - type: Transform
       pos: 3.3570313,-0.5247439
       parent: 1
-  - uid: 425
-    components:
-    - type: Transform
-      parent: 415
-    - type: Physics
-      canCollide: False
-  - uid: 426
-    components:
-    - type: Transform
-      parent: 415
-    - type: Physics
-      canCollide: False
-  - uid: 433
+  - uid: 209
     components:
     - type: Transform
       pos: 3.6174479,-0.53516054
       parent: 1
 - proto: DrinkWineBottleFull
   entities:
-  - uid: 420
+  - uid: 199
     components:
     - type: Transform
-      parent: 415
+      parent: 194
     - type: Physics
       canCollide: False
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 439
+  - uid: 210
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1430,7 +1448,7 @@ entities:
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 430
+  - uid: 211
     components:
     - type: Transform
       pos: 4.5,9.5
@@ -1442,10 +1460,10 @@ entities:
         Paper: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 431
+          ent: 212
 - proto: FirelockEdge
   entities:
-  - uid: 315
+  - uid: 213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1453,8 +1471,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 316
+      - 3
+  - uid: 214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1462,8 +1480,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 317
+      - 3
+  - uid: 215
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1471,8 +1489,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 318
+      - 3
+  - uid: 216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1480,10 +1498,10 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
+      - 3
 - proto: FirelockGlass
   entities:
-  - uid: 313
+  - uid: 217
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1491,8 +1509,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 314
+      - 3
+  - uid: 218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1500,8 +1518,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 319
+      - 3
+  - uid: 219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1509,71 +1527,71 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
+      - 3
 - proto: FoodPSB
   entities:
-  - uid: 335
+  - uid: 220
     components:
     - type: Transform
       pos: 3.2456388,-4.5989513
       parent: 1
-  - uid: 339
+  - uid: 221
     components:
     - type: Transform
       pos: 3.6207619,-4.27878
       parent: 1
-  - uid: 340
+  - uid: 222
     components:
     - type: Transform
       pos: 3.4749284,-4.424715
       parent: 1
-  - uid: 357
+  - uid: 223
     components:
     - type: Transform
       pos: 3.6910048,-4.4947867
       parent: 1
 - proto: FoodSnackBoritos
   entities:
-  - uid: 414
+  - uid: 200
     components:
     - type: Transform
-      parent: 415
+      parent: 194
     - type: Physics
       canCollide: False
 - proto: FoodSnackChips
   entities:
-  - uid: 422
+  - uid: 201
     components:
     - type: Transform
-      parent: 415
+      parent: 194
     - type: Physics
       canCollide: False
 - proto: FoodSnackChocolate
   entities:
-  - uid: 424
+  - uid: 202
     components:
     - type: Transform
-      parent: 415
+      parent: 194
     - type: Physics
       canCollide: False
 - proto: FoodSnackSus
   entities:
-  - uid: 85
+  - uid: 203
     components:
     - type: Transform
-      parent: 415
+      parent: 194
     - type: Physics
       canCollide: False
 - proto: FoodSpaceshroom
   entities:
-  - uid: 338
+  - uid: 224
     components:
     - type: Transform
       pos: 3.3186784,-4.2370844
       parent: 1
 - proto: GasPassiveVent
   entities:
-  - uid: 184
+  - uid: 225
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1581,12 +1599,12 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 172
+  - uid: 226
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 183
+  - uid: 227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1594,169 +1612,169 @@ entities:
       parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 152
+  - uid: 228
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 153
+  - uid: 229
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 154
+  - uid: 230
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 155
+  - uid: 231
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 157
+  - uid: 232
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 158
+  - uid: 233
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 159
+  - uid: 234
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 160
+  - uid: 235
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 161
+  - uid: 236
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 162
+  - uid: 237
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 163
+  - uid: 238
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 164
+  - uid: 239
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 166
+  - uid: 240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,7.5
       parent: 1
-  - uid: 167
+  - uid: 241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 168
+  - uid: 242
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,5.5
       parent: 1
-  - uid: 174
+  - uid: 243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 175
+  - uid: 244
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 176
+  - uid: 245
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,0.5
       parent: 1
-  - uid: 177
+  - uid: 246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 178
+  - uid: 247
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,2.5
       parent: 1
-  - uid: 179
+  - uid: 248
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 181
+  - uid: 249
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 182
+  - uid: 250
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 296
+  - uid: 251
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 297
+  - uid: 252
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 406
+  - uid: 253
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 156
+  - uid: 254
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 171
+  - uid: 255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 173
+  - uid: 256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 1
-  - uid: 180
+  - uid: 257
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1764,7 +1782,7 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 185
+  - uid: 258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1772,13 +1790,13 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 147
+  - uid: 259
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 148
+  - uid: 260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1786,18 +1804,18 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 151
+      - 3
+  - uid: 261
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
+      - 3
 - proto: GasVentScrubber
   entities:
-  - uid: 146
+  - uid: 262
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1805,8 +1823,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 149
+      - 3
+  - uid: 263
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1814,72 +1832,72 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
-  - uid: 150
+      - 3
+  - uid: 264
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 312
+      - 3
 - proto: GravityGeneratorMini
   entities:
-  - uid: 130
+  - uid: 265
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 99
+  - uid: 266
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 100
+  - uid: 267
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 101
+  - uid: 268
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 102
+  - uid: 269
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 103
+  - uid: 270
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 104
+  - uid: 271
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 105
+  - uid: 272
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 106
+  - uid: 273
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 123
+  - uid: 274
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 124
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1887,20 +1905,24 @@ entities:
       parent: 1
 - proto: GunneryServerLow
   entities:
-  - uid: 98
+  - uid: 276
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
+    - type: Battery
+      startingCharge: 0
+    - type: ApcPowerReceiver
+      powerLoad: 5
 - proto: Gyroscope
   entities:
-  - uid: 129
+  - uid: 277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
       parent: 1
-  - uid: 132
+  - uid: 278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1908,21 +1930,39 @@ entities:
       parent: 1
 - proto: HarmonicaInstrument
   entities:
-  - uid: 437
+  - uid: 279
     components:
     - type: Transform
       pos: 1.5325975,6.579827
       parent: 1
 - proto: LockerBoozeFilled
   entities:
-  - uid: 288
+  - uid: 280
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-- proto: LockerWallMaterialsFuelPlasmaFilled
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: LockerWallMaterialsFuelUraniumFilled
   entities:
-  - uid: 144
+  - uid: 290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1930,49 +1970,49 @@ entities:
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 326
+  - uid: 282
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
 - proto: MedicalBed
   entities:
-  - uid: 336
+  - uid: 283
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
 - proto: NFAshtray
   entities:
-  - uid: 349
+  - uid: 284
     components:
     - type: Transform
       rot: -6.283185307179586 rad
       pos: 0.731308,6.7981987
       parent: 1
-  - uid: 435
+  - uid: 285
     components:
     - type: Transform
       pos: 4.055274,0.6260797
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 429
+  - uid: 286
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
 - proto: Paper
   entities:
-  - uid: 431
+  - uid: 212
     components:
     - type: Transform
-      parent: 430
+      parent: 211
     - type: Physics
       canCollide: False
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 112
+  - uid: 287
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1980,93 +2020,93 @@ entities:
       parent: 1
 - proto: PlushieMoffbar
   entities:
-  - uid: 356
+  - uid: 288
     components:
     - type: Transform
       pos: 1.5139213,8.552594
       parent: 1
 - proto: PlushieSpaceLizard
   entities:
-  - uid: 388
+  - uid: 289
     components:
     - type: Transform
       pos: 2.7372432,-7.469452
       parent: 1
-- proto: PortableGeneratorPacmanShuttle
+- proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 38
+  - uid: 281
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
 - proto: PottedPlantRandom
   entities:
-  - uid: 286
+  - uid: 291
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 287
+  - uid: 292
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 348
+  - uid: 293
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 320
+  - uid: 294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 321
+  - uid: 295
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 322
+  - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 323
+  - uid: 297
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
 - proto: PoweredlightExterior
   entities:
-  - uid: 27
+  - uid: 298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-6.5
       parent: 1
-  - uid: 324
+  - uid: 299
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 1
-  - uid: 325
+  - uid: 300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,11.5
       parent: 1
-  - uid: 327
+  - uid: 301
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 328
+  - uid: 302
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2074,17 +2114,17 @@ entities:
       parent: 1
 - proto: Rack
   entities:
-  - uid: 391
+  - uid: 303
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 392
+  - uid: 304
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 428
+  - uid: 305
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2092,67 +2132,67 @@ entities:
       parent: 1
 - proto: RagItem
   entities:
-  - uid: 413
+  - uid: 204
+    components:
+    - type: Transform
+      parent: 194
+    - type: Physics
+      canCollide: False
+  - uid: 205
+    components:
+    - type: Transform
+      parent: 194
+    - type: Physics
+      canCollide: False
+  - uid: 206
+    components:
+    - type: Transform
+      parent: 194
+    - type: Physics
+      canCollide: False
+  - uid: 306
     components:
     - type: Transform
       pos: 4.629921,0.5917602
       parent: 1
-  - uid: 417
-    components:
-    - type: Transform
-      parent: 415
-    - type: Physics
-      canCollide: False
-  - uid: 418
-    components:
-    - type: Transform
-      parent: 415
-    - type: Physics
-      canCollide: False
-  - uid: 419
-    components:
-    - type: Transform
-      parent: 415
-    - type: Physics
-      canCollide: False
 - proto: Railing
   entities:
-  - uid: 119
+  - uid: 307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,9.5
       parent: 1
-  - uid: 120
+  - uid: 308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 121
+  - uid: 309
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,5.5
       parent: 1
-  - uid: 122
+  - uid: 310
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 1
-  - uid: 300
+  - uid: 311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,6.5
       parent: 1
-  - uid: 393
+  - uid: 312
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 394
+  - uid: 313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2160,25 +2200,25 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 116
+  - uid: 314
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 1
-  - uid: 118
+  - uid: 315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,10.5
       parent: 1
-  - uid: 345
+  - uid: 316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,5.5
       parent: 1
-  - uid: 346
+  - uid: 317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2186,108 +2226,78 @@ entities:
       parent: 1
 - proto: RandomDrinkGlass
   entities:
-  - uid: 301
+  - uid: 318
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 302
+  - uid: 319
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 303
+  - uid: 320
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
 - proto: RandomPosterAny
   entities:
-  - uid: 436
+  - uid: 321
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-- proto: RandomSpawner
-  entities:
-  - uid: 306
-    components:
-    - type: Transform
-      pos: 5.5,5.5
-      parent: 1
-  - uid: 309
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 337
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,1.5
-      parent: 1
-  - uid: 355
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 1
-  - uid: 390
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,5.5
-      parent: 1
 - proto: ReinforcedWindow
   entities:
-  - uid: 40
+  - uid: 322
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 41
+  - uid: 323
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 45
+  - uid: 324
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 46
+  - uid: 325
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 47
+  - uid: 326
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 48
+  - uid: 327
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 61
+  - uid: 328
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 62
+  - uid: 329
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
 - proto: ReinforcedWindowDiagonal
   entities:
-  - uid: 125
+  - uid: 330
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 126
+  - uid: 331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2295,7 +2305,7 @@ entities:
       parent: 1
 - proto: ShelfBar
   entities:
-  - uid: 415
+  - uid: 194
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2303,43 +2313,43 @@ entities:
       parent: 1
     - type: Storage
       storedItems:
-        416:
+        207:
           position: 0,3
           _rotation: South
-        424:
+        202:
           position: 2,0
           _rotation: South
-        85:
+        203:
           position: 3,0
           _rotation: South
-        414:
+        200:
           position: 3,1
           _rotation: South
-        422:
+        201:
           position: 2,1
           _rotation: South
-        419:
+        206:
           position: 2,3
           _rotation: South
-        417:
+        204:
           position: 3,3
           _rotation: South
-        418:
+        205:
           position: 1,3
           _rotation: South
-        420:
+        199:
           position: 4,0
           _rotation: South
-        421:
+        195:
           position: 4,3
           _rotation: South
-        423:
+        196:
           position: 5,3
           _rotation: South
-        425:
+        197:
           position: 0,0
           _rotation: South
-        426:
+        198:
           position: 1,0
           _rotation: South
     - type: ContainerContainer
@@ -2348,37 +2358,37 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 420
-          - 422
-          - 419
-          - 421
-          - 423
-          - 418
-          - 417
-          - 416
-          - 425
-          - 424
-          - 426
-          - 414
-          - 85
+          - 199
+          - 201
+          - 206
+          - 195
+          - 196
+          - 205
+          - 204
+          - 207
+          - 197
+          - 202
+          - 198
+          - 200
+          - 203
     - type: ActiveUserInterface
 - proto: SinkWide
   entities:
-  - uid: 329
+  - uid: 332
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 87
+  - uid: 333
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
 - proto: SodaDispenser
   entities:
-  - uid: 82
+  - uid: 334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2386,34 +2396,35 @@ entities:
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 310
+  - uid: 335
     components:
     - type: Transform
-      pos: 2.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
       parent: 1
 - proto: SprayBottleSpaceCleaner
   entities:
-  - uid: 416
+  - uid: 207
     components:
     - type: Transform
-      parent: 415
+      parent: 194
     - type: Physics
       canCollide: False
 - proto: StoolBar
   entities:
-  - uid: 65
+  - uid: 336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 66
+  - uid: 337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 77
+  - uid: 338
     components:
     - type: Transform
       anchored: False
@@ -2424,92 +2435,92 @@ entities:
       bodyType: Dynamic
 - proto: StorageCanister
   entities:
-  - uid: 254
+  - uid: 339
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 305
+  - uid: 340
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 133
+  - uid: 341
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
 - proto: Table
   entities:
-  - uid: 86
+  - uid: 342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 334
+  - uid: 343
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 427
+  - uid: 344
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
 - proto: TableCounterWood
   entities:
-  - uid: 68
+  - uid: 345
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 70
+  - uid: 346
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 72
+  - uid: 347
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 73
+  - uid: 348
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 74
+  - uid: 349
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 75
+  - uid: 350
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
 - proto: TableWood
   entities:
-  - uid: 63
+  - uid: 351
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 64
+  - uid: 352
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 307
+  - uid: 353
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 330
+  - uid: 354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2517,72 +2528,72 @@ entities:
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 2
+  - uid: 355
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 107
+  - uid: 356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-6.5
       parent: 1
-  - uid: 108
+  - uid: 357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 109
+  - uid: 358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-6.5
       parent: 1
-  - uid: 110
+  - uid: 359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 113
+  - uid: 360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 114
+  - uid: 361
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,9.5
       parent: 1
-  - uid: 115
+  - uid: 362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,5.5
       parent: 1
-  - uid: 117
+  - uid: 363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 1
-  - uid: 141
+  - uid: 364
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 142
+  - uid: 365
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
 - proto: UprightPianoInstrument
   entities:
-  - uid: 78
+  - uid: 366
     components:
     - type: Transform
       anchored: True
@@ -2593,346 +2604,346 @@ entities:
       bodyType: Static
 - proto: VendingMachineBooze
   entities:
-  - uid: 79
+  - uid: 367
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
 - proto: VendingMachineCigs
   entities:
-  - uid: 260
+  - uid: 368
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
 - proto: VendingMachineCondiments
   entities:
-  - uid: 331
+  - uid: 369
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 3
+  - uid: 370
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 4
+  - uid: 371
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 5
+  - uid: 372
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 6
+  - uid: 373
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 7
+  - uid: 374
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 8
+  - uid: 375
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 9
+  - uid: 376
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 10
+  - uid: 377
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 11
+  - uid: 378
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 12
+  - uid: 379
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 13
+  - uid: 380
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 14
+  - uid: 381
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 15
+  - uid: 382
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 16
+  - uid: 383
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 17
+  - uid: 384
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 18
+  - uid: 385
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
-  - uid: 19
+  - uid: 386
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 20
+  - uid: 387
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 21
+  - uid: 388
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 22
+  - uid: 389
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 23
+  - uid: 390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 24
+  - uid: 391
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 25
+  - uid: 392
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 1
-  - uid: 26
+  - uid: 393
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 28
+  - uid: 394
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 29
+  - uid: 395
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 30
+  - uid: 396
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 31
+  - uid: 397
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 32
+  - uid: 398
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 33
+  - uid: 399
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 34
+  - uid: 400
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 49
+  - uid: 401
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 50
+  - uid: 402
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 51
+  - uid: 403
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 52
+  - uid: 404
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 53
+  - uid: 405
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 54
+  - uid: 406
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 55
+  - uid: 407
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
-  - uid: 56
+  - uid: 408
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 57
+  - uid: 409
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 58
+  - uid: 410
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 59
+  - uid: 411
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 60
+  - uid: 412
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 97
+  - uid: 413
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
 - proto: WallSolid
   entities:
-  - uid: 35
+  - uid: 414
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 36
+  - uid: 415
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-1.5
       parent: 1
-  - uid: 37
+  - uid: 416
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 39
+  - uid: 417
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 42
+  - uid: 418
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 43
+  - uid: 419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 71
+  - uid: 420
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 83
+  - uid: 421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,7.5
       parent: 1
-  - uid: 84
+  - uid: 422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,7.5
       parent: 1
-  - uid: 137
+  - uid: 423
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 138
+  - uid: 424
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 139
+  - uid: 425
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 140
+  - uid: 426
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 311
+  - uid: 427
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
 - proto: WeaponShotgunDoubleBarreledRubber
   entities:
-  - uid: 350
+  - uid: 428
     components:
     - type: Transform
       pos: 1.4749517,-3.648872
       parent: 1
 - proto: WeaponTurretL85Autocannon
   entities:
-  - uid: 111
+  - uid: 429
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,13.5
       parent: 1
-  - uid: 344
+  - uid: 430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2940,7 +2951,7 @@ entities:
       parent: 1
 - proto: WelderMini
   entities:
-  - uid: 389
+  - uid: 431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2948,7 +2959,7 @@ entities:
       parent: 1
 - proto: Windoor
   entities:
-  - uid: 67
+  - uid: 432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2956,13 +2967,13 @@ entities:
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 69
+  - uid: 433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,3.5
       parent: 1
-  - uid: 165
+  - uid: 434
     components:
     - type: Transform
       anchored: False

--- a/Resources/Prototypes/_Mono/Shipyard/dram.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/dram.yml
@@ -7,7 +7,7 @@
   parent: BaseVessel
   name: SHM Dram
   description: Originally a fuel tanker, refitted to accomodate a mobile space-bar. Bottoms up!
-  price: 32250
+  price: 35250
   category: Small
   group: Shipyard
   shuttlePath: /Maps/_Mono/Shuttles/dram.yml
@@ -15,7 +15,7 @@
   class:
   - Civilian
   engine:
-  - Plasma
+  - Uranium
 
 - type: gameMap
   id: Dram

--- a/Resources/Prototypes/_Mono/Shipyard/dram.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/dram.yml
@@ -1,3 +1,20 @@
+# SPDX-FileCopyrightText: 2023 IHAN <IHAN>
+# SPDX-FileCopyrightText: 2023 Kennedy
+# SPDX-FileCopyrightText: 2023 PECK
+# SPDX-FileCopyrightText: 2023 RealIHaveANameOfficial
+# SPDX-FileCopyrightText: 2024 Debug
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Maxtone
+# SPDX-FileCopyrightText: 2024 Salvantrix
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Carolyn3114
+# SPDX-FileCopyrightText: 2025 KM-Catman
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 significant harassment
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Author Info
 # GitHub: Onezerooo0
 # Discord: onezero00


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- PACMAN (Plasma) Generator replaced with a SUPERPACMAN (Uranium) Generator and its respective fuel locker.
- Pre-placed trash generators removed.
- Wall-mounted Mass scanner moved next to the bar instead of in the cockpit.
- Price increased to 35250 from 32250 to account for updated generator and new Appraisegrid value.

## Why / Balance
Fixes #980. Ships already have trash spawned on them automatically. Mass scanners have no point being next to shuttle consoles.

## How to test
Purchase the Dram in-game.

## Media
Uranium Generator:
![Screenshot 2025-06-26 161136](https://github.com/user-attachments/assets/cdf9cc72-1e2e-440f-b6be-dbba8f984508)
Mass Scanner:
![Screenshot 2025-06-26 161155](https://github.com/user-attachments/assets/04ffdc7f-9993-4df4-9ed1-e2d9c217ea84)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Dram now costs 35250 and comes with a Uranium Generator.
