### PR TITLE
Adjusts Flyssa Price

### DIFF
--- a/Resources/Prototypes/_Mono/Catalogs/security_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/security_uplink_catalog.yml
@@ -272,7 +272,7 @@
   description: uplink-security-flyssa-voucher-desc
   productEntity: ShipVoucherFlyssa
   cost:
-    FederationMilitaryCredit: 750
+    FederationMilitaryCredit: 2500
   categories:
   - UplinkSecurityVouchers
   conditions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
increased Flyssas price

## Why / Balance

Flyssa is a capital ship with 6 300mm cannons of which there are no other examples of in the game with near unpenetrable armor, This ship should not cost same as that of a unarmored small cloaked ship, on top of that FMCs are easier to acquire in bulk in comparison to DCs.

:cl:
- tweak: Flyssa price increased!

