### PR TITLE
Revert "Powercreeps Wall Durability (#1239)", Adds Shipgun Explosion Types Instead

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -1,27 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Alex Evgrashin
-# SPDX-FileCopyrightText: 2022 Leon Friedrich
-# SPDX-FileCopyrightText: 2022 Snowni
-# SPDX-FileCopyrightText: 2022 Veritius
-# SPDX-FileCopyrightText: 2023 AJCM-git
-# SPDX-FileCopyrightText: 2023 Julian Giebel
-# SPDX-FileCopyrightText: 2023 Nemanja
-# SPDX-FileCopyrightText: 2023 TemporalOroboros
-# SPDX-FileCopyrightText: 2023 metalgearsloth
-# SPDX-FileCopyrightText: 2024 Dvir
-# SPDX-FileCopyrightText: 2024 Emisse
-# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
-# SPDX-FileCopyrightText: 2024 Kara
-# SPDX-FileCopyrightText: 2024 Saphire Lattice
-# SPDX-FileCopyrightText: 2024 Whatstone
-# SPDX-FileCopyrightText: 2024 emmafornash
-# SPDX-FileCopyrightText: 2025 Blu
-# SPDX-FileCopyrightText: 2025 BramvanZijp
-# SPDX-FileCopyrightText: 2025 Ed
-# SPDX-FileCopyrightText: 2025 Redrover1760
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
-- type: entity
+﻿- type: entity
   id: BasePlasticExplosive
   parent: BaseItem
   abstract: true

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -151,7 +151,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 4x
+        damage: 1200 # Mono - wall buff - 4x
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -184,7 +184,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 4x
+        damage: 1200 # Mono - wall buff - 4x
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -226,7 +226,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 4x
+        damage: 1200 # Mono - wall buff - 4x
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -271,7 +271,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 1000 # Mono - wall buff - 4x
+        damage: 400 # Mono - wall buff - 4x
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -300,7 +300,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 4x
+        damage: 1200 # Mono - wall buff - 4x
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -331,7 +331,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 4x
+        damage: 1200 # Mono - wall buff - 4x
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -364,7 +364,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 6000 # Mono - wall buff - 8x its diamonds bro
+        damage: 2400 # Mono - wall buff - 8x its diamonds bro
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -400,7 +400,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 2250 # Mono - wall buff - 3x gold is brittle
+        damage: 900 # Mono - wall buff - 3x gold is brittle
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -409,7 +409,7 @@
         acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
-        damage: 375
+        damage: 1500 # Mono
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -449,7 +449,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 1500 # Mono - wall buff - 2x
+        damage: 600 # Mono - wall buff - 2x
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -485,7 +485,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 4x
+        damage: 1200 # Mono - wall buff - 4x
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -494,7 +494,7 @@
         acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
-        damage: 1500
+        damage: 150
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -532,7 +532,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 4x
+        damage: 1200 # Mono - wall buff - 4x
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -541,7 +541,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 1500 # Mono - wall buff - 4x
+        damage: 600 # Mono - wall buff - 4x
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -605,7 +605,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 17500 # Mono - wall buff - 7.5x
+        damage: 7500 # Mono - wall buff - 7.5x
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -640,7 +640,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 10000 # Mono - wall buff - 2x
+        damage: 3500 # Mono - wall buff - 2x
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -649,7 +649,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 7500 # Mono - wall buff - 2x
+        damage: 2000 # Mono - wall buff - 2x
       behaviors:
       - !type:ChangeConstructionNodeBehavior
         node: girder
@@ -731,7 +731,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 8000 # Mono - wall buff - 5x
+        damage: 4000 # Mono - wall buff - 5x
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -740,7 +740,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 5000 # Mono - wall buff - 5x
+        damage: 3000 # Mono - wall buff - 5x
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -809,7 +809,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 6250 # Mono - wall buff - 5x
+        damage: 2500 # Mono - wall buff - 5x
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -818,7 +818,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 4375 # Mono - wall buff - 5x
+        damage: 1750 # Mono - wall buff - 5x
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -857,7 +857,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 8000
+        damage: 4000
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -866,7 +866,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 5000
+        damage: 3000
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -1054,7 +1054,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 9000 # Mono - wall buff - 6x
+        damage: 3600 # Mono - wall buff - 6x
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -1063,7 +1063,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 4500 # Mono - wall buff - 6x
+        damage: 1800 # Mono - wall buff - 6x
       behaviors:
       - !type:ChangeConstructionNodeBehavior
         node: girder
@@ -1093,7 +1093,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 9000 # Mono - wall buff - 6x
+        damage: 3600 # Mono - wall buff - 6x
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -1102,7 +1102,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 6000 # Mono - wall buff - 6x
+        damage: 2400 # Mono - wall buff - 6x
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -1172,7 +1172,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 6000 # Mono - wall buff - 6x
+        damage: 2400 # Mono - wall buff - 6x
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -1181,7 +1181,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 6x
+        damage: 1200 # Mono - wall buff - 6x
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -1227,7 +1227,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 4000 # Mono - wall buff - 4x
+        damage: 1600 # Mono - wall buff - 4x
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -1236,7 +1236,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 2000 # Mono - wall buff - 4x
+        damage: 800 # Mono - wall buff - 4x
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -1270,11 +1270,11 @@
   - type: Icon
     sprite: Structures/Walls/solid_diagonal.rsi
     state: state0
-  - type: Destructible # Mono - override HP stats from parent: WallShuttleDiagonal, matches reinforced wall
+  - type: Destructible # Mono - override HP stats from parent: WallShuttleDiagonal, matches solid wall
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 4000
+        damage: 1600
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -1283,7 +1283,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 2000
+        damage: 800
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -1313,7 +1313,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 3000 # Mono - wall buff - 4x
+        damage: 1200 # Mono - wall buff - 4x
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -1322,7 +1322,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 1500 # Mono - wall buff - 4x
+        damage: 600 # Mono - wall buff - 4x
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -1348,7 +1348,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 7500 # Mono - wall buff - 10x
+        damage: 3000 # Mono - wall buff - 10x
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -1357,7 +1357,7 @@
           collection: MetalSlam
     - trigger:
         !type:DamageTrigger
-        damage: 5000 # Mono - wall buff - alot - uranium is dense
+        damage: 2000 # Mono - wall buff - alot - uranium is dense
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -1,19 +1,3 @@
-# SPDX-FileCopyrightText: 2024 AndresE55
-# SPDX-FileCopyrightText: 2024 Whatstone
-# SPDX-FileCopyrightText: 2025 Dvir
-# SPDX-FileCopyrightText: 2025 Redrover1760
-# SPDX-FileCopyrightText: 2025 starch
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
-# SPDX-FileCopyrightText: 2024 AndresE55
-# SPDX-FileCopyrightText: 2024 Whatstone
-# SPDX-FileCopyrightText: 2025 Dvir
-# SPDX-FileCopyrightText: 2025 Redrover1760
-# SPDX-FileCopyrightText: 2025 starch
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 - type: entity
   name: breaching charge
   description: A breaching explosive for security officers to break through walls.

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -39,7 +39,7 @@
     radarColor: "#C92BCC"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: DefaultShipGun
     totalIntensity: 250
     intensitySlope: 6
     maxIntensity: 25
@@ -146,7 +146,7 @@
     color: "#6BC1FF"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBomb
+    explosionType: HardBombShipGun
     totalIntensity: 1250
     intensitySlope: 10
     maxIntensity: 55

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -41,7 +41,7 @@
     color: "#19AFFF"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBomb
+    explosionType: HardBombShipGun
     totalIntensity: 2000
     intensitySlope: 8
     maxIntensity: 800
@@ -82,7 +82,7 @@
     color: "#19AFFF"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBomb
+    explosionType: HardBombShipGun
     totalIntensity: 5000
     intensitySlope: 8
     maxIntensity: 3000
@@ -166,7 +166,7 @@
     color: "#FCBA03"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBomb
+    explosionType: HardBombShipGun
     totalIntensity: 40
     intensitySlope: 5
     maxIntensity: 25
@@ -227,7 +227,7 @@
   components:
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: DefaultShipGun
 
 # 150mm Tarnyx
 
@@ -295,7 +295,7 @@
     color: "#FCBA03"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBomb
+    explosionType: HardBombShipGun
     totalIntensity: 550
     intensitySlope: 5
     maxIntensity: 1150
@@ -335,7 +335,7 @@
     color: "#fc5a03"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBomb
+    explosionType: HardBombShipGun
     totalIntensity: 1000
     intensitySlope: 25
     maxIntensity: 75
@@ -375,7 +375,7 @@
     color: "#fc8c03"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBomb
+    explosionType: HardBombShipGun
     totalIntensity: 750
     intensitySlope: 35
     maxIntensity: 50
@@ -416,7 +416,7 @@
     color: "#FCBA03"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBomb
+    explosionType: HardBombShipGun
     totalIntensity: 1250
     intensitySlope: 5
     maxIntensity: 1450

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -32,7 +32,7 @@
     energy: 0.5
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: DefaultShipGun
     totalIntensity: 75
     intensitySlope: 8
     maxIntensity: 25
@@ -80,7 +80,7 @@
     energy: 0.5
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: DefaultShipGun
     totalIntensity: 150
     intensitySlope: 10
     maxIntensity: 55
@@ -128,7 +128,7 @@
     energy: 2
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: DefaultShipGun
     maxIntensity: 6000
     intensitySlope: 30
     totalIntensity: 6000
@@ -180,7 +180,7 @@
     disableDuration: 5
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: Default
+    explosionType: DefaultShipGun
     totalIntensity: 100
     intensitySlope: 10
     maxIntensity: 50

--- a/Resources/Prototypes/_Mono/explosion.yml
+++ b/Resources/Prototypes/_Mono/explosion.yml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2022 Alex Evgrashin
+# SPDX-FileCopyrightText: 2022 Leon Friedrich
+# SPDX-FileCopyrightText: 2022 Moony
+# SPDX-FileCopyrightText: 2022 keronshb
+# SPDX-FileCopyrightText: 2023 Dawid Bla
+# SPDX-FileCopyrightText: 2023 Emisse
+# SPDX-FileCopyrightText: 2023 Kara
+# SPDX-FileCopyrightText: 2023 Nemanja
+# SPDX-FileCopyrightText: 2023 Skye
+# SPDX-FileCopyrightText: 2023 ThunderBear2006
+# SPDX-FileCopyrightText: 2023 eclips_e
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2024 Mr. 27
+# SPDX-FileCopyrightText: 2024 liltenhead
+# SPDX-FileCopyrightText: 2025 Redrover1760
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#  Does not currently support prototype hot-reloading. See comments in c# file.
+
+- type: explosion
+  id: DefaultShipGun
+  damagePerIntensity:
+    types:
+      Heat: 2
+      Blunt: 2
+      Piercing: 2
+      Structural: 2
+  tileBreakChance: [0, 0.5, 1]
+  tileBreakIntensity: [0, 15, 30]
+  tileBreakRerollReduction: 20
+  lightColor: Orange
+  texturePath: /Textures/Effects/fire.rsi
+  fireStates: 3
+
+- type: explosion
+  id: HardBombShipGun
+  damagePerIntensity:
+    types:
+      Heat: 7.5
+      Blunt: 7.5
+      Piercing: 3
+      Structural: 20
+  tileBreakChance: [ 0, 0.5, 1 ]
+  tileBreakIntensity: [ 0, 15, 30 ]
+  tileBreakRerollReduction: 10
+  intensityPerState: 20
+  lightColor: Orange
+  texturePath: /Textures/Effects/fire.rsi
+  fireStates: 6
+
+# STOP
+# BEFORE YOU ADD MORE EXPLOSION TYPES CONSIDER IF AN EXISTING ONE IS SUITABLE
+# ADDING NEW ONES IS PROHIBITIVELY EXPENSIVE


### PR DESCRIPTION
This reverts commit 3e2034d74593ca2b5e57de10eca41aa1d62c3e75.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

powercreep is a horrible idea kids don't do it

Shipgun explosion types, better at cracking walls. Overall durabiliy is going down a bit but its not powercreeped.

Also buffs reinforced walls to 3000 HP from 2000 HP because they're reinforced...

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I hate powercreep

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Wall durability powercreep gone, shipgun explosives made less damaging instead
- fix: Fixed basic wall diagonals having reinforced wall level stats

