### PR TITLE
Makes ToggleableClothing Radial Menu Optional

### DIFF
--- a/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
@@ -1,3 +1,14 @@
+// SPDX-FileCopyrightText: 2022 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 Tony
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2025 ScyronX
+// SPDX-FileCopyrightText: 2025 starch
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Inventory;
 using Robust.Shared.Containers;

--- a/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ToggleableClothingComponent.cs
@@ -91,6 +91,12 @@ public sealed partial class ToggleableClothingComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool ReplaceCurrentClothing = false;
+
+    /// <summary>
+    ///     Monolith - Variable deciding wether the ToggleClothingAction uses radial menu.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool UseRadialMenu = false;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -1,3 +1,17 @@
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 TemporalOroboros
+// SPDX-FileCopyrightText: 2023 Ygg01
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Krunklehorn
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 nikthechampiongr
+// SPDX-FileCopyrightText: 2024 slarticodefast
+// SPDX-FileCopyrightText: 2024 to4no_fix
+// SPDX-FileCopyrightText: 2025 ScyronX
+// SPDX-FileCopyrightText: 2025 starch
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Actions;
 using Content.Shared.Clothing.Components;
 using Content.Shared.DoAfter;

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -325,8 +325,10 @@ public sealed class ToggleableClothingSystem : EntitySystem
         // If it have more attached clothings, it'll open radial menu
         if (comp.ClothingUids.Count == 1)
             ToggleClothing(args.Performer, toggleable, comp.ClothingUids.First().Key);
-        else
+        else if(toggleable.Comp.UseRadialMenu)
             _uiSystem.OpenUi(toggleable.Owner, ToggleClothingUiKey.Key, args.Performer);
+        else
+            ToggleClothing(args.Performer, toggleable);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
ToggleableClothing radial menu is turned off by default and optional now

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Radial menu is too buggy and so a more reliable alternative was required for the time being

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->