### PR TITLE
Lathe category bloat

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml
@@ -26,10 +26,14 @@
                         PlaceHolder="{Loc 'lathe-menu-search-designs'}"
                         HorizontalExpand="True">
                     </LineEdit>
+                </BoxContainer>
+                <BoxContainer Orientation="Horizontal"
+                              HorizontalExpand="True">
                     <OptionButton
                         Name="FilterOption"
                         MinWidth="100"
-                        StyleClasses="ButtonSquare"/>
+                        StyleClasses="ButtonSquare"
+                        HorizontalExpand="True"/>
                 </BoxContainer>
                 <BoxContainer Orientation="Vertical"
                     MinHeight="225"

--- a/Resources/Locale/en-US/_Mono/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/_Mono/lathe/lathe-categories.ftl
@@ -3,3 +3,38 @@ lathe-category-species = Species
 lathe-category-animals = Animals
 lathe-category-dangerous-animals = Dangerous Animals
 
+# Misc
+lathe-category-vouchers = Ship Vouchers
+
+# Mechs
+lathe-category-mech-weapons-s2s4 = S2/4 Mech Equipment
+lathe-category-mono-mech-weapons-light = Light Mech Weaponry
+lathe-category-mono-mech-weapons-medium = Medium Mech Weaponry
+lathe-category-mono-mech-weapons-heavy = Heavy Mech Weaponry
+lathe-category-s2-mechs = S2 Mechs
+lathe-category-s4-mechs = S4 Mechs
+lathe-category-combat-eva = Combat Hardsuits
+lathe-category-faction-gear = Faction Equipment
+
+# Ammo
+lathe-category-fmj-ammo = FMJ Ammo
+lathe-category-incen-ammo = Incendiary Ammo
+lathe-category-uranium-ammo = Uranium Ammo
+lathe-category-practice-ammo = Practice Ammo
+lathe-category-misc-ammo = Misc. Ammo
+lathe-category-ship-ammo = Ship Weapon
+
+# Weapons
+lathe-category-guns-rifles = Rifles
+lathe-category-guns-smgs = Submachine Guns
+lathe-category-guns-shotguns = Shotguns
+lathe-category-guns-dmrs = Designated Marksman Rifles
+lathe-category-guns-amrs = Anti-Material Rifles
+lathe-category-guns-mgs = Machine Guns
+lathe-category-guns-lmgs = Light Machine Guns
+lathe-category-guns-gpmgs = General-Purpose Machine Guns
+lathe-category-guns-sidearms = Sidearms
+lathe-category-guns-smartguns = Smartguns
+lathe-category-guns-ballistic = Ballistic Weapons
+lathe-category-guns-energy = Energy Weapons
+lathe-category-guns-explosive = Explosive Weapons

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/hardsuits.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/hardsuits.yml
@@ -1,6 +1,10 @@
 - type: latheRecipe
   id: ClothingOuterHardsuitSyndieReverseEngineered
   result: ClothingOuterHardsuitSyndieReverseEngineered
+  categories: # Mono
+  - CombatEva
+  - ArmorNF
+  - EVASuits
   completetime: 25
   materials:
      Steel: 6000
@@ -12,6 +16,10 @@
 - type: latheRecipe
   id: ClothingOuterHardsuitJuggernautReverseEngineered
   result: ClothingOuterHardsuitJuggernautReverseEngineered
+  categories: # Mono
+  - CombatEva
+  - ArmorNF
+  - EVASuits
   completetime: 25
   materials:
      Steel: 12000

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -67,6 +67,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponLaserCarbine
   result: WeaponLaserCarbine
+  categories: # Mono
+  - Weapons
+  - Energy
+  - Rifles
   materials:
     Steel: 2000
     Glass: 800
@@ -76,6 +80,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponAdvancedLaser
   result: WeaponAdvancedLaser
+  categories: # Mono
+  - Weapons
+  - Energy
+  - Sidearms
   materials:
     Steel: 1500
     Glass: 1000
@@ -85,6 +93,11 @@
   parent: BaseWeaponRecipeLong
   id: WeaponLaserCannon
   result: WeaponLaserCannon
+  categories: # Mono
+  - Weapons
+  - Energy
+  - Rifles
+  - AntiMaterial
   materials:
     Steel: 1250
     Plastic: 750
@@ -94,6 +107,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponLaserSvalinn
   result: WeaponLaserSvalinn
+  categories: # Mono
+  - Weapons
+  - Energy
+  - Sidearms
   materials:
     Steel: 2000
     Gold: 500
@@ -102,6 +119,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponXrayCannon
   result: WeaponXrayCannon
+  categories: # Mono
+  - Weapons
+  - Energy
+  - AntiMaterial
   materials:
     Steel: 1500
     Glass: 500
@@ -170,6 +191,9 @@
   parent: BaseAmmoRecipe
   id: AmmoBox12_gaugeTranquilizer
   result: AmmoBox12_gaugeTranquilizer
+  categories: # Mono
+  - MiscAmmo
+  - Ammo
   materials:
     Plastic: 240
     Steel: 160
@@ -238,6 +262,10 @@
   parent: WeaponDisabler
   id: WeaponDisablerSMG
   result: WeaponDisablerSMG
+  categories: # Mono
+  - Weapons
+  - Energy
+  - SMGs
   materials:
     Steel: 1000
     Glass: 500
@@ -254,6 +282,9 @@
 - type: latheRecipe
   id: 40mmGrenadeEMP
   result: 40mmGrenadeEMP
+  categories: # Mono
+  - MiscAmmo
+  - Ammo
   completetime: 3
   materials:
     Steel: 150
@@ -263,6 +294,9 @@
 - type: latheRecipe
   id: 40mmGrenadeThermobaric
   result: 40mmGrenadeThermobaric
+  categories: # Mono
+  - MiscAmmo
+  - Ammo
   completetime: 3
   materials:
     Steel: 450
@@ -272,6 +306,9 @@
 - type: latheRecipe
   id: 40mmGrenadeFlash
   result: 40mmGrenadeFlash
+  categories: # Mono
+  - MiscAmmo
+  - Ammo
   completetime: 3
   materials:
     Steel: 150
@@ -288,10 +325,6 @@
     Plastic: 1000
     Plasma: 500
     Glass: 500
-
-# mono changes start
-
-# mono changes end
 
 # Shitmed Recipes
 

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/security.yml
@@ -101,6 +101,11 @@
   parent: BaseWeaponRecipeLong
   id: WeaponSubMachineSmart
   result: WeaponSubMachineSmart
+  categories: # Mono
+  - SMGs
+  - SmartGuns
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1800
     Plastic: 750
@@ -111,5 +116,8 @@
   parent: BaseAmmoRecipe
   id: MagazineSmart
   result: MagazineSmart
+  categories: # Mono
+  - MiscAmmo
+  - Ammo
   materials:
     Steel: 550

--- a/Resources/Prototypes/_Mono/Recipes/Categories/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Categories/ammo.yml
@@ -1,0 +1,23 @@
+- type: latheCategory
+  id: FmjAmmo
+  name: lathe-category-fmj-ammo
+
+- type: latheCategory
+  id: IncenAmmo
+  name: lathe-category-incen-ammo
+
+- type: latheCategory
+  id: UraniumAmmo
+  name: lathe-category-uranium-ammo
+
+- type: latheCategory
+  id: PracticeAmmo
+  name: lathe-category-practice-ammo
+
+- type: latheCategory
+  id: MiscAmmo
+  name: lathe-category-misc-ammo
+
+- type: latheCategory
+  id: ShipAmmo
+  name: lathe-category-ship-ammo

--- a/Resources/Prototypes/_Mono/Recipes/Categories/categories.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Categories/categories.yml
@@ -14,3 +14,7 @@
 - type: latheCategory
   id: DangerousAnimals
   name: lathe-category-dangerous-animals
+
+- type: latheCategory
+  id: Vouchers
+  name: lathe-category-vouchers

--- a/Resources/Prototypes/_Mono/Recipes/Categories/gear.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Categories/gear.yml
@@ -1,0 +1,15 @@
+- type: latheCategory
+  id: S2Mechs
+  name: lathe-category-s2-mechs
+
+- type: latheCategory
+  id: S4Mechs
+  name: lathe-category-s4-mechs
+
+- type: latheCategory
+  id: CombatEva
+  name: lathe-category-combat-eva
+
+- type: latheCategory
+  id: FactionEquipment
+  name: lathe-category-faction-gear

--- a/Resources/Prototypes/_Mono/Recipes/Categories/guns.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Categories/guns.yml
@@ -1,0 +1,69 @@
+- type: latheCategory
+  id: Rifles
+  name: lathe-category-guns-rifles
+
+- type: latheCategory
+  id: SMGs
+  name: lathe-category-guns-smgs
+
+- type: latheCategory
+  id: Shotguns
+  name: lathe-category-guns-shotguns
+
+- type: latheCategory
+  id: DMRs
+  name: lathe-category-guns-dmrs
+
+- type: latheCategory
+  id: AntiMaterial
+  name: lathe-category-guns-amrs
+
+- type: latheCategory
+  id: MGs
+  name: lathe-category-guns-mgs
+
+- type: latheCategory
+  id: LMGs
+  name: lathe-category-guns-lmgs
+
+- type: latheCategory
+  id: GPMGs
+  name: lathe-category-guns-gpmgs
+
+- type: latheCategory
+  id: Sidearms
+  name: lathe-category-guns-sidearms
+
+- type: latheCategory
+  id: SmartGuns
+  name: lathe-category-guns-smartguns
+
+- type: latheCategory
+  id: Ballistic
+  name: lathe-category-guns-ballistic
+
+- type: latheCategory
+  id: Energy
+  name: lathe-category-guns-energy
+
+- type: latheCategory
+  id: Explosive
+  name: lathe-category-guns-explosive
+
+# mech slop
+
+- type: latheCategory
+  id: MonoMechGear
+  name: lathe-category-mech-weapons-s2s4
+
+- type: latheCategory
+  id: MonoMechLightWeapons
+  name: lathe-category-mono-mech-weapons-light
+
+- type: latheCategory
+  id: MonoMechMediumWeapons
+  name: lathe-category-mono-mech-weapons-medium
+
+- type: latheCategory
+  id: MonoMechHeavyWeapons
+  name: lathe-category-mono-mech-weapons-heavy

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/AllTheAmmo/VariousAmmo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/AllTheAmmo/VariousAmmo.yml
@@ -9,6 +9,9 @@
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
   id: CartridgeRocket
+  categories:
+  - MiscAmmo
+  - Ammo
   result: CartridgeRocket
   materials:
     Steel: 250
@@ -18,6 +21,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: MagazineSmartLMG
+  categories:
+  - MiscAmmo
+  - Ammo
   result: MagazineSmartLMG
   materials:
     Steel: 1000

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/BaseAmmo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/BaseAmmo.yml
@@ -2,12 +2,15 @@
 # boxes = magazine * 3-ish
 #.45 magnum gonna use intermediate
 
-#Base intermediate ammo magazines for 5.56, 5.45, 7.62x39mm and potential others 
+#Base intermediate ammo magazines for 5.56, 5.45, 7.62x39mm and potential others
 #Magazines:     [TOTAL = 475]
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJIntermediateMagazineRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 475
@@ -15,6 +18,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberIntermediateMagazineRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 75
@@ -23,6 +29,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryIntermediateMagazineRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 75
@@ -32,6 +41,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoPracticeIntermediateMagazineRecipe
+  categories:
+  - PracticeAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 47
@@ -39,6 +51,8 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoEmptyIntermediateMagazineRecipe
+  categories:
+  - Ammo
   abstract: true
   materials:
     Steel: 47
@@ -46,17 +60,23 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumIntermediateMagazineRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 175
     Uranium: 300
 
-#Base intermediate ammo speedloaders for .45 magnum, 5.56, 5.45, 7.62x39mm and potential others 
+#Base intermediate ammo speedloaders for .45 magnum, 5.56, 5.45, 7.62x39mm and potential others
 #speedloaders:     [TOTAL = 175]
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJIntermediateSpeedloaderRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 175
@@ -64,6 +84,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberIntermediateSpeedloaderRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 40
@@ -72,6 +95,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryIntermediateSpeedloaderRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 25
@@ -81,6 +107,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoPracticeIntermediateSpeedloaderRecipe
+  categories:
+  - PracticeAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 17
@@ -95,17 +124,23 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumIntermediateSpeedloaderRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 60
     Uranium: 125
 
-#Base intermediate ammo boxes for 5.56, 5.45, 7.62x39mm and potential others 
+#Base intermediate ammo boxes for 5.56, 5.45, 7.62x39mm and potential others
 #Boxes:     [TOTAL = 1425]
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJIntermediateAmmoBoxRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 1425
@@ -113,6 +148,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberIntermediateAmmoBoxRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 570
@@ -121,6 +159,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryIntermediateAmmoBoxRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 285
@@ -130,6 +171,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoPracticeIntermediateAmmoBoxRecipe
+  categories:
+  - PracticeAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 142
@@ -137,17 +181,23 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumIntermediateAmmoBoxRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 570
     Uranium: 855
 
-#Base Fully powered ammo magazines for all the other 7.62 (-7.62x39mm) 
+#Base Fully powered ammo magazines for all the other 7.62 (-7.62x39mm)
 #Magazines: [TOTAL = 575]
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJFullyPoweredMagazineRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 575
@@ -155,6 +205,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberFullyPoweredMagazineRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 125
@@ -163,6 +216,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryFullyPoweredMagazineRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 100
@@ -172,6 +228,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoPracticeFullyPoweredMagazineRecipe
+  categories:
+  - PracticeAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 57
@@ -186,17 +245,23 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumFullyPoweredMagazineRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 200
     Uranium: 375
 
-#Base Fully powered ammo boxes for all the other 7.62 (-7.62x39mm) 
+#Base Fully powered ammo boxes for all the other 7.62 (-7.62x39mm)
 #Boxes:     [TOTAL = 1725]
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJFullyPoweredAmmoBoxRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 1725
@@ -204,6 +269,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberFullyPoweredAmmoBoxRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 345
@@ -212,6 +280,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryFullyPoweredAmmoBoxRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 345
@@ -221,6 +292,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoPracticeFullyPoweredAmmoBoxRecipe
+  categories:
+  - PracticeAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 172
@@ -228,17 +302,23 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumFullyPoweredAmmoBoxRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 575
     Uranium: 1150
 
-#Base Fully powered ammo magazines for all the other 7.62 (-7.62x39mm) 
+#Base Fully powered ammo magazines for all the other 7.62 (-7.62x39mm)
 #speedloaders:     [TOTAL = 225]
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJFullyPoweredSpeedloaderRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 225
@@ -249,6 +329,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJPistolCaliberPistolMagazineRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 175
@@ -256,6 +339,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberPistolCaliberPistolMagazineRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 40
@@ -264,6 +350,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryPistolCaliberPistolMagazineRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 25
@@ -273,6 +362,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoPracticePistolCaliberPistolMagazineRecipe
+  categories:
+  - PracticeAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 17
@@ -287,6 +379,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumPistolCaliberPistolMagazineRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 60
@@ -298,6 +393,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJPistolCaliberSubMachineGunMagazineRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 375
@@ -305,6 +403,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberPistolCaliberSubMachineGunMagazineRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 50
@@ -313,6 +414,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryPistolCaliberSubMachineGunMagazineRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 75
@@ -322,6 +426,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoPracticePistolCaliberSubMachineGunMagazineRecipe
+  categories:
+  - PracticeAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 37
@@ -336,17 +443,23 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumPistolCaliberSubMachineGunMagazineRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 125
     Uranium: 250
 
-#Base PistolCaliber ammo speedloaders for .45 magnum, 5.56, 5.45, 7.62x39mm and potential others 
+#Base PistolCaliber ammo speedloaders for .45 magnum, 5.56, 5.45, 7.62x39mm and potential others
 #speedloaders:     [TOTAL = 175]
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJPistolCaliberSpeedloaderRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 175
@@ -354,6 +467,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberPistolCaliberSpeedloaderRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 40
@@ -362,6 +478,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryPistolCaliberSpeedloaderRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 25
@@ -371,6 +490,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoPracticePistolCaliberSpeedloaderRecipe
+  categories:
+  - PracticeAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 17
@@ -385,6 +507,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumPistolCaliberSpeedloaderRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 60
@@ -396,6 +521,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoFMJPistolCaliberAmmoBoxRecipe
+  categories:
+  - FmjAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 1125
@@ -403,6 +531,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoRubberPistolCaliberAmmoBoxRecipe
+  categories:
+  - MiscAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 175
@@ -411,6 +542,9 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoIncendiaryPistolCaliberAmmoBoxRecipe
+  categories:
+  - IncenAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 225
@@ -424,10 +558,12 @@
   materials:
     Steel: 112
 
-
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseAmmoUraniumPistolCaliberAmmoBoxRecipe
+  categories:
+  - UraniumAmmo
+  - Ammo
   abstract: true
   materials:
     Steel: 375

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/base_equipment.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/base_equipment.yml
@@ -6,6 +6,10 @@
   abstract: true
   id: MonoHardsuitT1Recipe
   parent: NFBaseEVASuitRecipe
+  categories:
+  - EVASuits
+  - CombatEva
+  - ArmorNF
   completetime: 15
   materials:
     Glass: 200

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/equipment_rogue.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/equipment_rogue.yml
@@ -63,16 +63,26 @@
 
 - type: latheRecipe
   id: ClothingMaskGasSyndicateRogue
+  categories:
+  - ClothesNF
+  - FactionEquipment
   parent: NFBaseMaskArmoredRecipe
   result: ClothingMaskGasSyndicate
 
 - type: latheRecipe
   id: ClothingOuterVestWebRogue
+  categories:
+  - ArmorNF
+  - ClothesNF
+  - FactionEquipment
   parent: NFBaseArmorRecipe
   result: ClothingOuterVestWeb
 
 - type: latheRecipe
   id: ClothingShoesBootsMagSyndieRogue
+  categories:
+  - ClothesNF
+  - FactionEquipment
   result: ClothingShoesBootsMagSyndie
   completetime: 5
   materials:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/melee_weapons.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/melee_weapons.yml
@@ -6,6 +6,9 @@
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
   id: EnergySwordRogue
+  categories:
+  - Energy
+  - Weapons
   result: EnergySword
   materials:
     Steel: 1200
@@ -16,6 +19,9 @@
 - type: latheRecipe
   parent: BaseWeaponRecipe
   id: EnergyDaggerRogue
+  categories:
+  - Energy
+  - Weapons
   result: EnergyDaggerLoud
   materials:
     Steel: 1200
@@ -26,6 +32,9 @@
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
   id: HFSwordVT7
+  categories:
+  - Energy
+  - Weapons
   result: WeaponVT7
   materials:
     Steel: 1000
@@ -37,6 +46,9 @@
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
   id: EnergyShieldTSF
+  categories:
+  - Energy
+  - Weapons
   result: EnergyShieldNfsd
   materials:
     Steel: 1500
@@ -47,6 +59,9 @@
 - type: latheRecipe
   parent: BaseWeaponRecipeLong
   id: EnergyShieldRogue
+  categories:
+  - Energy
+  - Weapons
   result: EnergyShield
   materials:
     Steel: 1500
@@ -57,6 +72,8 @@
 - type: latheRecipe
   parent: BaseWeaponRecipe
   id: CrowbarPocketTSF
+  categories:
+  - FactionEquipment
   result: CrowbarPocket
   materials:
     Steel: 1200

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/misc.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/misc.yml
@@ -8,6 +8,9 @@
   parent: BaseToolRecipe
   id: JawsOfLifeRogue
   result: SyndicateJawsOfLife
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 6
   materials:
     Steel: 1500
@@ -20,6 +23,9 @@
   parent: BaseToolRecipe
   id: ForensicsScannerTSF
   result: ForensicScanner
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 3
   materials:
     Steel: 1500
@@ -31,6 +37,9 @@
   parent: BaseToolRecipe
   id: DemagTSF
   result: Demag
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 10
   materials:
     Steel: 1500
@@ -45,6 +54,8 @@
   parent: BaseToolRecipe
   id: SutureTSF
   result: MedicatedSuture
+  categories:
+  - FactionEquipment
   completetime: 15
   materials:
     Steel: 50
@@ -56,6 +67,8 @@
   parent: BaseToolRecipe
   id: MeshTSF
   result: RegenerativeMesh
+  categories:
+  - FactionEquipment
   completetime: 15
   materials:
     Steel: 50
@@ -67,6 +80,9 @@
   parent: BaseToolRecipe
   id: HyposprayRogue
   result: Hypospray
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 15
   materials:
     Steel: 500
@@ -82,6 +98,9 @@
   parent: BaseToolRecipe
   id: EmagRogue
   result: Emag
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 20
   materials:
     Steel: 2500
@@ -96,6 +115,9 @@
   parent: BaseToolRecipe
   id: AccessBreakerRogue
   result: AccessBreaker
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 20
   materials:
     Steel: 2500
@@ -111,6 +133,9 @@
   parent: BaseToolRecipe
   id: NanolaminateFoamGrenadeTSF
   result: NanolaminateFoamGrenade
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 2
   materials:
     Steel: 300
@@ -123,6 +148,9 @@
   parent: BaseToolRecipe
   id: OreBoxFlatpackTSF
   result: OreBoxFlatpack
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 5
   materials:
     Steel: 600
@@ -133,6 +161,9 @@
   parent: BaseToolRecipe
   id: MotionDetectorTSF
   result: MotionDetector
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 3
   materials:
     Steel: 500
@@ -145,6 +176,9 @@
   parent: BaseToolRecipe
   id: MaterialBoxFlatpackTSF
   result: MaterialBoxFlatpack
+  categories:
+  - Tools
+  - FactionEquipment
   completetime: 5
   materials:
     Steel: 600
@@ -155,6 +189,10 @@
   parent: BaseToolRecipe
   id: SeismicChargeUSSP
   result: SeismicCharge
+  categories:
+  - FactionEquipment
+  - Weapons
+  - Explosive
   completetime: 2
   materials:
     Plastic: 100
@@ -164,6 +202,10 @@
   parent: BaseToolRecipe
   id: TearGasGrenadeUSSP
   result: TearGasGrenade
+  categories:
+  - FactionEquipment
+  - Weapons
+  - Explosive
   completetime: 2
   materials:
     Steel: 100
@@ -173,6 +215,10 @@
   parent: BaseToolRecipe
   id: GrenadeShrapnelUSSP
   result: GrenadeShrapnel
+  categories:
+  - FactionEquipment
+  - Weapons
+  - Explosive
   completetime: 2
   materials:
     Steel: 500
@@ -182,6 +228,10 @@
   parent: BaseToolRecipe
   id: GrenadeIncendiaryUSSP
   result: GrenadeIncendiary
+  categories:
+  - FactionEquipment
+  - Weapons
+  - Explosive
   completetime: 2
   materials:
     Steel: 500

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/ranged_weapons.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/ranged_weapons.yml
@@ -9,6 +9,9 @@
   parent: BaseWeaponRecipeLong
   id: WeaponLauncherRocket
   result: WeaponLauncherRocket
+  categories:
+  - Explosive
+  - Weapons
   materials:
     Steel: 2250
     Plasteel: 3500
@@ -21,6 +24,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleLecterTSF
   result: WeaponRifleLecter
+  categories:
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1200
     Plasteel: 1000
@@ -30,6 +37,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleVulcanTSF
   result: WeaponRifleVulcan
+  categories:
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1800
     Plasteel: 1000
@@ -39,6 +50,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponSubMachineGunDrozdTSF
   result: WeaponSubMachineGunDrozd
+  categories:
+  - SMGs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1000
     Plasteel: 500
@@ -48,6 +63,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleMR3CTSF
   result: WeaponRifleMR3C
+  categories:
+  - DMRs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1200
     Plasteel: 650
@@ -59,6 +78,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleWSPRRogue
   result: WeaponRifleWSPR
+  categories:
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1500
     Plasteel: 1200
@@ -68,6 +91,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleAnnieTSF
   result: WeaponRifleAnnie
+  categories:
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1500
     Plasteel: 1200
@@ -79,6 +106,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponSubMachineGunMla73Rogue
   result: WeaponSubMachineGunMla73
+  categories:
+  - SMGs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1500
     Plasteel: 800
@@ -90,6 +121,11 @@
 #  parent: BaseWeaponRecipeLong
 #  id: WeaponLMGMR8BTSF
 #  result: WeaponLMGMR8B
+#  categories:
+#  - GPMGs
+#  - MGs
+#  - Ballistic
+#  - Weapons
 #  materials:
 #    Steel: 6000
 #    Plasteel: 3000
@@ -100,6 +136,11 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleMR8CTSF
   result: WeaponRifleMR8C
+  categories:
+  - DMRs
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 4000
     Plasteel: 2000
@@ -112,6 +153,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleXlr556Tsf
   result: WeaponRifleXlr556
+  categories:
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 500
     Plasteel: 1500
@@ -124,6 +169,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponSubMachineGunC20rRogue
   result: WeaponSubMachineGunC20r
+  categories:
+  - SMGs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 700
     Plasteel: 1000
@@ -133,6 +182,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRevolverPythonRogue
   result: WeaponRevolverPython
+  categories:
+  - Sidearms
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1500
     Plasteel: 2000
@@ -145,6 +198,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponSubMachineGunWt550Rogue
   result: WeaponSubMachineGunWt550
+  categories:
+  - SMGs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 700
     Plasteel: 750
@@ -154,6 +211,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleM90Rogue
   result: WeaponRifleM90
+  categories:
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1800
     Plasteel: 800
@@ -166,6 +227,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponSubMachineGunAtreidesRogue
   result: WeaponSubMachineGunAtreides
+  categories:
+  - SMGs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1200
     Plasteel: 1500
@@ -175,6 +240,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponShotgunBulldogRogue
   result: WeaponShotgunBulldog
+  categories:
+  - Shotguns
+  - Ballistic
+  - Weapons
   materials:
     Steel: 2500
     Plasteel: 1200
@@ -187,6 +256,11 @@
   parent: BaseWeaponRecipeLong
   id: WeaponSniperHristovRogue
   result: WeaponSniperHristov
+  categories:
+  - DMRs
+  - AntiMaterial
+  - Ballistic
+  - Weapons
   materials:
     Steel: 7500
     Plasteel: 3000
@@ -200,6 +274,11 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleSVSUSSP
   result: WeaponRifleSVS
+  categories:
+  - Rifles
+  - DMRs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 100
     Wood: 1000
@@ -208,6 +287,11 @@
   parent: BaseWeaponRecipeLong
   id: WeaponSniperMosinUSSP
   result: WeaponSniperMosin
+  categories:
+  - Rifles
+  - DMRs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 100
     Plasteel: 100
@@ -217,6 +301,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRifleAK502USSP
   result: WeaponRifleAK502
+  categories:
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1800
     Plasteel: 800
@@ -227,6 +315,11 @@
   parent: BaseWeaponRecipeLong
   id: WeaponDP29USSP
   result: WeaponDP29
+  categories:
+  - GPMGs
+  - MGs
+  - Ballistic
+  - Weapons
   materials:
     Steel: 2500
     Plasteel: 2000
@@ -236,6 +329,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponRevolverMatebaUSSP
   result: WeaponRevolverMateba
+  categories:
+  - Sidearms
+  - Ballistic
+  - Weapons
   materials:
     Steel: 3000
     Plasteel: 3000
@@ -246,6 +343,10 @@
   parent: BaseWeaponRecipeLong
   id: WeaponShotgunBigLeadyUSSP
   result: WeaponShotgunBigLeady
+  categories:
+  - Shotguns
+  - Ballistic
+  - Weapons
   materials:
     Steel: 2500
     Plasteel: 2000

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/synthalloy.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/synthalloy.yml
@@ -5,6 +5,8 @@
 - type: latheRecipe
   id: SynthalloyProductionTsf
   result: MaterialSynthalloy10
+  categories:
+  - FactionEquipment
   completetime: 1
   materials:
     Plasteel: 1500
@@ -14,6 +16,8 @@
 - type: latheRecipe
   id: SynthalloyProductionTechDisk
   result: MaterialSynthalloy10
+  categories:
+  - FactionEquipment
   completetime: 2
   materials:
     Plasteel: 5000

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/universal_shipgun_ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/universal_shipgun_ammo.yml
@@ -5,6 +5,8 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: BaseShipgunAmmoRecipe
+  categories:
+  - ShipAmmo
   abstract: true
   materials:
     Steel: 2000

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/vouchers.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/vouchers.yml
@@ -7,6 +7,8 @@
 - type: latheRecipe
   abstract: true
   id: BaseVoucherRecipe
+  categories:
+  - Vouchers
   completetime: 120
 #Ussp
 - type: latheRecipe

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/equipment.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/equipment.yml
@@ -6,6 +6,10 @@
   id: MonoHardsuitWarlordRecipe
   parent: NFBaseEVASuitRecipe
   completetime: 30
+  categories:
+  - CombatEva
+  - EVASuits
+  - ArmorNF
   result: ClothingOuterHardsuitMercenaryWarlord
   materials:
     Glass: 2000

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/mech_boards.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/mech_boards.yml
@@ -5,30 +5,42 @@
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: BroadswordCentralElectronics
+  categories:
+  - S2Mechs
   result: BroadswordCentralElectronics
 
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: BroadswordPeripheralsElectronics
+  categories:
+  - S2Mechs
   result: BroadswordPeripheralsElectronics
 
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: BroadswordTargetingElectronics
+  categories:
+  - S2Mechs
   result: BroadswordTargetingElectronics
 
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: FlailCentralElectronics
+  categories:
+  - S4Mechs
   result: FlailCentralElectronics
 
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: FlailPeripheralsElectronics
+  categories:
+  - S4Mechs
   result: FlailPeripheralsElectronics
 
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: FlailTargetingElectronics
+  categories:
+  - S4Mechs
   result: FlailTargetingElectronics
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/mech_parts.yml
@@ -7,6 +7,8 @@
 - type: latheRecipe
   id: BroadswordHarness
   result: BroadswordHarness
+  categories:
+  - S2Mechs
   completetime: 25
   materials:
     Steel: 7000
@@ -17,6 +19,8 @@
 - type: latheRecipe
   id: BroadswordHead
   result: BroadswordHead
+  categories:
+  - S2Mechs
   completetime: 25
   materials:
     Steel: 2500
@@ -28,6 +32,8 @@
 - type: latheRecipe
   id: BroadswordLArm
   result: BroadswordLArm
+  categories:
+  - S2Mechs
   completetime: 25
   materials:
     Steel: 2000
@@ -37,6 +43,8 @@
 - type: latheRecipe
   id: BroadswordLLeg
   result: BroadswordLLeg
+  categories:
+  - S2Mechs
   completetime: 25
   materials:
     Steel: 2000
@@ -46,6 +54,8 @@
 - type: latheRecipe
   id: BroadswordRLeg
   result: BroadswordRLeg
+  categories:
+  - S2Mechs
   completetime: 25
   materials:
     Steel: 2200
@@ -55,6 +65,8 @@
 - type: latheRecipe
   id: BroadswordRArm
   result: BroadswordRArm
+  categories:
+  - S2Mechs
   completetime: 25
   materials:
     Steel: 2200
@@ -64,6 +76,8 @@
 - type: latheRecipe
   id: HalberdHarness
   result: HalberdHarness
+  categories:
+  - S2Mechs
   completetime: 25
   materials:
     Steel: 7000
@@ -74,6 +88,8 @@
 - type: latheRecipe
   id: SabreHarness
   result: SabreHarness
+  categories:
+  - S2Mechs
   completetime: 25
   materials:
     Steel: 7000
@@ -85,6 +101,8 @@
 - type: latheRecipe
   id: FlailHarness
   result: FlailHarness
+  categories:
+  - S4Mechs
   completetime: 40
   materials:
     Steel: 12000
@@ -95,6 +113,8 @@
 - type: latheRecipe
   id: FlailHead
   result: FlailHead
+  categories:
+  - S4Mechs
   completetime: 40
   materials:
     Steel: 5500
@@ -106,6 +126,8 @@
 - type: latheRecipe
   id: FlailLArm
   result: FlailLArm
+  categories:
+  - S4Mechs
   completetime: 40
   materials:
     Steel: 4000
@@ -115,6 +137,8 @@
 - type: latheRecipe
   id: FlailLLeg
   result: FlailLLeg
+  categories:
+  - S4Mechs
   completetime: 40
   materials:
     Steel: 2500
@@ -124,6 +148,8 @@
 - type: latheRecipe
   id: FlailRLeg
   result: FlailRLeg
+  categories:
+  - S4Mechs
   completetime: 40
   materials:
     Steel: 2500
@@ -133,6 +159,8 @@
 - type: latheRecipe
   id: FlailRArm
   result: FlailRArm
+  categories:
+  - S4Mechs
   completetime: 40
   materials:
     Steel: 4000
@@ -142,6 +170,8 @@
 - type: latheRecipe
   id: SpyglassHarness
   result: SpyglassHarness
+  categories:
+  - S4Mechs
   completetime: 40
   materials:
     Steel: 12000
@@ -153,6 +183,8 @@
 - type: latheRecipe
   id: MaceHarness
   result: MaceHarness
+  categories:
+  - S4Mechs
   completetime: 40
   materials:
     Steel: 12000
@@ -163,6 +195,8 @@
 - type: latheRecipe
   id: PowerCageMech
   result: PowerCageMech
+  categories:
+  - MonoMechGear
   completetime: 25
   materials:
     Steel: 600

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/mech_weapons.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/mech_weapons.yml
@@ -8,6 +8,9 @@
 - type: latheRecipe
   abstract: true
   id: BaseMechLightWeapon
+  categories:
+  - MonoMechGear
+  - MonoMechLightWeapons
   completetime: 15
   materials:
     Steel: 1200
@@ -35,6 +38,9 @@
 - type: latheRecipe
   abstract: true
   id: BaseMechMediumWeapon
+  categories:
+  - MonoMechGear
+  - MonoMechMediumWeapons
   completetime: 17.5
   materials:
     Steel: 1500
@@ -62,6 +68,9 @@
 - type: latheRecipe
   abstract: true
   id: BaseMechHeavyWeapon
+  categories:
+  - MonoMechGear
+  - MonoMechHeavyWeapons
   completetime: 17.5
   materials:
     Steel: 3500
@@ -94,7 +103,6 @@
     Gold: 200
     Silver: 1500
 
-
 - type: latheRecipe
   parent: BaseMechHeavyWeapon
   id: EWACMechaJammer
@@ -110,6 +118,8 @@
 - type: latheRecipe
   abstract: true
   id: BaseMechIFF
+  categories:
+  - MonoMechGear
   completetime: 5
   materials:
     Steel: 400

--- a/Resources/Prototypes/_NF/Recipes/Lathes/clothing-armor.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/clothing-armor.yml
@@ -26,6 +26,9 @@
   abstract: true
   id: NFBaseMaskArmoredRecipe
   parent: NFBaseArmorRecipe
+  categories: # Mono
+  - ArmorNF
+  - ClothesNF
   completetime: 2
   materials:
     Durathread: 300

--- a/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
@@ -5,6 +5,7 @@
   id: NFBaseEVASuitRecipe
   categories:
   - EVASuits
+  - ArmorNF # Mono
   applyMaterialDiscount: false
   completetime: 5
   materials:
@@ -40,6 +41,10 @@
   abstract: true
   id: NFBaseHardSuitArmoredRecipe
   parent: NFBaseEVASuitRecipe
+  categories: # Mono
+  - CombatEva
+  - EVASuits
+  - ArmorNF
   completetime: 8
   materials:
     Glass: 500
@@ -53,6 +58,9 @@
   abstract: true
   id: NFBaseMagBootsRecipe
   parent: NFBaseEVASuitRecipe
+  categories: # Mono
+  - Tools
+  - ClothesNF
   completetime: 8
   materials:
     Silver: 1000
@@ -314,6 +322,9 @@
   id: ClothingOuterHardsuitCap
   parent: NFBaseHardSuitArmoredRecipe
   result: ClothingOuterHardsuitCap
+  categories: # Mono
+  - ArmorNF
+  - EVASuits
 
 - type: latheRecipe
   id: ClothingOuterHardsuitScaf
@@ -324,11 +335,17 @@
   id: ClothingOuterHardsuitEngineeringWhite
   parent: NFBaseHardSuitArmoredRecipe
   result: ClothingOuterHardsuitEngineeringWhite
+  categories: # Mono
+  - ArmorNF
+  - EVASuits
 
 - type: latheRecipe
   id: ClothingOuterHardsuitMedical
   parent: NFBaseHardSuitArmoredRecipe
   result: ClothingOuterHardsuitMedical
+  categories: # Mono
+  - ArmorNF
+  - EVASuits
   materials:
     Glass: 500
     Plastic: 2000
@@ -342,11 +359,17 @@
   id: ClothingOuterHardsuitRd
   parent: NFBaseHardSuitArmoredRecipe
   result: UndeterminedVoidsuitRD
+  categories: # Mono
+  - ArmorNF
+  - EVASuits
 
 - type: latheRecipe
   id: ClothingOuterHardsuitLuxury
   parent: NFBaseHardSuitArmoredRecipe
   result: ClothingOuterHardsuitLuxury
+  categories: # Mono
+  - ArmorNF
+  - EVASuits
 
 - type: latheRecipe
   id: ClothingOuterHardsuitMaximPrototype

--- a/Resources/Prototypes/_NF/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/security.yml
@@ -6,6 +6,9 @@
   id: CrossbowBolt
   parent: BaseAmmoRecipe
   result: CrossbowBolt
+  categories: # Mono
+  - MiscAmmo
+  - Ammo
   materials:
     Steel: 20
 
@@ -13,14 +16,19 @@
   id: CrossbowBoltBroadhead
   parent: BaseAmmoRecipe
   result: CrossbowBoltBroadhead
+  categories: # Mono
+  - MiscAmmo
+  - Ammo
   materials:
     Steel: 25
-    
+
 - type: latheRecipe
   id: WeaponPistolPollock
   result: WeaponPistolPollock
   categories:
   - Weapons
+  - Sidearms # Mono
+  - Ballistic # Mono
   completetime: 3
   materials:
     Steel: 1000

--- a/Resources/Prototypes/_NF/Recipes/Lathes/weapons.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/weapons.yml
@@ -3,6 +3,10 @@
   id: WeaponLaserPistolNF
   parent: BaseWeaponRecipeLong
   result: WeaponLaserPistolNF
+  categories: # Mono
+  - Sidearms
+  - Energy
+  - Weapons
   materials:
     Steel: 1200
     Glass: 800
@@ -12,6 +16,10 @@
   id: WeaponRevolverArgenti
   parent: BaseWeaponRecipeLong
   result: WeaponRevolverArgenti
+  categories: # Mono
+  - Sidearms
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1500
     Plasteel: 500
@@ -20,6 +28,10 @@
   id: WeaponPistolMk58NF
   parent: BaseWeaponRecipeLong
   result: WeaponPistolMk58
+  categories: # Mono
+  - Sidearms
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1000
     Plasteel: 1200
@@ -29,6 +41,10 @@
   id: WeaponShotgunDoubleBarreled
   parent: BaseWeaponRecipeLong
   result: WeaponShotgunDoubleBarreled
+  categories: # Mono
+  - Shotguns
+  - Ballistic
+  - Weapons
   materials:
     Steel: 2000
     Plasteel: 800
@@ -38,6 +54,10 @@
   id: WeaponShotgunKammererNF
   parent: BaseWeaponRecipeLong
   result: WeaponShotgunKammerer
+  categories: # Mono
+  - Shotguns
+  - Ballistic
+  - Weapons
   materials:
     Steel: 500
     Plasteel: 1500
@@ -48,6 +68,10 @@
   id: WeaponRifleNovaliteC1
   parent: BaseWeaponRecipeLong
   result: WeaponRifleNovaliteC1
+  categories: # Mono
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 2500
     Plasteel: 1200
@@ -57,6 +81,10 @@
   id: WeaponRifleGestio
   parent: BaseWeaponRecipeLong
   result: WeaponRifleGestio
+  categories: # Mono
+  - Rifles
+  - Ballistic
+  - Weapons
   materials:
     Steel: 2500
     Plasteel: 1200
@@ -66,6 +94,9 @@
   id: CrossbowModern
   parent: BaseWeaponRecipeLong
   result: CrossbowModern
+  categories: # Mono
+  - Ballistic
+  - Weapons
   materials:
     Steel: 1000
     Plasteel: 500


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<img width="368" height="396" alt="image" src="https://github.com/user-attachments/assets/6ac7c7a0-c783-4dbd-b674-4aa13f718ee2" />
<img width="743" height="496" alt="image" src="https://github.com/user-attachments/assets/bc82de78-d85e-450d-ac5c-5295bc073aed" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added more lathe categories (incen ammo, rifles, smgs, combat EVA, etc). Bloat Supreme.
- tweak: Changed position of lathe category button. Now under with the search bar instead of on its side.