### PR TITLE
Fixes Rogue Bounties to Use 5x Numbers

### DIFF
--- a/Resources/Prototypes/_Mono/Catalogs/Bounties/pirate_bounties.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Bounties/pirate_bounties.yml
@@ -1,6 +1,6 @@
 - type: pirateBounty # Mono SCAF-> General Merc Suits including SCAF
   id: PirateBountyMercSuit
-  reward: 4
+  reward: 20
   description: pirate-bounty-description-merc-suit
   entries:
   - name: pirate-bounty-item-merc-suit
@@ -9,7 +9,7 @@
 
 - type: pirateBounty
   id: PirateBountyTacsuit
-  reward: 6
+  reward: 30
   description: pirate-bounty-description-tsfmctacsuit
   entries:
   - name: pirate-bounty-item-tsfmc-tacsuit
@@ -18,7 +18,7 @@
 
 - type: pirateBounty # Mono
   id: PirateBountyTSFEnergyWeapon
-  reward: 5
+  reward: 25
   description: pirate-bounty-description-energy-weapon
   entries:
   - name: pirate-bounty-item-energy-weapon
@@ -27,7 +27,7 @@
 
 - type: pirateBounty # Mono
   id: PirateBountyStandardTSFLongarm
-  reward: 4
+  reward: 20
   description: pirate-bounty-description-standard-tsf-longarm
   entries:
   - name: pirate-bounty-item-standard-tsf-longarm
@@ -36,7 +36,7 @@
 
 - type: pirateBounty # Mono
   id: PirateBountyExperimentalTSFWeapon
-  reward: 12
+  reward: 60
   description: pirate-bounty-description-experimental-tsf-weapon
   entries:
   - name: pirate-bounty-item-experimental-tsf-weapon
@@ -45,7 +45,7 @@
 
 - type: pirateBounty
   id: PirateBountyShipWeapon
-  reward: 4
+  reward: 20
   description: pirate-bounty-description-shipweapon
   spawnChest: false
   entries:
@@ -55,7 +55,7 @@
 
 - type: pirateBounty
   id: PirateBountyFentanylLarge
-  reward: 5
+  reward: 25
   description: pirate-bounty-description-generic
   entries:
   - name: pirate-bounty-item-fentanyl
@@ -64,7 +64,7 @@
 
 #- type: pirateBounty - Mono
 #  id: PirateBountyFentanylSmall
-#  reward: 2
+#  reward: 10
 #  description: pirate-bounty-description-generic
 #  entries:
 #  - name: pirate-bounty-item-fentanyl
@@ -73,7 +73,7 @@
 
 - type: pirateBounty
   id: PirateBountyFTLDrive
-  reward: 5
+  reward: 25
   description: pirate-bounty-description-generic
   spawnChest: false
   entries:
@@ -83,7 +83,7 @@
 
 - type: pirateBounty
   id: PirateBountyShipShield
-  reward: 5
+  reward: 25
   description: pirate-bounty-description-generic
   spawnChest: false
   entries:
@@ -93,7 +93,7 @@
 
 - type: pirateBounty
   id: PirateBountyGCS
-  reward: 4
+  reward: 20
   description: pirate-bounty-description-generic
   spawnChest: false
   entries:
@@ -122,7 +122,7 @@
 
 - type: pirateBounty # Mono
   id: PirateBountyEncryptionKeyTSFMC
-  reward: 5
+  reward: 25
   description: pirate-bounty-description-encryption-key-TSFMC
   entries:
   - name: pirate-bounty-item-encryption-key-TSFMC
@@ -131,7 +131,7 @@
 
 - type: pirateBounty
   id: PirateBountyTechfab
-  reward: 2
+  reward: 10
   description: pirate-bounty-description-techfab
   spawnChest: false
   entries:
@@ -141,7 +141,7 @@
 
 - type: pirateBounty
   id: PirateBountyCybernetics
-  reward: 4
+  reward: 20
   description: pirate-bounty-description-cybernetics
   entries:
   - name: pirate-bounty-item-cybernetics
@@ -150,7 +150,7 @@
 
 - type: pirateBounty
   id: PirateBountyRTG
-  reward: 3
+  reward: 15
   description: pirate-bounty-description-rtg
   spawnChest: false
   entries:

--- a/Resources/Prototypes/_Mono/Catalogs/Bounties/pirate_bounties.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Bounties/pirate_bounties.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: pirateBounty # Mono SCAF-> General Merc Suits including SCAF
   id: PirateBountyMercSuit
   reward: 20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

missed it

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Rogue bounties now use 5x numbers too

