### PR TITLE
Revert "Refactor Conflict Rule 1 - Adds Escalation"

### DIFF
--- a/Resources/ServerInfo/_Mono/Guidebook/Rules/Conflict/One_RandomDeathmatch.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Rules/Conflict/One_RandomDeathmatch.xml
@@ -4,21 +4,15 @@
 
 Players must have valid in-character reasons to kill or attack another player.
 
-- [color=red][bold]Random, unjustified violence (RDM) is not allowed.[/bold][/color]
-- [color=green]Civilians[/color] and other non-hostile characters must escalate conflict through [color=green]roleplay[/color] and [color=yellow]clear justification[/color].
--- [italic][color=yellow]This also applies when[/color][/italic] [bold][color=red]combatants[/color] engage with [color=green]non-hostile parties[/color][/bold]; they must initiate through [color=green]roleplay[/color] and cannot treat [color=yellow]neutral[/color] or [color=green]civilian[/color] characters as [bold]valid targets without cause[/bold].
-- [color=yellow]Non-lethal options[/color] (such as capturing, negotiating, or detaining) are strongly encouraged to foster deeper storylines and character development.
-- [italic][color=gray]Combat should feel like a natural escalation of roleplay—not an excuse for senseless violence.[/color][/italic]
+- [color=red][bold]Random, unprovoked attacks or killings (RDM) are not allowed.[/bold][/color]
+- [color=yellow]Non-lethal conflict[/color] and [color=green]roleplay escalation[/color] are strongly encouraged.
+- Combat should arise naturally through roleplay, with proper escalation and meaningful interaction.
+- [color=yellow]Non-lethal options[/color] (such as capturing, negotiating, or detaining) are strongly encouraged to foster deeper storylines.
 
-[italic][color=yellow]Faction Warfare:[/color][/italic]
-- The 3 main factions ([bold][color=#8B0000]Rogues/The Ashen Republic[/bold][/color], [bold][color=cyan]Trans-Solarian Federation (TSF)[/bold][/color], and [bold][color=#776654]USSP[/bold][/color]) begin each round hostile to one another, but faction wars may evolve through escalation, truces, or treaties as the round progresses.
-- [bold]Engagements may begin with combat when clear faction/company hostility is established (e.g., war).[/bold] You are [bold]not required[/bold] to talk before shooting if the situation justifies it.
-- [bold]Stealth, deception, and ambush tactics[/bold] are valid forms of engagement, especially for factions like the [bold][color=#8B0000]Rogues[/bold][/color] whose doctrine supports them.
-- [color=green]Roleplay is encouraged, especially after conflict[/color]; interrogation, negotiation, or aftermath RP is valuable and enriches the experience.
-- [bold]Formal alliances between the 3 main factions are not normally allowed.[/bold] [color=yellow]Temporary ceasefires or neutral interactions may occur[/color] (e.g. negotiation, mutual evacuation), but [bold][color=red]cooperation, coordination, or shared objectives[/color][/bold] are generally prohibited.
--- [bold][color=orange]Temporary ceasefires may be allowed in rare, existential circumstances[/color][/bold] (e.g. Romerol, Letoferol, ADS fleet). These should be [italic][color=yellow]brief, tense, and driven by necessity[/color][/italic]—not convenience or player preference.
--- [bold][color=green]Exception: Rare, well-developed alliances may occur[/color][/bold] if supported by meaningful roleplay, diplomacy, and strong narrative justification. These should be [italic][color=yellow]short-lived[/color][/italic], [italic][color=yellow]goal-specific[/color][/italic] (e.g. retaliation against a dominant faction), and are [bold][color=gray]subject to admin discretion[/color][/bold].
+[italic][color=yellow]Faction Conflict:[/color][/italic]
+- The 3 main factions ([bold][color=#8B0000]Rogues/The Ashen Republic[/bold][/color], [bold][color=cyan]Trans-Solarian Federation (TSF)[/bold][/color], and [bold][color=brown]USSP[/bold][/color], are hostile to eachother.
+- Escalation is not required for conflict between these 3 factions. This does not override safezone rules.
+- Alliances between these 3 main factions are disallowed, except in extreme circumstances that would threaten the entire sector (such as Letoferol/Romerol outbreaks).
 
-[italic][color=green]We encourage roleplay, but roleplay will not protect you from a bullet.[/color][/italic]
+[italic][color=green]Conflict should be meaningful, and prioritize roleplay over random violence.[/color][/italic]
 </Document>
-<!-- Coding is worse for my mental health than crack -->


### PR DESCRIPTION
Reverts Monolith-Station/Monolith#1680

Unironically it took like, me comparing the old rule to the new rule to realize in an instant the new rule is just bad compared the old one.

Old:
https://cdn.discordapp.com/attachments/1329352836433313823/1399983955356418205/rules.PNG?ex=688afc29&is=6889aaa9&hm=bf0ba8ae4f4f0d7540e3b1a10eda58ae7da2735a816ec675a09883602be0347b&

Old rules are simple and clear in very little words. New rules change almost nothing but instead go on long tangents. 

There are some ideas that should be transfered to the old rule, particularly alliance play but it should have been done much better.

Sorry for wasting your time Blu.