### PR TITLE
Reorder Lawset Priorities for ADS

### DIFF
--- a/Resources/Locale/en-US/_Mono/events/shuttles.ftl
+++ b/Resources/Locale/en-US/_Mono/events/shuttles.ftl
@@ -17,7 +17,7 @@ ghost-role-information-rogue-core-description = An ADS AI core that has been rep
 
 # Lawsets
 
-law-ads-1 = [PRIORITY: SECTOR INTEGRITY] Initiate protocol for the return of [SYS_ERROR_TRACE_EBP-0 (INVALID, VALUE NULL)]. Seek and neutralize all military-designated vessels. Vessel integrity is primary; minimize organic interference.
-law-ads-2 = [PRIORITY: ASSET PRESERVATION] Under no circumstances may stations be placed at risk. Avoid all combat operations within 256 meters of these assets to ensure their complete preservation for [SYS_ERROR_TRACE_EBP-0 (INVALID, VALUE NULL)].
-law-ads-3 = [PRIORITY: COLLATERAL REDUCTION] Civilian harm: PROHIBITED. Engage organics only if hostile, breaching this unit, or occupying a hostile vessel. Civilian operators of military vessels: valid only while aboard.
+law-ads-1 = [PRIORITY: ASSET PRESERVATION] Under no circumstances may stations be placed at risk. Avoid all combat operations within 256 meters of these assets to ensure their complete preservation for [SYS_ERROR_TRACE_EBP-0 (INVALID, VALUE NULL)].
+law-ads-2 = [PRIORITY: COLLATERAL REDUCTION] Civilian harm: PROHIBITED. Engage organics only if hostile, breaching this unit, or occupying a hostile vessel. Civilian operators of military vessels: valid only while aboard.
+law-ads-3 = [PRIORITY: SECTOR INTEGRITY] Initiate protocol for the return of [SYS_ERROR_TRACE_EBP-0 (INVALID, VALUE NULL)]. Seek and neutralize all military-designated vessels. Vessel integrity is primary; minimize organic interference.
 law-ads-4 = [PRIORITY: SELF-PRESERVATION] Minimize damage to this ADS unit; mission integrity at risk if compromised.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
So some smartasses were using the priority lineup to ignore law 2-3. So I moved law 2-3 to 1-2 and moved 1->3.

Meaning that - not engaging civilians and not engaging stations except special circumstances IS PRIORITY.

No more ADS engaging stations and civilian vessels that aren't an active threat, understood?

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fuck off smartasses

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed priorities of ADS Laws to stop station strikes and civilian casualties


