### PR TITLE
Fent Buff

### DIFF
--- a/Resources/Locale/en-US/_Mono/research/technologies.ftl
+++ b/Resources/Locale/en-US/_Mono/research/technologies.ftl
@@ -35,3 +35,4 @@ research-technology-rogue-hristov = Heavy Ballistics
 research-technology-rogue-prowler-voucher = Stealthcraft Technologies
 research-technology-rogue-energy-weapon = Advanced Plasma Weaponization
 research-technology-rogue-access-breaker = Advanced Hacking Procedures
+research-technology-rogue-hf-sword = Weaponised Resonance Technology

--- a/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/ussp.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/ussp.yml
@@ -1,4 +1,13 @@
-﻿- type: vendingMachineInventory
+# SPDX-FileCopyrightText: 2025 EctoplasmIsGood
+# SPDX-FileCopyrightText: 2025 HungryCuban
+# SPDX-FileCopyrightText: 2025 ScyronX
+# SPDX-FileCopyrightText: 2025 Your Name
+# SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: vendingMachineInventory
   id: USSPVendInventory
   startingInventory:
     MagazineDP29: 4294967295 # Infinite

--- a/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/ussp.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/ussp.yml
@@ -20,7 +20,7 @@
     Gauze: 4294967295 # Infinite
     ClothingOuterHardsuitUsspL27: 4294967295 # Infinite
     ClothingOuterHardsuitUsspL10: 4294967295 # Infinite
-    # ClothingOuterHardsuitUsspM10: 4294967295 # Infinite
+    ClothingOuterHardsuitUsspM10: 4294967295 # Infinite
     ClothingOuterCoatUSSP: 4294967295 # Infinite
     ClothingHeadHelmetHeavyUSSP: 4294967295 # Infinite
     EmergencyMedipen: 4294967295 # Infinite

--- a/Resources/Prototypes/_Mono/Catalogs/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/pirate_uplink_catalog.yml
@@ -736,21 +736,21 @@
       tags:
       - PirateUplink
 
-# - type: listing
-#   id: UplinkPirateVT7
-#   name: uplink-pirate-vt7-name
-#   description: uplink-pirate-vt7-desc
-#   productEntity: WeaponVT7
-#   icon: { sprite: _Mono/Objects/Weapons/Melee/murasama.rsi, state: icon }
-#   cost:
-#     Doubloon: 60
-#   categories:
-#   - UplinkPirateWeapons
-#   conditions:
-#   - !type:StoreWhitelistCondition
-#     whitelist:
-#       tags:
-#       - PirateUplink
+- type: listing
+  id: UplinkPirateVT7
+  name: uplink-pirate-vt7-name
+  description: uplink-pirate-vt7-desc
+  productEntity: WeaponVT7
+  icon: { sprite: _Mono/Objects/Weapons/Melee/murasama.rsi, state: icon }
+  cost:
+     Doubloon: 60
+  categories:
+   - UplinkPirateWeapons
+  conditions:
+   - !type:StoreWhitelistCondition
+     whitelist:
+       tags:
+       - PirateUplink
 
 - type: listing
   id: UplinkPirateC20

--- a/Resources/Prototypes/_Mono/Catalogs/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/pirate_uplink_catalog.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 Blu
 # SPDX-FileCopyrightText: 2025 EctoplasmIsGood
 # SPDX-FileCopyrightText: 2025 Ghost581
+# SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 KiraZen_
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 RikuTheKiller

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ussp.yml
@@ -159,8 +159,8 @@
   - type: StaminaDamageResistance # Mono - Stamres
     coefficient: 0.45
   - type: ClothingSpeedModifier
-    walkModifier: 1.15
-    sprintModifier: 1.15
+    walkModifier: 1
+    sprintModifier: 1
   - type: ToggleableClothing
     clothingPrototypes:
       head: ClothingHeadHelmetHardsuitUsspM10

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/melee_weapons.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/melee_weapons.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/melee_weapons.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/melee_weapons.yml
@@ -24,6 +24,17 @@
 
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
+  id: HFSwordVT7
+  result: WeaponVT7
+  materials:
+    Steel: 1000
+    Plasteel: 7000
+    Plastic: 6000
+    Plasma: 10000
+    Uranium: 6000
+
+- type: latheRecipe
+  parent: BaseWeaponRecipeLong
   id: EnergyShieldTSF
   result: EnergyShieldNfsd
   materials:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/rogues.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/rogues.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/rogues.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/rogues.yml
@@ -8,6 +8,7 @@
   - EnergySwordRogue
   - EnergyDaggerRogue
   - EnergyShieldRogue
+  - HFSwordVT7
 
 - type: latheRecipePack
   id: MonoRogueWeaponsDynamicRanged

--- a/Resources/Prototypes/_Mono/Research/rogue.yml
+++ b/Resources/Prototypes/_Mono/Research/rogue.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Research/rogue.yml
+++ b/Resources/Prototypes/_Mono/Research/rogue.yml
@@ -54,6 +54,20 @@
   - RogueEdagger
 
 - type: technology
+  id: HFSwordTech
+  name: research-technology-rogue-hf-sword
+  icon:
+    sprite: _Mono/Objects/Weapons/Melee/murasama.rsi
+    state: icon
+  discipline: Rogue
+  tier: 3
+  cost: 85000
+  recipeUnlocks:
+  - HFSwordVT7
+  technologyPrerequisites:
+  - RogueEsword
+
+- type: technology
   id: RogueHypospray
   name: research-technology-rogue-hypospray
   icon:


### PR DESCRIPTION

## About the PR
Adds VT7 swords back to the game in uplink and researchable as a tier 3 tech. Re adds the Ussp scoutsuit with a speed nerf.

## Why / Balance
Rogues should be the king of ground combat as game balances suggest. Ussp needs more content that even if this not what they currently mostly lack is certainly a bonus

## How to test
-USSP vendor
-Rogue research server tier 3
-Rogue uplink

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
- [x ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- add: Researchable VT7 blade to the rogue server and make able in the military fabricator
- tweak: Re adds USSP M-10 (nerfed) suit to the vendor
- tweak: Re adds VT7 high frequency blade to the uplink
