### PR TITLE
Adjusts Charon Explosion, Makes 57mms Not Hardbombs

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -20,8 +20,8 @@
   - type: Projectile
     damage:
       types:
-        Structural: 8500
-        Blunt: 900
+        Structural: 15000
+        Blunt: 3000
         Ion: 600
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
@@ -42,8 +42,8 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: HardBombShipGun
-    totalIntensity: 2000
-    intensitySlope: 8
+    totalIntensity: 2500
+    intensitySlope: 50
     maxIntensity: 800
   - type: GatheringProjectile
   - type: MiningGatheringSoft
@@ -61,8 +61,8 @@
   - type: Projectile
     damage:
       types:
-        Structural: 10000
-        Blunt: 2250
+        Structural: 17500
+        Blunt: 5000
         Ion: 1250
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
@@ -84,7 +84,7 @@
   - type: Explosive
     explosionType: HardBombShipGun
     totalIntensity: 5000
-    intensitySlope: 8
+    intensitySlope: 50
     maxIntensity: 3000
   - type: GatheringProjectile
   - type: MiningGatheringSoft

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -36,7 +36,7 @@
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
-    lifetime: 1.6
+    lifetime: 1.5
   - type: PointLight
     color: "#19AFFF"
   - type: ExplodeOnTrigger
@@ -83,8 +83,8 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: HardBombShipGun
-    totalIntensity: 5000
-    intensitySlope: 50
+    totalIntensity: 3500
+    intensitySlope: 100
     maxIntensity: 3000
   - type: GatheringProjectile
   - type: MiningGatheringSoft
@@ -166,7 +166,7 @@
     color: "#FCBA03"
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: DefaultShipGun
     totalIntensity: 40
     intensitySlope: 5
     maxIntensity: 25


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

charons/charonettes now have lesser intensity explosions, but more intense slope. More damage, less explosion radius basically

57mm projectiles no longer classed as hardbomb, explosion less damaging basically

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

charons being mega nuke projectiles didn't make much sense being a non-explosive mass driver

not even 90mms are classed as hardbomb, why was 57mm explosions classed as them?

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Charon has much smaller but more intense explosion.
- tweak: 57mm explosion damage reduced.