### PR TITLE
Remove Europa as Capital

### DIFF
--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/europa.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/europa.yml
@@ -19,7 +19,6 @@
   guidebookPage: Null
   class:
   - Pirate
-  - Capital
   engine:
   - AME
 


### PR DESCRIPTION
shrimple

:cl: lirpa
- tweak: The Europa is no longer a capital ship.