### PR TITLE
More tech disk slop

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -631,6 +631,20 @@
     - WeaponMechCombatArsenal
     - AdvancedAmmoRecipePack
     - SmartGun # Goobstation
+    # Mono start
+    - MonoTSFWeaponsDynamicMelee
+    - MonoTSFWeaponsDynamicRanged
+    - MonoTSFMiscDynamic
+    - MonoTSFAmmo
+    - MonoRogueWeaponsDynamicMelee
+    - MonoRogueWeaponsDynamicRanged
+    - MonoRogueMiscDynamic
+    - MonoRogueAmmo
+    - MonoUSSPMiscDynamic
+    - MonoUSSPWeaponsDynamicRanged
+    - MonoUSSPAmmo
+    - UniversalShellAmmo
+    # Mono end
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/shields.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/shields.yml
@@ -1,0 +1,64 @@
+- type: entity
+  id: MachineShieldMS100Circuitboard
+  parent: BaseMachineCircuitboard
+  name: MS-100 shield generator board
+  description: A machine board for a shield generator.
+  components:
+    - type: Sprite
+      state: security
+    - type: MachineBoard
+      prototype: ShieldGeneratorSmall
+      componentRequirements:
+        AmeFuelContainer:
+          amount: 3
+          defaultPrototype: AmeJar
+      stackRequirements:
+        Glass: 10
+        Steel: 10
+        Plasma: 30
+        Plasteel: 10
+
+- type: entity
+  id: MachineShieldMS250Circuitboard
+  parent: BaseMachineCircuitboard
+  name: MS-250 shield generator board
+  description: A machine board for a shield generator.
+  components:
+  - type: Sprite
+    state: security
+  - type: MachineBoard
+    prototype: ShieldGeneratorMedium
+    componentRequirements:
+      AmeFuelContainer:
+        amount: 5
+        defaultPrototype: AmeJar
+    stackRequirements:
+      Glass: 10
+      Steel: 10
+      Plasma: 30
+      Plasteel: 20
+      Gold: 10
+      Silver: 10
+
+- type: entity
+  id: MachineShieldMS500Circuitboard
+  parent: BaseMachineCircuitboard
+  name: MS-500 shield generator board
+  description: A machine board for a shield generator.
+  components:
+  - type: Sprite
+    state: security
+  - type: MachineBoard
+    prototype: ShieldGenerator
+    componentRequirements:
+      AmeFuelContainer:
+        amount: 8
+        defaultPrototype: AmeJar
+    stackRequirements:
+      Glass: 30
+      Steel: 30
+      Plasma: 50
+      Plasteel: 50
+      Gold: 15
+      Silver: 15
+      Uranium: 30

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/tech_disk_spawners.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/tech_disk_spawners.yml
@@ -22,11 +22,14 @@
     - TechDiskCivMS250
     - TechDiskCivCTLA50
     - TechDiskCivShipComps
-    chance: 0.95
+    - TechDiskCivBackpackWaterTank
+    chance: 1
     offset: 0.0
     rarePrototypes:
     - SpawnLootTechDisksT2Faction
     - SpawnLootTechDisksT2Mech
+    - TechDiskCivMicroreactors
+    - TechDiskCivAdvancedTools
     rareChance: 0.3
 
 - type: entity
@@ -51,7 +54,7 @@
     - TechDiskC20r
     - TechDiskM90
     - TechDiskMla73
-    chance: 0.95
+    chance: 1
     offset: 0.0
     rarePrototypes:
     - TechDiskRogueToolsAdvanced
@@ -87,7 +90,7 @@
     - TechDiskMechWeaponsLight
     - TechDiskMechWeaponsMedium
     - TechDiskMechWeaponsHeavy
-    chance: 0.95
+    chance: 1
     offset: 0.0
     rarePrototypes:
     - SpawnLootTechDisksT3Fracture
@@ -112,7 +115,7 @@
     - TechDiskMechS4Spec
     - TechDiskMechS2Base
     - TechDiskMechS2Spec
-    chance: 0.95
+    chance: 1
     offset: 0.0
     rarePrototypes:
     - SpawnLootTechDisksT3Fracture
@@ -137,5 +140,5 @@
     - TechDiskBluespaceBags
     - TechDiskShields
     - TechDiskFtl
-    chance: 0.95
+    chance: 1
     offset: 0.0

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/tech_disk_spawners.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/tech_disk_spawners.yml
@@ -19,6 +19,9 @@
     - TechDiskCivBluespaceBags
     - TechDiskRCD
     - TechDiskMechCiv
+    - TechDiskCivMS250
+    - TechDiskCivCTLA50
+    - TechDiskCivShipComps
     chance: 0.95
     offset: 0.0
     rarePrototypes:
@@ -45,6 +48,9 @@
     - TechDiskTSFBandit
     - TechDiskTSFLecter
     - TechDiskTSFDrozd
+    - TechDiskC20r
+    - TechDiskM90
+    - TechDiskMla73
     chance: 0.95
     offset: 0.0
     rarePrototypes:
@@ -52,6 +58,8 @@
     - TechDiskTSFICWS
     - TechDiskTSFAnnie
     - TechDiskEnergyWeapons
+    - TechDiskBulldog
+    - TechDiskHristov
     - SpawnLootTechDisksT3Fracture
     rareChance: 0.15
 
@@ -127,5 +135,7 @@
     - TechDiskSynthalloy
     - TechDiskSpeedBoots
     - TechDiskBluespaceBags
+    - TechDiskShields
+    - TechDiskFtl
     chance: 0.95
     offset: 0.0

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/tech_disks.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/tech_disks.yml
@@ -429,6 +429,66 @@
 
 - type: entity
   parent: BaseItem
+  id: TechDiskCivShipComps
+  name: civilian ship components tech disk
+  description: A disk capable of adding basic shields and FTL drives to a server's recipes.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#395933"
+    - state: label
+    - state: protect
+    - state: civilian
+  - type: TechnologyDisk
+    recipes:
+    - MachineDriveCTLA25Circuitboard
+    - MachineShieldMS100Circuitboard
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskCivCTLA50
+  name: civilian CTLA-50 tech disk
+  description: A disk capable of adding CTLA-50/25 FTL drives to a server's recipes.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#395933"
+    - state: label
+    - state: protect
+    - state: civilian
+  - type: TechnologyDisk
+    recipes:
+    - MachineDriveCTLA50Circuitboard
+    - MachineDriveCTLA25Circuitboard
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskCivMS250
+  name: civilian MS-250 shield tech disk
+  description: A disk capable of adding MS-250/MS-100 shield boards to a server's recipes.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#395933"
+    - state: label
+    - state: protect
+    - state: civilian
+  - type: TechnologyDisk
+    recipes:
+    - MachineShieldMS250Circuitboard
+    - MachineShieldMS100Circuitboard
+
+- type: entity
+  parent: BaseItem
   id: TechDiskSpeedBoots
   name: pre-fracture speed manipulation tech disk
   description: A disk capable of adding speed boots to a server's recipes.
@@ -446,6 +506,50 @@
   - type: TechnologyDisk
     recipes:
     - ClothingShoesBootsSpeed
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskFtl
+  name: pre-fracture bluespace drive tech disk
+  description: A disk capable of adding FTL drives to a server's recipes.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#d4d4d4"
+    - state: label
+    - state: protect
+    - state: holo
+      shader: unshaded
+  - type: TechnologyDisk
+    recipes:
+    - MachineDriveCTLA25sCircuitboard
+    - MachineDriveCTLA50Circuitboard
+    - MachineDriveCTLA25Circuitboard
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskShields
+  name: pre-fracture shield technology tech disk
+  description: A disk capable of adding ship shield tech to a server's recipes.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#d4d4d4"
+    - state: label
+    - state: protect
+    - state: holo
+      shader: unshaded
+  - type: TechnologyDisk
+    recipes:
+    - MachineShieldMS500Circuitboard
+    - MachineShieldMS250Circuitboard
+    - MachineShieldMS100Circuitboard
 
 - type: entity
   parent: BaseItem
@@ -512,6 +616,8 @@
     - EnergySwordRogue
     - EnergyDaggerRogue
     - EnergyShieldRogue
+
+# tsf stuff
 
 - type: entity
   parent: BaseItem
@@ -583,7 +689,7 @@
   parent: BaseItem
   id: TechDiskTSFBandit
   name: TSF Bandit faction tech disk
-  description: A disk capable of adding the M-6 Lecter and its ammo to a server's recipes, for faction techfabs.
+  description: A disk capable of adding the MR-3 Bandit and its ammo to a server's recipes, for faction techfabs.
   components:
   - type: Sprite
     sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
@@ -624,6 +730,8 @@
     - Magazine5.56x45mmEmpty
     - AmmoBox5.56x45mmFMJ
 
+# universal stuff
+
 - type: entity
   parent: BaseItem
   id: TechDiskUniversalShipAmmo
@@ -647,10 +755,12 @@
     - 150mmApShellUniversal
     - 150mmEmpShellUniversal
 
+# rogue stuff
+
 - type: entity
   parent: BaseItem
   id: TechDiskRogueTools
-  name: Ashen Republic equipment faction tech disk
+  name: ASR equipment faction tech disk
   description: A disk capable of adding various tools of Rogues to a server's recipes, for faction techfabs.
   components:
   - type: Sprite
@@ -671,7 +781,7 @@
 - type: entity
   parent: BaseItem
   id: TechDiskRogueToolsAdvanced
-  name: high-tech Ashen Republic equipment faction tech disk
+  name: high-tech ASR equipment faction tech disk
   description: A disk capable of adding the hacking equipment of Rogues to a server's recipes, for faction techfabs.
   components:
   - type: Sprite
@@ -688,3 +798,112 @@
     recipes:
     - EmagRogue
     - AccessBreakerRogue
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskC20r
+  name: ASR C-20r faction tech disk
+  description: A disk capable of adding the C-20r and its ammo to a server's recipes, for faction techfabs.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#454545"
+    - state: label
+    - state: protect
+    - state: gun
+  - type: TechnologyDisk
+    recipes:
+    - WeaponSubMachineGunC20rRogue
+    - Magazine9x19mmSubMachineGunFMJ
+    - Magazine9x19mmSubMachineGunEmpty
+    - AmmoBox9x19mmFMJ
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskM90
+  name: ASR M-90 faction tech disk
+  description: A disk capable of adding the M-90 and its ammo to a server's recipes, for faction techfabs.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#454545"
+    - state: label
+    - state: protect
+    - state: gun
+  - type: TechnologyDisk
+    recipes:
+    - WeaponRifleM90Rogue
+    - Magazine7.62x51mmFMJ
+    - Magazine7.62x51mmEmpty
+    - AmmoBox7.62x51mmFMJ
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskBulldog
+  name: ASR bulldog faction tech disk
+  description: A disk capable of adding the Bulldog and its ammo to a server's recipes, for faction techfabs.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#454545"
+    - state: label
+    - state: protect
+    - state: gun
+  - type: TechnologyDisk
+    recipes:
+    - WeaponShotgunBulldogRogue
+    - Magazine12_gaugeBuckshot
+    - Magazine12_gaugeSlug
+    - Magazine12_gaugeEmpty
+    - AmmoBox12_gaugeBuckshot
+    - AmmoBox12_gaugeSlug
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskHristov
+  name: ASR Hristov faction tech disk
+  description: A disk capable of adding the Hristov and its ammo to a server's recipes, for faction techfabs.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#454545"
+    - state: label
+    - state: protect
+    - state: gun
+  - type: TechnologyDisk
+    recipes:
+    - WeaponSniperHristovRogue
+    - AmmoBox145x114mmBig
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskMla73
+  name: ASR MLA-73 faction tech disk
+  description: A disk capable of adding the MLA-73 and its ammo to a server's recipes, for faction techfabs.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#454545"
+    - state: label
+    - state: protect
+    - state: gun
+  - type: TechnologyDisk
+    recipes:
+    - WeaponSubMachineGunMla73Rogue
+    - Magazine635x40mmCaseless
+    - AmmoBox635x40mmCaseless

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/tech_disks.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/tech_disks.yml
@@ -429,6 +429,66 @@
 
 - type: entity
   parent: BaseItem
+  id: TechDiskCivMicroreactors
+  name: civilian high-efficiency power cells tech disk
+  description: A disk capable of adding microreactors and hyper-capacity cells to a server's recipes.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#395933"
+    - state: label
+    - state: protect
+    - state: civilian
+  - type: TechnologyDisk
+    recipes:
+    - PowerCellMicroreactor
+    - PowerCellHyperNF
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskCivAdvancedTools
+  name: civilian power tools tech disk
+  description: A disk capable of adding jaws of life and power drills to a server's recipes.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#395933"
+    - state: label
+    - state: protect
+    - state: civilian
+  - type: TechnologyDisk
+    recipes:
+    - JawsOfLife
+    - PowerDrill
+
+- type: entity
+  parent: BaseItem
+  id: TechDiskCivBackpackWaterTank
+  name: civilian power washer tech disk
+  description: A disk capable of adding high-capacity fluid sprays & tanks to a server's recipes. It would never be used for a flamethrower, I swear!
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Research/researchdisk.rsi
+    layers:
+    - state: icon
+      map: ["enum.DamageStateVisualLayers.Base"]
+      color: "#395933"
+    - state: label
+    - state: protect
+    - state: civilian
+  - type: TechnologyDisk
+    recipes:
+    - WeaponSprayNozzle
+    - ClothingBackpackWaterTank
+
+- type: entity
+  parent: BaseItem
   id: TechDiskCivShipComps
   name: civilian ship components tech disk
   description: A disk capable of adding basic shields and FTL drives to a server's recipes.

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/shuttles.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/shuttles.yml
@@ -19,3 +19,6 @@
   - MachineGCSHighCircuitboard
   - AdvancedRadarConsoleCircuitboard
   - ComputerIFFCircuitboard
+  - MachineShieldMS100Circuitboard
+  - MachineShieldMS250Circuitboard
+  - MachineShieldMS500Circuitboard

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/electronics.yml
@@ -59,3 +59,18 @@
   parent: BaseGoldCircuitboardRecipe
   id: ComputerIFFCircuitboard
   result: ComputerIFFCircuitboard
+
+- type: latheRecipe
+  parent: BaseGoldCircuitboardRecipe
+  id: MachineShieldMS100Circuitboard
+  result: MachineShieldMS100Circuitboard
+
+- type: latheRecipe
+  parent: BaseGoldCircuitboardRecipe
+  id: MachineShieldMS250Circuitboard
+  result: MachineShieldMS250Circuitboard
+
+- type: latheRecipe
+  parent: BaseGoldCircuitboardRecipe
+  id: MachineShieldMS500Circuitboard
+  result: MachineShieldMS500Circuitboard

--- a/Resources/Prototypes/_Mono/shield_generator.yml
+++ b/Resources/Prototypes/_Mono/shield_generator.yml
@@ -115,6 +115,20 @@
         path: "/Audio/Effects/teleport_departure.ogg"
         params:
           pitch: 0.5
+  - type: Machine
+    board: MachineShieldMS500Circuitboard
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_board
+    - machine_parts
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
+  - type: PirateBountyItem
+    id: ShipShield
 
 # Medium-End
 - type: entity
@@ -149,6 +163,20 @@
     radius: 2
     energy: 1.5
     color: "#9933FF"
+  - type: Machine
+    board: MachineShieldMS250Circuitboard
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_board
+    - machine_parts
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
+  - type: PirateBountyItem
+    id: ShipShield
 
 # Low-End
 - type: entity
@@ -183,3 +211,17 @@
     radius: 2
     energy: 1.5
     color: "#3399FF"
+  - type: Machine
+    board: MachineShieldMS100Circuitboard
+  - type: Construction
+    graph: Machine
+    node: machine
+    containers:
+    - machine_board
+    - machine_parts
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
+  - type: PirateBountyItem
+    id: ShipShield

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
@@ -167,6 +167,15 @@
     dynamicPacks:
     - NFNfsdTechfabDeprecated
     - AdvancedAmmoRecipePack
+    # Mono start
+    - MonoTSFWeaponsDynamicMelee
+    - MonoTSFWeaponsDynamicRanged
+    - MonoTSFMiscDynamic
+    - MonoTSFAmmo
+    - UniversalShellAmmo
+    - UniversalRailgunAmmo
+    - UniversalTorpedoAmmo
+    # Mono end
   - type: EmagLatheRecipes
     emagStaticPacks:
     - NFNfsdTechfabDeprecatedEmag
@@ -204,6 +213,20 @@
     dynamicPacks:
     - NFMercenaryTechfabDeprecated
     - AdvancedAmmoRecipePack
+    # Mono start
+    - MonoTSFWeaponsDynamicMelee
+    - MonoTSFWeaponsDynamicRanged
+    - MonoTSFMiscDynamic
+    - MonoTSFAmmo
+    - MonoRogueWeaponsDynamicMelee
+    - MonoRogueWeaponsDynamicRanged
+    - MonoRogueMiscDynamic
+    - MonoRogueAmmo
+    - MonoUSSPMiscDynamic
+    - MonoUSSPWeaponsDynamicRanged
+    - MonoUSSPAmmo
+    - UniversalShellAmmo
+    # Mono end
   - type: EmagLatheRecipes
     emagStaticPacks:
     - NFMercenaryTechfabDeprecatedEmag
@@ -254,6 +277,21 @@
     dynamicPacks:
     - NFHackedMercenaryTechfabDeprecated
     - AdvancedAmmoRecipePack
+    - SmartGun # Goobstation
+    # Mono start
+    - MonoTSFWeaponsDynamicMelee
+    - MonoTSFWeaponsDynamicRanged
+    - MonoTSFMiscDynamic
+    - MonoTSFAmmo
+    - MonoRogueWeaponsDynamicMelee
+    - MonoRogueWeaponsDynamicRanged
+    - MonoRogueMiscDynamic
+    - MonoRogueAmmo
+    - MonoUSSPMiscDynamic
+    - MonoUSSPWeaponsDynamicRanged
+    - MonoUSSPAmmo
+    - UniversalShellAmmo
+    # Mono end
   - type: PirateBountyItem # Mono
     id: Techfab
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Merc, TSF, and Security techfabs can now make SOME faction recipes (mostly the guns and tools, not armor and vouchers and whatnot). Not ALL. Merc techfabs can also make smartguns now.
- add: Added a lot more tech disks to the pool, mainly for rogue weapons, FTL drives, advanced tools/microreactors, and finally adding a way to get the higher-power shield gens (MS-250 and MS-500)
- tweak: Shield gens are deconstructible machines again w/ machine boards. Still as expensive as the old ones were.
- fix: Fixed Bandit tech disk referencing Lecter in description.