### PR TITLE
Update combat.yml (TOW Energy Cost Fix + Others)

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -181,7 +181,7 @@
     maxCharge: 500
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM302
-    fireCost: 600
+    fireCost: 500
   - type: Appearance
   - type: AmmoCounter
 
@@ -302,7 +302,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
   - type: Battery
-    maxCharge: 600
+    maxCharge: 500
   - type: ProjectileBatteryAmmoProvider
     proto: BlanketFlare
     fireCost: 500


### PR DESCRIPTION
## About the PR
Fixed the TOW missile for mechs not being able to fire

## Why / Balance
People couldn't use it at all

## How to test
release build


## Requirements
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
- [x ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**

:cl:
-fix: Fixed TOW Mech missile not firing, and other energy stats to not draw more than whats needed
