### PR TITLE
Captain's Voidsuit Selector Fix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -118,7 +118,6 @@
     #      prob: 0.25 # Frontier
     #    - id: ClothingBeltSheathFilled # Frontier
     #    - id: ClothingHeadsetAltCommand # Frontier
-    - id: UndeterminedVoidsuitCap
     #    - id: ClothingOuterArmorCaptainCarapace
     #    - id: CommsComputerCircuitboard # Frontier
     #    - id: DoorRemoteCommand # Frontier


### PR DESCRIPTION
## About the PR
This one on me, I accidentally added unidentified voidsuit selector BOTH to hardsuit and regular captain's locker tables.

## Why / Balance
Because of my oversight, every captain's locker comes with voidsuit selector, but if it's the one that comes with hardsuit, it will contain two voidsuit selectors. This PR fixes that.

## How to test
run localhost, spawn in captain's locker, regular one should have no selector and [Hardsuit] one contains only one selector.

## Media
Very small fix, no need.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
None, not anymore

**Changelog**
:cl:
- fix: Captain's locker should have only one voidsuit selector at a time now.
