### PR TITLE
You Can No Longer Fire Unanchored Guns on Grids

### DIFF
--- a/Content.Server/_Mono/FireControl/FireControlSystem.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.cs
@@ -197,7 +197,7 @@ public sealed partial class FireControlSystem : EntitySystem
 
         while (query.MoveNext(out var controllable, out var controlComp))
         {
-            if (_xform.GetGrid(controllable) == grid)
+            if (_xform.GetGrid(controllable) == grid && EntityManager.GetComponent<TransformComponent>(controllable).Anchored)
                 TryRegister(controllable, controlComp);
         }
 

--- a/Content.Server/_Mono/FireControl/FireControlSystem.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.cs
@@ -1,3 +1,10 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 RikuTheKiller
+// SPDX-FileCopyrightText: 2025 ScyronX
+// SPDX-FileCopyrightText: 2025 ark1368
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 // Copyright Rane (elijahrane@gmail.com) 2025
 // All rights reserved. Relicensed under AGPL with permission
 


### PR DESCRIPTION
## About the PR
removes the ability to fire unanchored guns on grids

**Changelog**

:cl:
- tweak: Unanchored artillery can no longer be fired with a gunnery console!
