### PR TITLE
Revert "Increases Uncryo Max Time"

### DIFF
--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -52,7 +52,7 @@ public sealed class NFCCVars
     /// The time in seconds after which a cryosleeping body is considered expired and can be deleted from the storage map.
     /// </summary>
     public static readonly CVarDef<float> CryoExpirationTime =
-        CVarDef.Create("nf14.uncryo.maxtime", 360 * 60f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("nf14.uncryo.maxtime", 180 * 60f, CVar.SERVER | CVar.REPLICATED);
 
     /*
      *  Public Transit


### PR DESCRIPTION
Reverts Monolith-Station/Monolith#825

Apparently a potential lag source with the mob collision change on frontier... Gonna revert to test to see if it changes anything.