### PR TITLE
Adjusted 7.62x39 to Be Higher Then 5.56x45

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
@@ -23,6 +23,7 @@
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
@@ -36,7 +36,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 21
+        Piercing: 25
 
 - type: entity
   id: Bullet7.62x39mmPractice
@@ -69,8 +69,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 4
-        Heat: 17
+        Blunt: 5
+        Heat: 18
 
 - type: entity
   id: Bullet7.62x39mmUranium
@@ -81,8 +81,8 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 9
-        Piercing: 12
+        Radiation: 10
+        Piercing: 13
 
 - type: entity
   id: Bullet7.62x39mmSubsonic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Buffed 7.62x39 by 4 damage to make up for the 5.56x45 damage

**Changelog**

:cl: Scyron
- tweak: buffed 7.62x39 damage to be higher then 5.56x45!

