### PR TITLE
Survival Box Buff

### DIFF
--- a/Resources/Maps/_Mono/Test/dev_map.yml
+++ b/Resources/Maps/_Mono/Test/dev_map.yml
@@ -1113,7 +1113,7 @@ entities:
     - type: Transform
       pos: -2.5470388,-3.54282
       parent: 2
-- proto: BoxSurvivalNFOxygenExtended
+- proto: BoxSurvivalMonoOxygenExtended
   entities:
   - uid: 114
     components:

--- a/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 deltanedas
+# SPDX-FileCopyrightText: 2025 Redrover1760
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   abstract: true
   parent: [BaseItem, PowerCellSlotMediumItem, RecyclableItemDeviceSmall] # Frontier: added RecyclableItemDeviceSmall

--- a/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/base_handheld.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [BaseItem, PowerCellSlotSmallItem, RecyclableItemDeviceSmall] # Frontier: added RecyclableItemDeviceSmall
+  parent: [BaseItem, PowerCellSlotMediumItem, RecyclableItemDeviceSmall] # Frontier: added RecyclableItemDeviceSmall
   id: BaseHandheldComputer
   components:
   - type: ActivatableUIRequiresPowerCell

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -215,8 +215,8 @@
           Quantity: 12
         - ReagentId: TranexamicAcid
           Quantity: 3
-  - type: Tag
-    tags: []
+  - type: Tag # Mono
+    tags: [SurvivalBox]
 
 - type: entity
   name: poison auto-injector
@@ -467,8 +467,8 @@
             Quantity: 10
           - ReagentId: Barozine
             Quantity: 20
-  - type: Tag
-    tags: []
+  - type: Tag # Mono
+    tags: [SurvivalBox]
 
 - type: entity
   name: hyperzine injector

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Redrover1760
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: BoxSurvivalEngineering
   id: BoxBaseSurvivalMono

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
@@ -1,0 +1,63 @@
+- type: entity
+  parent: BoxSurvivalEngineering
+  id: BoxBaseSurvivalMono
+  name: Emergency Survival Box
+  description: A dedicated, standard issue survival box for the Colossus sector. Holds utility tools to keep you alive in an emergency.
+  suffix: Oxygen
+  components:
+  - type: Item
+    size: Normal # Frontier Large<Normal
+    shape:
+    - 0,0,2,1
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,3,2
+    whitelist:
+      components:
+      - GasTank
+      - Tool
+      - ToggleCellDraw
+      - RadarConsole
+      - BreathMask
+      - LightBehaviour
+      tags:
+      - MREFood
+      - SurvivalBox
+  - type: Sprite
+    layers:
+      - state: internals
+      - state: extendedtank
+
+- type: entity
+  parent: BoxBaseSurvivalMono
+  id: BoxSurvivalMonoOxygenExtended
+  suffix: Oxygen
+  components:
+  - type: StorageFill
+    contents:
+      - id: DoubleEmergencyOxygenTankFilled
+      - id: SpaceMedipen
+      - id: EmergencyMedipen
+      - id: Flare
+        amount: 2
+      - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+      - id: CrowbarPocket
+      - id: HandHeldMassScanner
+
+- type: entity
+  parent: BoxBaseSurvivalMono
+  id: BoxSurvivalMonoNitrogenExtended
+  suffix: Nitrogen
+  components:
+  - type: StorageFill
+    contents:
+      - id: DoubleEmergencyNitrogenTankFilled
+      - id: SpaceMedipen
+
+      - id: EmergencyMedipen
+      - id: Flare
+        amount: 2
+      - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
+      - id: CrowbarPocket
+      - id: HandHeldMassScanner

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/salvmaint_locker.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/salvmaint_locker.yml
@@ -39,11 +39,13 @@
 # SPDX-FileCopyrightText: 2024 themias
 # SPDX-FileCopyrightText: 2024 xprospero
 # SPDX-FileCopyrightText: 2025 Julian Giebel
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 Southbridge
 # SPDX-FileCopyrightText: 2025 centcomofficer24
 # SPDX-FileCopyrightText: 2025 lzk
 # SPDX-FileCopyrightText: 2025 slarticodefast
 # SPDX-FileCopyrightText: 2025 tonotom
+# SPDX-FileCopyrightText: 2025 tonotom1
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/salvmaint_locker.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/salvmaint_locker.yml
@@ -464,8 +464,8 @@
       #Survival box
       - !type:GroupSelector
         children:
-        - id: BoxSurvivalNFOxygen
-        - id: BoxSurvivalNFNitrogen
+        - id: BoxSurvivalMonoOxygenExtended
+        - id: BoxSurvivalMonoNitrogenExtended
       #Salvagecore bevvy
       - !type:GroupSelector
         children:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/mre.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/mre.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/mre.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/mre.yml
@@ -22,3 +22,6 @@
     - id: DrinkWaterBottleFull
     sound:
       path: /Audio/Effects/unwrap.ogg
+  - type: Tag
+    tags: 
+    - SurvivalBox

--- a/Resources/Prototypes/_Mono/tags.yml
+++ b/Resources/Prototypes/_Mono/tags.yml
@@ -332,3 +332,8 @@
 
 - type: Tag
   id: TechDiskMono
+
+# survival kit
+
+- type: Tag
+  id: SurvivalBox

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/emergency.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Dvir
 # SPDX-FileCopyrightText: 2024 Salvantrix
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/emergency.yml
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+# UNUSED in loadouts.
+
 - type: entity
   parent: BoxSurvival
   id: BoxSurvivalNFOxygen

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/survival.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/survival.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Redrover1760
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 #Survival boxes all replaced with mono versions with extended tanks.
 - type: loadout
   id: ContractorBoxSurvivalNFOxygenExtended

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/survival.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Contractor/survival.yml
@@ -1,49 +1,20 @@
-#T0
-- type: loadout
-  id: ContractorBoxSurvivalNFOxygen
-  name: oxygen survival box
-  hideEffects:
-  - !type:GroupLoadoutEffect
-    proto: OxygenBreatherNF
-  storage:
-    back:
-    - BoxSurvivalNFOxygen
-
-- type: loadout
-  id: ContractorBoxSurvivalNFNitrogen
-  name: nitrogen survival box
-  hideEffects:
-  - !type:GroupLoadoutEffect
-    proto: NitrogenBreatherNF
-  storage:
-    back:
-    - BoxSurvivalNFNitrogen
-
-#T1
+#Survival boxes all replaced with mono versions with extended tanks.
 - type: loadout
   id: ContractorBoxSurvivalNFOxygenExtended
   name: extended-oxygen survival box
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: ContractorT1
   hideEffects:
   - !type:GroupLoadoutEffect
     proto: OxygenBreatherNF
-  price: 1000
   storage:
     back:
-    - BoxSurvivalNFOxygenExtended
+    - BoxSurvivalMonoOxygenExtended
 
 - type: loadout
   id: ContractorBoxSurvivalNFNitrogenExtended
   name: extended-nitrogen survival box
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: ContractorT1
   hideEffects:
   - !type:GroupLoadoutEffect
     proto: NitrogenBreatherNF
-  price: 1000
   storage:
     back:
-    - BoxSurvivalNFNitrogenExtended
+    - BoxSurvivalMonoNitrogenExtended

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/survival.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/survival.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Redrover1760
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 #T1
 - type: loadout
   id: NfsdBoxSurvivalNfsdOxygen

--- a/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/survival.yml
+++ b/Resources/Prototypes/_NF/Loadouts/Jobs/Nfsd/survival.yml
@@ -7,7 +7,7 @@
     proto: OxygenBreatherNF
   storage:
     back:
-    - BoxSurvivalNFOxygenExtended
+    - BoxSurvivalMonoOxygenExtended
 
 - type: loadout
   id: NfsdBoxSurvivalNfsdNitrogen
@@ -17,4 +17,4 @@
     proto: NitrogenBreatherNF
   storage:
     back:
-    - BoxSurvivalNFNitrogenExtended
+    - BoxSurvivalMonoNitrogenExtended

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -892,12 +892,13 @@
   - ClothingNeckAutismPin
   - ClothingNeckGoldAutismPin
 
-- type: loadoutGroup
+- type: loadoutGroup # Mono - removed standard supply boxes.
   id: ContractorBoxSurvival
   name: loadout-group-contractor-survival-box
+  hidden: true # Mono
   minLimit: 1
   loadouts:
-  - ContractorBoxSurvivalNFOxygenExtended
+  - ContractorBoxSurvivalNFOxygenExtended 
   - ContractorBoxSurvivalNFNitrogenExtended
   fallbacks:
   - ContractorBoxSurvivalNFOxygenExtended

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -897,13 +897,11 @@
   name: loadout-group-contractor-survival-box
   minLimit: 1
   loadouts:
-  - ContractorBoxSurvivalNFOxygen
-  - ContractorBoxSurvivalNFNitrogen
   - ContractorBoxSurvivalNFOxygenExtended
   - ContractorBoxSurvivalNFNitrogenExtended
   fallbacks:
-  - ContractorBoxSurvivalNFOxygen
-  - ContractorBoxSurvivalNFNitrogen
+  - ContractorBoxSurvivalNFOxygenExtended
+  - ContractorBoxSurvivalNFNitrogenExtended
 
 - type: loadoutGroup
   id: ContractorEncryptionKey

--- a/Resources/nf_migration.yml
+++ b/Resources/nf_migration.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 chrome-cirrus
+# SPDX-FileCopyrightText: 2025 AndresE55
+# SPDX-FileCopyrightText: 2025 Checkraze
+# SPDX-FileCopyrightText: 2025 Dvir
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 dustylens
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # 2023-09-10
 ClothingUniformMailCarrier: ClothingUniformJumpsuitMailCarrier
 ClothingUniformSkirtMailCarrier: ClothingUniformJumpskirtMailCarrier

--- a/Resources/nf_migration.yml
+++ b/Resources/nf_migration.yml
@@ -23,10 +23,10 @@ APCBasicEmpImmune: APCBasic
 Ashtray: NFAshtray
 
 # 2024-05-25
-BoxSurvival: BoxSurvivalNFOxygen
-BoxSurvivalEngineering: BoxSurvivalNFOxygenExtended
-BoxSurvivalMedical: BoxSurvivalNFOxygen
-BoxHug: BoxSurvivalNFOxygen
+BoxSurvival: BoxSurvivalMonoOxygenExtended
+BoxSurvivalEngineering: BoxSurvivalMonoOxygenExtended
+BoxSurvivalMedical: BoxSurvivalMonoOxygenExtended
+BoxHug: BoxSurvivalMonoOxygenExtended
 
 # 2024-07-19
 ComputerTabletopComputerIFFPOI: ComputerTabletopIFFPOI


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Removes standard survival boxes from loadout.

Replaced with extended type survival box for free. Extended survival box reworked to have more capacity, take up less space but restrictions on what it can hold.

Name + Desc of survival box edited.

Adds a mass scanner and two flares to each survival box.

Handheld mass scanners (and other handheld computers, handheld crew monitor/station maps) spawn with a medium power cell

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I hate 3x3 bulky items that I have to dump at roundstart as they're basically worthless in terms of inventory management.

I hate how mass scanners aren't default equipment (they are in Hullrot at least.)

The default survival box is just completely worthless too so may as well get rid of it.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="462" height="173" alt="Survival 1" src="https://github.com/user-attachments/assets/9f70837b-c3d0-4fd5-a8e6-932dcc8e4fb4" />
<img width="222" height="128" alt="Survival 2" src="https://github.com/user-attachments/assets/be6a6e17-3450-4e2c-bafd-cf941fc9e7eb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Removed standard survival boxes from loadout. Only extended variant remains, and costs 0 credits.
- tweak: Reworked the loadout extended survival box to take up less inventory space, have more space, and have a whitelist for items it can hold.
- tweak: Survival boxes now contain a mass scanner and two flares.
- tweak: Handheld mass scanners (and crew monitors and station maps) now start with a medium power cell.

