### PR TITLE
USSP Can Grant Access + Fix Colonel Being Able to Open Rogue Doors

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -80,6 +80,9 @@ public sealed partial class IdCardConsoleComponent : Component
         "Sergeant", // Frontier
         "Service",
         "StationTrafficController", // Frontier
+        "USSP", // Mono
+        "USSPHigh", // Mono
+        "USSPCommand", // Mono
         //"Theatre",
     };
 

--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -1,3 +1,22 @@
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Kesiath
+// SPDX-FileCopyrightText: 2023 Mnemotechnican
+// SPDX-FileCopyrightText: 2023 Moony
+// SPDX-FileCopyrightText: 2023 Velcroboy
+// SPDX-FileCopyrightText: 2023 moonheart08
+// SPDX-FileCopyrightText: 2024 Dvir
+// SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+// SPDX-FileCopyrightText: 2024 Kara
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 Salvantrix
+// SPDX-FileCopyrightText: 2024 c4llv07e
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2024 neuPanda
+// SPDX-FileCopyrightText: 2025 HungryCuban
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Access.Systems;
 using Content.Shared.Containers.ItemSlots;
 using Robust.Shared.GameStates;

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -38,4 +38,3 @@
   - Chapel
   - Hydroponics
   - Atmospherics
-  - Pirate

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -38,3 +38,4 @@
   - Chapel
   - Hydroponics
   - Atmospherics
+#  - Pirate # Mono

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -1,3 +1,19 @@
+# SPDX-FileCopyrightText: 2022 Emisse
+# SPDX-FileCopyrightText: 2022 metalgearsloth
+# SPDX-FileCopyrightText: 2022 mirrorcult
+# SPDX-FileCopyrightText: 2023 Kesiath
+# SPDX-FileCopyrightText: 2023 Puro
+# SPDX-FileCopyrightText: 2023 Velcroboy
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 deltanedas
+# SPDX-FileCopyrightText: 2024 neuPanda
+# SPDX-FileCopyrightText: 2025 HungryCuban
+# SPDX-FileCopyrightText: 2025 KiraZen_
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: accessGroup
   id: AllAccess
   tags:


### PR DESCRIPTION

## About the PR
Adds the ability to give USSP access to contractors and mercenaries, faction related roles cant get these access. Also noticed in testing that Colonels could unlock rogue doors since they have "AA"

## Why / Balance
Players can interact with the USSP better

## How to test
-Spawn a Card ID console
-Put a USSP card in it as priority card
-Put a civilian/merc card (should be able to give access)
-Put a faction id card (shouldn't be able to give access)

## Media
![2025-7-01_22 01 41](https://github.com/user-attachments/assets/aaf5685e-3847-4c5a-a64c-f55d93800af4)
![2025-7-01_22 01 28](https://github.com/user-attachments/assets/edbff1b0-a475-44c8-be9f-304d9fb20f3b)


## Requirements

- [ x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
- [ x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.


## Breaking changes

**Changelog**

:cl:
- add: USSP can give access with card console
- fix: Colonel could open Rogue locked doors

