### PR TITLE
Adds Safety Check to Grid Cleanup System

### DIFF
--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -174,7 +174,7 @@ public sealed class GridCleanupSystem : EntitySystem
 
             // Check to ensure no mobs will be deleted
             var mobQuery = AllEntityQuery<MobStateComponent, TransformComponent>();
-            while (mobQuery.MoveNext(out var mobUid, out _, out var mobxform))
+            while (mobQuery.MoveNext(out var _, out _, out var mobxform))
             {
                 if (mobxform.GridUid == null || mobxform.MapUid == null || xform.GridUid == xform.GridUid)
                 {

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -6,8 +6,10 @@ using Content.Shared.Mobs.Components;
 
 namespace Content.Server.Shuttles.Systems;
 
+/// TODO: Move to Mono Namespace
+
 /// <summary>
-/// This system cleans up small grid fragments that have less than a specified number of tiles after a delay. TODO: Move to Mono Namespace
+/// This system cleans up small grid fragments that have less than a specified number of tiles after a delay. 
 /// </summary>
 public sealed class GridCleanupSystem : EntitySystem
 {

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -181,6 +181,7 @@ public sealed class GridCleanupSystem : EntitySystem
 
             // Check to ensure no mobs will be deleted
             var mobQuery = AllEntityQuery<MobStateComponent, TransformComponent>();
+            var entityCheck = false;
             while (mobQuery.MoveNext(out var mobUid, out _, out var mobxform))
             {
                 if (mobxform.GridUid == null || mobxform.MapUid == null || mobxform.GridUid != xform.GridUid)
@@ -188,12 +189,17 @@ public sealed class GridCleanupSystem : EntitySystem
 
                 Logger.DebugS("salvage", $"Update: Mob {mobUid} detected on {gridUid}, removing grid from cleanup queue");
                 toRemove.Add(gridUid);
+                entityCheck = true;
+                break;
             }
 
+            if (entityCheck == true)
+                continue;
+
             // Delete the grid immediately to prevent the possibility of a mob entering after deletion is queued
+            Del(gridUid);
             Logger.DebugS("salvage", $"Update: Deleting {gridUid} with {CountTiles((gridUid, grid))} tiles");
             toRemove.Add(gridUid);
-            Del(gridUid);
         }
 
         // Remove processed grids from the pending list

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Redrover1760
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Timing;

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -186,7 +186,7 @@ public sealed class GridCleanupSystem : EntitySystem
                 if (mobxform.GridUid == null || mobxform.MapUid == null || mobxform.GridUid != xform.GridUid)
                     continue;
 
-                Logger.DebugS("salvage", $"Update: Mob {mobUid}} detected on {gridUid}, removing grid from cleanup queue");
+                Logger.DebugS("salvage", $"Update: Mob {mobUid} detected on {gridUid}, removing grid from cleanup queue");
                 toRemove.Add(gridUid);
             }
 

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -185,7 +185,7 @@ public sealed class GridCleanupSystem : EntitySystem
             {
                 if (mobxform.GridUid == null || mobxform.MapUid == null)
                     continue;
-                if (xform.GridUid == xform.GridUid)
+                if (mobxform.GridUid == xform.GridUid)
                 {
                     Logger.DebugS("salvage", $"Update: Mob {mobUid}} detected on {gridUid}, removing grid from cleanup queue");
                     toRemove.Add(gridUid);

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -183,13 +183,11 @@ public sealed class GridCleanupSystem : EntitySystem
             var mobQuery = AllEntityQuery<MobStateComponent, TransformComponent>();
             while (mobQuery.MoveNext(out var mobUid, out _, out var mobxform))
             {
-                if (mobxform.GridUid == null || mobxform.MapUid == null)
+                if (mobxform.GridUid == null || mobxform.MapUid == null || mobxform.GridUid != xform.GridUid)
                     continue;
-                if (mobxform.GridUid == xform.GridUid)
-                {
-                    Logger.DebugS("salvage", $"Update: Mob {mobUid}} detected on {gridUid}, removing grid from cleanup queue");
-                    toRemove.Add(gridUid);
-                }
+
+                Logger.DebugS("salvage", $"Update: Mob {mobUid}} detected on {gridUid}, removing grid from cleanup queue");
+                toRemove.Add(gridUid);
             }
 
             // Delete the grid immediately to prevent the possibility of a mob entering after deletion is queued

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -7,7 +7,7 @@ using Content.Shared.Mobs.Components;
 namespace Content.Server.Shuttles.Systems;
 
 /// <summary>
-/// This system cleans up small grid fragments that have less than a specified number of tiles after a delay.
+/// This system cleans up small grid fragments that have less than a specified number of tiles after a delay. TODO: Move to Mono Namespace
 /// </summary>
 public sealed class GridCleanupSystem : EntitySystem
 {

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -183,13 +183,13 @@ public sealed class GridCleanupSystem : EntitySystem
             var mobQuery = AllEntityQuery<MobStateComponent, TransformComponent>();
             while (mobQuery.MoveNext(out var mobUid, out _, out var mobxform))
             {
-                if (mobxform.GridUid == null || mobxform.MapUid == null || xform.GridUid == xform.GridUid)
+                if (mobxform.GridUid == null || mobxform.MapUid == null)
+                    continue;
+                if (xform.GridUid == xform.GridUid)
                 {
                     Logger.DebugS("salvage", $"Update: Mob {mobUid}} detected on {gridUid}, removing grid from cleanup queue");
                     toRemove.Add(gridUid);
-                    continue;
                 }
-
             }
 
             // Delete the grid immediately to prevent the possibility of a mob entering after deletion is queued

--- a/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
+++ b/Content.Server/Shuttles/Systems/GridCleanupSystem.cs
@@ -176,10 +176,11 @@ public sealed class GridCleanupSystem : EntitySystem
 
             // Check to ensure no mobs will be deleted
             var mobQuery = AllEntityQuery<MobStateComponent, TransformComponent>();
-            while (mobQuery.MoveNext(out var _, out _, out var mobxform))
+            while (mobQuery.MoveNext(out var mobUid, out _, out var mobxform))
             {
                 if (mobxform.GridUid == null || mobxform.MapUid == null || xform.GridUid == xform.GridUid)
                 {
+                    Logger.DebugS("salvage", $"Update: Mob {mobUid}} detected on {gridUid}, removing grid from cleanup queue");
                     toRemove.Add(gridUid);
                     continue;
                 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Checks to ensure no mobs are on a grid before deleting it. Makes grid deletions instant to avoid Queued deletions bypassing this check.

Also increases the time before a deletions is attempted.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

yeah that's bad

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Players shouldn't be deleted by grid cleanup anymore