### PR TITLE
Give Expeds More Budget to Work With

### DIFF
--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -35,7 +35,6 @@ using Content.Server.Salvage.Expeditions;
 using Content.Server.Salvage.Expeditions.Structure;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
-using Content.Server.Spawners.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Atmos;

--- a/Content.Shared/Salvage/SharedSalvageSystem.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.cs
@@ -75,15 +75,15 @@ public abstract partial class SharedSalvageSystem : EntitySystem
         switch (rating)
         {
             case DifficultyRating.Minimal:
-                return 4;
-            case DifficultyRating.Minor:
-                return 6;
-            case DifficultyRating.Moderate:
                 return 8;
-            case DifficultyRating.Hazardous:
-                return 10;
-            case DifficultyRating.Extreme:
+            case DifficultyRating.Minor:
                 return 12;
+            case DifficultyRating.Moderate:
+                return 16;
+            case DifficultyRating.Hazardous:
+                return 20;
+            case DifficultyRating.Extreme:
+                return 30;
             default:
                 throw new ArgumentOutOfRangeException(nameof(rating), rating, null);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Expeds had a limited budget to work with determined by difficulty, frontier set these values so low that having weather modifiers that cost ~2 points now bricks them because they run out of budget (or makes them spawn with jack shit loot/enemies).

## Why / Balance
Fix bricked exped generation + make expeds harder

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Salvage expeditions have more budget per difficulty now. (this should affect things like how many enemies spawn, how much loot, what weather, what temp, atmos, etc). Should also fix expedition console bricking sometimes, and barely any loot spawning other times.