### PR TITLE
Remove Anti-Fun From Affected Seeds

### DIFF
--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -1432,10 +1432,11 @@
       Min: 1
       Max: 5
       PotencyDivisor: 20
-  seedless: true # Frontier
-  preventSwabbing: true # Frontier
-  preventClipping: true # Frontier
-  permanentlySeedless: true # Frontier
+#Mono - antifun disabled
+#  seedless: true # Frontier
+#  preventSwabbing: true # Frontier
+#  preventClipping: true # Frontier
+#  permanentlySeedless: true # Frontier
 
 - type: seed
   id: fakeCapfruit
@@ -1462,10 +1463,11 @@
       Min: 1
       Max: 5
       PotencyDivisor: 20
-  seedless: true # Frontier
-  preventSwabbing: true # Frontier
-  preventClipping: true # Frontier
-  permanentlySeedless: true # Frontier
+#Mono - antifun disabled
+#  seedless: true # Frontier
+#  preventSwabbing: true # Frontier
+#  preventClipping: true # Frontier
+#  permanentlySeedless: true # Frontier
 
 - type: seed
   id: realCapfruit
@@ -1492,10 +1494,11 @@
       Min: 1
       Max: 5
       PotencyDivisor: 20
-  seedless: true # Frontier
-  preventSwabbing: true # Frontier
-  preventClipping: true # Frontier
-  permanentlySeedless: true # Frontier
+#Mono - antifun disabled
+#  seedless: true # Frontier
+#  preventSwabbing: true # Frontier
+#  preventClipping: true # Frontier
+#  permanentlySeedless: true # Frontier
 
 - type: seed
   id: rice

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -1,3 +1,40 @@
+# SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto
+# SPDX-FileCopyrightText: 2021 Elijahrane
+# SPDX-FileCopyrightText: 2021 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2021 metalgearsloth
+# SPDX-FileCopyrightText: 2022 Alex Evgrashin
+# SPDX-FileCopyrightText: 2022 Kevin Zheng
+# SPDX-FileCopyrightText: 2022 Michael Phillips
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2023 612
+# SPDX-FileCopyrightText: 2023 Doru991
+# SPDX-FileCopyrightText: 2023 DoubleRiceEddiedd
+# SPDX-FileCopyrightText: 2023 Fluffiest Floofers
+# SPDX-FileCopyrightText: 2023 FoxxoTrystan
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 Morb
+# SPDX-FileCopyrightText: 2023 Stealthbomber16
+# SPDX-FileCopyrightText: 2023 Vladislav Kadira
+# SPDX-FileCopyrightText: 2023 ZeroDayDaemon
+# SPDX-FileCopyrightText: 2023 drteaspoon420
+# SPDX-FileCopyrightText: 2023 lapatison
+# SPDX-FileCopyrightText: 2024 BombasterDS
+# SPDX-FileCopyrightText: 2024 Ed
+# SPDX-FileCopyrightText: 2024 Gyrandola
+# SPDX-FileCopyrightText: 2024 RumiTiger
+# SPDX-FileCopyrightText: 2024 Tayrtahn
+# SPDX-FileCopyrightText: 2024 Ubaser
+# SPDX-FileCopyrightText: 2024 potato1234_x
+# SPDX-FileCopyrightText: 2024 saga3152
+# SPDX-FileCopyrightText: 2024 slarticodefast
+# SPDX-FileCopyrightText: 2025 Boaz1111
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 tonotom
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: seed
   id: wheat
   name: seeds-wheat-name

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2023 Dvir
+# SPDX-FileCopyrightText: 2023 terezi4real
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Iocanthos
+# SPDX-FileCopyrightText: 2024 RichardRahl123
+# SPDX-FileCopyrightText: 2024 dustylens
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 tonotom
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: SeedBase
   name: packet of speso seeds

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -246,4 +246,5 @@
       Min: 1
       Max: 4
       PotencyDivisor: 25
-  preventSwabbing: true # they're bees
+#Mono - antifun disabled: we can just pretend bees are affected because they eat pollen so we can keep the FUN aspects of botany intact
+#  preventSwabbing: true # they're bees


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Comments out unfun anti-clip, anti-seed, anti-swab shit from Gatfruit and capfruit + bees

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Botany without swabbing is not engaging. Fuck outta here.

Nobody is going to mass Pythons when there's vastly more usable options anyway.

If there's a concern with farming money with Pythons, keep in mind you must manually eat each and every single fruit to claim the prize.

## How to test
<!-- Describe the way it can be tested -->

Swab that shit

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Babby yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
- [ X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
tweak: Gatfruit and capfruit can be swabbed, seeded, and clipped again. Bees can now be swabbed. 