### PR TITLE
Mech Changes

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -40,6 +40,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Mech;
 using Content.Shared.Mech.Components;
 using Content.Shared.Mech.EntitySystems;
+using Content.Shared.Mech.Equipment.Components; // Monolith
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
 using Content.Shared.Shuttles.BUIStates;
@@ -324,7 +325,20 @@ public sealed partial class MechSystem : SharedMechSystem
 
     private void OnEmpAttempt(EntityUid uid, MechComponent comp, EmpAttemptEvent args) // Monolith
     {
-                base.BreakMech(uid, comp);
+        if (comp.Broken != true)
+            _damageable.TryChangeDamage(uid, comp.EMPdamage);
+
+        if (TryComp<BatteryComponent>(comp.BatterySlot.ContainedEntity, out var battery))
+        {
+            var maxCharge = battery.MaxCharge;
+            var currentCharge = battery.CurrentCharge;
+            var chargeDelta = maxCharge / 2;
+
+            if (chargeDelta > currentCharge)
+                chargeDelta = currentCharge;
+
+            TryChangeEnergy(uid, -chargeDelta, comp);
+        }
     }
 
     private void ToggleMechUi(EntityUid uid, MechComponent? component = null, EntityUid? user = null)

--- a/Content.Shared/Mech/Components/MechComponent.cs
+++ b/Content.Shared/Mech/Components/MechComponent.cs
@@ -1,3 +1,16 @@
+// SPDX-FileCopyrightText: 2022 Nemanja
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 LordEclipse
+// SPDX-FileCopyrightText: 2023 brainfood1183
+// SPDX-FileCopyrightText: 2023 deltanedas
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 BeeRobynn
+// SPDX-FileCopyrightText: 2025 ScyronX
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.FixedPoint;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;

--- a/Content.Shared/Mech/Components/MechComponent.cs
+++ b/Content.Shared/Mech/Components/MechComponent.cs
@@ -3,6 +3,8 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Content.Shared.Damage; //Monolith
+
 
 namespace Content.Shared.Mech.Components;
 
@@ -61,6 +63,18 @@ public sealed partial class MechComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float MechToPilotDamageMultiplier;
+
+    /// <summary>
+    /// Monolith: The damage dealt by EMPs.
+    /// </summary>
+    [DataField]
+    public DamageSpecifier EMPdamage = new()
+    {
+        DamageDict = new()
+        {
+            { "Blunt", 600 },
+        }
+    };
 
     /// <summary>
     /// Whether the mech has been destroyed and is no longer pilotable.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 wewman222
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -242,7 +242,7 @@
     brokenState: broadsword-broken
     mechToPilotDamageMultiplier: 0
     airtight: false
-    maxIntegrity: 800
+    maxIntegrity: 500
     pilotWhitelist:
       components:
         - HumanoidAppearance


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
EMPs no longer instakill mechs

**Changelog**

:cl:
- tweak: EMPs now do 250 damage and drain a half of the battery when deployed on mechs!
