### PR TITLE
Rebalance Sevastopol Disk Printer

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/disk_printer.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/disk_printer.yml
@@ -16,9 +16,8 @@
     drawRate: 120000
   - type: ItemGenerator
     prototypes:
-    - SpawnLootTechDisksT1
-    - SpawnLootTechDisksT2Faction
-    - SpawnLootTechDisksT3Fracture
+    - SpawnLootTechDisksPrinterT1
+    - SpawnLootTechDisksPrinterT2
     miningInterval: 450
     powerDraw: 120000
     requireExpedition: false
@@ -97,3 +96,114 @@
     radius: 0.8
     energy: 0.5
     color: "#00AACC"
+
+- type: entity
+  name: tech disk printer disks
+  id: SpawnLootTechDisksPrinterT1
+  parent: MarkerBasePlaceFree
+  suffix: "Tech Disk Printer T1"
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+      scale: 0.7, 0.7
+    - sprite: _NF/Markers/general.rsi
+      state: questionmark
+      color: red
+  - type: RandomSpawner
+    prototypes:
+    - TechDiskCivBluespaceBags
+    - TechDiskRCD
+    - TechDiskMechCiv
+    - TechDiskCivMS250
+    - TechDiskCivCTLA50
+    - TechDiskCivShipComps
+    - TechDiskCivBackpackWaterTank
+    - TechDiskTSFLecter
+    - TechDiskTSFDrozd
+    - TechDiskC20r
+    - TechDiskUniversalShipAmmo
+    - ResearchDisk5000
+    - ResearchDisk10000
+    chance: 0.95
+    offset: 0.0
+    rarePrototypes:
+    - SpawnLootTechDisksPrinterT2
+    - SpawnLootTechDisksT2Mech
+    rareChance: 0.15
+
+- type: entity
+  name: tech disk printer disks
+  id: SpawnLootTechDisksPrinterT2
+  parent: MarkerBasePlaceFree
+  suffix: "Tech Disk Printer T2"
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+      scale: 0.7, 0.7
+    - sprite: _NF/Markers/general.rsi
+      state: questionmark
+      color: red
+  - type: RandomSpawner
+    prototypes:
+    - TechDiskM90
+    - TechDiskMla73
+    - TechDiskRogueTools
+    - TechDiskTSFAnnie
+    - TechDiskBulldog
+    - TechDiskShields
+    - TechDiskFtl
+    chance: 0.95
+    offset: 0.0
+    rarePrototypes:
+    - SpawnLootTechDisksPrinterT3
+    rareChance: 0.15
+
+- type: entity
+  name: tech disk printer disks
+  id: SpawnLootTechDisksPrinterT3
+  parent: MarkerBasePlaceFree
+  suffix: "Tech Disk Printer T3"
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+      scale: 0.7, 0.7
+    - sprite: _NF/Markers/general.rsi
+      state: questionmark
+      color: red
+  - type: RandomSpawner
+    prototypes:
+    - TechDiskTSFICWS
+    - TechDiskEnergyWeapons
+    - TechDiskHristov
+    - TechDiskSynthalloy
+    chance: 0.95
+    offset: 0.0
+    rarePrototypes:
+    - SpawnLootTechDisksPrinterT4
+    rareChance: 0.15
+
+- type: entity
+  name: tech disk printer disks
+  id: SpawnLootTechDisksPrinterT4
+  parent: MarkerBasePlaceFree
+  suffix: "Tech Disk Printer T4"
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+      scale: 0.7, 0.7
+    - sprite: _NF/Markers/general.rsi
+      state: questionmark
+      color: red
+  - type: RandomSpawner
+    prototypes:
+    - TechDiskBluespaceBags
+    - TechDiskSynthalloy
+    chance: 0.95
+    offset: 0.0
+    rarePrototypes:
+    - TechDiskSpeedBoots
+    rareChance: 0.1

--- a/Resources/Prototypes/_Mono/PointsOfInterest/sevastopol.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/sevastopol.yml
@@ -15,8 +15,8 @@
   id: Sevastopol
   parent: BasePOI
   name: 'Sevastopol Data Storage Center'
-  minimumDistance: 9650
-  maximumDistance: 16400
+  minimumDistance: 3500
+  maximumDistance: 7500
   spawnGroup: Required
   gridPath: /Maps/_Mono/POI/sevastopol.yml
   addComponents:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Higher tier tech disks should be rarer in Sevastopol's printer now. Point disks can also be printed now. Sevastopol moved to be 3.5km-7.5km from 0,0
