### PR TITLE
Mech Buffs (Armor and Energy)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -410,8 +410,8 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 3000
-    startingCharge: 3000
+    maxCharge: 6000
+    startingCharge: 6000
 
 - type: entity
   id: PowerCageHigh

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -74,7 +74,7 @@
     brokenState: broadsword-broken
     mechToPilotDamageMultiplier: 0
     airtight: true
-    maxIntegrity: 600
+    maxIntegrity: 1200
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -104,7 +104,7 @@
     requireNoGrid: true
     shape: square
   - type: Damageable
-    damageModifierSet: MediumArmorNT
+    damageModifierSet: HeavyArmorNT
   - type: Repairable
     fuelCost: 40
     doAfterDelay: 30
@@ -164,7 +164,7 @@
     brokenState: broadsword-broken
     mechToPilotDamageMultiplier: 0
     airtight: true
-    maxIntegrity: 450
+    maxIntegrity: 900
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -189,7 +189,7 @@
     baseSprintSpeed: 1
     weightlessModifier: 35
   - type: Damageable
-    damageModifierSet: MediumArmorNT
+    damageModifierSet: HeavyArmorNT
   - type: RadarBlip
     radarColor: "#CF0E0E"
     scale: 4
@@ -269,7 +269,7 @@
     baseWalkSpeed: 3
     baseSprintSpeed: 6
   - type: Damageable
-    damageModifierSet: MediumArmorNT
+    damageModifierSet: HeavyArmorNT
   - type: RadarBlip
     radarColor: "#CF0E0E"
     scale: 4
@@ -326,7 +326,7 @@
     brokenState: flail-broken
     mechToPilotDamageMultiplier: 0
     airtight: true
-    maxIntegrity: 900
+    maxIntegrity: 1800
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -407,7 +407,7 @@
     brokenState: flail-broken
     mechToPilotDamageMultiplier: 0
     airtight: true
-    maxIntegrity: 500
+    maxIntegrity: 1000
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -489,7 +489,7 @@
     mechToPilotDamageMultiplier: 0
     maxEquipmentAmount: 1
     airtight: true
-    maxIntegrity: 600
+    maxIntegrity: 1200
     pilotWhitelist:
       components:
         - HumanoidAppearance


### PR DESCRIPTION
## About the PR
Updated mech armor + HP values, as with giving the fuel cells more energy. Players have been complaining about how it's locked by research, and too weak to really use, so it makes sense buffing an enormous resource sink to be useable.

## Why / Balance
People won't have their 2 hour investments destroyed in 5 seconds.

## How to test
release/tools build

## Media


## Requirements
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
- [x ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.


**Changelog**

:cl:
- tweak: Updated Mech armor and HP to be more durable.
- tweak: Updated Mech fuel cells to contain much more energy
-->
