### PR TITLE
Sellsword: Walking Back The Price Nerf

### DIFF
--- a/Resources/Prototypes/_Mono/Shipyard/sellsword.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/sellsword.yml
@@ -16,7 +16,7 @@
   parent: BaseVessel
   name: UW Sellsword
   description: An escort picket comprising a claustrophobic, cast-plastitanium coffin enrobing a 203mm gun and VESPERA swarm missile pod. Combat life expectancy of 4 minutes. Has a military IFF designation.
-  price: 62500 # nearly TWO FIFTHS the cost is the kargil. markup 10% from 47600
+  price: 48500 # nearly ONE HALF the cost is the kargil. markup 15% from 42250
   category: Small
   group: Shipyard
   access: Mercenary


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Drops the markup of the Sellsword from 47% of appraisegrid down to 15%. No other changes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The dust from THE INCIDENT has settled. Removal of the 501 dropped appraisegrid value anyway so the markup was effectively double dipping anyhow. Since there are no fucked up weapons attached that enable unhinged low effort fraglust the price based deterrence can be tentatively walked back.

## How to test
<!-- Describe the way it can be tested -->

Observe buy price at CO shipyard

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Minor change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
- [X ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: With the dust settled, the Sellsword can return to a lower price bracket.