### PR TITLE
More MODsuits in Lockers

### DIFF
--- a/Resources/Locale/en-US/_Mono/set-selector/selectable-sets.ftl
+++ b/Resources/Locale/en-US/_Mono/set-selector/selectable-sets.ftl
@@ -5,3 +5,12 @@ selectable-set-rd-hardsuit-desc =
 selectable-set-rd-modsuit-name = Minerva Modsuit
 selectable-set-rd-modsuit-desc =
     A MODsuit for heavy research. Quite resistant.
+
+selectable-set-cap-hardsuit-name = Captain's armored spacesuit
+selectable-set-cap-hardsuit-desc =
+    A spacesuit for shuttle owners. Features light bulletproof plates.
+
+selectable-set-cap-modsuit-name = Magnate Modsuit
+selectable-set-cap-modsuit-desc =
+    A MODsuit intended for shuttle owners. It has some luxurious gems
+    surrounding it.

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -43,7 +43,8 @@
     #      prob: 0.25 # Frontier
     #    - id: ClothingBeltSheathFilled # Frontier
     #    - id: ClothingHeadsetAltCommand # Frontier
-    - id: ClothingOuterArmorCaptainCarapace
+    - id: UndeterminedVoidsuitCap
+    #    - id: ClothingOuterArmorCaptainCarapace
     #    - id: CommsComputerCircuitboard # Frontier
     #    - id: DoorRemoteCommand # Frontier
     #    - id: MedalCase # Frontier
@@ -70,7 +71,8 @@
   id: FillCaptainHardsuit
   table: !type:AllSelector
     children:
-    - id: ClothingOuterHardsuitCap
+    - id: UndeterminedVoidsuitCap
+#        - id: ClothingOuterHardsuitCap
     - id: ClothingMaskGasCaptain
     #    - id: JetpackCaptainFilled # Frontier
     #    - id: OxygenTankFilled # Frontier
@@ -299,7 +301,8 @@
   table: !type:AllSelector
     children:
     - id: ClothingMaskBreath
-    - id: ClothingOuterHardsuitRd
+    - id: UndeterminedVoidsuitRD
+#        - id: ClothingOuterHardsuitRd
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
     - id: JetpackMiniFilled # Frontier

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -1,3 +1,77 @@
+# SPDX-FileCopyrightText: 2021 Alex Evgrashin
+# SPDX-FileCopyrightText: 2021 SETh lafuente
+# SPDX-FileCopyrightText: 2021 SethLafuente
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2022 0x6273
+# SPDX-FileCopyrightText: 2022 Fishfish458
+# SPDX-FileCopyrightText: 2022 Jessica M
+# SPDX-FileCopyrightText: 2022 Lamrr
+# SPDX-FileCopyrightText: 2022 Leon Friedrich
+# SPDX-FileCopyrightText: 2022 Peptide90
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2022 Ripmorld
+# SPDX-FileCopyrightText: 2022 Willhelm53
+# SPDX-FileCopyrightText: 2022 WlarusFromDaSpace
+# SPDX-FileCopyrightText: 2022 ZeroDayDaemon
+# SPDX-FileCopyrightText: 2022 fishfish458 <fishfish458>
+# SPDX-FileCopyrightText: 2022 mirrorcult
+# SPDX-FileCopyrightText: 2022 router
+# SPDX-FileCopyrightText: 2023 Aexxie
+# SPDX-FileCopyrightText: 2023 Alekshhh
+# SPDX-FileCopyrightText: 2023 AsikKEsel
+# SPDX-FileCopyrightText: 2023 Checkraze
+# SPDX-FileCopyrightText: 2023 Dvir
+# SPDX-FileCopyrightText: 2023 Emisse
+# SPDX-FileCopyrightText: 2023 EnDecc
+# SPDX-FileCopyrightText: 2023 Kara
+# SPDX-FileCopyrightText: 2023 Kevin Zheng
+# SPDX-FileCopyrightText: 2023 KingFroozy
+# SPDX-FileCopyrightText: 2023 Lei Yunxing
+# SPDX-FileCopyrightText: 2023 Nairod
+# SPDX-FileCopyrightText: 2023 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2023 PursuitInAshes
+# SPDX-FileCopyrightText: 2023 Raitononai
+# SPDX-FileCopyrightText: 2023 RobbyTheFish
+# SPDX-FileCopyrightText: 2023 Skarletto
+# SPDX-FileCopyrightText: 2023 TheEmber
+# SPDX-FileCopyrightText: 2023 Ubaser
+# SPDX-FileCopyrightText: 2023 Whisper
+# SPDX-FileCopyrightText: 2023 chromiumboy
+# SPDX-FileCopyrightText: 2023 crazybrain23
+# SPDX-FileCopyrightText: 2023 lapatison
+# SPDX-FileCopyrightText: 2023 lzk228
+# SPDX-FileCopyrightText: 2023 ssdaniel24
+# SPDX-FileCopyrightText: 2024 ArchRBX
+# SPDX-FileCopyrightText: 2024 ArtisticRoomba
+# SPDX-FileCopyrightText: 2024 Boaz1111
+# SPDX-FileCopyrightText: 2024 Flareguy
+# SPDX-FileCopyrightText: 2024 FungiFellow
+# SPDX-FileCopyrightText: 2024 Futuristic-OK
+# SPDX-FileCopyrightText: 2024 Ghagliiarghii
+# SPDX-FileCopyrightText: 2024 Hanz
+# SPDX-FileCopyrightText: 2024 Jeff
+# SPDX-FileCopyrightText: 2024 Maxtone
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 Nim
+# SPDX-FileCopyrightText: 2024 Plykiya
+# SPDX-FileCopyrightText: 2024 ScarKy0
+# SPDX-FileCopyrightText: 2024 SlamBamActionman
+# SPDX-FileCopyrightText: 2024 Velcroboy
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2024 lzk
+# SPDX-FileCopyrightText: 2024 metalgearsloth
+# SPDX-FileCopyrightText: 2024 Эдуард
+# SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 Coolsurf6
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 Schepka
+# SPDX-FileCopyrightText: 2025 Theodore Lukin
+# SPDX-FileCopyrightText: 2025 dustylens
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entityTable
   id: LockerFillQuarterMaster
   table: !type:AllSelector

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -117,8 +117,7 @@
     #      prob: 0.25 # Frontier
     #    - id: ClothingBeltSheathFilled # Frontier
     #    - id: ClothingHeadsetAltCommand # Frontier
-    - id: UndeterminedVoidsuitCap
-    #    - id: ClothingOuterArmorCaptainCarapace
+    - id: ClothingOuterArmorCaptainCarapace
     #    - id: CommsComputerCircuitboard # Frontier
     #    - id: DoorRemoteCommand # Frontier
     #    - id: MedalCase # Frontier

--- a/Resources/Prototypes/_Mono/Catalogs/selectable_sets.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/selectable_sets.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Schepka
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 #RD
 
 - type: thiefBackpackSet

--- a/Resources/Prototypes/_Mono/Catalogs/selectable_sets.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/selectable_sets.yml
@@ -1,3 +1,5 @@
+#RD
+
 - type: thiefBackpackSet
   id: VoidsuitSelectorRDHardsuit
   name: selectable-set-rd-hardsuit-name
@@ -17,3 +19,25 @@
     state: control
   content:
   - ClothingModsuitResearchDirectorPowerCell
+
+#Captain
+
+- type: thiefBackpackSet
+  id: VoidsuitSelectorCapHardsuit
+  name: selectable-set-cap-hardsuit-name
+  description: selectable-set-cap-hardsuit-desc
+  sprite:
+    sprite: Clothing/OuterClothing/Hardsuits/capspace.rsi
+    state: icon
+  content:
+  - ClothingOuterHardsuitCap
+
+- type: thiefBackpackSet
+  id: VoidsuitSelectorCapModsuit
+  name: selectable-set-cap-modsuit-name
+  description: selectable-set-cap-modsuit-desc
+  sprite:
+    sprite: _Goobstation/Clothing/Back/Modsuits/captain.rsi
+    state: control
+  content:
+  - ClothingModsuitCaptainPowerCell

--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/voidsuitselectors.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/voidsuitselectors.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Schepka
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # RD
 - type: entity
   id: UndeterminedVoidsuitRD

--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/voidsuitselectors.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/voidsuitselectors.yml
@@ -19,3 +19,25 @@
     interfaces:
       enum.ThiefBackpackUIKey.Key:
         type: ThiefBackpackBoundUserInterface
+
+# Captain
+- type: entity
+  id: UndeterminedVoidsuitCap
+  name: Captain voidsuit selector
+  description: A small remote utilizing bluespace technology to drop in a voidsuit or hardsuit of your choosing.
+  parent: BaseItem
+  components:
+  - type: Sprite
+    sprite: _Goobstation/Objects/Devices/unique_teleporters.rsi
+    state: standard
+  - type: ThiefUndeterminedBackpack
+    possibleSets:
+    - VoidsuitSelectorCapModsuit
+    - VoidsuitSelectorCapHardsuit
+    maxSelectedSets: 1
+  - type: ActivatableUI
+    key: enum.ThiefBackpackUIKey.Key
+  - type: UserInterface
+    interfaces:
+      enum.ThiefBackpackUIKey.Key:
+        type: ThiefBackpackBoundUserInterface


### PR DESCRIPTION
## About the PR
Added a new voidsuit selector for either captain's hardsuit or modsuit, on top of it this voidsuit selector along with RD one now spawns in their respective lockers or suit storages.

## Why / Balance
Magnat modsuit (Captain's modsuit) remained unused while was completely functional so I simply added a way to obtain it.
Minerva modsuit was only obtainable from tier 3 experimental research, while the hardsuit counterpart came in RD lockers as well, so I simply added a way to choose

## How to test
Run localhost, spawn in either RD or captain's locker (Must be the [Hardsuit] one), they will come with respective voidsuit selectors

## Media

https://github.com/user-attachments/assets/4a2154a8-7f68-4a75-b4d4-41e321d311f1

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
None that I know of

**Changelog**
:cl:
- add: Added a voidsuit selector for captain's hardsuit or modsuit
- tweak: Removed hardsuits from RD and captain lockers and replaced them with voidsuit selectors
