### PR TITLE
Makes Gadyuka a Cloak Killer

### DIFF
--- a/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
@@ -13,7 +13,6 @@
   - Pursuit
   engine:
   - Uranium
-
   cloakHunter: true
   company:
   - USSP

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
@@ -14,6 +14,9 @@
   engine:
   - Uranium
 
+  cloakHunter: true
+  company:
+  - USSP
 - type: gameMap
   id: Gadyuka
   mapName: 'Gadyuka'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: vessel
   id: Gadyuka
   parent: BaseVesselAntag


### PR DESCRIPTION
## About the PR
Makes gadyuka a cloak killer

## Why / Balance
Spear is one, and USSP currently has no way to defend against prowler.

## How to test
Spawning in as USSP, buying gadyuka, buying a prowler from hideout and moving it to camelot to test it

## Media
<img width="1089" height="766" alt="Screenshot 2025-07-15 173802" src="https://github.com/user-attachments/assets/31f2e2cb-4b66-4f67-8a64-6b2db922114a" />
<img width="1345" height="839" alt="Screenshot 2025-07-15 173816" src="https://github.com/user-attachments/assets/1982b43d-8809-4dec-bc8d-a543ac330b06" />


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
N/A

**Changelog**

:cl:
- tweak: Turned Gadyuka into a cloakHunter

