### PR TITLE
Buffs Wspr

### DIFF
--- a/Resources/Locale/en-US/_Mono/store/pirate-uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Mono/store/pirate-uplink-catalog.ftl
@@ -180,10 +180,10 @@ uplink-pirate-box-smg-magazine-name = Box of 9x19mm SMG magazines
 uplink-pirate-box-smg-magazine-desc = A box filled with 3 9x19mm smg magazines.
 
 uplink-subsonic-mag-name = 7.62x39mm subsonic rifle mag
-uplink-subsonic-mag-desc = Supports the WSPR and Annie.
+uplink-subsonic-mag-desc = Supports the WSPR.
 
 uplink-subsonic-box-name = 7.62x39mm subsonic rifle box
-uplink-subsonic-box-desc = A box of ammo for the WSPR and Annie.
+uplink-subsonic-box-desc = A box of ammo for the WSPR.
 
 uplink-pirate-box-highcal-name = 12.7x99mm box
 uplink-pirate-box-highcal-desc = A box of general-purpose ammunition for the Burner heavy rifle.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -105,7 +105,6 @@
         whitelist:
           tags:
             - Magazine7.62x39mmSubsonic
-            - Magazine7.62x39mmFMJ
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
@@ -114,7 +113,6 @@
         whitelist:
           tags:
             - Cartridge7.62x39mmSubsonic
-            - Cartridge7.62x39mmFMJ
   - type: MagazineVisuals
     magState: mag
     steps: 1

--- a/Resources/Prototypes/_Mono/Catalogs/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/pirate_uplink_catalog.yml
@@ -637,7 +637,7 @@
   description: uplink-subsonic-mag-desc
   productEntity: Magazine7.62x39mmSubsonic
   cost:
-    Doubloon: 5
+    Doubloon: 4
   categories:
   - UplinkPirateAmmo
   conditions:
@@ -652,7 +652,7 @@
   description: uplink-subsonic-box-desc
   productEntity: AmmoBox7.62x39mmSubsonic
   cost:
-    Doubloon: 10
+    Doubloon: 7
   categories:
   - UplinkPirateAmmo
   conditions:

--- a/Resources/Prototypes/_Mono/Catalogs/security_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/security_uplink_catalog.yml
@@ -136,35 +136,35 @@
         tags:
           - SecurityUplink
 
-- type: listing
-  id: UplinkSecurityMagazineSubsonic
-  name:  uplink-subsonic-mag-name
-  description: uplink-subsonic-mag-desc
-  productEntity: Magazine7.62x39mmSubsonic
-  cost:
-    FederationMilitaryCredit: 3
-  categories:
-  - UplinkSecurityAmmo
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - SecurityUplink
+#- type: listing
+#  id: UplinkSecurityMagazineSubsonic
+#  name:  uplink-subsonic-mag-name
+#  description: uplink-subsonic-mag-desc
+#  productEntity: Magazine7.62x39mmSubsonic
+#  cost:
+#    FederationMilitaryCredit: 3
+#  categories:
+#  - UplinkSecurityAmmo
+#  conditions:
+#  - !type:StoreWhitelistCondition
+#    whitelist:
+#      tags:
+#      - SecurityUplink
 
-- type: listing
-  id: UplinkSecurityBoxSubsonic
-  name:  uplink-subsonic-box-name
-  description: uplink-subsonic-box-desc
-  productEntity: AmmoBox7.62x39mmSubsonic
-  cost:
-    FederationMilitaryCredit: 10
-  categories:
-  - UplinkSecurityAmmo
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - SecurityUplink
+#- type: listing
+#  id: UplinkSecurityBoxSubsonic
+#  name:  uplink-subsonic-box-name
+#  description: uplink-subsonic-box-desc
+#  productEntity: AmmoBox7.62x39mmSubsonic
+#  cost:
+#    FederationMilitaryCredit: 10
+#  categories:
+#  - UplinkSecurityAmmo
+#  conditions:
+#  - !type:StoreWhitelistCondition
+#    whitelist:
+#      tags:
+#      - SecurityUplink
 
 - type: listing
   id: UplinkSecurityMagazine8x65mm

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
@@ -64,4 +64,4 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 18
+        Piercing: 23

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
@@ -1,3 +1,32 @@
+# SPDX-FileCopyrightText: 2020 AJCM-git
+# SPDX-FileCopyrightText: 2020 DrSmugleaf
+# SPDX-FileCopyrightText: 2020 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2021 Leon Friedrich
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2022 Charlese2
+# SPDX-FileCopyrightText: 2022 Kara
+# SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2022 metalgearsloth
+# SPDX-FileCopyrightText: 2022 ninruB
+# SPDX-FileCopyrightText: 2023 AndresE55
+# SPDX-FileCopyrightText: 2023 Boaz1111
+# SPDX-FileCopyrightText: 2023 Flareguy
+# SPDX-FileCopyrightText: 2023 Jackal298
+# SPDX-FileCopyrightText: 2023 LankLTE
+# SPDX-FileCopyrightText: 2023 Vordenburg
+# SPDX-FileCopyrightText: 2023 kerisargit
+# SPDX-FileCopyrightText: 2023 vanx
+# SPDX-FileCopyrightText: 2023 vanx <vanx#5477>
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 IProduceWidgets
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 Plykiya
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 core-mene
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: Bullet7.62x39mmFMJ
   name: bullet (7.62x39mm FMJ)

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/AllTheAmmo/Intermediate_7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/AllTheAmmo/Intermediate_7.62x39mm.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 HungryCuban
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 core-mene
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/AllTheAmmo/Intermediate_7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/AllTheAmmo/Intermediate_7.62x39mm.yml
@@ -40,6 +40,11 @@
   id: MagazineDP29
   result: MagazineDP29
 
+- type: latheRecipe
+  parent: BaseAmmoFMJIntermediateMagazineRecipe
+  id: Magazine7.62x39mmSubsonic
+  result: Magazine7.62x39mmSubsonic
+
 #Speedloaders
 
 - type: latheRecipe

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/ammo.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/ammo.yml
@@ -5,9 +5,9 @@
 - type: latheRecipePack
   id: MonoRogueAmmo
   recipes:
-  - Magazine7.62x39mmFMJ # AKM/WSPR
+  - Magazine7.62x39mmFMJ # AKM
   - Magazine7.62x39mmEmpty # AKM/WSPR
-  - AmmoBox7.62x39mmFMJ # AKM/WSPR
+  - AmmoBox7.62x39mmFMJ # AKM
   - Magazine7.62x51mmFMJ # M-90
   - Magazine7.62x51mmEmpty # M-90
   - AmmoBox7.62x51mmFMJ # M-90
@@ -31,3 +31,5 @@
   - AmmoBox145x114mmBig # Hristov
   - Magazine635x40mmCaseless # MlA-73
   - AmmoBox635x40mmCaseless # MlA-73
+  - Magazine7.62x39mmSubsonic # WSPR
+  - AmmoBox7.62x39mmSubsonic # WSPR

--- a/Resources/Prototypes/_Mono/Research/Rogue/rogue_weapons.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/rogue_weapons.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 HungryCuban
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Research/Rogue/rogue_weapons.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/rogue_weapons.yml
@@ -134,6 +134,8 @@
   cost: 25000
   recipeUnlocks:
   - WeaponRifleWSPRRogue
+  - Magazine7.62x39mmSubsonic
+  - AmmoBox7.62x39mmSubsonic
   - WeaponSubMachineGunMla73Rogue
   - Magazine635x40mmCaseless
   - AmmoBox635x40mmCaseless


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

restricts wspr ammo to subsonic

buffs subsonic to do more damage than fmj

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

why is this exotic ammo type so garbage avto I told you to buff this 10 days ago smh

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: WSPR only can fire subsonic ammo, subsonic ammo damage 18>23, two more than FMJ variant
- tweak: Subsonic ammo costs slightly less in rogue uplink, removed from tsfmc uplink (annie doesn't use it anymore anyways). Made clear it only is for the WSPR

