### PR TITLE
Changed Out Sekunda's Grinder with Hotplate, Added Chem Locker

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/USSP/sekunda.yml
+++ b/Resources/Maps/_Mono/Shuttles/USSP/sekunda.yml
@@ -17,13 +17,14 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 meta:
+
   format: 7
   category: Grid
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/30/2025 18:52:03
-  entityCount: 516
+  time: 07/01/2025 22:04:38
+  entityCount: 517
 maps: []
 grids:
 - 1
@@ -875,7 +876,7 @@ entities:
   - uid: 85
     components:
     - type: Transform
-      pos: -1.9142275,-9.567103
+      pos: -1.5488551,-8.523378
       parent: 1
 - proto: CableApcExtension
   entities:
@@ -1698,6 +1699,13 @@ entities:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
+- proto: ChemistryHotplate
+  entities:
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
 - proto: ChemMaster
   entities:
   - uid: 241
@@ -2208,14 +2216,15 @@ entities:
   - uid: 309
     components:
     - type: Transform
-      pos: -1.3585517,-9.600763
+      pos: -1.1899669,-9.725307
       parent: 1
-- proto: KitchenReagentGrinder
+- proto: LockerWallChemistryFilled
   entities:
-  - uid: 310
+  - uid: 517
     components:
     - type: Transform
-      pos: -1.5,-9.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,-11.5
       parent: 1
 - proto: LockerWallMaterialsFuelUraniumFilled2
   entities:


### PR DESCRIPTION
## About the PR
Changed out grinder in the Sekundas chem lab with a hotplate, as grinder is basically useless, and put a chem locker on the wall.

## Why / Balance
Sekunda chemistry can now function alot more better, as a vital machine now isnt missing.
## How to test
Go USSP, buy Sekunda

## Media
Small change:
![image](https://github.com/user-attachments/assets/cf8f9bbd-36e7-4c8d-b3e6-c8331dde0126)


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Changed out Sekunda's grinder with hotplate
- add: Added chem locker to Sekunda
