### PR TITLE
Changed Akula's Many Plasti Walls with Reinforced

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/USSP/akula.yml
+++ b/Resources/Maps/_Mono/Shuttles/USSP/akula.yml
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: 2023 Cheackraze
+# SPDX-FileCopyrightText: 2023 Kennedy
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 dustylens
+# SPDX-FileCopyrightText: 2025 Ricky
+# SPDX-FileCopyrightText: 2025 RikuTheKiller
+# SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 kyres1
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 meta:
   format: 7
   category: Grid

--- a/Resources/Maps/_Mono/Shuttles/USSP/akula.yml
+++ b/Resources/Maps/_Mono/Shuttles/USSP/akula.yml
@@ -1,24 +1,10 @@
-# SPDX-FileCopyrightText: 2023 Cheackraze
-# SPDX-FileCopyrightText: 2023 Kennedy
-# SPDX-FileCopyrightText: 2024 Dvir
-# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
-# SPDX-FileCopyrightText: 2024 dustylens
-# SPDX-FileCopyrightText: 2025 Ricky
-# SPDX-FileCopyrightText: 2025 RikuTheKiller
-# SPDX-FileCopyrightText: 2025 core-mene
-# SPDX-FileCopyrightText: 2025 grandalff
-# SPDX-FileCopyrightText: 2025 kyres1
-# SPDX-FileCopyrightText: 2025 starch
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 meta:
   format: 7
   category: Grid
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 07/09/2025 21:45:25
+  time: 07/13/2025 10:21:51
   entityCount: 405
 maps: []
 grids:
@@ -2293,11 +2279,6 @@ entities:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 298
-    components:
-    - type: Transform
-      pos: -3.5,-8.5
-      parent: 1
   - uid: 299
     components:
     - type: Transform
@@ -2309,42 +2290,21 @@ entities:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 301
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
-      parent: 1
   - uid: 302
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 303
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 1
   - uid: 304
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 305
-    components:
-    - type: Transform
-      pos: 4.5,-6.5
-      parent: 1
   - uid: 306
     components:
     - type: Transform
       pos: 1.5,-3.5
-      parent: 1
-  - uid: 307
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
       parent: 1
   - uid: 308
     components:
@@ -2357,43 +2317,15 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 1
-  - uid: 310
-    components:
-    - type: Transform
-      pos: 4.5,-7.5
-      parent: 1
-  - uid: 311
-    components:
-    - type: Transform
-      pos: 4.5,-8.5
-      parent: 1
   - uid: 312
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 313
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
   - uid: 314
     components:
     - type: Transform
       pos: -1.5,-4.5
-      parent: 1
-  - uid: 315
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 316
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
       parent: 1
   - uid: 317
     components:
@@ -2421,16 +2353,6 @@ entities:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 322
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 323
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
   - uid: 324
     components:
     - type: Transform
@@ -2448,36 +2370,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,12.5
-      parent: 1
-  - uid: 327
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,11.5
-      parent: 1
-  - uid: 328
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,10.5
-      parent: 1
-  - uid: 329
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,9.5
-      parent: 1
-  - uid: 330
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,9.5
-      parent: 1
-  - uid: 331
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,8.5
       parent: 1
   - uid: 332
     components:
@@ -2514,36 +2406,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,7.5
-      parent: 1
-  - uid: 338
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,8.5
-      parent: 1
-  - uid: 339
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,9.5
-      parent: 1
-  - uid: 340
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,9.5
-      parent: 1
-  - uid: 341
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,10.5
-      parent: 1
-  - uid: 342
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,11.5
       parent: 1
   - uid: 343
     components:
@@ -2585,23 +2447,11 @@ entities:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 350
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-0.5
-      parent: 1
   - uid: 351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,1.5
-      parent: 1
-  - uid: 352
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-0.5
       parent: 1
   - uid: 353
     components:
@@ -2638,12 +2488,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 359
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-0.5
-      parent: 1
   - uid: 360
     components:
     - type: Transform
@@ -2655,95 +2499,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 362
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,1.5
-      parent: 1
-  - uid: 363
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,3.5
-      parent: 1
   - uid: 364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,3.5
-      parent: 1
-  - uid: 365
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,4.5
-      parent: 1
-  - uid: 366
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,4.5
-      parent: 1
-  - uid: 367
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,6.5
-      parent: 1
-  - uid: 368
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,5.5
-      parent: 1
-  - uid: 369
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,7.5
-      parent: 1
-  - uid: 370
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,8.5
-      parent: 1
-  - uid: 371
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,6.5
-      parent: 1
-  - uid: 372
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,5.5
-      parent: 1
-  - uid: 373
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,7.5
-      parent: 1
-  - uid: 374
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,8.5
-      parent: 1
-  - uid: 375
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,10.5
-      parent: 1
-  - uid: 376
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,10.5
       parent: 1
   - uid: 377
     components:
@@ -2762,51 +2522,10 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,13.5
       parent: 1
-  - uid: 380
-    components:
-    - type: Transform
-      pos: 0.5,1.5
-      parent: 1
-  - uid: 381
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,4.5
-      parent: 1
-  - uid: 382
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,4.5
-      parent: 1
   - uid: 383
     components:
     - type: Transform
       pos: 0.5,7.5
-      parent: 1
-  - uid: 384
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,11.5
-      parent: 1
-  - uid: 385
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,12.5
-      parent: 1
-  - uid: 386
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,11.5
-      parent: 1
-  - uid: 387
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,12.5
       parent: 1
   - uid: 388
     components:
@@ -2840,6 +2559,236 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
   - uid: 393
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed Akula's many plasti walls with reinforced

## Why / Balance
Akula was too armored for its size

## How to test
USSP shipyard

## Media
<img width="265" height="772" alt="Screenshot 2025-07-13 132707" src="https://github.com/user-attachments/assets/974f80a6-6e3a-45b3-b802-689a6a1fcf37" />
<img width="265" height="763" alt="Screenshot 2025-07-13 132813" src="https://github.com/user-attachments/assets/52d5e65c-624e-4b28-9471-2b61af20439e" />
<img width="278" height="748" alt="Screenshot 2025-07-13 132844" src="https://github.com/user-attachments/assets/ce36d1f6-dfa1-4ebf-8c97-a97a5aeb26f8" />
<img width="204" height="174" alt="Screenshot 2025-07-13 133145" src="https://github.com/user-attachments/assets/2dc11865-9695-4f0e-9586-fb122981bed4" />
<img width="792" height="744" alt="Screenshot 2025-07-13 133418" src="https://github.com/user-attachments/assets/1aa2030b-b02f-46e1-b783-3ed835ae2f92" />
Compared to Gadyuka

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**

:cl:
- tweak: Comrades! USSP is determine Akula is waste too much resource for such small size on armor, so we remove many plastitanium wall and change for reinforced one, so plastitanium used to bigger ships! Za rodynu!
