### PR TITLE
Fentanyl Rebalance

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 mikusssssss
+# SPDX-FileCopyrightText: 2025 sleepyyapril
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   name: fentanyl crystal
   parent: [ BaseItem, BaseC3ChemContraband ]

--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
@@ -10,7 +10,7 @@
   - type: Item
     size: Tiny
   - type: StaticPrice
-    price: 2500 # People can consistently pump out a million in less than an hour of fent production, fuck that.
+    price: 1250 # People can consistently pump out a million in less than an hour of fent production, fuck that.
   - type: Food
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/_Mono/Recipes/Reactions/fentanyl.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Reactions/fentanyl.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2025 LukeZurg22
+# SPDX-FileCopyrightText: 2025 sleepyyapril
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: reaction
   id: Fentanyl
   impact: Low

--- a/Resources/Prototypes/_Mono/Recipes/Reactions/fentanyl.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Reactions/fentanyl.yml
@@ -15,27 +15,8 @@
       amount: 0.5
     Kelotane:
       amount: 0.5
-    CarpoToxin:
-      amount: 1
   products:
     Fentanyl: 5.5
-
-- type: reaction
-  id: FentanylVestine
-  impact: Low
-  reactants:
-    SpaceDrugs:
-      amount: 2
-    Desoxyephedrine:
-      amount: 2
-    SodiumHydroxide:
-      amount: 0.5
-    Phenol:
-      amount: 0.5
-    Vestine:
-      amount: 1
-  products:
-    Fentanyl: 10 # vestine is annoying..
 
 - type: reaction # this reaction is to prevent people from mixing fent and dylo for combat meds, and to serve as something to prevent mass crystallization
   id: FentanylIncompatibility


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
1. Fentanyl sell price halved.
2. Made the default recipe easier by removing the need for carpotoxin.
3. Removed the fentanyl vestine recipe.

You should now be able to easily make an absolute metric fuckton of crystals on any side, not just Rogues.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Given the nature of removing carpotoxin from the equation, the biggest concern is how easily people would get even 10,000 fentanyl. Depending on how much people can get, I'll likely need to nerf it or buff it more. Given that the output is ~2x less than the vestine recipe and the sell price is halved, this is effectively a quarter of its former glory, but it allows USSP and even civvies to more easily do the same thing Rogues do.

A secondary concern is that USSP might never allow Rogues to sell fentanyl on their station again as they can make their own, or maybe they might be more willing considering they don't need to. I don't know where it'll go in that sense, but I'm awfully curious to find out.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Fentanyl is no longer easier for rogues than anyone else, removing the default recipe's need for carpotoxin.
- tweak: Fentanyl's sell price was halved, mostly as a balance for all sides being able to get it much easier.
- remove: The vestine recipe for fentanyl was removed. 