### PR TITLE
Major FTL Rework

### DIFF
--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -1,3 +1,18 @@
+// SPDX-FileCopyrightText: 2023 Checkraze
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2024 Dvir
+// SPDX-FileCopyrightText: 2024 MilenVolf
+// SPDX-FileCopyrightText: 2024 SlamBamActionman
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2024 Wiebe Geertsma
+// SPDX-FileCopyrightText: 2024 checkraze
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 GreaseMonk
+// SPDX-FileCopyrightText: 2025 Redrover1760
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Station.Components;
 using Content.Shared.Popups;
 using Content.Shared.Shuttles.Components;

--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -21,7 +21,7 @@ public sealed partial class SalvageSystem
 {
     [ValidatePrototypeId<EntityPrototype>]
     public const string CoordinatesDisk = "CoordinatesDisk";
-    private const float ShuttleFTLRange = 100f;
+    private const float ShuttleFTLRange = 5f;
     private const float ShuttleFTLMassThreshold = 50f;
 
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;

--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -36,7 +36,7 @@ public sealed partial class SalvageSystem
 {
     [ValidatePrototypeId<EntityPrototype>]
     public const string CoordinatesDisk = "CoordinatesDisk";
-    private const float ShuttleFTLRange = 1f;
+    private const float ShuttleFTLRange = 0f;
     private const float ShuttleFTLMassThreshold = 50f;
 
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;

--- a/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
+++ b/Content.Server/Salvage/SalvageSystem.ExpeditionConsole.cs
@@ -21,7 +21,7 @@ public sealed partial class SalvageSystem
 {
     [ValidatePrototypeId<EntityPrototype>]
     public const string CoordinatesDisk = "CoordinatesDisk";
-    private const float ShuttleFTLRange = 5f;
+    private const float ShuttleFTLRange = 1f;
     private const float ShuttleFTLMassThreshold = 50f;
 
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -279,7 +279,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
         if (shuttleUid is { Valid: true })
         {
             var shuttle = _entManager.GetComponent<ShuttleComponent>(shuttleUid.Value);
-            _shuttle.FTLToCoordinates(shuttleUid.Value, shuttle, new EntityCoordinates(mapUid, coords), 0f, 5.5f, 50f);
+            _shuttle.FTLToCoordinates(shuttleUid.Value, shuttle, new EntityCoordinates(mapUid, coords), 0f, 30f, 35f); // StartupTime 5.5f->30f, 50f->35f
         }
 
         List<Vector2i> reservedTiles = new();

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -1,3 +1,24 @@
+// SPDX-FileCopyrightText: 2023 Cheackraze
+// SPDX-FileCopyrightText: 2023 Visne
+// SPDX-FileCopyrightText: 2023 deltanedas
+// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2024 Checkraze
+// SPDX-FileCopyrightText: 2024 ElectroJr
+// SPDX-FileCopyrightText: 2024 Kara
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 MilenVolf
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 SlamBamActionman
+// SPDX-FileCopyrightText: 2024 Vasilis
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2024 checkraze
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2025 Dvir
+// SPDX-FileCopyrightText: 2025 GreaseMonk
+// SPDX-FileCopyrightText: 2025 Redrover1760
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using System.Numerics;
 using System.Threading;

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -28,7 +28,7 @@ public sealed partial class ShuttleConsoleSystem
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly SharedShuttleSystem _sharedShuttle = default!;
 
-    private const float ShuttleFTLRange = 1f;
+    private const float ShuttleFTLRange = 0f;
     private const float ShuttleFTLMassThreshold = 50f;
 
     private void InitializeFTL()

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -28,7 +28,7 @@ public sealed partial class ShuttleConsoleSystem
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly SharedShuttleSystem _sharedShuttle = default!;
 
-    private const float ShuttleFTLRange = 100f;
+    private const float ShuttleFTLRange = 5f;
     private const float ShuttleFTLMassThreshold = 50f;
 
     private void InitializeFTL()

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -28,7 +28,7 @@ public sealed partial class ShuttleConsoleSystem
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly SharedShuttleSystem _sharedShuttle = default!;
 
-    private const float ShuttleFTLRange = 5f;
+    private const float ShuttleFTLRange = 1f;
     private const float ShuttleFTLMassThreshold = 50f;
 
     private void InitializeFTL()

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -80,25 +80,25 @@ public sealed partial class CCVars
     ///     How long the warmup time before FTL start should be.
     /// </summary>
     public static readonly CVarDef<float> FTLStartupTime =
-        CVarDef.Create("shuttle.startup_time", 5.5f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.startup_time", 30f, CVar.SERVERONLY);
 
     /// <summary>
     ///     How long a shuttle spends in FTL.
     /// </summary>
     public static readonly CVarDef<float> FTLTravelTime =
-        CVarDef.Create("shuttle.travel_time", 20f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.travel_time", 30f, CVar.SERVERONLY);
 
     /// <summary>
     ///     How long the final stage of FTL before arrival should be.
     /// </summary>
     public static readonly CVarDef<float> FTLArrivalTime =
-        CVarDef.Create("shuttle.arrival_time", 5f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.arrival_time", 10f, CVar.SERVERONLY);
 
     /// <summary>
     ///     How much time needs to pass before a shuttle can FTL again.
     /// </summary>
     public static readonly CVarDef<float> FTLCooldown =
-        CVarDef.Create("shuttle.cooldown", 10f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.cooldown", 45f, CVar.SERVERONLY);
 
     /// <summary>
     ///     The maximum <see cref="PhysicsComponent.Mass"/> a grid can have before it becomes unable to FTL.

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -1,4 +1,13 @@
-﻿using Content.Shared.Administration;
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 GreaseMonk
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Redrover1760
+// SPDX-FileCopyrightText: 2025 Simon
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Administration;
 using Content.Shared.CCVar.CVarAccess;
 using Robust.Shared.Configuration;
 

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -80,25 +80,25 @@ public sealed partial class CCVars
     ///     How long the warmup time before FTL start should be.
     /// </summary>
     public static readonly CVarDef<float> FTLStartupTime =
-        CVarDef.Create("shuttle.startup_time", 30f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.startup_time", 5.5f, CVar.SERVERONLY);
 
     /// <summary>
     ///     How long a shuttle spends in FTL.
     /// </summary>
     public static readonly CVarDef<float> FTLTravelTime =
-        CVarDef.Create("shuttle.travel_time", 30f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.travel_time", 20f, CVar.SERVERONLY);
 
     /// <summary>
     ///     How long the final stage of FTL before arrival should be.
     /// </summary>
     public static readonly CVarDef<float> FTLArrivalTime =
-        CVarDef.Create("shuttle.arrival_time", 10f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.arrival_time", 5f, CVar.SERVERONLY);
 
     /// <summary>
     ///     How much time needs to pass before a shuttle can FTL again.
     /// </summary>
     public static readonly CVarDef<float> FTLCooldown =
-        CVarDef.Create("shuttle.cooldown", 45f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.cooldown", 10f, CVar.SERVERONLY);
 
     /// <summary>
     ///     The maximum <see cref="PhysicsComponent.Mass"/> a grid can have before it becomes unable to FTL.

--- a/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
+++ b/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Redrover1760
+// SPDX-FileCopyrightText: 2025 gus
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Mono.Ships;

--- a/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
+++ b/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
@@ -22,7 +22,7 @@ public sealed partial class FTLDriveComponent : Component
     /// </summary>
     [DataField]
     [AutoNetworkedField]
-    public float Cooldown = 10f;
+    public float Cooldown = 45f; // Mono
 
 
     /// <summary>
@@ -30,12 +30,12 @@ public sealed partial class FTLDriveComponent : Component
     /// </summary>
     [DataField]
     [AutoNetworkedField]
-    public float HyperSpaceTime = 20f;
+    public float HyperSpaceTime = 15f; // Mono
 
     /// <summary>
     /// The FTL duration until the jump starts.
     /// </summary>
     [DataField]
     [AutoNetworkedField]
-    public float StartupTime = 5.5f;
+    public float StartupTime = 30f; // Mono
 }

--- a/Resources/Maps/_Mono/Shuttles/Nfsd/fracture.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/fracture.yml
@@ -1,3 +1,16 @@
+# SPDX-FileCopyrightText: 2023 Cheackraze
+# SPDX-FileCopyrightText: 2023 FoxxoTrystan
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Mr. Samuel
+# SPDX-FileCopyrightText: 2025 Alice "Arimah" Heurlin
+# SPDX-FileCopyrightText: 2025 Checkraze
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 RikuTheKiller
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 meta:
   format: 7
   category: Grid

--- a/Resources/Maps/_Mono/Shuttles/Nfsd/fracture.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/fracture.yml
@@ -2192,7 +2192,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -3.5,-5.5
       parent: 1
-- proto: MachineFTLDrive25S
+- proto: MachineFTLDrive25
   entities:
   - uid: 268
     components:

--- a/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/bluespaceworks.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/bluespaceworks.yml
@@ -2,5 +2,5 @@
   id: BlueSpaceVendInventory
   startingInventory:
     FTLDriveFlatpack: 4294967295 # Infinite
-    FTLDrive50Flatpack: 4294967295 # Infinite
-    FTLDrive25SFlatpack: 4294967295 # Infinite
+#    FTLDrive50Flatpack: 4294967295 # Infinite
+#    FTLDrive25SFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/bluespaceworks.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/VendingMachines/Inventories/bluespaceworks.yml
@@ -1,4 +1,9 @@
-﻿- type: vendingMachineInventory
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 gus
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: vendingMachineInventory
   id: BlueSpaceVendInventory
   startingInventory:
     FTLDriveFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
@@ -59,7 +59,7 @@
   - type: Flatpack
     entity: MachineFTLDrive
   - type: StaticPrice
-    vendPrice: 50000
+    vendPrice: 25000
 
 - type: entity
   parent: BaseFlatpack

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
@@ -59,7 +59,7 @@
   - type: Flatpack
     entity: MachineFTLDrive
   - type: StaticPrice
-    vendPrice: 100000
+    vendPrice: 50000
 
 - type: entity
   parent: BaseFlatpack

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
@@ -59,7 +59,7 @@
   - type: Flatpack
     entity: MachineFTLDrive
   - type: StaticPrice
-    price: 1700
+    vendPrice: 100000
 
 - type: entity
   parent: BaseFlatpack
@@ -70,7 +70,7 @@
   - type: Flatpack
     entity: MachineFTLDrive50
   - type: StaticPrice
-    price: 3000
+    vendPrice: 200000
 
 - type: entity
   parent: BaseFlatpack
@@ -81,7 +81,7 @@
   - type: Flatpack
     entity: MachineFTLDrive25S
   - type: StaticPrice
-    price: 5000
+    vendPrice: 300000
 
 - type: entity
   parent: BaseFlatpack

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
@@ -119,7 +119,7 @@
       color: "#7E16F7"
   - type: FTLDrive
     range: 25000
-    cooldown: 20
+    cooldown: 30
     hyperSpaceTime: 7.5
     startupTime: 20
   - type: ApcPowerReceiver

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
@@ -10,7 +10,7 @@
   id: MachineFTLDrive
   parent: BaseMachinePowered
   name: CTLA-25 bluespace drive
-  description: A FTL drive that extends a ship's FTL range to ~5 kilometers. Does not stack.
+  description: A FTL drive that extends a ship's FTL range to ~25 kilometers. Does not stack.
   placement:
     mode: SnapgridCenter
   components:
@@ -29,7 +29,10 @@
         shader: unshaded
         color: "#349BEB"
     - type: FTLDrive
-      range: 5000
+      range: 25000
+      cooldown: 45
+      hyperSpaceTime: 15
+      startupTime: 45
     - type: ApcPowerReceiver
       powerLoad: 2000
     - type: PointLight
@@ -71,7 +74,7 @@
   parent: MachineFTLDrive
   id: MachineFTLDrive50
   name: CTLA-50 bluespace drive
-  description: A FTL drive that extends a ship's FTL range to ~10 kilometers. Does not stack.
+  description: A FTL drive that extends a ship's FTL range to ~50 kilometers. Does not stack.
   components:
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/drive.rsi
@@ -84,7 +87,10 @@
       shader: unshaded
       color: "#E6173E"
   - type: FTLDrive
-    range: 10000
+    range: 50000
+    cooldown: 45
+    hyperSpaceTime: 20
+    startupTime: 45
   - type: ApcPowerReceiver
     powerLoad: 4000
   - type: PointLight
@@ -99,7 +105,7 @@
   parent: MachineFTLDrive
   id: MachineFTLDrive25S
   name: CTLA-25s bluespace drive
-  description: An advanced FTL drive that extends a ship's FTL range to ~5 kilometers, but with upgrades to allow for faster recharge and flight times. Does not stack.
+  description: An advanced FTL drive that extends a ship's FTL range to ~25 kilometers, but with upgrades to allow for faster recharge and less of a cooldown. Does not stack.
   components:
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/drive.rsi
@@ -112,10 +118,10 @@
       shader: unshaded
       color: "#7E16F7"
   - type: FTLDrive
-    range: 5000
-    cooldown: 7.5
-    hyperSpaceTime: 15
-    startupTime: 4.2
+    range: 25000
+    cooldown: 30
+    hyperSpaceTime: 7.5
+    startupTime: 30
   - type: ApcPowerReceiver
     powerLoad: 4000
   - type: PointLight

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
@@ -29,7 +29,7 @@
         shader: unshaded
         color: "#349BEB"
     - type: FTLDrive
-      range: 25000
+      range: 15000
       cooldown: 45
       hyperSpaceTime: 15
       startupTime: 30
@@ -87,7 +87,7 @@
       shader: unshaded
       color: "#E6173E"
   - type: FTLDrive
-    range: 50000
+    range: 35000
     cooldown: 45
     hyperSpaceTime: 20
     startupTime: 45
@@ -118,7 +118,7 @@
       shader: unshaded
       color: "#7E16F7"
   - type: FTLDrive
-    range: 25000
+    range: 15000
     cooldown: 30
     hyperSpaceTime: 7.5
     startupTime: 20

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
@@ -32,7 +32,7 @@
       range: 25000
       cooldown: 45
       hyperSpaceTime: 15
-      startupTime: 45
+      startupTime: 30
     - type: ApcPowerReceiver
       powerLoad: 2000
     - type: PointLight
@@ -119,9 +119,9 @@
       color: "#7E16F7"
   - type: FTLDrive
     range: 25000
-    cooldown: 30
+    cooldown: 20
     hyperSpaceTime: 7.5
-    startupTime: 30
+    startupTime: 20
   - type: ApcPowerReceiver
     powerLoad: 4000
   - type: PointLight

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
@@ -87,7 +87,7 @@
       shader: unshaded
       color: "#E6173E"
   - type: FTLDrive
-    range: 35000
+    range: 30000
     cooldown: 45
     hyperSpaceTime: 20
     startupTime: 45

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/ftldrive.yml
@@ -105,7 +105,7 @@
   parent: MachineFTLDrive
   id: MachineFTLDrive25S
   name: CTLA-25s bluespace drive
-  description: An advanced FTL drive that extends a ship's FTL range to ~25 kilometers, but with upgrades to allow for faster recharge and less of a cooldown. Does not stack.
+  description: An advanced FTL drive that extends a ship's FTL range to ~25 kilometers, but with upgrades to allow for faster recharge and less travel time. Does not stack.
   components:
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/drive.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

FTL drives are now absurdly long ranged with much more startup and cooldown times.

New stats

CTLA-25:
Range: 25000m
Startup time: 30s
Travel time: 15s
Cooldown: 45s

CTLA-50
Range: 50000m
Startup time: 45s
Travel time: 20s
Cooldown: 45s

CTLA-25s
Range: 25000m
Startup time: 20s
Travel time: 7.5s
Cooldown: 30s

CTLA 25 increased to 25k in vendor

other CTLA drives removed from vendor, still accessible via tech. CTLA-25s replaced with CTLA-25 on the Fracture

You can now FTL near other ships, that's just gone entirely.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

FTL is too uncommitable. FTL in is no risk, FTL out is no risk and easy to do.

Therefore, we make it go SUPER Far, but take a long chargeup!

CTLA 50 and 25s being easily accessible are not really necessary and kinda bad so they're gone from the drivevend, locked behind technology and progression. The base CTLA-25 is still in the drivevend but costs 25k now to be a proper luxury item.

You do not need FTL anymore now that everyone is at 60 m/s maxspeed.

Future reworks to FTL in general is planned but I think this is the best state FTL can be in at the moment.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: FTL longer ranged, more cooldown/startuptime. 25km is now standard CTLA 25, takes 30 seconds to enter FTL, 15 seconds to travel, and 45 seconds of cooldown, other FTL drives numbered similarly.
- tweak: CTLA-25s and CTLA-50 removed from drivevend (still accessible from tech). CTLA-25 flatpack priced at 25k.
- tweak: CTLA-25s removed from fracture, replaced with CTLA-25