### PR TITLE
Unstrangle Volumetrics

### DIFF
--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Simon
 // SPDX-FileCopyrightText: 2025 GreaseMonk
 // SPDX-FileCopyrightText: 2025 sleepyyapril
+// SPDX-FileCopyrightText: 2025 tonotom
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -141,7 +141,7 @@ public sealed partial class CCVars
     ///     in-game.
     /// </summary>
     public static readonly CVarDef<float> AtmosSpeedup =
-        CVarDef.Create("atmos.speedup", 2f, CVar.SERVERONLY); // Frontier 8f<2f
+        CVarDef.Create("atmos.speedup", 8f, CVar.SERVERONLY);
 
     /// <summary>
     ///     Like atmos.speedup, but only for gas and reaction heat values. 64x means


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Did you know, burn chambers were ass this whole time because someone decided to kneecap volumetric pump volume values by 4x which made scrubbers work at 25% rate? 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This doesn't alter tickrates. This alters the amount of change between ticks.

## How to test
<!-- Describe the way it can be tested -->

Doubt you need to, it's a ccvar being set to its default value

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Ccvar change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
- [X ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

It's just a ccvar change

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Volumetric pumps (including scrubbers) set back to their default rate: they were kneecapped by 4x.
