### PR TITLE
DME EVA Suit, Small DME Shareholder Change

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/shareholder.yml
+++ b/Resources/Maps/_Mono/Shuttles/shareholder.yml
@@ -1,33 +1,11 @@
-# SPDX-FileCopyrightText: 2022 20kdc
-# SPDX-FileCopyrightText: 2022 Nemanja
-# SPDX-FileCopyrightText: 2022 Peptide90
-# SPDX-FileCopyrightText: 2022 metalgearsloth
-# SPDX-FileCopyrightText: 2022 retequizzle
-# SPDX-FileCopyrightText: 2023 Dawid Bla
-# SPDX-FileCopyrightText: 2023 Leon Friedrich
-# SPDX-FileCopyrightText: 2024 Emisse
-# SPDX-FileCopyrightText: 2024 Kara
-# SPDX-FileCopyrightText: 2024 Mangohydra
-# SPDX-FileCopyrightText: 2024 Nairod
-# SPDX-FileCopyrightText: 2024 QueerNB
-# SPDX-FileCopyrightText: 2024 Ubaser
-# SPDX-FileCopyrightText: 2025 Ark
-# SPDX-FileCopyrightText: 2025 RealSchepka
-# SPDX-FileCopyrightText: 2025 RikuTheKiller
-# SPDX-FileCopyrightText: 2025 compilatron
-# SPDX-FileCopyrightText: 2025 significant harassment
-# SPDX-FileCopyrightText: 2025 starch
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 meta:
   format: 7
   category: Grid
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 07/02/2025 15:52:43
-  entityCount: 219
+  time: 07/09/2025 18:46:11
+  entityCount: 220
 maps: []
 grids:
 - 1
@@ -113,6 +91,56 @@ entities:
             id: BrickTileDarkLineW
           decals:
             6: 2,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            12: 9,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            11: 9,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            26: 6,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinEndW
+          decals:
+            13: 5,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerSw
+          decals:
+            22: 6,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            14: 9,2
+            15: 9,3
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            23: 6,4
+            24: 7,4
+            25: 8,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            16: 8,1
+            17: 7,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            20: 6,3
+            21: 6,2
     - type: GridAtmosphere
       version: 2
       data:
@@ -185,6 +213,8 @@ entities:
     - type: RadiationGridResistance
     - type: BecomesStation
       id: Shareholder
+    - type: ShipGridLock
+      locked: False
 - proto: AirAlarm
   entities:
   - uid: 2
@@ -993,6 +1023,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,0.5
+      parent: 1
+- proto: LockerWallEVAColorDMEFilled
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 9.5,5.5
       parent: 1
 - proto: LockerWallEVAColorSalvageFilled
   entities:

--- a/Resources/Maps/_Mono/Shuttles/shareholder.yml
+++ b/Resources/Maps/_Mono/Shuttles/shareholder.yml
@@ -1,3 +1,26 @@
+# SPDX-FileCopyrightText: 2022 20kdc
+# SPDX-FileCopyrightText: 2022 Nemanja
+# SPDX-FileCopyrightText: 2022 Peptide90
+# SPDX-FileCopyrightText: 2022 metalgearsloth
+# SPDX-FileCopyrightText: 2022 retequizzle
+# SPDX-FileCopyrightText: 2023 Dawid Bla
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2024 Emisse
+# SPDX-FileCopyrightText: 2024 Kara
+# SPDX-FileCopyrightText: 2024 Mangohydra
+# SPDX-FileCopyrightText: 2024 Nairod
+# SPDX-FileCopyrightText: 2024 QueerNB
+# SPDX-FileCopyrightText: 2024 Ubaser
+# SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 RealSchepka
+# SPDX-FileCopyrightText: 2025 RikuTheKiller
+# SPDX-FileCopyrightText: 2025 Schepka
+# SPDX-FileCopyrightText: 2025 compilatron
+# SPDX-FileCopyrightText: 2025 significant harassment
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 meta:
   format: 7
   category: Grid

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/locker_wallmount.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/locker_wallmount.yml
@@ -1,0 +1,5 @@
+# DME
+- type: entity
+  parent: [ LockerWallEVAColorDME, StorageFillEVASuitDME ]
+  id: LockerWallEVAColorDMEFilled
+  suffix: Filled

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/locker_wallmount.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/locker_wallmount.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Schepka
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # DME
 - type: entity
   parent: [ LockerWallEVAColorDME, StorageFillEVASuitDME ]

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/StorageFillTemplates/departmental_eva.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/StorageFillTemplates/departmental_eva.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Schepka
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # DME
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/StorageFillTemplates/departmental_eva.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/StorageFillTemplates/departmental_eva.yml
@@ -1,0 +1,13 @@
+# DME
+- type: entity
+  abstract: true
+  id: StorageFillEVASuitDME
+  description: Contains a standard issue DME Contractor EVA kit.
+  components:
+  - type: StorageFill
+    contents:
+    - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: ClothingOuterEVASuitDME
+    - id: ClothingMaskBreath
+    - id: JetpackMiniFilled

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/softsuit-helmets.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/softsuit-helmets.yml
@@ -1,0 +1,26 @@
+# DME
+- type: entity
+  parent: ClothingHeadEVAHelmetWithLightBase
+  id: ClothingHeadEVAHelmetDME
+  name: DME EVA Helmet
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: _NF/Clothing/Head/Helmets/eva_color.rsi
+    layers:
+    - state: icon-base
+      color: "#403642"
+    - state: icon-reinforced-points
+      color: "#be42c9"
+    - state: icon-visor
+      color: "#75122e"
+  - type: Clothing
+    sprite: _NF/Clothing/Head/Helmets/eva_color.rsi
+    clothingVisuals:
+      head:
+      - state: equipped-head-base
+        color: "#403642"
+      - state: equipped-head-reinforced-points
+        color: "#be42c9"
+      - state: equipped-head-visor
+        color: "#75122e"

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/softsuit-helmets.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/softsuit-helmets.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Schepka
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # DME
 - type: entity
   parent: ClothingHeadEVAHelmetWithLightBase

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/softsuits.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Schepka
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # DME
 - type: entity
   parent: NFClothingOuterEVASuitBase

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/softsuits.yml
@@ -1,0 +1,61 @@
+# DME
+- type: entity
+  parent: NFClothingOuterEVASuitBase
+  id: ClothingOuterEVASuitDME
+  name: DME EVA Suit
+  description: An EVA suit with a built-in helmet commonly issued to wealthy traders.
+  components:
+  - type: Sprite
+    sprite: _NF/Clothing/OuterClothing/Suits/eva_color.rsi
+    layers:
+    - state: icon-base
+      color: "#403642"
+    - state: icon-decals-01
+      color: "#be42c9"
+    - state: icon-reinforced-points
+      color: "#75122e"
+    - state: icon-breathing-gear
+    - state: icon-unshaded
+      shader: unshaded
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left-base
+        color: "#403642"
+      - state: inhand-left-decals-01
+        color: "#be42c9"
+      - state: inhand-left-reinforced-points
+        color: "#75122e"
+      - state: inhand-left-breathing-gear
+      - state: inhand-left-unshaded
+        shader: unshaded
+      right:
+      - state: inhand-right-base
+        color: "#403642"
+      - state: inhand-right-decals-01
+        color: "#be42c9"
+      - state: inhand-right-reinforced-points
+        color: "#75122e"
+      - state: inhand-right-breathing-gear
+      - state: inhand-right-unshaded
+        shader: unshaded
+  - type: Clothing
+    sprite: _NF/Clothing/OuterClothing/Suits/eva_color.rsi
+    clothingVisuals:
+      outerClothing:
+      - state: equipped-base
+        color: "#403642"
+      - state: equipped-decals-01
+        color: "#be42c9"
+      - state: equipped-reinforced-points
+        color: "#75122e"
+      - state: equipped-breathing-gear
+      - state: equipped-unshaded
+        shader: unshaded
+  - type: Armor
+    modifiers:
+      coefficients: # Mono
+        Caustic: 0.75
+  - type: ToggleableClothing
+    clothingPrototypes:
+      head:  ClothingHeadEVAHelmetDME

--- a/Resources/Prototypes/_Mono/Entities/Structures/Storage/Closets/wall_departments.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Storage/Closets/wall_departments.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Schepka
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # DME
 - type: entity
   id: LockerWallColorDME

--- a/Resources/Prototypes/_Mono/Entities/Structures/Storage/Closets/wall_departments.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Storage/Closets/wall_departments.yml
@@ -1,0 +1,26 @@
+# DME
+- type: entity
+  id: LockerWallColorDME
+  parent: LockerWallColorBase
+  name: DME wall locker
+  suffix: DME, Company
+  components:
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.StorageVisualLayers.Base"]
+      color: "#75122e"
+    - state: door
+      map: ["enum.StorageVisualLayers.Door"]
+      color: "#403642"
+    - state: door-decal-line-02
+      map: [ decal1 ]
+      color: "#be42c9"
+    - state: door-decal-null
+      map: [ decal2 ]
+      color: "#be42c9"
+    - state: welded
+      visible: false
+      map: ["enum.WeldableLayers.BaseWelded"]
+    - state: locked
+      map: ["enum.LockVisualLayers.Lock"]

--- a/Resources/Prototypes/_Mono/Entities/Structures/Storage/Closets/wall_departments_eva.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Storage/Closets/wall_departments_eva.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Schepka
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # DME
 - type: entity
   categories: [ HideSpawnMenu ] # debloat spawn menu

--- a/Resources/Prototypes/_Mono/Entities/Structures/Storage/Closets/wall_departments_eva.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Storage/Closets/wall_departments_eva.yml
@@ -1,0 +1,26 @@
+# DME
+- type: entity
+  categories: [ HideSpawnMenu ] # debloat spawn menu
+  id: LockerWallEVAColorDME
+  parent: LockerWallColorBase
+  name: DME EVA wall locker
+  components:
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.StorageVisualLayers.Base"]
+      color: "#75122e"
+    - state: door
+      map: ["enum.StorageVisualLayers.Door"]
+      color: "#403642"
+    - state: door-decal-line-01
+      map: [ decal1 ]
+      color: "#be42c9"
+    - state: door-decal-eva-02
+      map: [ decal2 ]
+      color: "#be42c9"
+    - state: welded
+      visible: false
+      map: ["enum.WeldableLayers.BaseWelded"]
+    - state: locked
+      map: ["enum.LockVisualLayers.Lock"]

--- a/Resources/Prototypes/_Mono/Shipyard/shareholder.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/shareholder.yml
@@ -5,7 +5,11 @@
 # SPDX-FileCopyrightText: 2024 Long YM
 # SPDX-FileCopyrightText: 2024 Maxtone
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 KM-Catman
 # SPDX-FileCopyrightText: 2025 RealSchepka
+# SPDX-FileCopyrightText: 2025 Schepka
+# SPDX-FileCopyrightText: 2025 UnicornOnLSD
+# SPDX-FileCopyrightText: 2025 plethorian
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/shareholder.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/shareholder.yml
@@ -21,7 +21,7 @@
   parent: BaseVessel
   name: DME Shareholder
   description: Cheap and affordable salvage vessel that comes with a comfortable lounge at the cost of leaving no budget for the rest.
-  price: 18000
+  price: 19000
   category: Small
   group: Shipyard
   shuttlePath: /Maps/_Mono/Shuttles/shareholder.yml


### PR DESCRIPTION
## About the PR
Added DME EVA suit with corresponding EVA locker, this is mostly a precursor for future DME shuttles, but the locker was already added to Shareholder and slightly bumped up its price accordingly.

On top of that, the yml files this PR adds would make it easier for other companies to add their own EVA suits in the future.
## Why / Balance
This EVA will be used on DME shuttle series to give them extra flavor in the future.

## How to test
run localhost, spawn in a shareholder, the shuttle will already contain a DME EVA locker in the front room.

## Media
![image](https://github.com/user-attachments/assets/957c1395-ab1d-439a-af24-0fc5749a7d5b)
## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
None that I know of.

**Changelog**
:cl:
- add: Added DME EVA Suit to DME Shareholder, sail in style.

