### PR TITLE
Adds the WarlorD Suit to Merc Loadouts

### DIFF
--- a/Resources/Prototypes/_Mono/Loadouts/Mercenary/groups.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/Mercenary/groups.yml
@@ -59,6 +59,7 @@
   - MercenaryClothingOuterArmorBPVestHeavy
   - MercenaryClothingOuterArmorBPVestPolyvalent
   - MercenaryClothingOuterArmorBPVestStabproof
+  - MercenaryClothingOuterHardsuitMercenaryWarlord
 
 - type: loadoutGroup
   id: MonoMercenaryGloves # ONLY TO BE USED AS A SUBGROUP FOR _NF MERCENARY GROUPS

--- a/Resources/Prototypes/_Mono/Loadouts/Mercenary/groups.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/Mercenary/groups.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 IndependentSpacer
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Loadouts/Mercenary/outer.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/Mercenary/outer.yml
@@ -45,3 +45,10 @@
   price: 250
   equipment:
     outerClothing: ClothingOuterArmorBPVestStabproof
+
+- type: loadout
+  id: MercenaryClothingOuterHardsuitMercenaryWarlord
+  price: 50000
+  equipment:
+    outerClothing: ClothingOuterHardsuitMercenaryWarlord
+    

--- a/Resources/Prototypes/_Mono/Loadouts/Mercenary/outer.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/Mercenary/outer.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 IndependentSpacer
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION

## About the PR
Adds the WarlorD suit as an outer clothing loadout option for mercs

## Why / Balance
The suit as it stands is way too time consuming to get compared to standard mercenary options, namely the SCAF suit and the normal mercenary hardsuits which are available roundstart, while having worse direct combat stats. This option makes it a nice utility sidegrade available in the loadout for quite a price.

## How to test
Select it in the outer clothing category in your loadout as a mercenary

## Media
<img width="545" height="75" alt="obraz" src="https://github.com/user-attachments/assets/c87bf84f-e70f-4144-8542-fff6d9efbcba" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes


:cl:
- tweak: Added the WarlorD suit as a loadout option for mercs

