### PR TITLE
Changed Sekunda's Price

### DIFF
--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
@@ -7,7 +7,7 @@
   parent: BaseVesselAntag
   name: NCS Sekunda
   description: A USSP corpsman and fire support ship, comes with an FTL drive, tiny medical and chemical bay, light arnament and a cramped interior.
-  price: 45000
+  price: 55000
   category: Medium
   group: Ussp
   access: USSP


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Increased Sekunda's price from 45k to 55k, as many insisted on. Mainly due to CTLA selling for dirt cheap compared to buying price, among its utility.

## Why / Balance
Price reflecting utility and buy price more...

## How to test
Going into USSP shipyard

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**

:cl:
- tweak: Changed Sekunda price yet again, from 45k to 55k, as recommended by more experienced mappers.
