### PR TITLE
Certain Mech Guns Cant Fire on Grids Anymore

### DIFF
--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -16,6 +16,7 @@
 // SPDX-FileCopyrightText: 2025 Ark
 // SPDX-FileCopyrightText: 2025 BeeRobynn
 // SPDX-FileCopyrightText: 2025 Blu
+// SPDX-FileCopyrightText: 2025 ScyronX
 // SPDX-FileCopyrightText: 2025 wewman222
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -548,6 +548,12 @@ public abstract class SharedMechSystem : EntitySystem
             return;
         }
 
+        if (TryComp<TransformComponent>(uid, out var xform) && xform.GridUid != null && component.PreventFireOnGrid)
+        {
+            args.Cancel();
+            return;
+        }
+
         var ev = new HandleMechEquipmentBatteryEvent();
         RaiseLocalEvent(uid, ev);
     }

--- a/Content.Shared/Mech/Equipment/Components/MechEquipmentComponent.cs
+++ b/Content.Shared/Mech/Equipment/Components/MechEquipmentComponent.cs
@@ -1,4 +1,12 @@
-﻿using Content.Shared.DoAfter;
+// SPDX-FileCopyrightText: 2022 Nemanja
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 keronshb
+// SPDX-FileCopyrightText: 2025 ScyronX
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.DoAfter;
 using Content.Shared.Mech.Components;
 using Robust.Shared.Serialization;
 

--- a/Content.Shared/Mech/Equipment/Components/MechEquipmentComponent.cs
+++ b/Content.Shared/Mech/Equipment/Components/MechEquipmentComponent.cs
@@ -19,6 +19,12 @@ public sealed partial class MechEquipmentComponent : Component
     /// The mech that the equipment is inside of.
     /// </summary>
     [ViewVariables] public EntityUid? EquipmentOwner;
+
+    /// <summary>
+    /// Monolith: Equipment that cant be fired on grids.
+    /// </summary>
+    [DataField]
+    public bool PreventFireOnGrid = false;
 }
 
 /// <summary>

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 wewman222
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -90,6 +90,8 @@
   suffix: Mech Weapon, Gun, Combat, Cannon
   parent: [ BaseMechWeaponRange, MediumMechMountEquipment ]
   components:
+  - type: MechEquipment
+    preventFireOnGrid: true
   - type: Sprite
     sprite: _Mono/Objects/Specific/Mech/tgmc_mecha_weapons.rsi
     state: sniper64x32
@@ -116,6 +118,8 @@
   suffix: Mech Weapon, Gun, Combat, Cannon
   parent: [ BaseMechWeaponRange, MediumMechMountEquipment ]
   components:
+  - type: MechEquipment
+    preventFireOnGrid: true
   - type: Sprite
     sprite: _Mono/Objects/Specific/Mech/tgmc_mecha_weapons.rsi
     state: laserrifle64x32
@@ -142,6 +146,8 @@
   suffix: Mech Weapon, Gun, Combat, Cannon
   parent: [ BaseMechWeaponRange, MediumMechMountEquipment ]
   components:
+  - type: MechEquipment
+    preventFireOnGrid: true
   - type: Sprite
     sprite: _Mono/Objects/Specific/Mech/tgmc_mecha_weapons.rsi
     state: tow64x32
@@ -169,6 +175,8 @@
   suffix: Mech Weapon, Gun, Combat, Missile
   parent: [ BaseMechWeaponRange, HeavyMechMountEquipment ]
   components:
+  - type: MechEquipment
+    preventFireOnGrid: true
   - type: Sprite
     sprite: _Mono/Objects/Specific/Mech/tgmc_mecha_weapons.rsi
     state: rpg64x32
@@ -194,6 +202,8 @@
   suffix: Mech Weapon, Gun, Combat, Cannon
   parent: [ BaseMechWeaponRange, HeavyMechMountEquipment ]
   components:
+  - type: MechEquipment
+    preventFireOnGrid: true
   - type: Sprite
     sprite: _Mono/Objects/Specific/Mech/tgmc_mecha_weapons.rsi
     state: heavycannon64x32
@@ -223,6 +233,8 @@
   suffix: Mech Weapon, Gun, Combat, EnergyCannon
   parent: [ BaseMechWeaponRange, HeavyMechMountEquipment ]
   components:
+  - type: MechEquipment
+    preventFireOnGrid: true
   - type: Sprite
     sprite: _Mono/Objects/Specific/Mech/tgmc_mecha_weapons.rsi
     state: flamer64x32
@@ -252,6 +264,8 @@
   suffix: Mech Weapon, Gun, Combat, EWAR
   parent: [ BaseMechWeaponRange, EWARMechMountEquipment ]
   components:
+  - type: MechEquipment
+    preventFireOnGrid: true
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: tesla
@@ -278,6 +292,8 @@
   suffix: Mech Weapon, Gun, Combat, EWAR
   parent: [ BaseMechWeaponRange, EWARMechMountEquipment ]
   components:
+  - type: MechEquipment
+    preventFireOnGrid: true
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: tesla


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Medium and heavy mech weapons can only be fired in space now

**Changelog**

:cl: Scyron
- tweak: Medium and heavy mech weapons can only be fired in space now!


