### PR TITLE
Fixing Sekunda, the New USSP Ship I 100% Didnt Goof

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/USSP/sekunda.yml
+++ b/Resources/Maps/_Mono/Shuttles/USSP/sekunda.yml
@@ -1,25 +1,11 @@
-# SPDX-FileCopyrightText: 2023 Cheackraze
-# SPDX-FileCopyrightText: 2023 Kennedy
-# SPDX-FileCopyrightText: 2024 Dvir
-# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
-# SPDX-FileCopyrightText: 2024 dustylens
-# SPDX-FileCopyrightText: 2025 Junerisms
-# SPDX-FileCopyrightText: 2025 RikuTheKiller
-# SPDX-FileCopyrightText: 2025 grandalff
-# SPDX-FileCopyrightText: 2025 revoemagcoconut
-# SPDX-FileCopyrightText: 2025 significant harassment
-# SPDX-FileCopyrightText: 2025 starch
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 meta:
   format: 7
   category: Grid
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/29/2025 16:09:58
-  entityCount: 515
+  time: 06/30/2025 18:52:03
+  entityCount: 516
 maps: []
 grids:
 - 1
@@ -218,7 +204,8 @@ entities:
             1: 32768
           -1,-4:
             1: 7
-            0: 63232
+            0: 62208
+            3: 1024
           -1,-3:
             0: 34945
             3: 17472
@@ -231,7 +218,8 @@ entities:
             2: 12544
             0: 2056
           0,-4:
-            0: 64785
+            0: 32017
+            3: 32768
             1: 12
           0,-3:
             0: 30577
@@ -348,9 +336,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 278
-      - 277
-      - 14
+      - 285
+      - 284
+      - 13
   - uid: 3
     components:
     - type: Transform
@@ -358,28 +346,17 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 279
-      - 276
-      - 15
+      - 286
+      - 283
+      - 14
 - proto: AirlockExternalGlassUSSPLocked
   entities:
   - uid: 4
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-13.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,-14.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -1337.6731
-      state: Opening
-    - type: DeviceLinkSink
-      invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        7:
-        - DoorStatus: DoorBolt
-      lastSignals:
-        DoorStatus: True
 - proto: AirlockExternalShuttleUSSPLocked
   entities:
   - uid: 5
@@ -399,11 +376,6 @@ entities:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        4:
-        - DockStatus: DoorBolt
-        - DoorStatus: DoorBolt
     - type: DeviceLinkSink
       invokeCounter: 2
 - proto: AirlockHatchUSSP
@@ -413,29 +385,24 @@ entities:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 9
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
 - proto: AirlockUSSP
   entities:
-  - uid: 10
+  - uid: 9
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 11
+  - uid: 10
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 12
+  - uid: 11
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 13
+  - uid: 12
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -443,7 +410,7 @@ entities:
       parent: 1
 - proto: AirSensor
   entities:
-  - uid: 14
+  - uid: 13
     components:
     - type: Transform
       pos: -0.5,0.5
@@ -451,7 +418,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 2
-  - uid: 15
+  - uid: 14
     components:
     - type: Transform
       pos: 0.5,-9.5
@@ -461,32 +428,32 @@ entities:
       - 3
 - proto: APCBasic
   entities:
-  - uid: 16
+  - uid: 15
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 17
+  - uid: 16
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-11.5
       parent: 1
-  - uid: 18
+  - uid: 17
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-4.5
       parent: 1
-  - uid: 19
+  - uid: 18
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
 - proto: APCHighCapacity
   entities:
-  - uid: 20
+  - uid: 19
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -494,19 +461,19 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 21
+  - uid: 20
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-12.5
       parent: 1
-  - uid: 22
+  - uid: 21
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-17.5
       parent: 1
-  - uid: 23
+  - uid: 22
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -514,909 +481,914 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 24
+  - uid: 23
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 25
+  - uid: 24
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 26
+  - uid: 25
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 27
+  - uid: 26
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 28
+  - uid: 27
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
-  - uid: 29
+  - uid: 28
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 1
-  - uid: 30
+  - uid: 29
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-  - uid: 31
+  - uid: 30
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 32
+  - uid: 31
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 33
+  - uid: 32
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 34
+  - uid: 33
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 1
-  - uid: 35
+  - uid: 34
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-  - uid: 36
+  - uid: 35
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 37
+  - uid: 36
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 38
+  - uid: 37
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 39
+  - uid: 38
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-  - uid: 40
+  - uid: 39
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 41
+  - uid: 40
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 42
+  - uid: 41
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 43
+  - uid: 42
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-6.5
       parent: 1
-  - uid: 44
+  - uid: 43
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-6.5
       parent: 1
-  - uid: 45
+  - uid: 44
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 46
+  - uid: 45
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-8.5
       parent: 1
-  - uid: 47
+  - uid: 46
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-8.5
       parent: 1
-  - uid: 48
+  - uid: 47
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 49
+  - uid: 48
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-9.5
       parent: 1
-  - uid: 50
+  - uid: 49
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-9.5
       parent: 1
-  - uid: 51
+  - uid: 50
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-10.5
       parent: 1
-  - uid: 52
+  - uid: 51
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-14.5
       parent: 1
-  - uid: 53
+  - uid: 52
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-16.5
       parent: 1
-  - uid: 54
+  - uid: 53
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-17.5
       parent: 1
-  - uid: 55
+  - uid: 54
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-16.5
       parent: 1
-  - uid: 56
+  - uid: 55
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-16.5
       parent: 1
-  - uid: 57
+  - uid: 56
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-16.5
       parent: 1
-  - uid: 58
+  - uid: 57
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-15.5
       parent: 1
-  - uid: 59
+  - uid: 58
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-15.5
       parent: 1
-  - uid: 60
+  - uid: 59
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-15.5
       parent: 1
-  - uid: 61
+  - uid: 60
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-15.5
       parent: 1
-  - uid: 62
+  - uid: 61
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-16.5
       parent: 1
-  - uid: 63
+  - uid: 62
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-16.5
       parent: 1
-  - uid: 64
+  - uid: 63
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-15.5
       parent: 1
-  - uid: 65
+  - uid: 64
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-15.5
       parent: 1
-  - uid: 66
+  - uid: 65
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-16.5
       parent: 1
-  - uid: 67
+  - uid: 66
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-17.5
       parent: 1
-  - uid: 68
+  - uid: 67
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-16.5
       parent: 1
-  - uid: 69
+  - uid: 68
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-14.5
       parent: 1
-  - uid: 70
+  - uid: 69
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 71
+  - uid: 70
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-9.5
       parent: 1
-  - uid: 72
+  - uid: 71
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-10.5
       parent: 1
-  - uid: 73
+  - uid: 72
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-8.5
       parent: 1
-  - uid: 74
+  - uid: 73
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-8.5
       parent: 1
-  - uid: 75
+  - uid: 74
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-7.5
       parent: 1
-  - uid: 76
+  - uid: 75
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-2.5
       parent: 1
-  - uid: 77
+  - uid: 76
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-2.5
       parent: 1
-  - uid: 78
+  - uid: 77
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 79
+  - uid: 78
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 80
+  - uid: 79
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 81
+  - uid: 80
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,6.5
       parent: 1
-  - uid: 82
+  - uid: 81
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,5.5
       parent: 1
-  - uid: 83
+  - uid: 82
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,5.5
       parent: 1
-  - uid: 84
+  - uid: 83
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,6.5
       parent: 1
-  - uid: 85
+  - uid: 84
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
 - proto: BoxBeaker
   entities:
-  - uid: 86
+  - uid: 85
     components:
     - type: Transform
       pos: -1.9142275,-9.567103
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 87
+  - uid: 86
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 88
+  - uid: 87
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 89
+  - uid: 88
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 90
+  - uid: 89
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 91
+  - uid: 90
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 92
+  - uid: 91
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 93
+  - uid: 92
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 94
+  - uid: 93
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 95
+  - uid: 94
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 96
+  - uid: 95
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 97
+  - uid: 96
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 98
+  - uid: 97
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 99
+  - uid: 98
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 100
+  - uid: 99
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 101
+  - uid: 100
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 102
+  - uid: 101
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 103
+  - uid: 102
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 104
+  - uid: 103
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 105
+  - uid: 104
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
-  - uid: 106
+  - uid: 105
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 107
+  - uid: 106
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 108
+  - uid: 107
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 109
+  - uid: 108
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 110
+  - uid: 109
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 111
+  - uid: 110
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 112
+  - uid: 111
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 113
+  - uid: 112
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 114
+  - uid: 113
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 115
+  - uid: 114
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 116
+  - uid: 115
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 117
+  - uid: 116
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 118
+  - uid: 117
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 119
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-  - uid: 120
+  - uid: 118
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 121
+  - uid: 119
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 122
+  - uid: 120
     components:
     - type: Transform
-      pos: -0.5,1.5
+      pos: 0.5,0.5
       parent: 1
-  - uid: 123
+  - uid: 121
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 124
+  - uid: 122
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 125
+  - uid: 123
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 126
+  - uid: 124
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 127
+  - uid: 125
     components:
     - type: Transform
       pos: 5.5,-10.5
       parent: 1
-  - uid: 128
+  - uid: 126
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 129
+  - uid: 127
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 130
+  - uid: 128
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 131
+  - uid: 129
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 132
+  - uid: 130
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 133
+  - uid: 131
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 134
+  - uid: 132
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 135
+  - uid: 133
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 136
+  - uid: 134
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 137
+  - uid: 135
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 138
+  - uid: 136
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 139
+  - uid: 137
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 140
+  - uid: 138
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 141
+  - uid: 139
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 142
+  - uid: 140
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 143
+  - uid: 141
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 144
+  - uid: 142
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 145
+  - uid: 143
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 146
+  - uid: 144
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 147
+  - uid: 145
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 148
+  - uid: 146
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 149
+  - uid: 147
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 150
+  - uid: 148
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 151
+  - uid: 149
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 1
-  - uid: 152
+  - uid: 150
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
-  - uid: 153
+  - uid: 151
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 154
+  - uid: 152
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 155
+  - uid: 153
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 156
+  - uid: 154
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 157
+  - uid: 155
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 158
+  - uid: 156
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 159
+  - uid: 157
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 1
-  - uid: 160
+  - uid: 158
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 161
+  - uid: 159
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
-  - uid: 162
+  - uid: 160
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 163
+  - uid: 161
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 164
+  - uid: 162
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 165
+  - uid: 163
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 166
+  - uid: 164
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
-  - uid: 167
+  - uid: 165
     components:
     - type: Transform
-      pos: 2.5,-12.5
+      pos: 1.5,-13.5
       parent: 1
-  - uid: 168
-    components:
-    - type: Transform
-      pos: 2.5,-13.5
-      parent: 1
-  - uid: 169
+  - uid: 166
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 170
+  - uid: 167
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 171
+  - uid: 168
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 172
+  - uid: 169
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 173
+  - uid: 170
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 174
+  - uid: 171
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 175
+  - uid: 172
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 176
+  - uid: 173
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 177
+  - uid: 174
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 178
+  - uid: 175
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 179
+  - uid: 176
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 180
+  - uid: 177
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 181
+  - uid: 178
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
   - uid: 182
     components:
     - type: Transform
-      pos: 1.5,-4.5
+      pos: 1.5,-13.5
       parent: 1
   - uid: 183
     components:
     - type: Transform
-      pos: -0.5,-12.5
+      pos: 0.5,-1.5
       parent: 1
   - uid: 184
     components:
     - type: Transform
-      pos: -1.5,-12.5
-      parent: 1
-  - uid: 185
-    components:
-    - type: Transform
-      pos: -1.5,-13.5
+      pos: -0.5,-1.5
       parent: 1
 - proto: CableMV
   entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
   - uid: 186
     components:
     - type: Transform
-      pos: 1.5,-10.5
+      pos: 0.5,-11.5
       parent: 1
   - uid: 187
     components:
     - type: Transform
-      pos: 1.5,-11.5
+      pos: 1.5,-10.5
       parent: 1
   - uid: 188
     components:
     - type: Transform
-      pos: 2.5,-10.5
+      pos: 1.5,-11.5
       parent: 1
   - uid: 189
     components:
     - type: Transform
-      pos: 3.5,-10.5
+      pos: 2.5,-10.5
       parent: 1
   - uid: 190
     components:
     - type: Transform
-      pos: 1.5,-4.5
+      pos: 3.5,-10.5
       parent: 1
   - uid: 191
     components:
@@ -1476,207 +1448,218 @@ entities:
   - uid: 202
     components:
     - type: Transform
-      pos: -1.5,-13.5
+      pos: -1.5,-12.5
       parent: 1
   - uid: 203
     components:
     - type: Transform
-      pos: -1.5,-12.5
+      pos: -1.5,-11.5
       parent: 1
   - uid: 204
     components:
     - type: Transform
-      pos: -1.5,-11.5
+      pos: 2.5,-9.5
       parent: 1
   - uid: 205
     components:
     - type: Transform
-      pos: 2.5,-9.5
+      pos: 3.5,-9.5
       parent: 1
   - uid: 206
     components:
     - type: Transform
-      pos: 3.5,-9.5
+      pos: -0.5,-0.5
       parent: 1
-- proto: CableTerminal
-  entities:
   - uid: 207
     components:
     - type: Transform
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-13.5
+      pos: 2.5,-13.5
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 208
+  - uid: 210
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 209
+  - uid: 211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-12.5
       parent: 1
-  - uid: 210
+  - uid: 212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-12.5
       parent: 1
-  - uid: 211
+  - uid: 213
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: 1.5707963267948966 rad
       pos: -0.5,-12.5
       parent: 1
-  - uid: 212
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-12.5
-      parent: 1
-  - uid: 213
+  - uid: 214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 214
-    components:
-    - type: Transform
-      pos: -2.5,-12.5
-      parent: 1
   - uid: 215
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-12.5
-      parent: 1
-  - uid: 216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-11.5
       parent: 1
-  - uid: 217
+  - uid: 216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-10.5
       parent: 1
-  - uid: 218
+  - uid: 217
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-9.5
       parent: 1
-  - uid: 219
+  - uid: 218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
-  - uid: 220
+  - uid: 219
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-7.5
       parent: 1
-  - uid: 221
+  - uid: 220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 222
+  - uid: 221
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-  - uid: 223
+  - uid: 222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
-  - uid: 224
+  - uid: 223
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 225
+  - uid: 224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-1.5
       parent: 1
-  - uid: 226
+  - uid: 225
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-13.5
       parent: 1
-  - uid: 227
+  - uid: 226
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-14.5
       parent: 1
-  - uid: 228
+  - uid: 227
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-15.5
       parent: 1
-  - uid: 229
+  - uid: 228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-16.5
       parent: 1
-  - uid: 230
+  - uid: 229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-12.5
       parent: 1
-  - uid: 231
+  - uid: 230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-12.5
       parent: 1
-  - uid: 232
+  - uid: 231
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-12.5
       parent: 1
-  - uid: 233
+  - uid: 232
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-12.5
       parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 234
+  - uid: 236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 235
+  - uid: 237
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 236
+  - uid: 238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1684,7 +1667,7 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 237
+  - uid: 239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1692,21 +1675,28 @@ entities:
       parent: 1
 - proto: ChemDispenser
   entities:
-  - uid: 238
+  - uid: 240
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
 - proto: ChemMaster
   entities:
-  - uid: 239
+  - uid: 241
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
+- proto: ClosetToolFilled
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 1
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 240
+  - uid: 243
     components:
     - type: Transform
       pos: -0.5,1.5
@@ -1717,7 +1707,7 @@ entities:
       startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 241
+  - uid: 244
     components:
     - type: Transform
       pos: 1.5,1.5
@@ -1728,7 +1718,7 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 242
+  - uid: 245
     components:
     - type: Transform
       pos: 0.5,2.5
@@ -1753,7 +1743,7 @@ entities:
       - device-button-8
 - proto: ComputerWallmountCrewMonitoring
   entities:
-  - uid: 243
+  - uid: 246
     components:
     - type: Transform
       pos: -0.5,2.5
@@ -1764,7 +1754,7 @@ entities:
       startingCharge: 0
 - proto: ComputerWallmountRadar
   entities:
-  - uid: 303
+  - uid: 247
     components:
     - type: Transform
       pos: 5.5,-11.5
@@ -1773,7 +1763,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 513
+  - uid: 248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1783,7 +1773,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 514
+  - uid: 249
     components:
     - type: Transform
       pos: -4.5,-11.5
@@ -1794,7 +1784,7 @@ entities:
       startingCharge: 0
 - proto: ComputerWallmountStationRecords
   entities:
-  - uid: 244
+  - uid: 250
     components:
     - type: Transform
       pos: 1.5,2.5
@@ -1803,60 +1793,67 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
+- proto: CrateFreezer
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 1
 - proto: CrateMedicalSurgery
   entities:
-  - uid: 245
+  - uid: 252
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 246
+  - uid: 253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 1
-  - uid: 247
+  - uid: 254
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
 - proto: EmergencyRollerBed
   entities:
-  - uid: 248
+  - uid: 255
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 249
+  - uid: 256
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
 - proto: GasMixerOn
   entities:
-  - uid: 250
+  - uid: 257
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-12.5
       parent: 1
     - type: GasMixer
-      inletTwoConcentration: 0.78
-      inletOneConcentration: 0.22
+      inletTwoConcentration: 0.22000003
+      inletOneConcentration: 0.78
 - proto: GasPassiveVent
   entities:
-  - uid: 251
+  - uid: 258
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 252
+  - uid: 259
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1864,123 +1861,123 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 253
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-12.5
-      parent: 1
-  - uid: 254
+  - uid: 260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-12.5
       parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-12.5
+      parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 255
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 256
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-9.5
-      parent: 1
-  - uid: 257
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-9.5
-      parent: 1
-  - uid: 258
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 259
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-9.5
-      parent: 1
-  - uid: 260
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-9.5
-      parent: 1
-  - uid: 261
+  - uid: 262
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 262
+  - uid: 263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 269
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-12.5
       parent: 1
-  - uid: 263
+  - uid: 270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-11.5
       parent: 1
-  - uid: 264
+  - uid: 271
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-10.5
       parent: 1
-  - uid: 265
+  - uid: 272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
-  - uid: 266
+  - uid: 273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-7.5
       parent: 1
-  - uid: 267
+  - uid: 274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 268
+  - uid: 275
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 269
+  - uid: 276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-  - uid: 270
+  - uid: 277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
-  - uid: 271
+  - uid: 278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 272
+  - uid: 279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1988,7 +1985,7 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 273
+  - uid: 280
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1996,13 +1993,13 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 274
+  - uid: 281
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-13.5
       parent: 1
-  - uid: 275
+  - uid: 282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2010,7 +2007,7 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 276
+  - uid: 283
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2019,7 +2016,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 277
+  - uid: 284
     components:
     - type: Transform
       pos: 0.5,-0.5
@@ -2029,7 +2026,7 @@ entities:
       - 2
 - proto: GasVentScrubber
   entities:
-  - uid: 278
+  - uid: 285
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2038,7 +2035,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 2
-  - uid: 279
+  - uid: 286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2049,89 +2046,89 @@ entities:
       - 3
 - proto: GravityGeneratorMini
   entities:
-  - uid: 280
+  - uid: 287
     components:
     - type: Transform
-      pos: 3.5,-13.5
+      pos: 2.5,-13.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 281
+  - uid: 288
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 282
+  - uid: 289
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 283
+  - uid: 290
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 284
+  - uid: 291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 285
+  - uid: 292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 286
+  - uid: 293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-16.5
       parent: 1
-  - uid: 287
+  - uid: 294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-16.5
       parent: 1
-  - uid: 288
+  - uid: 295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-16.5
       parent: 1
-  - uid: 289
+  - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-16.5
       parent: 1
-  - uid: 290
+  - uid: 297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-16.5
       parent: 1
-  - uid: 291
+  - uid: 298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-16.5
       parent: 1
-  - uid: 292
+  - uid: 299
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-9.5
       parent: 1
-  - uid: 293
+  - uid: 300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 294
+  - uid: 301
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2139,13 +2136,13 @@ entities:
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 295
+  - uid: 302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
       parent: 1
-  - uid: 296
+  - uid: 303
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2153,7 +2150,7 @@ entities:
       parent: 1
 - proto: GunneryServerLow
   entities:
-  - uid: 297
+  - uid: 304
     components:
     - type: Transform
       pos: 1.5,-5.5
@@ -2164,49 +2161,54 @@ entities:
       powerLoad: 5
 - proto: Gyroscope
   entities:
-  - uid: 298
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 306
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
-  - uid: 299
+  - uid: 307
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 300
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-11.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 1
-  - uid: 301
+  - uid: 308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-11.5
       parent: 1
+- proto: HandheldHealthAnalyzer
+  entities:
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -1.3585517,-9.600763
+      parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 302
+  - uid: 310
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-- proto: LockerWallMaterialsFuelUraniumFilled
+- proto: LockerWallMaterialsFuelUraniumFilled2
   entities:
-  - uid: 515
+  - uid: 311
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 1
 - proto: LockerWallMedicalFilled
   entities:
-  - uid: 304
+  - uid: 312
     components:
     - type: Transform
       pos: 1.5,-6.5
@@ -2231,38 +2233,35 @@ entities:
         - 0
 - proto: MachineFTLDrive
   entities:
-  - uid: 305
+  - uid: 313
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
+- proto: MedicalAppraisalTool
+  entities:
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 1.5888169,-7.431237
+      parent: 1
 - proto: MedicalTechFab
   entities:
-  - uid: 306
+  - uid: 315
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 307
+  - uid: 316
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 308
-    components:
-    - type: Transform
-      anchored: True
-      pos: -2.5,-13.5
-      parent: 1
-    - type: Physics
-      bodyType: Static
-- proto: OxygenCanister
-  entities:
-  - uid: 309
+  - uid: 317
     components:
     - type: Transform
       anchored: True
@@ -2270,51 +2269,66 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
+- proto: OxygenCanister
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      anchored: True
+      pos: -2.5,-13.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
 - proto: PaperBin20
   entities:
-  - uid: 310
+  - uid: 319
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
 - proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 311
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 321
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 312
+  - uid: 322
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
-  - uid: 313
+  - uid: 323
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 314
+  - uid: 324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-15.5
       parent: 1
-  - uid: 315
+  - uid: 325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-5.5
       parent: 1
-  - uid: 316
+  - uid: 326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 317
+  - uid: 327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2322,56 +2336,56 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 318
+  - uid: 328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-10.5
       parent: 1
-  - uid: 319
+  - uid: 329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 1
-  - uid: 320
+  - uid: 330
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
 - proto: Railing
   entities:
-  - uid: 321
+  - uid: 331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 322
+  - uid: 332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 323
+  - uid: 333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 324
+  - uid: 334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-  - uid: 325
+  - uid: 335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 326
+  - uid: 336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2379,21 +2393,15 @@ entities:
       parent: 1
 - proto: RandomSpawner
   entities:
-  - uid: 327
+  - uid: 337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-11.5
       parent: 1
-  - uid: 328
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-12.5
-      parent: 1
 - proto: SinkWide
   entities:
-  - uid: 329
+  - uid: 338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2401,91 +2409,82 @@ entities:
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 330
+  - uid: 339
     components:
     - type: Transform
-      pos: 2.5,-13.5
+      pos: 1.5,-13.5
       parent: 1
-    - type: PowerNetworkBattery
-      maxSupply: 5000
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 331
+  - uid: 340
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 332
+  - uid: 341
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: SpawnPointUSSPCommissar
   entities:
-  - uid: 333
+  - uid: 342
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: SpawnPointUSSPCorporal
   entities:
-  - uid: 334
+  - uid: 343
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: SpawnPointUSSPMedic
   entities:
-  - uid: 335
+  - uid: 344
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
 - proto: SpawnPointUSSPRifleman
   entities:
-  - uid: 336
+  - uid: 345
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: SpawnPointUSSPSergeant
   entities:
-  - uid: 337
+  - uid: 346
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: StasisBed
   entities:
-  - uid: 338
+  - uid: 347
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-- proto: SubstationBasic
-  entities:
-  - uid: 339
-    components:
-    - type: Transform
-      pos: -1.5,-13.5
-      parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 340
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-10.5
       parent: 1
-  - uid: 341
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-4.5
-      parent: 1
 - proto: SuitStorageWallmountUssp
   entities:
-  - uid: 342
+  - uid: 350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2493,844 +2492,829 @@ entities:
       parent: 1
 - proto: Table
   entities:
-  - uid: 343
+  - uid: 351
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
       parent: 1
-  - uid: 344
+  - uid: 352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-9.5
       parent: 1
-  - uid: 345
+  - uid: 353
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 346
+  - uid: 354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
-  - uid: 347
+  - uid: 355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-  - uid: 348
+  - uid: 356
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 349
+  - uid: 357
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-    - type: Thruster
-      enabled: False
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 350
+  - uid: 358
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 351
+  - uid: 359
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 1
-  - uid: 352
+  - uid: 360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-6.5
       parent: 1
-  - uid: 353
+  - uid: 361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-8.5
       parent: 1
-  - uid: 354
+  - uid: 362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-8.5
       parent: 1
-  - uid: 355
+  - uid: 363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-15.5
       parent: 1
-  - uid: 356
+  - uid: 364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-15.5
       parent: 1
-  - uid: 357
+  - uid: 365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-15.5
       parent: 1
-  - uid: 358
+  - uid: 366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-15.5
       parent: 1
-  - uid: 359
+  - uid: 367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-15.5
       parent: 1
-  - uid: 360
+  - uid: 368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-15.5
       parent: 1
-  - uid: 361
+  - uid: 369
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
-  - uid: 362
+  - uid: 370
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 1
-  - uid: 363
+  - uid: 371
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 1
-  - uid: 364
+  - uid: 372
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 1
-- proto: ToolboxMechanicalFilled
-  entities:
-  - uid: 365
-    components:
-    - type: Transform
-      pos: 3.5,-12.5
-      parent: 1
 - proto: VendingMachineChemicals
   entities:
-  - uid: 366
+  - uid: 373
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 367
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 368
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 369
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
-      parent: 1
-  - uid: 370
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 371
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 372
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
-  - uid: 373
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 1
   - uid: 374
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,-11.5
       parent: 1
   - uid: 375
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,1.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,-11.5
       parent: 1
   - uid: 376
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,-1.5
+      pos: -2.5,0.5
       parent: 1
   - uid: 377
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-1.5
+      pos: -2.5,1.5
       parent: 1
   - uid: 378
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-0.5
+      pos: 2.5,1.5
       parent: 1
   - uid: 379
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-1.5
+      pos: 2.5,0.5
       parent: 1
   - uid: 380
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,0.5
+      pos: -2.5,2.5
       parent: 1
   - uid: 381
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
       parent: 1
   - uid: 382
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
+      pos: -1.5,-0.5
       parent: 1
   - uid: 383
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-6.5
+      pos: -1.5,2.5
       parent: 1
   - uid: 384
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
       parent: 1
   - uid: 385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,-1.5
+      pos: -2.5,-1.5
       parent: 1
   - uid: 386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,0.5
+      pos: 1.5,-1.5
       parent: 1
   - uid: 387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,-0.5
+      pos: 5.5,-0.5
       parent: 1
   - uid: 388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,1.5
+      pos: 3.5,-1.5
       parent: 1
   - uid: 389
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-2.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
       parent: 1
   - uid: 390
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-2.5
+      pos: -2.5,-3.5
       parent: 1
   - uid: 391
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,-1.5
+      pos: 5.5,-1.5
       parent: 1
   - uid: 392
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,2.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 393
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,2.5
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
       parent: 1
   - uid: 394
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,2.5
+      pos: -3.5,-1.5
       parent: 1
   - uid: 395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 396
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,3.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,3.5
+      pos: 3.5,1.5
       parent: 1
   - uid: 398
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,3.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
       parent: 1
   - uid: 399
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
       parent: 1
   - uid: 400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,3.5
+      pos: -4.5,-1.5
       parent: 1
   - uid: 401
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,4.5
+      pos: -0.5,2.5
       parent: 1
   - uid: 402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,-1.5
+      pos: 2.5,2.5
       parent: 1
   - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-1.5
+      pos: 1.5,2.5
       parent: 1
   - uid: 404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-1.5
+      pos: 3.5,2.5
       parent: 1
   - uid: 405
     components:
     - type: Transform
-      pos: 4.5,-9.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
       parent: 1
   - uid: 406
     components:
     - type: Transform
-      pos: 2.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
       parent: 1
   - uid: 407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,3.5
+      pos: -1.5,3.5
       parent: 1
   - uid: 408
     components:
     - type: Transform
-      pos: -1.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
       parent: 1
   - uid: 409
     components:
     - type: Transform
-      pos: -1.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
       parent: 1
   - uid: 410
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,4.5
+      pos: 1.5,4.5
       parent: 1
   - uid: 411
     components:
     - type: Transform
-      pos: 2.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
       parent: 1
   - uid: 412
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-4.5
+      pos: 2.5,-1.5
       parent: 1
   - uid: 413
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,-5.5
+      pos: -0.5,-1.5
       parent: 1
   - uid: 414
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-7.5
+      pos: 4.5,-9.5
       parent: 1
   - uid: 415
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-7.5
+      pos: 2.5,4.5
       parent: 1
   - uid: 416
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-6.5
+      pos: 0.5,3.5
       parent: 1
   - uid: 417
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-6.5
+      pos: -1.5,5.5
       parent: 1
   - uid: 418
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-4.5
+      pos: -1.5,4.5
       parent: 1
   - uid: 419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-4.5
+      pos: 0.5,4.5
       parent: 1
   - uid: 420
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-11.5
+      pos: 2.5,5.5
       parent: 1
   - uid: 421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-5.5
+      pos: 1.5,-4.5
       parent: 1
   - uid: 422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-0.5
+      pos: -1.5,-5.5
       parent: 1
   - uid: 423
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-10.5
+      pos: -1.5,-7.5
       parent: 1
   - uid: 424
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 433
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 425
+  - uid: 434
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 1
-  - uid: 426
+  - uid: 435
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 427
+  - uid: 436
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 428
+  - uid: 437
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 429
-    components:
-    - type: Transform
-      pos: 3.5,-7.5
-      parent: 1
-  - uid: 430
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-14.5
-      parent: 1
-  - uid: 431
-    components:
-    - type: Transform
-      pos: 4.5,-8.5
-      parent: 1
-  - uid: 432
-    components:
-    - type: Transform
-      pos: 4.5,-10.5
-      parent: 1
-  - uid: 433
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-10.5
-      parent: 1
-  - uid: 434
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-11.5
-      parent: 1
-  - uid: 435
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-14.5
-      parent: 1
-  - uid: 436
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-13.5
-      parent: 1
-  - uid: 437
-    components:
-    - type: Transform
-      pos: 6.5,-13.5
-      parent: 1
   - uid: 438
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-14.5
+      pos: 3.5,-7.5
       parent: 1
   - uid: 439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,-14.5
+      pos: 5.5,-14.5
       parent: 1
   - uid: 440
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-11.5
+      pos: 4.5,-8.5
       parent: 1
   - uid: 441
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-17.5
+      pos: 4.5,-10.5
       parent: 1
   - uid: 442
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,-13.5
+      pos: -2.5,-10.5
       parent: 1
   - uid: 443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,-11.5
+      pos: 4.5,-14.5
       parent: 1
   - uid: 444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-14.5
+      pos: 5.5,-13.5
       parent: 1
   - uid: 445
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-14.5
+      pos: 6.5,-13.5
       parent: 1
   - uid: 446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,-14.5
+      pos: -3.5,-14.5
       parent: 1
   - uid: 447
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-14.5
+      pos: -4.5,-14.5
       parent: 1
   - uid: 448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-14.5
+      pos: -4.5,-11.5
       parent: 1
   - uid: 449
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-17.5
       parent: 1
   - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,-13.5
+      pos: -4.5,-13.5
       parent: 1
   - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,-14.5
+      pos: 5.5,-11.5
       parent: 1
   - uid: 452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,-15.5
+      pos: -2.5,-14.5
       parent: 1
   - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-15.5
+      pos: -1.5,-14.5
       parent: 1
   - uid: 454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-15.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-15.5
+      parent: 1
+  - uid: 460
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-15.5
       parent: 1
-  - uid: 455
+  - uid: 461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-15.5
       parent: 1
-  - uid: 456
+  - uid: 462
     components:
     - type: Transform
       pos: -5.5,-13.5
       parent: 1
-  - uid: 457
-    components:
-    - type: Transform
-      pos: -5.5,-11.5
-      parent: 1
-  - uid: 458
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-16.5
-      parent: 1
-  - uid: 459
-    components:
-    - type: Transform
-      pos: 6.5,-11.5
-      parent: 1
-  - uid: 460
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-10.5
-      parent: 1
-  - uid: 461
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
-      parent: 1
-  - uid: 462
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-10.5
-      parent: 1
   - uid: 463
     components:
     - type: Transform
-      pos: 5.5,-7.5
+      pos: -5.5,-11.5
       parent: 1
   - uid: 464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-16.5
+      pos: -0.5,-16.5
       parent: 1
   - uid: 465
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-16.5
+      parent: 1
+  - uid: 471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-17.5
       parent: 1
-  - uid: 466
+  - uid: 472
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-17.5
       parent: 1
-  - uid: 467
+  - uid: 473
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-17.5
       parent: 1
-  - uid: 468
+  - uid: 474
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 469
+  - uid: 475
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 470
+  - uid: 476
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 471
+  - uid: 477
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 472
+  - uid: 478
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 473
+  - uid: 479
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 474
+  - uid: 480
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 475
+  - uid: 481
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 476
+  - uid: 482
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 477
+  - uid: 483
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 478
+  - uid: 484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-  - uid: 479
+  - uid: 485
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 480
+  - uid: 486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-14.5
       parent: 1
-  - uid: 481
+  - uid: 487
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-14.5
       parent: 1
-  - uid: 482
+  - uid: 488
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 483
+  - uid: 489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-16.5
       parent: 1
-  - uid: 484
+  - uid: 490
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-17.5
       parent: 1
-  - uid: 485
+  - uid: 491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-17.5
       parent: 1
-  - uid: 486
+  - uid: 492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3338,109 +3322,104 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 487
+  - uid: 493
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 488
+  - uid: 494
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 489
+  - uid: 495
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 490
+  - uid: 496
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 491
+  - uid: 497
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 492
+  - uid: 498
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 493
-    components:
-    - type: Transform
-      pos: -1.5,-11.5
-      parent: 1
-  - uid: 494
+  - uid: 499
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 495
+  - uid: 500
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 496
+  - uid: 501
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 497
+  - uid: 502
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 498
+  - uid: 503
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-  - uid: 499
+  - uid: 504
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 500
+  - uid: 505
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 501
+  - uid: 506
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 502
+  - uid: 507
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 503
+  - uid: 508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 504
+  - uid: 509
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 505
+  - uid: 510
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 506
+  - uid: 511
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3448,20 +3427,20 @@ entities:
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 507
+  - uid: 512
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: WeaponTurretAK570
   entities:
-  - uid: 508
+  - uid: 513
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 509
+  - uid: 514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3469,23 +3448,16 @@ entities:
       parent: 1
 - proto: WeaponTurretDravon
   entities:
-  - uid: 510
+  - uid: 515
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 511
+  - uid: 516
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-0.5
-      parent: 1
-- proto: Wrench
-  entities:
-  - uid: 512
-    components:
-    - type: Transform
-      pos: -1.9012706,-12.450154
       parent: 1
 ...

--- a/Resources/Maps/_Mono/Shuttles/USSP/sekunda.yml
+++ b/Resources/Maps/_Mono/Shuttles/USSP/sekunda.yml
@@ -1,3 +1,21 @@
+# SPDX-FileCopyrightText: 2023 Alexander Evgrashin
+# SPDX-FileCopyrightText: 2023 Banshee
+# SPDX-FileCopyrightText: 2023 Cheackraze
+# SPDX-FileCopyrightText: 2023 RealIHaveANameOfficial
+# SPDX-FileCopyrightText: 2024 Checkraze
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Salvantrix
+# SPDX-FileCopyrightText: 2024 dustylens
+# SPDX-FileCopyrightText: 2025 Alkheemist
+# SPDX-FileCopyrightText: 2025 KiraZen_
+# SPDX-FileCopyrightText: 2025 RikuTheKiller
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 meta:
   format: 7
   category: Grid

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
@@ -7,7 +7,7 @@
   parent: BaseVesselAntag
   name: NCS Sekunda
   description: A USSP corpsman and fire support ship, comes with an FTL drive, tiny medical and chemical bay, light arnament and a cramped interior.
-  price: 35500
+  price: 43000
   category: Medium
   group: Ussp
   access: USSP

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
@@ -7,7 +7,7 @@
   parent: BaseVesselAntag
   name: NCS Sekunda
   description: A USSP corpsman and fire support ship, comes with an FTL drive, tiny medical and chemical bay, light arnament and a cramped interior.
-  price: 43000
+  price: 45000
   category: Medium
   group: Ussp
   access: USSP


### PR DESCRIPTION
## About the PR
Mainly just made the price actually reflect the ships price, as appraise grid was used before initialization before, and added a 5% bonus on that; fixed power issues and changed the uranium locker for the double generator variant; removed a useless substation and moved another from the connecting bridge to the cockpit; turned on that one thruster; added a health analyzer; added a freezer in the back; replaced one toolbox with a tool locker.

## Why / Balance
Ships should cost their price and be also useable.
## How to test
Load game up, join as USSP, buy Sekunda, price is actually as stated (besides the extra 5%), ship has sufficient power supply for its draw, all thrusters are on.

## Media
Small fix, so dont think its needed, BUUUUUUT, 
![Screenshot 2025-06-30 220626](https://github.com/user-attachments/assets/1a44fb0c-b3db-4f09-8ecd-af60da1144bc)
![Screenshot 2025-06-30 220633](https://github.com/user-attachments/assets/a3ce73cc-a872-4cea-9e1c-9ab9df20a3cf)
![Screenshot 2025-06-30 220646](https://github.com/user-attachments/assets/963a509e-f7e5-40a3-82e3-c52806d4115f)
![Screenshot 2025-06-30 220715](https://github.com/user-attachments/assets/6c5ce29d-78a9-43d7-ba0c-1bc029ec61df)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Tweaked Sekunda interior very very slightly.
- fix: Fixed Sekunda pricing and power issues.
