### PR TITLE
Removed Radar Blips From Jetpacks and Vehicles

### DIFF
--- a/Content.Server/Movement/Systems/JetpackSystem.cs
+++ b/Content.Server/Movement/Systems/JetpackSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
-using Content.Server._Mono.Radar;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.Collections;
@@ -12,41 +11,12 @@ public sealed class JetpackSystem : SharedJetpackSystem
 {
     [Dependency] private readonly GasTankSystem _gasTank = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly EntityManager _entityManager = default!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-        
-        // Subscribe to ActiveJetpackComponent events
-        SubscribeLocalEvent<ActiveJetpackComponent, ComponentStartup>(OnJetpackActivated);
-        SubscribeLocalEvent<ActiveJetpackComponent, ComponentShutdown>(OnJetpackDeactivated);
-    }
 
     protected override bool CanEnable(EntityUid uid, JetpackComponent component)
     {
         return base.CanEnable(uid, component) &&
                TryComp<GasTankComponent>(uid, out var gasTank) &&
                !(gasTank.Air.TotalMoles < component.MoleUsage);
-    }
-    
-    /// <summary>
-    /// Adds radar blip to jetpacks when they are activated
-    /// </summary>
-    private void OnJetpackActivated(EntityUid uid, ActiveJetpackComponent component, ComponentStartup args)
-    {
-        var blip = EnsureComp<RadarBlipComponent>(uid);
-        blip.RadarColor = Color.Cyan;
-        blip.Scale = 0.5f;
-        blip.VisibleFromOtherGrids = true;
-    }
-    
-    /// <summary>
-    /// Removes radar blip from jetpacks when they are deactivated
-    /// </summary>
-    private void OnJetpackDeactivated(EntityUid uid, ActiveJetpackComponent component, ComponentShutdown args) 
-    {
-        RemComp<RadarBlipComponent>(uid);
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/Movement/Systems/JetpackSystem.cs
+++ b/Content.Server/Movement/Systems/JetpackSystem.cs
@@ -1,3 +1,13 @@
+// SPDX-FileCopyrightText: 2022 Júlio César Ueti
+// SPDX-FileCopyrightText: 2022 rolfero
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Wrexbe (Josh)
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 ScyronX
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Movement.Components;

--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -1,28 +1,7 @@
-using Content.Server._Mono.Radar; //Lua mod
-using Content.Shared.Buckle.Components; //Lua mod
 using Content.Shared.Vehicle;
-using Content.Shared.Vehicle.Components; //Lua mod
 
 namespace Content.Server.Vehicle;
 
 public sealed class VehicleSystem : SharedVehicleSystem
 {
-    //Lua start
-    protected override void OnStrapped(EntityUid uid, VehicleComponent component, ref StrappedEvent args)
-    {
-        base.OnStrapped(uid, component, ref args);
-
-        var blip = EnsureComp<RadarBlipComponent>(uid);
-        blip.RadarColor = Color.Cyan;
-        blip.Scale = 0.5f;
-        blip.VisibleFromOtherGrids = true;
-    }
-
-    protected override void OnUnstrapped(EntityUid uid, VehicleComponent component, ref UnstrappedEvent args)
-    {
-        RemComp<RadarBlipComponent>(uid);
-
-        base.OnUnstrapped(uid, component, ref args);
-    }
-    //Lua end
 }

--- a/Content.Server/Vehicle/VehicleSystem.cs
+++ b/Content.Server/Vehicle/VehicleSystem.cs
@@ -1,3 +1,15 @@
+// SPDX-FileCopyrightText: 2022 DrSmugleaf
+// SPDX-FileCopyrightText: 2022 Leon Friedrich
+// SPDX-FileCopyrightText: 2022 Rane
+// SPDX-FileCopyrightText: 2023 AJCM-git
+// SPDX-FileCopyrightText: 2023 Daniil Sikinami
+// SPDX-FileCopyrightText: 2024 checkraze
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2025 HacksLua
+// SPDX-FileCopyrightText: 2025 ScyronX
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Vehicle;
 
 namespace Content.Server.Vehicle;

--- a/Content.Shared/Vehicle/SharedVehicleSystem.cs
+++ b/Content.Shared/Vehicle/SharedVehicleSystem.cs
@@ -108,7 +108,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
     }
 
     // Umbra: vehicle changes
-    protected virtual void OnUnstrapped(EntityUid uid, VehicleComponent component, ref UnstrappedEvent args) //Lua: private void<protected virtual void
+    private void OnUnstrapped(EntityUid uid, VehicleComponent component, ref UnstrappedEvent args)
     {
         // Remove rider
         var riderUid = args.Buckle.Owner;
@@ -157,7 +157,7 @@ public abstract partial class SharedVehicleSystem : EntitySystem
         }
     }
 
-    protected virtual void OnStrapped(EntityUid uid, VehicleComponent component, ref StrappedEvent args) //Lua: private void<protected virtual void
+    private void OnStrapped(EntityUid uid, VehicleComponent component, ref StrappedEvent args)
     {
         var riderUid = args.Buckle.Owner;
 

--- a/Content.Shared/Vehicle/SharedVehicleSystem.cs
+++ b/Content.Shared/Vehicle/SharedVehicleSystem.cs
@@ -1,3 +1,22 @@
+// SPDX-FileCopyrightText: 2022 Rane
+// SPDX-FileCopyrightText: 2022 metalgearsloth
+// SPDX-FileCopyrightText: 2023 Daniil Sikinami
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 Nemanja
+// SPDX-FileCopyrightText: 2023 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2023 brainfood1183
+// SPDX-FileCopyrightText: 2023 deltanedas
+// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2024 AJCM-git
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2024 checkraze
+// SPDX-FileCopyrightText: 2024 themias
+// SPDX-FileCopyrightText: 2025 HacksLua
+// SPDX-FileCopyrightText: 2025 ScyronX
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Numerics;
 using Content.Shared._NF.Vehicle.Components;
 using Content.Shared.Access.Components;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed radar blips from jetpacks and vehicles

## Why / Balance
These features outright removed boarding gameplay or reduced them to little known or faction locked game mechanics getting rid of them will improve combat


**Changelog**

:cl:
- remove: Removed radar blips from jetpacks and vehicles!
