### PR TITLE
Unhardcode Laser Drill Component Needing Exped

### DIFF
--- a/Content.Server/_Mono/Miner/ItemGeneratorComponent.cs
+++ b/Content.Server/_Mono/Miner/ItemGeneratorComponent.cs
@@ -10,13 +10,8 @@ using Robust.Shared.Prototypes;
 namespace Content.Server._Mono.Miner;
 
 [RegisterComponent]
-public sealed partial class LaserDrillComponent : Component
+public sealed partial class ItemGeneratorComponent : Component
 {
-    /// <summary>
-    /// How much ore does this thing have in its buffer. Why does this exist?
-    /// </summary>
-    [DataField("accumulatedOre")]
-    public float AccumulatedOre = 0f;
 
     /// <summary>
     /// Time since last update
@@ -25,27 +20,27 @@ public sealed partial class LaserDrillComponent : Component
     public TimeSpan LastUpdate = TimeSpan.Zero;
 
     /// <summary>
-    /// Miner working SFX
+    /// Generator working SFX
     /// </summary>
     [DataField("miningSound")]
     public SoundSpecifier MiningSound = new SoundPathSpecifier("/Audio/Machines/circuitprinter.ogg");
 
     /// <summary>
-    /// How often the miner produces TC (in seconds)
+    /// Time between item generation actions
     /// </summary>
     [DataField("miningInterval")]
     public float MiningInterval = 10.0f;
 
     /// <summary>
-    /// Power consumption
+    /// Power consumption in watts
     /// </summary>
     [DataField("powerDraw")]
     public float PowerDraw = 30000f;
 
     /// <summary>
-    /// List of entities that can be spawned by this component. One will be randomly
-    /// chosen for each entity spawned. When multiple entities are spawned at once,
-    /// each will be randomly chosen separately.
+    /// List of entities that can be spawned by this component.
+    /// If you don't want it spawning inside the generator's container, set it to spawn a random spawner instead.
+    /// Each will be randomly chosen separately.
     /// </summary>
     [DataField]
     public List<EntProtoId> Prototypes = [];
@@ -62,4 +57,7 @@ public sealed partial class LaserDrillComponent : Component
     ///     If this doesn't exist, then the origin grid and map will be filled in, instead.
     /// </summary>
     public EntityUid? OriginStation;
+
+    [DataField]
+    public bool RequireExpedition = false;
 }

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/laser_drill.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/laser_drill.yml
@@ -14,11 +14,12 @@
   - type: PowerConsumer
     voltage: High
     drawRate: 50000
-  - type: LaserDrill
+  - type: ItemGenerator
     prototypes:
     - SpawnLootOres15
     miningInterval: 15
     powerDraw: 50000
+    requireExpedition: true
   - type: Battery
     maxCharge: 1000
     pricePerJoule: 0.0003


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
adds bool to say if ur drill needs exped or whatever
renames the laserdrill system shit cuz it no longer hardcoded

## Why / Balance
item generator that needs power can be useful for future (such as resource/disk generator poi)

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
LaserDrillComponent and LaserDrillSystem renamed to ItemGeneratorComponent and ItemGeneratorSystem
AccumulatedOre variable removed

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
nothing player facing no CL