### PR TITLE
Rate Limits Chunk Loading, Removes Unloading, Adds More Preload Area to Biome System

### DIFF
--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -264,7 +264,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         if (!TryComp<BiomeComponent>(targetMapUid, out var biome))
             return;
 
-        var preloadArea = new Vector2(32f, 32f);
+        var preloadArea = new Vector2(256f, 256f);
         var targetArea = new Box2(targetMap.Position - preloadArea, targetMap.Position + preloadArea);
         Preload(targetMapUid, biome, targetArea);
     }
@@ -343,7 +343,6 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             _activeChunks.Add(biome, _tilePool.Get());
             _markerChunks.GetOrNew(biome);
         }
-
         // Get chunks in range
         foreach (var pSession in Filter.GetAllPlayers(_playerManager))
         {
@@ -403,7 +402,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             // Load new chunks
             LoadChunks(biome, gridUid, grid, biome.Seed);
             // Unload old chunks
-            UnloadChunks(biome, gridUid, grid, biome.Seed);
+            //UnloadChunks(biome, gridUid, grid, biome.Seed);
         }
 
         _handledEntities.Clear();

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -49,7 +49,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Threading;
 using Robust.Shared.Utility;
-using Robust.Shared.Timing;
+using Robust.Shared.Timing; // Mono
 using ChunkIndicesEnumerator = Robust.Shared.Map.Enumerators.ChunkIndicesEnumerator;
 
 namespace Content.Server.Parallax;
@@ -281,7 +281,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         if (!TryComp<BiomeComponent>(targetMapUid, out var biome))
             return;
 
-        var preloadArea = new Vector2(256f, 256f);
+        var preloadArea = new Vector2(256f, 256f); // 32->256 Mono
         var targetArea = new Box2(targetMap.Position - preloadArea, targetMap.Position + preloadArea);
         Preload(targetMapUid, biome, targetArea);
     }
@@ -350,7 +350,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
     {
         base.Update(frameTime);
         var biomes = AllEntityQuery<BiomeComponent>();
-        var overallWatch = new Stopwatch();
+        var overallWatch = new Stopwatch(); // Mono
 
         while (biomes.MoveNext(out var biome))
         {
@@ -403,10 +403,10 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
 
         var loadBiomes = AllEntityQuery<BiomeComponent, MapGridComponent>();
 
-        overallWatch.Start();
+        overallWatch.Start(); // Mono
         while (loadBiomes.MoveNext(out var gridUid, out var biome, out var grid))
         {
-            if (overallWatch.Elapsed > _maximumProcessTime)
+            if (overallWatch.Elapsed > _maximumProcessTime) // Mono
                 return;
 
             // If not MapInit don't run it.
@@ -419,7 +419,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             // Load new chunks
             LoadChunks(biome, gridUid, grid, biome.Seed);
             // Unload old chunks
-            //UnloadChunks(biome, gridUid, grid, biome.Seed);
+            //UnloadChunks(biome, gridUid, grid, biome.Seed); // Mono this fixes lag no really
         }
 
         _handledEntities.Clear();

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -1,3 +1,20 @@
+// SPDX-FileCopyrightText: 2023 Cheackraze
+// SPDX-FileCopyrightText: 2023 Checkraze
+// SPDX-FileCopyrightText: 2024 Dvir
+// SPDX-FileCopyrightText: 2024 Ed
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 MilenVolf
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 Plykiya
+// SPDX-FileCopyrightText: 2024 TemporalOroboros
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Redrover1760
+// SPDX-FileCopyrightText: 2025 metalgearsloth
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

rate limits chunk loading so it doesn't uber lag the server as much

chunks are qdel'd on expedition shuttle leave so the only usage of unloading chunks is completely irrelevant so removes biome server unloading entirely. For future potential biomesystem usage with lasting planets we can reconsider needing unloading again but its probably infinitely better to restrict the map size to like a 1000 by 1000 area or something.

memory usage is minimum even if you fly around and try to load as many chunks as humanly possible, may cause issues but fuck it the lag is gone.

Increased preload area so normal expedition gameplay now has no lag whatsoever because 64/64 is way too small for our dungeons. Also unloading made preloading irrelevant pretty sure so that's fixed too.

to note this is all serverside so clientside has not changed at all

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

yay

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Expedition lag fix attempt
