### PR TITLE
Self-Charging Energy Shields Port

### DIFF
--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -1,3 +1,26 @@
+// SPDX-FileCopyrightText: 2021 20kdc
+// SPDX-FileCopyrightText: 2021 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto
+// SPDX-FileCopyrightText: 2021 Visne
+// SPDX-FileCopyrightText: 2022 Rane
+// SPDX-FileCopyrightText: 2022 corentt
+// SPDX-FileCopyrightText: 2022 mirrorcult
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 Vasilis
+// SPDX-FileCopyrightText: 2023 deltanedas
+// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2024 Aviu00
+// SPDX-FileCopyrightText: 2024 BramvanZijp
+// SPDX-FileCopyrightText: 2024 Brandon Hu
+// SPDX-FileCopyrightText: 2024 GreaseMonk
+// SPDX-FileCopyrightText: 2024 Tayrtahn
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2025 Dvir
+// SPDX-FileCopyrightText: 2025 Errant
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.Cargo.Systems;
 using Content.Server.Emp;

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -18,6 +18,7 @@
 // SPDX-FileCopyrightText: 2024 Whatstone
 // SPDX-FileCopyrightText: 2025 Dvir
 // SPDX-FileCopyrightText: 2025 Errant
+// SPDX-FileCopyrightText: 2025 Redrover1760
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -274,7 +274,7 @@ namespace Content.Server.Power.EntitySystems
             if (!Resolve(uid, ref battery))
                 return false;
 
-            return battery.CurrentCharge / battery.MaxCharge >= 0.99f;
+            return battery.CurrentCharge >= battery.MaxCharge;
         }
 
         // Goobstation

--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -232,9 +232,9 @@ public sealed partial class PowerCellSystem : SharedPowerCellSystem
         OnBatteryExamined(batteryEnt.GetValueOrDefault(uid), battery, args); // Goobstation
     }
 
-    private void OnBatteryExamined(EntityUid uid, BatteryComponent? component, ExaminedEvent args)
+    public void OnBatteryExamined(EntityUid uid, BatteryComponent? component, ExaminedEvent args) // WD EDIT
     {
-        if (component != null)
+        if (Resolve(uid, ref component, false)) // WD EDIT
         {
             var charge = component.CurrentCharge / component.MaxCharge * 100;
             args.PushMarkup(Loc.GetString("power-cell-component-examine-details", ("currentCharge", $"{charge:F0}")));

--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -1,3 +1,32 @@
+// SPDX-FileCopyrightText: 2021 DrSmugleaf
+// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto
+// SPDX-FileCopyrightText: 2021 Ygg01
+// SPDX-FileCopyrightText: 2022 Mervill
+// SPDX-FileCopyrightText: 2022 Moony
+// SPDX-FileCopyrightText: 2022 ShadowCommander
+// SPDX-FileCopyrightText: 2022 mirrorcult
+// SPDX-FileCopyrightText: 2022 themias
+// SPDX-FileCopyrightText: 2022 wrexbe
+// SPDX-FileCopyrightText: 2023 AJCM-git
+// SPDX-FileCopyrightText: 2023 Chief-Engineer
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 Nemanja
+// SPDX-FileCopyrightText: 2023 Sailor
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 Vasilis
+// SPDX-FileCopyrightText: 2023 Visne
+// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2023 keronshb
+// SPDX-FileCopyrightText: 2024 Aviu00
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 Tayrtahn
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2024 slarticodefast
+// SPDX-FileCopyrightText: 2025 Ark
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Emp;
 using Content.Server.Power.Components;
 using Content.Shared.Examine;

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -1,3 +1,44 @@
+// SPDX-FileCopyrightText: 2022 Flipp Syder
+// SPDX-FileCopyrightText: 2022 Nemanja
+// SPDX-FileCopyrightText: 2022 Paul Ritter
+// SPDX-FileCopyrightText: 2022 Rane
+// SPDX-FileCopyrightText: 2022 Visne
+// SPDX-FileCopyrightText: 2022 metalgearsloth
+// SPDX-FileCopyrightText: 2022 themias
+// SPDX-FileCopyrightText: 2023 AJCM-git
+// SPDX-FileCopyrightText: 2023 Arendian
+// SPDX-FileCopyrightText: 2023 Chief-Engineer
+// SPDX-FileCopyrightText: 2023 Ilya Chvilyov
+// SPDX-FileCopyrightText: 2023 Kara
+// SPDX-FileCopyrightText: 2023 MendaxxDev
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 TaralGit
+// SPDX-FileCopyrightText: 2023 and_a
+// SPDX-FileCopyrightText: 2023 deltanedas
+// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2024 Aviu00
+// SPDX-FileCopyrightText: 2024 Bixkitts
+// SPDX-FileCopyrightText: 2024 Cojoke
+// SPDX-FileCopyrightText: 2024 DrSmugleaf
+// SPDX-FileCopyrightText: 2024 Dvir
+// SPDX-FileCopyrightText: 2024 Ed
+// SPDX-FileCopyrightText: 2024 Jake Huxell
+// SPDX-FileCopyrightText: 2024 Jessica M
+// SPDX-FileCopyrightText: 2024 LordCarve
+// SPDX-FileCopyrightText: 2024 RiceMar1244
+// SPDX-FileCopyrightText: 2024 Sigil
+// SPDX-FileCopyrightText: 2024 VividPups
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2024 beck-thompson
+// SPDX-FileCopyrightText: 2024 eoineoineoin
+// SPDX-FileCopyrightText: 2024 keronshb
+// SPDX-FileCopyrightText: 2024 nikthechampiongr
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Leon Friedrich
+// SPDX-FileCopyrightText: 2025 SlamBamActionman
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using System.Numerics;
 using Content.Server._Mono.FireControl;

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -211,7 +211,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
                             FireEffects(fromEffect, result.Distance, dir.Normalized().ToAngle(), hitscan, hit, user);
 
-                            var ev = new HitScanReflectAttemptEvent(user, gunUid, hitscan.Reflective, dir, false);
+                            var ev = new HitScanReflectAttemptEvent(user, gunUid, hitscan.Reflective, dir, false, hitscan.Damage); // WD EDIT
                             RaiseLocalEvent(hit, ref ev);
 
                             if (!ev.Reflected)

--- a/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Server._White.Blocking;
+
+[RegisterComponent]
+public sealed partial class RechargeableBlockingComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float DischargedRechargeRate = 1.33f;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float ChargedRechargeRate = 2f;
+
+    [ViewVariables]
+    public bool Discharged;
+}

--- a/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Aviu00
+// SPDX-FileCopyrightText: 2025 Redrover1760
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
@@ -8,10 +8,10 @@ namespace Content.Server._White.Blocking;
 public sealed partial class RechargeableBlockingComponent : Component
 {
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float DischargedRechargeRate = 2f;
+    public float DischargedRechargeRate = 4f;
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float ChargedRechargeRate = 3f;
+    public float ChargedRechargeRate = 5f;
 
     [ViewVariables]
     public bool Discharged;

--- a/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Aviu00
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace Content.Server._White.Blocking;
 
 [RegisterComponent]

--- a/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
@@ -8,10 +8,10 @@ namespace Content.Server._White.Blocking;
 public sealed partial class RechargeableBlockingComponent : Component
 {
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float DischargedRechargeRate = 1.33f;
+    public float DischargedRechargeRate = 2f;
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float ChargedRechargeRate = 2f;
+    public float ChargedRechargeRate = 3f;
 
     [ViewVariables]
     public bool Discharged;

--- a/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
@@ -1,0 +1,106 @@
+using Content.Server.Popups;
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+using Content.Server.PowerCell;
+using Content.Shared.Damage;
+using Content.Shared.Examine;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.PowerCell.Components;
+
+namespace Content.Server._White.Blocking;
+
+public sealed class RechargeableBlockingSystem : EntitySystem
+{
+    [Dependency] private readonly BatterySystem _battery = default!;
+    [Dependency] private readonly ItemToggleSystem _itemToggle = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly PowerCellSystem _powerCell = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RechargeableBlockingComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<RechargeableBlockingComponent, DamageChangedEvent>(OnDamageChanged);
+        SubscribeLocalEvent<RechargeableBlockingComponent, ItemToggleActivateAttemptEvent>(AttemptToggle);
+        SubscribeLocalEvent<RechargeableBlockingComponent, ChargeChangedEvent>(OnChargeChanged);
+        SubscribeLocalEvent<RechargeableBlockingComponent, PowerCellChangedEvent>(OnPowerCellChanged);
+    }
+
+    private void OnExamined(EntityUid uid, RechargeableBlockingComponent component, ExaminedEvent args)
+    {
+        if (!component.Discharged)
+        {
+            _powerCell.OnBatteryExamined(uid, null, args);
+            return;
+        }
+
+        args.PushMarkup(Loc.GetString("rechargeable-blocking-discharged"));
+        args.PushMarkup(Loc.GetString("rechargeable-blocking-remaining-time", ("remainingTime", GetRemainingTime(uid))));
+    }
+
+    private int GetRemainingTime(EntityUid uid)
+    {
+        if (!_battery.TryGetBatteryComponent(uid, out var batteryComponent, out var batteryUid)
+            || !TryComp<BatterySelfRechargerComponent>(batteryUid, out var recharger)
+            || recharger is not { AutoRechargeRate: > 0, AutoRecharge: true })
+            return 0;
+
+        return (int) MathF.Round((batteryComponent.MaxCharge - batteryComponent.CurrentCharge) /
+                                 recharger.AutoRechargeRate);
+    }
+
+    private void OnDamageChanged(EntityUid uid, RechargeableBlockingComponent component, DamageChangedEvent args)
+    {
+        if (!_battery.TryGetBatteryComponent(uid, out var batteryComponent, out var batteryUid)
+            || !_itemToggle.IsActivated(uid)
+            || args.DamageDelta == null)
+            return;
+
+        var batteryUse = Math.Min(args.DamageDelta.GetTotal().Float(), batteryComponent.CurrentCharge);
+        _battery.TryUseCharge(batteryUid.Value, batteryUse, batteryComponent);
+    }
+
+    private void AttemptToggle(EntityUid uid, RechargeableBlockingComponent component, ref ItemToggleActivateAttemptEvent args)
+    {
+        if (!component.Discharged)
+            return;
+
+        _popup.PopupEntity(Loc.GetString("rechargeable-blocking-remaining-time-popup",
+                ("remainingTime", GetRemainingTime(uid))),
+            args.User ?? uid);
+        args.Cancelled = true;
+    }
+    private void OnChargeChanged(EntityUid uid, RechargeableBlockingComponent component, ChargeChangedEvent args)
+    {
+        CheckCharge(uid, component);
+    }
+
+    private void OnPowerCellChanged(EntityUid uid, RechargeableBlockingComponent component, PowerCellChangedEvent args)
+    {
+        CheckCharge(uid, component);
+    }
+
+    private void CheckCharge(EntityUid uid, RechargeableBlockingComponent component)
+    {
+        if (!_battery.TryGetBatteryComponent(uid, out var battery, out _))
+            return;
+
+        BatterySelfRechargerComponent? recharger;
+        if (battery.CurrentCharge < 1)
+        {
+            if (TryComp(uid, out recharger))
+                recharger.AutoRechargeRate = component.DischargedRechargeRate;
+
+            component.Discharged = true;
+            _itemToggle.TryDeactivate(uid, predicted: false);
+            return;
+        }
+
+        if (battery.CurrentCharge < battery.MaxCharge)
+            return;
+
+        component.Discharged = false;
+        if (TryComp(uid, out recharger))
+                recharger.AutoRechargeRate = component.ChargedRechargeRate;
+    }
+}

--- a/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Aviu00
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -51,6 +51,9 @@ public sealed partial class BlockingSystem
             if (!TryComp<DamageableComponent>(component.BlockingItem, out var dmgComp))
                 return;
 
+            if (!_toggle.IsActivated(component.BlockingItem.Value)) // Goobstation
+                return;
+
             var blockFraction = blocking.IsBlocking ? blocking.ActiveBlockFraction : blocking.PassiveBlockFraction;
             blockFraction = Math.Clamp(blockFraction, 0, 1);
             _damageable.TryChangeDamage(component.BlockingItem, blockFraction * args.OriginalDamage);

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -1,3 +1,17 @@
+// SPDX-FileCopyrightText: 2022 Flipp Syder
+// SPDX-FileCopyrightText: 2022 Nemanja
+// SPDX-FileCopyrightText: 2022 Paul Ritter
+// SPDX-FileCopyrightText: 2022 keronshb
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2023 themias
+// SPDX-FileCopyrightText: 2024 Aviu00
+// SPDX-FileCopyrightText: 2024 nikthechampiongr
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Robust.Shared.Audio;

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Item.ItemToggle;
 using Content.Shared.Maps;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Physics;
@@ -37,6 +38,7 @@ public sealed partial class BlockingSystem : EntitySystem
     [Dependency] private readonly ExamineSystemShared _examine = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly ItemToggleSystem _toggle = default!; // Goobstation
 
     public override void Initialize()
     {
@@ -317,6 +319,8 @@ public sealed partial class BlockingSystem : EntitySystem
             return;
 
         var fraction = component.IsBlocking ? component.ActiveBlockFraction : component.PassiveBlockFraction;
+        if (!_toggle.IsActivated(uid)) // Goobstation
+            fraction = 0f;
         var modifier = component.IsBlocking ? component.ActiveBlockDamageModifier : component.PassiveBlockDamageModifer;
 
         var msg = new FormattedMessage();

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -1,3 +1,20 @@
+// SPDX-FileCopyrightText: 2022 Kara
+// SPDX-FileCopyrightText: 2022 keronshb
+// SPDX-FileCopyrightText: 2022 metalgearsloth
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Jezithyr
+// SPDX-FileCopyrightText: 2023 LankLTE
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 themias
+// SPDX-FileCopyrightText: 2024 Aviu00
+// SPDX-FileCopyrightText: 2024 Dvir
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 beck-thompson
+// SPDX-FileCopyrightText: 2025 TemporalOroboros
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.Shared.Actions;
 using Content.Shared.Damage;

--- a/Content.Shared/Weapons/Ranged/Events/HitScanReflectAttempt.cs
+++ b/Content.Shared/Weapons/Ranged/Events/HitScanReflectAttempt.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared.Damage;
 using Content.Shared.Weapons.Reflect;
 
 namespace Content.Shared.Weapons.Ranged.Events;
@@ -8,4 +9,5 @@ namespace Content.Shared.Weapons.Ranged.Events;
 /// and changing <see cref="Direction"/> where shot will go next
 /// </summary>
 [ByRefEvent]
-public record struct HitScanReflectAttemptEvent(EntityUid? Shooter, EntityUid SourceItem, ReflectType Reflective, Vector2 Direction, bool Reflected);
+public record struct HitScanReflectAttemptEvent(EntityUid? Shooter, EntityUid SourceItem, ReflectType Reflective,
+    Vector2 Direction, bool Reflected, DamageSpecifier? Damage); // WD EDIT

--- a/Content.Shared/Weapons/Ranged/Events/HitScanReflectAttempt.cs
+++ b/Content.Shared/Weapons/Ranged/Events/HitScanReflectAttempt.cs
@@ -1,3 +1,10 @@
+// SPDX-FileCopyrightText: 2023 Chief-Engineer
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Aviu00
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Numerics;
 using Content.Shared.Damage;
 using Content.Shared.Weapons.Reflect;

--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -27,6 +27,11 @@ public sealed partial class ReflectComponent : Component
 
     [DataField("soundOnReflect")]
     public SoundSpecifier? SoundOnReflect = new SoundPathSpecifier("/Audio/Weapons/Guns/Hits/laser_sear_wall.ogg");
+
+    // WD START
+    [DataField, AutoNetworkedField]
+    public float DamageOnReflectModifier;
+    // WD END
 }
 
 [Flags]

--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -1,3 +1,12 @@
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2024 Aviu00
+// SPDX-FileCopyrightText: 2024 Hannah Giovanna Dawson
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -1,3 +1,22 @@
+// SPDX-FileCopyrightText: 2023 Chief-Engineer
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Kara
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 avery
+// SPDX-FileCopyrightText: 2023 kalane15
+// SPDX-FileCopyrightText: 2024 Aviu00
+// SPDX-FileCopyrightText: 2024 Hannah Giovanna Dawson
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 Plykiya
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Redrover1760
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Content.Shared.Administration.Logs;

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -67,10 +67,17 @@ public sealed class ReflectSystem : EntitySystem
         if (args.Reflected)
             return;
 
-        foreach (var ent in _inventorySystem.GetHandOrInventoryEntities(uid, SlotFlags.All & ~SlotFlags.POCKET))
+        // Get all reflective items - from hands and vest slot
+        var reflectiveItems = new List<(EntityUid Entity, ReflectComponent Component)>();
+
+        // Check if the entity has hands component
+        if (TryComp<HandsComponent>(uid, out var handsComp))
         {
-            if (!TryReflectHitscan(uid, ent, args.Shooter, args.SourceItem, args.Direction, args.Damage, out var dir))
-                continue;
+            // Check items in hands
+            foreach (var hand in handsComp.Hands.Values)
+            {
+                if (hand.HeldEntity == null)
+                    continue;
 
                 var ent = hand.HeldEntity.Value;
                 if (TryComp<ReflectComponent>(ent, out var reflectComp) &&
@@ -111,13 +118,12 @@ public sealed class ReflectSystem : EntitySystem
         var bestReflector = reflectiveItems[0];
 
         // Try to reflect with the best reflector
-        if (TryReflectHitscan(uid, bestReflector.Entity, args.Shooter, args.SourceItem, args.Direction, out var dir))
+        if (TryReflectHitscan(uid, bestReflector.Entity, args.Shooter, args.SourceItem, args.Direction, args.Damage, out var dir))
         {
             args.Direction = dir.Value;
             args.Reflected = true;
         }
     }
-
     private void OnReflectUserCollide(EntityUid uid, ReflectUserComponent component, ref ProjectileReflectAttemptEvent args)
     {
         // First, check the projectile's reflective type

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Audio;
+using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
@@ -39,6 +40,7 @@ public sealed class ReflectSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] private readonly InventorySystem _inventorySystem = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!; // WD EDIT
 
     public override void Initialize()
     {
@@ -65,17 +67,10 @@ public sealed class ReflectSystem : EntitySystem
         if (args.Reflected)
             return;
 
-        // Get all reflective items - from hands and vest slot
-        var reflectiveItems = new List<(EntityUid Entity, ReflectComponent Component)>();
-
-        // Check if the entity has hands component
-        if (TryComp<HandsComponent>(uid, out var handsComp))
+        foreach (var ent in _inventorySystem.GetHandOrInventoryEntities(uid, SlotFlags.All & ~SlotFlags.POCKET))
         {
-            // Check items in hands
-            foreach (var hand in handsComp.Hands.Values)
-            {
-                if (hand.HeldEntity == null)
-                    continue;
+            if (!TryReflectHitscan(uid, ent, args.Shooter, args.SourceItem, args.Direction, args.Damage, out var dir))
+                continue;
 
                 var ent = hand.HeldEntity.Value;
                 if (TryComp<ReflectComponent>(ent, out var reflectComp) &&
@@ -227,6 +222,14 @@ public sealed class ReflectSystem : EntitySystem
 
         if (Resolve(projectile, ref projectileComp, false))
         {
+            // WD EDIT START
+            if (reflect.DamageOnReflectModifier != 0)
+            {
+                _damageable.TryChangeDamage(reflector, projectileComp.Damage * reflect.DamageOnReflectModifier,
+                    projectileComp.IgnoreResistances, origin: projectileComp.Shooter);
+            }
+            // WD EDIT END
+
             _adminLogger.Add(LogType.BulletHit, LogImpact.Medium, $"{ToPrettyString(user)} reflected {ToPrettyString(projectile)} from {ToPrettyString(projectileComp.Weapon)} shot by {projectileComp.Shooter}");
 
             projectileComp.Shooter = user;
@@ -249,7 +252,7 @@ public sealed class ReflectSystem : EntitySystem
             return;
         }
 
-        if (TryReflectHitscan(uid, uid, args.Shooter, args.SourceItem, args.Direction, out var dir))
+        if (TryReflectHitscan(uid, uid, args.Shooter, args.SourceItem, args.Direction, args.Damage, out var dir)) // WD EDIT
         {
             args.Direction = dir.Value;
             args.Reflected = true;
@@ -262,6 +265,7 @@ public sealed class ReflectSystem : EntitySystem
         EntityUid? shooter,
         EntityUid shotSource,
         Vector2 direction,
+        DamageSpecifier? damage, // WD EDIT
         [NotNullWhen(true)] out Vector2? newDirection)
     {
         if (!TryComp<ReflectComponent>(reflector, out var reflect) ||
@@ -277,6 +281,11 @@ public sealed class ReflectSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("reflect-shot"), user);
             _audio.PlayPvs(reflect.SoundOnReflect, user, AudioHelpers.WithVariation(0.05f, _random));
         }
+
+        // WD EDIT START
+        if (reflect.DamageOnReflectModifier != 0 && damage != null)
+            _damageable.TryChangeDamage(reflector, damage * reflect.DamageOnReflectModifier, origin: shooter);
+        // WD EDIT END
 
         var spread = _random.NextAngle(-reflect.Spread / 2, reflect.Spread / 2);
         newDirection = -spread.RotateVec(direction);

--- a/Resources/Locale/en-US/_white/rechargeable-blocking/rechargeable-blocking.ftl
+++ b/Resources/Locale/en-US/_white/rechargeable-blocking/rechargeable-blocking.ftl
@@ -1,0 +1,3 @@
+rechargeable-blocking-discharged = It is [color=red]discharged[/color].
+rechargeable-blocking-remaining-time = Time left to charge: [color=green]{ $remainingTime }[/color] seconds.
+rechargeable-blocking-remaining-time-popup = { $remainingTime } seconds left to charge.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -72,6 +72,7 @@
 # SPDX-FileCopyrightText: 2024 AlexUm & XGabriel08X
 # SPDX-FileCopyrightText: 2024 Alzore
 # SPDX-FileCopyrightText: 2024 ArtisticRoomba
+# SPDX-FileCopyrightText: 2024 Aviu00
 # SPDX-FileCopyrightText: 2024 Boaz1111
 # SPDX-FileCopyrightText: 2024 ERROR404
 # SPDX-FileCopyrightText: 2024 Ed

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -255,7 +255,7 @@
   discountDownTo:
     Telecrystal: 15 # Mono #5->3 Mono Edit
   cost:
-    Telecrystal: 30 # Mono #8->6 Mono Edit
+    Telecrystal: 40 # Mono #8->6 Mono Edit
   categories:
   - UplinkWeaponry
 #  conditions: # Mono normal uplink

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -27,6 +27,7 @@
 # SPDX-FileCopyrightText: 2025 BramvanZijp
 # SPDX-FileCopyrightText: 2025 DieselMohawk
 # SPDX-FileCopyrightText: 2025 Nox
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 the-hivequeen
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -373,10 +373,17 @@
   description: Exotic energy shield, when folded, can even fit in your pocket.
   components:
     - type: ItemToggle
+      predictable: false # WD EDIT
       soundActivate:
         path: /Audio/Weapons/ebladeon.ogg
       soundDeactivate:
         path: /Audio/Weapons/ebladeoff.ogg
+      # WD EDIT START
+      soundFailToActivate:
+        path: /Audio/Machines/button.ogg
+        params:
+          variation: 0.250
+      # WD EDIT END
     - type: ItemToggleActiveSound
       activeSound:
         path: /Audio/Weapons/ebladehum.ogg
@@ -414,11 +421,12 @@
       netsync: false
       enabled: false
       radius: 1.5
-      energy: 2
-      color: blue
+      energy: 0.7 # WD EDIT
+      color: "#678AD9" # WD EDIT
     - type: ItemTogglePointLight
     - type: Reflect
-      reflectProb: 0.95
+      reflectProb: 1 # WD EDIT
+      damageOnReflectModifier: 1 # Goob edit
       reflects:
         - Energy
     - type: Blocking
@@ -427,7 +435,7 @@
           Blunt: 1.0
           Slash: 0.9
           Piercing: 0.85
-          Heat: 0.6
+          Heat: 0.5 # WD EDIT
       activeBlockModifier:
         coefficients:
           Blunt: 1.2
@@ -440,30 +448,17 @@
     - type: Appearance
     - type: Damageable
       damageContainer: Shield
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 180
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
-            damage: 100
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-            - !type:PlaySoundBehavior
-              sound:
-                collection: GlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                BrokenEnergyShield:
-                  min: 1
-                  max: 1
     - type: StaticPrice
       price: 350
+      # WD EDIT START
+    - type: Battery
+      maxCharge: 50
+      startingCharge: 50
+    - type: BatterySelfRecharger
+      autoRecharge: true
+      autoRechargeRate: 2
+    - type: RechargeableBlocking
+      # WD EDIT END
 
 - type: entity
   name: broken energy shield

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -489,7 +489,7 @@
       startingCharge: 50
     - type: BatterySelfRecharger
       autoRecharge: true
-      autoRechargeRate: 3
+      autoRechargeRate: 5
     - type: RechargeableBlocking
       # WD EDIT END
 

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -1,3 +1,36 @@
+# SPDX-FileCopyrightText: 2022 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2022 Visne
+# SPDX-FileCopyrightText: 2022 keronshb
+# SPDX-FileCopyrightText: 2023 Darkie
+# SPDX-FileCopyrightText: 2023 DrSmugleaf
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 Michael Cu
+# SPDX-FileCopyrightText: 2023 Nim
+# SPDX-FileCopyrightText: 2023 PixelTK
+# SPDX-FileCopyrightText: 2023 Slava0135
+# SPDX-FileCopyrightText: 2023 lzk
+# SPDX-FileCopyrightText: 2023 sTiKyt
+# SPDX-FileCopyrightText: 2024 Aviu00
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Elysium206
+# SPDX-FileCopyrightText: 2024 Hannah Giovanna Dawson
+# SPDX-FileCopyrightText: 2024 Kara
+# SPDX-FileCopyrightText: 2024 Nairod
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 Plykiya
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2024 degradka
+# SPDX-FileCopyrightText: 2024 deltanedas
+# SPDX-FileCopyrightText: 2024 liltenhead
+# SPDX-FileCopyrightText: 2024 metalgearsloth
+# SPDX-FileCopyrightText: 2024 slarticodefast
+# SPDX-FileCopyrightText: 2025 BramvanZijp
+# SPDX-FileCopyrightText: 2025 DieselMohawk
+# SPDX-FileCopyrightText: 2025 Nox
+# SPDX-FileCopyrightText: 2025 the-hivequeen
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   name: base shield
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -489,7 +489,7 @@
       startingCharge: 50
     - type: BatterySelfRecharger
       autoRecharge: true
-      autoRechargeRate: 2
+      autoRechargeRate: 3
     - type: RechargeableBlocking
       # WD EDIT END
 

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -486,8 +486,8 @@
       price: 350
       # WD EDIT START
     - type: Battery
-      maxCharge: 50
-      startingCharge: 50
+      maxCharge: 60
+      startingCharge: 60
     - type: BatterySelfRecharger
       autoRecharge: true
       autoRechargeRate: 5

--- a/Resources/Prototypes/_Mono/Catalogs/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/pirate_uplink_catalog.yml
@@ -279,7 +279,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Melee/e_shield.rsi, state: eshield-on }
   productEntity: EnergyShield
   cost:
-    Doubloon: 20
+    Doubloon: 40
   categories:
   - UplinkPirateUtility
   conditions:

--- a/Resources/Prototypes/_NF/Catalog/security_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/security_uplink_catalog.yml
@@ -1012,7 +1012,7 @@
   productEntity: EnergyShieldNfsd
   icon: { sprite: _NF/Objects/Weapons/Melee/e_shield.rsi, state: eshield-on }
   cost:
-    FederationMilitaryCredit: 20
+    FederationMilitaryCredit: 40
   categories:
     - UplinkSecurityUtility
   conditions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Ports https://github.com/Goob-Station/Goob-Station/pull/1152. Adjusts values to be tankier. Uplink prices increased

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Energy shields aren't sustainable at all in long rounds over multiple engagements, and I like how they recharge elsewhere

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![Recharge 2](https://github.com/user-attachments/assets/889237c3-295d-4da1-ae49-2ea36ed20b91)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Eshield now doesn't break. Instead, it discharges. Hp reduced: 100 -> 60. Recharges 5 hp per second. When it is fully discharged, it is unusable until it recharges. It takes 15 seconds to recharge after it is fully discharged. Shield gets damaged when it reflects lasers though, but has 50% heat resistance. Can be EMPd now. Cost increased across various uplinks.
- fix: Toggleable shields can't block damage while toggled off.
