### PR TITLE
Gear Tweaks

### DIFF
--- a/Resources/Maps/_Mono/POI/cove.yml
+++ b/Resources/Maps/_Mono/POI/cove.yml
@@ -26,7 +26,7 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/27/2025 04:33:23
+  time: 08/06/2025 21:45:57
   entityCount: 4842
 maps: []
 grids:
@@ -2082,7 +2082,8 @@ entities:
           -3,-3:
             0: 61440
           -3,-2:
-            0: 60943
+            0: 59407
+            7: 1536
           -2,-3:
             0: 61440
           -2,-2:
@@ -2240,6 +2241,21 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
     - type: GasTileOverlay
     - type: NavMap
@@ -2256,11 +2272,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1955
-      - 2597
-      - 2631
-      - 2630
-      - 2596
+      - 2025
+      - 2668
+      - 2702
+      - 2701
+      - 2667
   - uid: 3
     components:
     - type: Transform
@@ -2269,16 +2285,16 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1939
-      - 1938
-      - 2636
-      - 2602
-      - 2603
-      - 2639
-      - 2604
-      - 2605
-      - 2638
-      - 1937
+      - 2009
+      - 2008
+      - 2707
+      - 2673
+      - 2674
+      - 2710
+      - 2675
+      - 2676
+      - 2709
+      - 2007
   - uid: 4
     components:
     - type: Transform
@@ -2287,12 +2303,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1940
-      - 1955
-      - 1954
-      - 1939
-      - 2635
-      - 2601
+      - 2010
+      - 2025
+      - 2024
+      - 2009
+      - 2706
+      - 2672
   - uid: 5
     components:
     - type: Transform
@@ -2300,13 +2316,13 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1954
-      - 1956
-      - 1958
-      - 1957
-      - 1961
-      - 2642
-      - 2608
+      - 2024
+      - 2026
+      - 2028
+      - 2027
+      - 2031
+      - 2713
+      - 2679
   - uid: 6
     components:
     - type: Transform
@@ -2315,9 +2331,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1958
-      - 2643
-      - 2609
+      - 2028
+      - 2714
+      - 2680
   - uid: 7
     components:
     - type: Transform
@@ -2326,9 +2342,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1956
-      - 2612
-      - 2647
+      - 2026
+      - 2683
+      - 2718
   - uid: 8
     components:
     - type: Transform
@@ -2337,9 +2353,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1960
-      - 2634
-      - 2599
+      - 2030
+      - 2705
+      - 2670
   - uid: 9
     components:
     - type: Transform
@@ -2347,11 +2363,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1960
-      - 1957
-      - 1959
-      - 2633
-      - 2600
+      - 2030
+      - 2027
+      - 2029
+      - 2704
+      - 2671
   - uid: 10
     components:
     - type: Transform
@@ -2360,9 +2376,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1959
-      - 2598
-      - 2632
+      - 2029
+      - 2669
+      - 2703
   - uid: 11
     components:
     - type: Transform
@@ -2371,9 +2387,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1962
-      - 2606
-      - 2641
+      - 2032
+      - 2677
+      - 2712
   - uid: 12
     components:
     - type: Transform
@@ -2382,12 +2398,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1962
-      - 1961
-      - 1963
-      - 2607
-      - 2640
-      - 1947
+      - 2032
+      - 2031
+      - 2033
+      - 2678
+      - 2711
+      - 2017
   - uid: 13
     components:
     - type: Transform
@@ -2395,14 +2411,14 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1963
-      - 2611
-      - 2644
-      - 2645
-      - 2610
-      - 2646
-      - 2613
-      - 1943
+      - 2033
+      - 2682
+      - 2715
+      - 2716
+      - 2681
+      - 2717
+      - 2684
+      - 2013
   - uid: 14
     components:
     - type: Transform
@@ -2410,16 +2426,16 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1948
-      - 1967
-      - 1966
-      - 1951
-      - 1965
-      - 1964
-      - 2656
-      - 2621
-      - 2623
-      - 2657
+      - 2018
+      - 2037
+      - 2036
+      - 2021
+      - 2035
+      - 2034
+      - 2727
+      - 2692
+      - 2694
+      - 2728
   - uid: 15
     components:
     - type: Transform
@@ -2428,10 +2444,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1965
-      - 1964
-      - 2655
-      - 2622
+      - 2035
+      - 2034
+      - 2726
+      - 2693
   - uid: 16
     components:
     - type: Transform
@@ -2440,10 +2456,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1967
-      - 1966
-      - 2624
-      - 2658
+      - 2037
+      - 2036
+      - 2695
+      - 2729
   - uid: 17
     components:
     - type: Transform
@@ -2451,11 +2467,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1936
-      - 1950
-      - 1949
-      - 2614
-      - 2649
+      - 2006
+      - 2020
+      - 2019
+      - 2685
+      - 2720
       - 119
       - 121
       - 120
@@ -2467,9 +2483,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1944
-      - 2615
-      - 2648
+      - 2014
+      - 2686
+      - 2719
   - uid: 19
     components:
     - type: Transform
@@ -2478,17 +2494,17 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1945
-      - 1947
-      - 1944
-      - 1936
-      - 1937
-      - 1943
-      - 1942
-      - 2650
-      - 2617
-      - 2616
-      - 2651
+      - 2015
+      - 2017
+      - 2014
+      - 2006
+      - 2007
+      - 2013
+      - 2012
+      - 2721
+      - 2688
+      - 2687
+      - 2722
   - uid: 20
     components:
     - type: Transform
@@ -2497,10 +2513,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1946
-      - 1945
-      - 2659
-      - 2625
+      - 2016
+      - 2015
+      - 2730
+      - 2696
   - uid: 21
     components:
     - type: Transform
@@ -2514,8 +2530,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2654
-      - 2620
+      - 2725
+      - 2691
   - uid: 23
     components:
     - type: Transform
@@ -2523,8 +2539,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2653
-      - 2619
+      - 2724
+      - 2690
   - uid: 24
     components:
     - type: Transform
@@ -2533,13 +2549,13 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1971
-      - 2660
-      - 2626
-      - 1953
-      - 1968
-      - 1970
-      - 1969
+      - 2041
+      - 2731
+      - 2697
+      - 2023
+      - 2038
+      - 2040
+      - 2039
   - uid: 25
     components:
     - type: Transform
@@ -2548,10 +2564,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1971
-      - 1972
-      - 2627
-      - 2661
+      - 2041
+      - 2042
+      - 2698
+      - 2732
   - uid: 26
     components:
     - type: Transform
@@ -2559,9 +2575,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1972
-      - 2662
-      - 2628
+      - 2042
+      - 2733
+      - 2699
 - proto: AirAlarmFreezer
   entities:
   - uid: 27
@@ -2572,8 +2588,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2663
-      - 2629
+      - 2734
+      - 2700
 - proto: AirCanister
   entities:
   - uid: 28
@@ -2953,6 +2969,12 @@ entities:
     - type: Transform
       pos: -8.5,2.5
       parent: 1
+    - type: Door
+      secondsUntilStateChange: -12.317997
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
   - uid: 94
     components:
     - type: Transform
@@ -3109,7 +3131,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 17
-      - 1926
+      - 1996
   - uid: 120
     components:
     - type: Transform
@@ -3118,7 +3140,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 17
-      - 1926
+      - 1996
   - uid: 121
     components:
     - type: Transform
@@ -3127,7 +3149,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 17
-      - 1926
+      - 1996
 - proto: AmmoTechFab
   entities:
   - uid: 122
@@ -6432,4193 +6454,4193 @@ entities:
     - type: Transform
       pos: 16.5,22.5
       parent: 1
-  - uid: 3580
+  - uid: 766
     components:
     - type: Transform
       pos: 19.5,12.5
       parent: 1
-  - uid: 3586
+  - uid: 767
     components:
     - type: Transform
       pos: 19.5,11.5
       parent: 1
-  - uid: 3587
+  - uid: 768
     components:
     - type: Transform
       pos: 18.5,11.5
       parent: 1
-  - uid: 3593
+  - uid: 769
     components:
     - type: Transform
       pos: 20.5,10.5
       parent: 1
-  - uid: 4099
+  - uid: 770
     components:
     - type: Transform
       pos: 19.5,13.5
       parent: 1
-  - uid: 4123
+  - uid: 771
     components:
     - type: Transform
       pos: 19.5,10.5
       parent: 1
-  - uid: 4749
+  - uid: 772
     components:
     - type: Transform
       pos: -12.5,7.5
       parent: 1
-  - uid: 4750
+  - uid: 773
     components:
     - type: Transform
       pos: -14.5,16.5
       parent: 1
-  - uid: 4751
+  - uid: 774
     components:
     - type: Transform
       pos: -12.5,18.5
       parent: 1
-  - uid: 4752
+  - uid: 775
     components:
     - type: Transform
       pos: -12.5,17.5
       parent: 1
-  - uid: 4791
+  - uid: 776
     components:
     - type: Transform
       pos: -12.5,28.5
       parent: 1
-  - uid: 4792
+  - uid: 777
     components:
     - type: Transform
       pos: 8.5,37.5
       parent: 1
-  - uid: 4793
+  - uid: 778
     components:
     - type: Transform
       pos: 9.5,37.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 766
+  - uid: 779
     components:
     - type: Transform
       pos: -1.5,32.5
       parent: 1
-  - uid: 767
+  - uid: 780
     components:
     - type: Transform
       pos: -0.5,33.5
       parent: 1
-  - uid: 768
+  - uid: 781
     components:
     - type: Transform
       pos: -1.5,33.5
       parent: 1
-  - uid: 769
+  - uid: 782
     components:
     - type: Transform
       pos: -2.5,23.5
       parent: 1
-  - uid: 770
+  - uid: 783
     components:
     - type: Transform
       pos: -1.5,23.5
       parent: 1
-  - uid: 771
+  - uid: 784
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 1
-  - uid: 772
+  - uid: 785
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 1
-  - uid: 773
+  - uid: 786
     components:
     - type: Transform
       pos: -0.5,25.5
       parent: 1
-  - uid: 774
+  - uid: 787
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
-  - uid: 775
+  - uid: 788
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 776
+  - uid: 789
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 1
-  - uid: 777
+  - uid: 790
     components:
     - type: Transform
       pos: 1.5,22.5
       parent: 1
-  - uid: 778
+  - uid: 791
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 1
-  - uid: 779
+  - uid: 792
     components:
     - type: Transform
       pos: 0.5,24.5
       parent: 1
-  - uid: 780
+  - uid: 793
     components:
     - type: Transform
       pos: 3.5,22.5
       parent: 1
-  - uid: 781
+  - uid: 794
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 1
-  - uid: 782
+  - uid: 795
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 1
-  - uid: 783
+  - uid: 796
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
-  - uid: 784
+  - uid: 797
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 1
-  - uid: 785
+  - uid: 798
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 786
+  - uid: 799
     components:
     - type: Transform
       pos: 11.5,18.5
       parent: 1
-  - uid: 787
+  - uid: 800
     components:
     - type: Transform
       pos: 10.5,18.5
       parent: 1
-  - uid: 788
+  - uid: 801
     components:
     - type: Transform
       pos: 10.5,17.5
       parent: 1
-  - uid: 789
+  - uid: 802
     components:
     - type: Transform
       pos: 9.5,17.5
       parent: 1
-  - uid: 790
+  - uid: 803
     components:
     - type: Transform
       pos: 8.5,17.5
       parent: 1
-  - uid: 791
+  - uid: 804
     components:
     - type: Transform
       pos: 7.5,17.5
       parent: 1
-  - uid: 792
+  - uid: 805
     components:
     - type: Transform
       pos: 6.5,17.5
       parent: 1
-  - uid: 793
+  - uid: 806
     components:
     - type: Transform
       pos: 5.5,17.5
       parent: 1
-  - uid: 794
+  - uid: 807
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 1
-  - uid: 795
+  - uid: 808
     components:
     - type: Transform
       pos: 3.5,17.5
       parent: 1
-  - uid: 796
+  - uid: 809
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 1
-  - uid: 797
+  - uid: 810
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1
-  - uid: 798
+  - uid: 811
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 799
+  - uid: 812
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 1
-  - uid: 800
+  - uid: 813
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
-  - uid: 801
+  - uid: 814
     components:
     - type: Transform
       pos: -15.5,26.5
       parent: 1
-  - uid: 802
+  - uid: 815
     components:
     - type: Transform
       pos: -14.5,26.5
       parent: 1
-  - uid: 803
+  - uid: 816
     components:
     - type: Transform
       pos: -13.5,26.5
       parent: 1
-  - uid: 804
+  - uid: 817
     components:
     - type: Transform
       pos: -12.5,26.5
       parent: 1
-  - uid: 805
+  - uid: 818
     components:
     - type: Transform
       pos: -12.5,25.5
       parent: 1
-  - uid: 806
+  - uid: 819
     components:
     - type: Transform
       pos: -12.5,24.5
       parent: 1
-  - uid: 807
+  - uid: 820
     components:
     - type: Transform
       pos: -12.5,23.5
       parent: 1
-  - uid: 808
+  - uid: 821
     components:
     - type: Transform
       pos: -12.5,22.5
       parent: 1
-  - uid: 809
+  - uid: 822
     components:
     - type: Transform
       pos: -12.5,21.5
       parent: 1
-  - uid: 810
+  - uid: 823
     components:
     - type: Transform
       pos: -12.5,20.5
       parent: 1
-  - uid: 811
+  - uid: 824
     components:
     - type: Transform
       pos: -12.5,19.5
       parent: 1
-  - uid: 812
+  - uid: 825
     components:
     - type: Transform
       pos: -12.5,18.5
       parent: 1
-  - uid: 813
+  - uid: 826
     components:
     - type: Transform
       pos: -12.5,17.5
       parent: 1
-  - uid: 814
+  - uid: 827
     components:
     - type: Transform
       pos: -11.5,15.5
       parent: 1
-  - uid: 815
+  - uid: 828
     components:
     - type: Transform
       pos: -11.5,16.5
       parent: 1
-  - uid: 816
+  - uid: 829
     components:
     - type: Transform
       pos: -10.5,16.5
       parent: 1
-  - uid: 817
+  - uid: 830
     components:
     - type: Transform
       pos: -9.5,16.5
       parent: 1
-  - uid: 818
+  - uid: 831
     components:
     - type: Transform
       pos: -8.5,16.5
       parent: 1
-  - uid: 819
+  - uid: 832
     components:
     - type: Transform
       pos: -7.5,16.5
       parent: 1
-  - uid: 820
+  - uid: 833
     components:
     - type: Transform
       pos: -6.5,16.5
       parent: 1
-  - uid: 821
+  - uid: 834
     components:
     - type: Transform
       pos: -5.5,16.5
       parent: 1
-  - uid: 822
+  - uid: 835
     components:
     - type: Transform
       pos: -5.5,17.5
       parent: 1
-  - uid: 823
+  - uid: 836
     components:
     - type: Transform
       pos: -4.5,17.5
       parent: 1
-  - uid: 824
+  - uid: 837
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 1
-  - uid: 825
+  - uid: 838
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
-  - uid: 826
+  - uid: 839
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 1
-  - uid: 827
+  - uid: 840
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 828
+  - uid: 841
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 1
-  - uid: 829
+  - uid: 842
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 1
-  - uid: 830
+  - uid: 843
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 1
-  - uid: 831
+  - uid: 844
     components:
     - type: Transform
       pos: -12.5,5.5
       parent: 1
-  - uid: 832
+  - uid: 845
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 1
-  - uid: 833
+  - uid: 846
     components:
     - type: Transform
       pos: -12.5,7.5
       parent: 1
-  - uid: 834
+  - uid: 847
     components:
     - type: Transform
       pos: -12.5,8.5
       parent: 1
-  - uid: 835
+  - uid: 848
     components:
     - type: Transform
       pos: -12.5,9.5
       parent: 1
-  - uid: 836
+  - uid: 849
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 1
-  - uid: 837
+  - uid: 850
     components:
     - type: Transform
       pos: -13.5,10.5
       parent: 1
-  - uid: 838
+  - uid: 851
     components:
     - type: Transform
       pos: -13.5,11.5
       parent: 1
-  - uid: 839
+  - uid: 852
     components:
     - type: Transform
       pos: -13.5,12.5
       parent: 1
-  - uid: 840
+  - uid: 853
     components:
     - type: Transform
       pos: -13.5,13.5
       parent: 1
-  - uid: 841
+  - uid: 854
     components:
     - type: Transform
       pos: -13.5,14.5
       parent: 1
-  - uid: 842
+  - uid: 855
     components:
     - type: Transform
       pos: -13.5,15.5
       parent: 1
-  - uid: 843
+  - uid: 856
     components:
     - type: Transform
       pos: -12.5,15.5
       parent: 1
-  - uid: 844
+  - uid: 857
     components:
     - type: Transform
       pos: -12.5,16.5
       parent: 1
-  - uid: 845
+  - uid: 858
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 1
-  - uid: 846
+  - uid: 859
     components:
     - type: Transform
       pos: 10.5,29.5
       parent: 1
-  - uid: 847
+  - uid: 860
     components:
     - type: Transform
       pos: 3.5,33.5
       parent: 1
-  - uid: 848
+  - uid: 861
     components:
     - type: Transform
       pos: 10.5,27.5
       parent: 1
-  - uid: 849
+  - uid: 862
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 1
-  - uid: 850
+  - uid: 863
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 1
-  - uid: 851
+  - uid: 864
     components:
     - type: Transform
       pos: 4.5,33.5
       parent: 1
-  - uid: 852
+  - uid: 865
     components:
     - type: Transform
       pos: 1.5,33.5
       parent: 1
-  - uid: 853
+  - uid: 866
     components:
     - type: Transform
       pos: 8.5,21.5
       parent: 1
-  - uid: 854
+  - uid: 867
     components:
     - type: Transform
       pos: -9.5,31.5
       parent: 1
-  - uid: 855
+  - uid: 868
     components:
     - type: Transform
       pos: -3.5,33.5
       parent: 1
-  - uid: 856
+  - uid: 869
     components:
     - type: Transform
       pos: 8.5,20.5
       parent: 1
-  - uid: 857
+  - uid: 870
     components:
     - type: Transform
       pos: 10.5,26.5
       parent: 1
-  - uid: 858
+  - uid: 871
     components:
     - type: Transform
       pos: 10.5,25.5
       parent: 1
-  - uid: 859
+  - uid: 872
     components:
     - type: Transform
       pos: 8.5,22.5
       parent: 1
-  - uid: 860
+  - uid: 873
     components:
     - type: Transform
       pos: -8.5,31.5
       parent: 1
-  - uid: 861
+  - uid: 874
     components:
     - type: Transform
       pos: 8.5,18.5
       parent: 1
-  - uid: 862
+  - uid: 875
     components:
     - type: Transform
       pos: -2.5,33.5
       parent: 1
-  - uid: 863
+  - uid: 876
     components:
     - type: Transform
       pos: -5.5,33.5
       parent: 1
-  - uid: 864
+  - uid: 877
     components:
     - type: Transform
       pos: -4.5,33.5
       parent: 1
-  - uid: 865
+  - uid: 878
     components:
     - type: Transform
       pos: -6.5,31.5
       parent: 1
-  - uid: 866
+  - uid: 879
     components:
     - type: Transform
       pos: -5.5,31.5
       parent: 1
-  - uid: 867
+  - uid: 880
     components:
     - type: Transform
       pos: 8.5,19.5
       parent: 1
-  - uid: 868
+  - uid: 881
     components:
     - type: Transform
       pos: 10.5,24.5
       parent: 1
-  - uid: 869
+  - uid: 882
     components:
     - type: Transform
       pos: 10.5,22.5
       parent: 1
-  - uid: 870
+  - uid: 883
     components:
     - type: Transform
       pos: 10.5,23.5
       parent: 1
-  - uid: 871
+  - uid: 884
     components:
     - type: Transform
       pos: 9.5,22.5
       parent: 1
-  - uid: 872
+  - uid: 885
     components:
     - type: Transform
       pos: -5.5,32.5
       parent: 1
-  - uid: 873
+  - uid: 886
     components:
     - type: Transform
       pos: -11.5,31.5
       parent: 1
-  - uid: 874
+  - uid: 887
     components:
     - type: Transform
       pos: -10.5,31.5
       parent: 1
-  - uid: 875
+  - uid: 888
     components:
     - type: Transform
       pos: -12.5,28.5
       parent: 1
-  - uid: 876
+  - uid: 889
     components:
     - type: Transform
       pos: -7.5,31.5
       parent: 1
-  - uid: 877
+  - uid: 890
     components:
     - type: Transform
       pos: -12.5,30.5
       parent: 1
-  - uid: 878
+  - uid: 891
     components:
     - type: Transform
       pos: -12.5,31.5
       parent: 1
-  - uid: 879
+  - uid: 892
     components:
     - type: Transform
       pos: -12.5,29.5
       parent: 1
-  - uid: 880
+  - uid: 893
     components:
     - type: Transform
       pos: -12.5,27.5
       parent: 1
-  - uid: 881
+  - uid: 894
     components:
     - type: Transform
       pos: 9.5,33.5
       parent: 1
-  - uid: 882
+  - uid: 895
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 1
-  - uid: 883
+  - uid: 896
     components:
     - type: Transform
       pos: 10.5,33.5
       parent: 1
-  - uid: 884
+  - uid: 897
     components:
     - type: Transform
       pos: 5.5,33.5
       parent: 1
-  - uid: 885
+  - uid: 898
     components:
     - type: Transform
       pos: 6.5,33.5
       parent: 1
-  - uid: 886
+  - uid: 899
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 1
-  - uid: 887
+  - uid: 900
     components:
     - type: Transform
       pos: 7.5,33.5
       parent: 1
-  - uid: 888
+  - uid: 901
     components:
     - type: Transform
       pos: 10.5,32.5
       parent: 1
-  - uid: 889
+  - uid: 902
     components:
     - type: Transform
       pos: 8.5,33.5
       parent: 1
-  - uid: 890
+  - uid: 903
     components:
     - type: Transform
       pos: 10.5,31.5
       parent: 1
-  - uid: 891
+  - uid: 904
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 1
-  - uid: 892
+  - uid: 905
     components:
     - type: Transform
       pos: 10.5,30.5
       parent: 1
-  - uid: 893
+  - uid: 906
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 1
-  - uid: 894
+  - uid: 907
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 1
-  - uid: 895
+  - uid: 908
     components:
     - type: Transform
       pos: -9.5,-0.5
       parent: 1
-  - uid: 896
+  - uid: 909
     components:
     - type: Transform
       pos: -9.5,-1.5
       parent: 1
-  - uid: 897
+  - uid: 910
     components:
     - type: Transform
       pos: -10.5,-1.5
       parent: 1
-  - uid: 898
+  - uid: 911
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 1
-  - uid: 899
+  - uid: 912
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 900
+  - uid: 913
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 1
-  - uid: 901
+  - uid: 914
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 1
-  - uid: 902
+  - uid: 915
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 1
-  - uid: 903
+  - uid: 916
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 1
-  - uid: 904
+  - uid: 917
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 1
-  - uid: 905
+  - uid: 918
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 906
+  - uid: 919
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 907
+  - uid: 920
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 908
+  - uid: 921
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 909
+  - uid: 922
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 910
+  - uid: 923
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 911
+  - uid: 924
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 912
+  - uid: 925
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 913
+  - uid: 926
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 914
+  - uid: 927
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 915
+  - uid: 928
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 916
+  - uid: 929
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 917
+  - uid: 930
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 918
+  - uid: 931
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 919
+  - uid: 932
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 920
+  - uid: 933
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 921
+  - uid: 934
     components:
     - type: Transform
       pos: 17.5,16.5
       parent: 1
-  - uid: 922
+  - uid: 935
     components:
     - type: Transform
       pos: 7.5,33.5
       parent: 1
-  - uid: 923
+  - uid: 936
     components:
     - type: Transform
       pos: 8.5,33.5
       parent: 1
-  - uid: 924
+  - uid: 937
     components:
     - type: Transform
       pos: -2.5,33.5
       parent: 1
-  - uid: 925
+  - uid: 938
     components:
     - type: Transform
       pos: -0.5,33.5
       parent: 1
-  - uid: 926
+  - uid: 939
     components:
     - type: Transform
       pos: 10.5,30.5
       parent: 1
-  - uid: 927
+  - uid: 940
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 1
-  - uid: 928
+  - uid: 941
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 1
-  - uid: 929
+  - uid: 942
     components:
     - type: Transform
       pos: 10.5,27.5
       parent: 1
-  - uid: 930
+  - uid: 943
     components:
     - type: Transform
       pos: 10.5,23.5
       parent: 1
-  - uid: 931
+  - uid: 944
     components:
     - type: Transform
       pos: -12.5,29.5
       parent: 1
-  - uid: 932
+  - uid: 945
     components:
     - type: Transform
       pos: -12.5,30.5
       parent: 1
-  - uid: 933
+  - uid: 946
     components:
     - type: Transform
       pos: 1.5,33.5
       parent: 1
-  - uid: 934
+  - uid: 947
     components:
     - type: Transform
       pos: -12.5,31.5
       parent: 1
-  - uid: 935
+  - uid: 948
     components:
     - type: Transform
       pos: -10.5,31.5
       parent: 1
-  - uid: 936
+  - uid: 949
     components:
     - type: Transform
       pos: -11.5,31.5
       parent: 1
-  - uid: 937
+  - uid: 950
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 1
-  - uid: 938
+  - uid: 951
     components:
     - type: Transform
       pos: -9.5,31.5
       parent: 1
-  - uid: 939
+  - uid: 952
     components:
     - type: Transform
       pos: 5.5,33.5
       parent: 1
-  - uid: 940
+  - uid: 953
     components:
     - type: Transform
       pos: -8.5,31.5
       parent: 1
-  - uid: 941
+  - uid: 954
     components:
     - type: Transform
       pos: -6.5,31.5
       parent: 1
-  - uid: 942
+  - uid: 955
     components:
     - type: Transform
       pos: -7.5,31.5
       parent: 1
-  - uid: 943
+  - uid: 956
     components:
     - type: Transform
       pos: -5.5,31.5
       parent: 1
-  - uid: 944
+  - uid: 957
     components:
     - type: Transform
       pos: -5.5,32.5
       parent: 1
-  - uid: 945
+  - uid: 958
     components:
     - type: Transform
       pos: -5.5,33.5
       parent: 1
-  - uid: 946
+  - uid: 959
     components:
     - type: Transform
       pos: -4.5,33.5
       parent: 1
-  - uid: 947
+  - uid: 960
     components:
     - type: Transform
       pos: -3.5,33.5
       parent: 1
-  - uid: 948
+  - uid: 961
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 1
-  - uid: 949
+  - uid: 962
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 1
-  - uid: 950
+  - uid: 963
     components:
     - type: Transform
       pos: -5.5,23.5
       parent: 1
-  - uid: 951
+  - uid: 964
     components:
     - type: Transform
       pos: -6.5,23.5
       parent: 1
-  - uid: 952
+  - uid: 965
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 1
-  - uid: 953
+  - uid: 966
     components:
     - type: Transform
       pos: 3.5,22.5
       parent: 1
-  - uid: 954
+  - uid: 967
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
-  - uid: 955
+  - uid: 968
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 1
-  - uid: 956
+  - uid: 969
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 957
+  - uid: 970
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 1
-  - uid: 958
+  - uid: 971
     components:
     - type: Transform
       pos: 3.5,25.5
       parent: 1
-  - uid: 959
+  - uid: 972
     components:
     - type: Transform
       pos: 6.5,23.5
       parent: 1
-  - uid: 960
+  - uid: 973
     components:
     - type: Transform
       pos: 5.5,24.5
       parent: 1
-  - uid: 961
+  - uid: 974
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 1
-  - uid: 962
+  - uid: 975
     components:
     - type: Transform
       pos: 7.5,23.5
       parent: 1
-  - uid: 963
+  - uid: 976
     components:
     - type: Transform
       pos: 6.5,24.5
       parent: 1
-  - uid: 964
+  - uid: 977
     components:
     - type: Transform
       pos: 11.5,18.5
       parent: 1
-  - uid: 965
+  - uid: 978
     components:
     - type: Transform
       pos: 11.5,17.5
       parent: 1
-  - uid: 966
+  - uid: 979
     components:
     - type: Transform
       pos: 10.5,17.5
       parent: 1
-  - uid: 967
+  - uid: 980
     components:
     - type: Transform
       pos: 9.5,17.5
       parent: 1
-  - uid: 968
+  - uid: 981
     components:
     - type: Transform
       pos: 8.5,17.5
       parent: 1
-  - uid: 969
+  - uid: 982
     components:
     - type: Transform
       pos: 7.5,17.5
       parent: 1
-  - uid: 970
+  - uid: 983
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 1
-  - uid: 971
+  - uid: 984
     components:
     - type: Transform
       pos: 7.5,15.5
       parent: 1
-  - uid: 972
+  - uid: 985
     components:
     - type: Transform
       pos: 7.5,14.5
       parent: 1
-  - uid: 973
+  - uid: 986
     components:
     - type: Transform
       pos: 7.5,13.5
       parent: 1
-  - uid: 974
+  - uid: 987
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 1
-  - uid: 975
+  - uid: 988
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 1
-  - uid: 976
+  - uid: 989
     components:
     - type: Transform
       pos: 9.5,37.5
       parent: 1
-  - uid: 977
+  - uid: 990
     components:
     - type: Transform
       pos: 8.5,19.5
       parent: 1
-  - uid: 978
+  - uid: 991
     components:
     - type: Transform
       pos: 8.5,18.5
       parent: 1
-  - uid: 979
+  - uid: 992
     components:
     - type: Transform
       pos: -7.5,23.5
       parent: 1
-  - uid: 980
+  - uid: 993
     components:
     - type: Transform
       pos: -7.5,22.5
       parent: 1
-  - uid: 981
+  - uid: 994
     components:
     - type: Transform
       pos: -7.5,21.5
       parent: 1
-  - uid: 982
+  - uid: 995
     components:
     - type: Transform
       pos: -8.5,21.5
       parent: 1
-  - uid: 983
+  - uid: 996
     components:
     - type: Transform
       pos: -9.5,21.5
       parent: 1
-  - uid: 984
+  - uid: 997
     components:
     - type: Transform
       pos: -10.5,21.5
       parent: 1
-  - uid: 985
+  - uid: 998
     components:
     - type: Transform
       pos: -11.5,21.5
       parent: 1
-  - uid: 986
+  - uid: 999
     components:
     - type: Transform
       pos: -12.5,21.5
       parent: 1
-  - uid: 987
+  - uid: 1000
     components:
     - type: Transform
       pos: -12.5,22.5
       parent: 1
-  - uid: 988
+  - uid: 1001
     components:
     - type: Transform
       pos: -12.5,23.5
       parent: 1
-  - uid: 989
+  - uid: 1002
     components:
     - type: Transform
       pos: -12.5,24.5
       parent: 1
-  - uid: 990
+  - uid: 1003
     components:
     - type: Transform
       pos: -12.5,25.5
       parent: 1
-  - uid: 991
+  - uid: 1004
     components:
     - type: Transform
       pos: -12.5,26.5
       parent: 1
-  - uid: 992
+  - uid: 1005
     components:
     - type: Transform
       pos: -13.5,26.5
       parent: 1
-  - uid: 993
+  - uid: 1006
     components:
     - type: Transform
       pos: -14.5,26.5
       parent: 1
-  - uid: 994
+  - uid: 1007
     components:
     - type: Transform
       pos: -15.5,26.5
       parent: 1
-  - uid: 995
+  - uid: 1008
     components:
     - type: Transform
       pos: 9.5,38.5
       parent: 1
-  - uid: 996
+  - uid: 1009
     components:
     - type: Transform
       pos: 9.5,39.5
       parent: 1
-  - uid: 997
+  - uid: 1010
     components:
     - type: Transform
       pos: 9.5,40.5
       parent: 1
-  - uid: 998
+  - uid: 1011
     components:
     - type: Transform
       pos: 9.5,41.5
       parent: 1
-  - uid: 999
+  - uid: 1012
     components:
     - type: Transform
       pos: 9.5,42.5
       parent: 1
-  - uid: 1000
+  - uid: 1013
     components:
     - type: Transform
       pos: 9.5,43.5
       parent: 1
-  - uid: 1001
+  - uid: 1014
     components:
     - type: Transform
       pos: 9.5,44.5
       parent: 1
-  - uid: 1002
+  - uid: 1015
     components:
     - type: Transform
       pos: 10.5,44.5
       parent: 1
-  - uid: 1003
+  - uid: 1016
     components:
     - type: Transform
       pos: -16.5,35.5
       parent: 1
-  - uid: 1004
+  - uid: 1017
     components:
     - type: Transform
       pos: -15.5,35.5
       parent: 1
-  - uid: 1005
+  - uid: 1018
     components:
     - type: Transform
       pos: -14.5,35.5
       parent: 1
-  - uid: 1006
+  - uid: 1019
     components:
     - type: Transform
       pos: -14.5,34.5
       parent: 1
-  - uid: 1007
+  - uid: 1020
     components:
     - type: Transform
       pos: -14.5,33.5
       parent: 1
-  - uid: 1008
+  - uid: 1021
     components:
     - type: Transform
       pos: -14.5,32.5
       parent: 1
-  - uid: 1009
+  - uid: 1022
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 1010
+  - uid: 1023
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 1011
+  - uid: 1024
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 1012
+  - uid: 1025
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 1
-  - uid: 1013
+  - uid: 1026
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 1
-  - uid: 1014
+  - uid: 1027
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 1
-  - uid: 1015
+  - uid: 1028
     components:
     - type: Transform
       pos: -10.5,-7.5
       parent: 1
-  - uid: 1016
+  - uid: 1029
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 1
-  - uid: 1017
+  - uid: 1030
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 1
-  - uid: 1018
+  - uid: 1031
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 1
-  - uid: 1019
+  - uid: 1032
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 1
-  - uid: 1020
+  - uid: 1033
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 1
-  - uid: 1021
+  - uid: 1034
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 1
-  - uid: 1022
+  - uid: 1035
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 1
-  - uid: 1023
+  - uid: 1036
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 1
-  - uid: 1024
+  - uid: 1037
     components:
     - type: Transform
       pos: -12.5,-0.5
       parent: 1
-  - uid: 1025
+  - uid: 1038
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 1
-  - uid: 1026
+  - uid: 1039
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 1
-  - uid: 1027
+  - uid: 1040
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 1
-  - uid: 1028
+  - uid: 1041
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 1
-  - uid: 1029
+  - uid: 1042
     components:
     - type: Transform
       pos: -13.5,3.5
       parent: 1
-  - uid: 1030
+  - uid: 1043
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 1
-  - uid: 1031
+  - uid: 1044
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 1
-  - uid: 1032
+  - uid: 1045
     components:
     - type: Transform
       pos: -16.5,3.5
       parent: 1
-  - uid: 1033
+  - uid: 1046
     components:
     - type: Transform
       pos: -17.5,3.5
       parent: 1
-  - uid: 1034
+  - uid: 1047
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 1
-  - uid: 1035
+  - uid: 1048
     components:
     - type: Transform
       pos: -20.5,3.5
       parent: 1
-  - uid: 1036
+  - uid: 1049
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 1
-  - uid: 1037
+  - uid: 1050
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 1
-  - uid: 1038
+  - uid: 1051
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 1
-  - uid: 1039
+  - uid: 1052
     components:
     - type: Transform
       pos: -11.5,15.5
       parent: 1
-  - uid: 1040
+  - uid: 1053
     components:
     - type: Transform
       pos: -12.5,15.5
       parent: 1
-  - uid: 1041
+  - uid: 1054
     components:
     - type: Transform
       pos: -12.5,16.5
       parent: 1
-  - uid: 1042
+  - uid: 1055
     components:
     - type: Transform
       pos: -13.5,16.5
       parent: 1
-  - uid: 1043
+  - uid: 1056
     components:
     - type: Transform
       pos: -14.5,16.5
       parent: 1
-  - uid: 1044
+  - uid: 1057
     components:
     - type: Transform
       pos: -15.5,16.5
       parent: 1
-  - uid: 1045
+  - uid: 1058
     components:
     - type: Transform
       pos: -16.5,16.5
       parent: 1
-  - uid: 1046
+  - uid: 1059
     components:
     - type: Transform
       pos: -16.5,17.5
       parent: 1
-  - uid: 1047
+  - uid: 1060
     components:
     - type: Transform
       pos: -16.5,18.5
       parent: 1
-  - uid: 1048
+  - uid: 1061
     components:
     - type: Transform
       pos: -16.5,19.5
       parent: 1
-  - uid: 1049
+  - uid: 1062
     components:
     - type: Transform
       pos: -17.5,19.5
       parent: 1
-  - uid: 1050
+  - uid: 1063
     components:
     - type: Transform
       pos: -18.5,19.5
       parent: 1
-  - uid: 1051
+  - uid: 1064
     components:
     - type: Transform
       pos: -12.5,14.5
       parent: 1
-  - uid: 1052
+  - uid: 1065
     components:
     - type: Transform
       pos: -12.5,13.5
       parent: 1
-  - uid: 1053
+  - uid: 1066
     components:
     - type: Transform
       pos: -12.5,12.5
       parent: 1
-  - uid: 1054
+  - uid: 1067
     components:
     - type: Transform
       pos: -12.5,11.5
       parent: 1
-  - uid: 1055
+  - uid: 1068
     components:
     - type: Transform
       pos: -13.5,11.5
       parent: 1
-  - uid: 1056
+  - uid: 1069
     components:
     - type: Transform
       pos: -14.5,11.5
       parent: 1
-  - uid: 1057
+  - uid: 1070
     components:
     - type: Transform
       pos: -15.5,11.5
       parent: 1
-  - uid: 1058
+  - uid: 1071
     components:
     - type: Transform
       pos: -16.5,11.5
       parent: 1
-  - uid: 1059
+  - uid: 1072
     components:
     - type: Transform
       pos: -17.5,11.5
       parent: 1
-  - uid: 1060
+  - uid: 1073
     components:
     - type: Transform
       pos: -18.5,11.5
       parent: 1
-  - uid: 1061
+  - uid: 1074
     components:
     - type: Transform
       pos: -18.5,12.5
       parent: 1
-  - uid: 1062
+  - uid: 1075
     components:
     - type: Transform
       pos: 11.5,16.5
       parent: 1
-  - uid: 1063
+  - uid: 1076
     components:
     - type: Transform
       pos: 10.5,29.5
       parent: 1
-  - uid: 1064
+  - uid: 1077
     components:
     - type: Transform
       pos: 8.5,22.5
       parent: 1
-  - uid: 1065
+  - uid: 1078
     components:
     - type: Transform
       pos: 8.5,21.5
       parent: 1
-  - uid: 1066
+  - uid: 1079
     components:
     - type: Transform
       pos: 8.5,20.5
       parent: 1
-  - uid: 1067
+  - uid: 1080
     components:
     - type: Transform
       pos: 10.5,33.5
       parent: 1
-  - uid: 1068
+  - uid: 1081
     components:
     - type: Transform
       pos: 6.5,33.5
       parent: 1
-  - uid: 1069
+  - uid: 1082
     components:
     - type: Transform
       pos: 10.5,32.5
       parent: 1
-  - uid: 1070
+  - uid: 1083
     components:
     - type: Transform
       pos: 10.5,31.5
       parent: 1
-  - uid: 1071
+  - uid: 1084
     components:
     - type: Transform
       pos: 9.5,33.5
       parent: 1
-  - uid: 1072
+  - uid: 1085
     components:
     - type: Transform
       pos: 9.5,22.5
       parent: 1
-  - uid: 1073
+  - uid: 1086
     components:
     - type: Transform
       pos: 3.5,33.5
       parent: 1
-  - uid: 1074
+  - uid: 1087
     components:
     - type: Transform
       pos: 10.5,26.5
       parent: 1
-  - uid: 1075
+  - uid: 1088
     components:
     - type: Transform
       pos: 10.5,25.5
       parent: 1
-  - uid: 1076
+  - uid: 1089
     components:
     - type: Transform
       pos: 10.5,24.5
       parent: 1
-  - uid: 1077
+  - uid: 1090
     components:
     - type: Transform
       pos: 10.5,22.5
       parent: 1
-  - uid: 1078
+  - uid: 1091
     components:
     - type: Transform
       pos: 4.5,33.5
       parent: 1
-  - uid: 1079
+  - uid: 1092
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
-  - uid: 1080
+  - uid: 1093
     components:
     - type: Transform
       pos: -10.5,11.5
       parent: 1
-  - uid: 1081
+  - uid: 1094
     components:
     - type: Transform
       pos: -4.5,11.5
       parent: 1
-  - uid: 1082
+  - uid: 1095
     components:
     - type: Transform
       pos: -9.5,11.5
       parent: 1
-  - uid: 1083
+  - uid: 1096
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 1
-  - uid: 1084
+  - uid: 1097
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 1
-  - uid: 1085
+  - uid: 1098
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 1
-  - uid: 1086
+  - uid: 1099
     components:
     - type: Transform
       pos: -11.5,11.5
       parent: 1
-  - uid: 1087
+  - uid: 1100
     components:
     - type: Transform
       pos: -1.5,33.5
       parent: 1
-  - uid: 1088
+  - uid: 1101
     components:
     - type: Transform
       pos: -1.5,32.5
       parent: 1
-  - uid: 1089
+  - uid: 1102
     components:
     - type: Transform
       pos: -12.5,27.5
       parent: 1
-  - uid: 1090
+  - uid: 1103
     components:
     - type: Transform
       pos: -12.5,28.5
       parent: 1
-  - uid: 1091
+  - uid: 1104
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 1
-  - uid: 1092
+  - uid: 1105
     components:
     - type: Transform
       pos: -2.5,31.5
       parent: 1
-  - uid: 1093
+  - uid: 1106
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 1094
+  - uid: 1107
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 1095
+  - uid: 1108
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 1096
+  - uid: 1109
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 1097
+  - uid: 1110
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 1098
+  - uid: 1111
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 1099
+  - uid: 1112
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 1100
+  - uid: 1113
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 1101
+  - uid: 1114
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 1102
+  - uid: 1115
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 1103
+  - uid: 1116
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 1104
+  - uid: 1117
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 1105
+  - uid: 1118
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 1106
+  - uid: 1119
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 1107
+  - uid: 1120
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 1108
+  - uid: 1121
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 1109
+  - uid: 1122
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 1110
+  - uid: 1123
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 1111
+  - uid: 1124
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 1112
+  - uid: 1125
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 1113
+  - uid: 1126
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 1114
+  - uid: 1127
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 1115
+  - uid: 1128
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 1116
+  - uid: 1129
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 1117
+  - uid: 1130
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 1118
+  - uid: 1131
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 1119
+  - uid: 1132
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 1120
+  - uid: 1133
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 1121
+  - uid: 1134
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 1122
+  - uid: 1135
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 1123
+  - uid: 1136
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 1124
+  - uid: 1137
     components:
     - type: Transform
       pos: -13.5,31.5
       parent: 1
-  - uid: 1125
+  - uid: 1138
     components:
     - type: Transform
       pos: -14.5,31.5
       parent: 1
-  - uid: 1126
+  - uid: 1139
     components:
     - type: Transform
       pos: 9.5,36.5
       parent: 1
-  - uid: 1127
+  - uid: 1140
     components:
     - type: Transform
       pos: 9.5,35.5
       parent: 1
-  - uid: 1128
+  - uid: 1141
     components:
     - type: Transform
       pos: 9.5,34.5
       parent: 1
-  - uid: 1129
+  - uid: 1142
     components:
     - type: Transform
       pos: 4.5,32.5
       parent: 1
-  - uid: 1130
+  - uid: 1143
     components:
     - type: Transform
       pos: -7.5,32.5
       parent: 1
-  - uid: 1131
+  - uid: 1144
     components:
     - type: Transform
       pos: -7.5,33.5
       parent: 1
-  - uid: 1132
+  - uid: 1145
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 1133
+  - uid: 1146
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 1
-  - uid: 1134
+  - uid: 1147
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 1135
+  - uid: 1148
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 1
-  - uid: 1136
+  - uid: 1149
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 1137
+  - uid: 1150
     components:
     - type: Transform
       pos: 11.5,27.5
       parent: 1
-  - uid: 1138
+  - uid: 1151
     components:
     - type: Transform
       pos: 12.5,27.5
       parent: 1
-  - uid: 1139
+  - uid: 1152
     components:
     - type: Transform
       pos: 13.5,27.5
       parent: 1
-  - uid: 1140
+  - uid: 1153
     components:
     - type: Transform
       pos: 14.5,27.5
       parent: 1
-  - uid: 1141
+  - uid: 1154
     components:
     - type: Transform
       pos: 15.5,27.5
       parent: 1
-  - uid: 1142
+  - uid: 1155
     components:
     - type: Transform
       pos: 16.5,27.5
       parent: 1
-  - uid: 1143
+  - uid: 1156
     components:
     - type: Transform
       pos: 16.5,28.5
       parent: 1
-  - uid: 1144
+  - uid: 1157
     components:
     - type: Transform
       pos: 16.5,29.5
       parent: 1
-  - uid: 1145
+  - uid: 1158
     components:
     - type: Transform
       pos: 16.5,30.5
       parent: 1
-  - uid: 1146
+  - uid: 1159
     components:
     - type: Transform
       pos: 16.5,31.5
       parent: 1
-  - uid: 1147
+  - uid: 1160
     components:
     - type: Transform
       pos: 17.5,27.5
       parent: 1
-  - uid: 1148
+  - uid: 1161
     components:
     - type: Transform
       pos: 18.5,27.5
       parent: 1
-  - uid: 1149
+  - uid: 1162
     components:
     - type: Transform
       pos: 18.5,26.5
       parent: 1
-  - uid: 1150
+  - uid: 1163
     components:
     - type: Transform
       pos: 18.5,25.5
       parent: 1
-  - uid: 1151
+  - uid: 1164
     components:
     - type: Transform
       pos: 18.5,24.5
       parent: 1
-  - uid: 1152
+  - uid: 1165
     components:
     - type: Transform
       pos: 18.5,23.5
       parent: 1
-  - uid: 1153
+  - uid: 1166
     components:
     - type: Transform
       pos: 18.5,22.5
       parent: 1
-  - uid: 1154
+  - uid: 1167
     components:
     - type: Transform
       pos: 17.5,23.5
       parent: 1
-  - uid: 1155
+  - uid: 1168
     components:
     - type: Transform
       pos: 16.5,23.5
       parent: 1
-  - uid: 1156
+  - uid: 1169
     components:
     - type: Transform
       pos: 15.5,23.5
       parent: 1
-  - uid: 1157
+  - uid: 1170
     components:
     - type: Transform
       pos: 19.5,22.5
       parent: 1
-  - uid: 1158
+  - uid: 1171
     components:
     - type: Transform
       pos: 20.5,22.5
       parent: 1
-  - uid: 1159
+  - uid: 1172
     components:
     - type: Transform
       pos: 21.5,22.5
       parent: 1
-  - uid: 1160
+  - uid: 1173
     components:
     - type: Transform
       pos: 22.5,22.5
       parent: 1
-  - uid: 1161
+  - uid: 1174
     components:
     - type: Transform
       pos: 23.5,22.5
       parent: 1
-  - uid: 1162
+  - uid: 1175
     components:
     - type: Transform
       pos: 24.5,22.5
       parent: 1
-  - uid: 1163
+  - uid: 1176
     components:
     - type: Transform
       pos: 25.5,22.5
       parent: 1
-  - uid: 1164
+  - uid: 1177
     components:
     - type: Transform
       pos: 26.5,22.5
       parent: 1
-  - uid: 1165
+  - uid: 1178
     components:
     - type: Transform
       pos: 27.5,22.5
       parent: 1
-  - uid: 1166
+  - uid: 1179
     components:
     - type: Transform
       pos: 17.5,17.5
       parent: 1
-  - uid: 1167
+  - uid: 1180
     components:
     - type: Transform
       pos: 16.5,17.5
       parent: 1
-  - uid: 1168
+  - uid: 1181
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 1
-  - uid: 1169
+  - uid: 1182
     components:
     - type: Transform
       pos: 14.5,17.5
       parent: 1
-  - uid: 1170
+  - uid: 1183
     components:
     - type: Transform
       pos: 13.5,17.5
       parent: 1
-  - uid: 1171
+  - uid: 1184
     components:
     - type: Transform
       pos: 12.5,17.5
       parent: 1
-  - uid: 1172
+  - uid: 1185
     components:
     - type: Transform
       pos: 17.5,14.5
       parent: 1
-  - uid: 1173
+  - uid: 1186
     components:
     - type: Transform
       pos: 17.5,15.5
       parent: 1
-  - uid: 1174
+  - uid: 1187
     components:
     - type: Transform
       pos: 18.5,14.5
       parent: 1
-  - uid: 1175
+  - uid: 1188
     components:
     - type: Transform
       pos: 19.5,14.5
       parent: 1
-  - uid: 1176
+  - uid: 1189
     components:
     - type: Transform
       pos: 20.5,14.5
       parent: 1
-  - uid: 1177
+  - uid: 1190
     components:
     - type: Transform
       pos: 21.5,14.5
       parent: 1
-  - uid: 1178
+  - uid: 1191
     components:
     - type: Transform
       pos: 21.5,13.5
       parent: 1
-  - uid: 1179
+  - uid: 1192
     components:
     - type: Transform
       pos: 21.5,12.5
       parent: 1
-  - uid: 1180
+  - uid: 1193
     components:
     - type: Transform
       pos: 22.5,12.5
       parent: 1
-  - uid: 1181
+  - uid: 1194
     components:
     - type: Transform
       pos: 23.5,12.5
       parent: 1
-  - uid: 1182
+  - uid: 1195
     components:
     - type: Transform
       pos: 24.5,12.5
       parent: 1
-  - uid: 1183
+  - uid: 1196
     components:
     - type: Transform
       pos: 25.5,12.5
       parent: 1
-  - uid: 1184
+  - uid: 1197
     components:
     - type: Transform
       pos: 26.5,12.5
       parent: 1
-  - uid: 1185
+  - uid: 1198
     components:
     - type: Transform
       pos: 27.5,12.5
       parent: 1
-  - uid: 1186
+  - uid: 1199
     components:
     - type: Transform
       pos: 27.5,13.5
       parent: 1
-  - uid: 1187
+  - uid: 1200
     components:
     - type: Transform
       pos: -14.5,27.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 1188
+  - uid: 1201
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,24.5
       parent: 1
-  - uid: 1189
+  - uid: 1202
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,25.5
       parent: 1
-  - uid: 1190
+  - uid: 1203
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 1191
+  - uid: 1204
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,17.5
       parent: 1
-  - uid: 1192
+  - uid: 1205
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 1
 - proto: CargoPalletSell
   entities:
-  - uid: 1193
+  - uid: 1206
     components:
     - type: Transform
       pos: 12.5,5.5
       parent: 1
-  - uid: 1194
+  - uid: 1207
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 1195
+  - uid: 1208
     components:
     - type: Transform
       pos: 11.5,5.5
       parent: 1
-  - uid: 1196
+  - uid: 1209
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 1197
+  - uid: 1210
     components:
     - type: Transform
       pos: 10.5,5.5
       parent: 1
-  - uid: 1198
+  - uid: 1211
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 1199
+  - uid: 1212
     components:
     - type: Transform
       pos: 9.5,5.5
       parent: 1
-  - uid: 1200
+  - uid: 1213
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
 - proto: CargoTelepad
   entities:
-  - uid: 1201
+  - uid: 1214
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 1
 - proto: CarpetBlack
   entities:
-  - uid: 1202
+  - uid: 1215
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 1
-  - uid: 1203
+  - uid: 1216
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
-  - uid: 1204
+  - uid: 1217
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 1
-  - uid: 1205
+  - uid: 1218
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 1
-  - uid: 1206
+  - uid: 1219
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 1
-  - uid: 1207
+  - uid: 1220
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 1208
+  - uid: 1221
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,12.5
       parent: 1
-  - uid: 1209
+  - uid: 1222
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 1210
+  - uid: 1223
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 1
-  - uid: 1211
+  - uid: 1224
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 1
-  - uid: 1212
+  - uid: 1225
     components:
     - type: Transform
       pos: -10.5,-1.5
       parent: 1
-  - uid: 1213
+  - uid: 1226
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 1
-  - uid: 1214
+  - uid: 1227
     components:
     - type: Transform
       pos: -0.5,25.5
       parent: 1
-  - uid: 1215
+  - uid: 1228
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 1216
+  - uid: 1229
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 1
-  - uid: 1217
+  - uid: 1230
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
-  - uid: 1218
+  - uid: 1231
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 1
-  - uid: 1219
+  - uid: 1232
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 1
-  - uid: 1220
+  - uid: 1233
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 1
-  - uid: 1221
+  - uid: 1234
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 1
-  - uid: 1222
+  - uid: 1235
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 1223
+  - uid: 1236
     components:
     - type: Transform
       pos: 1.5,27.5
       parent: 1
-  - uid: 1224
+  - uid: 1237
     components:
     - type: Transform
       pos: 2.5,27.5
       parent: 1
-  - uid: 1225
+  - uid: 1238
     components:
     - type: Transform
       pos: 1.5,28.5
       parent: 1
-  - uid: 1226
+  - uid: 1239
     components:
     - type: Transform
       pos: 2.5,28.5
       parent: 1
-  - uid: 1227
+  - uid: 1240
     components:
     - type: Transform
       pos: 5.5,17.5
       parent: 1
-  - uid: 1228
+  - uid: 1241
     components:
     - type: Transform
       pos: 7.5,17.5
       parent: 1
-  - uid: 1229
+  - uid: 1242
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 1
-  - uid: 1230
+  - uid: 1243
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 1
-  - uid: 1231
+  - uid: 1244
     components:
     - type: Transform
       pos: 7.5,14.5
       parent: 1
-  - uid: 1232
+  - uid: 1245
     components:
     - type: Transform
       pos: 8.5,17.5
       parent: 1
-  - uid: 1233
+  - uid: 1246
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 1
-  - uid: 1234
+  - uid: 1247
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 1235
+  - uid: 1248
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 1
-  - uid: 1236
+  - uid: 1249
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 1237
+  - uid: 1250
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 1238
+  - uid: 1251
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
-  - uid: 1239
+  - uid: 1252
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 1
-  - uid: 1240
+  - uid: 1253
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 1241
+  - uid: 1254
     components:
     - type: Transform
       pos: -6.5,16.5
       parent: 1
-  - uid: 1242
+  - uid: 1255
     components:
     - type: Transform
       pos: -7.5,17.5
       parent: 1
-  - uid: 1243
+  - uid: 1256
     components:
     - type: Transform
       pos: -5.5,16.5
       parent: 1
-  - uid: 1244
+  - uid: 1257
     components:
     - type: Transform
       pos: -5.5,17.5
       parent: 1
-  - uid: 1245
+  - uid: 1258
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
-  - uid: 1246
+  - uid: 1259
     components:
     - type: Transform
       pos: 11.5,12.5
       parent: 1
-  - uid: 1247
+  - uid: 1260
     components:
     - type: Transform
       pos: 10.5,12.5
       parent: 1
-  - uid: 1248
+  - uid: 1261
     components:
     - type: Transform
       pos: 9.5,12.5
       parent: 1
-  - uid: 1249
+  - uid: 1262
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 1250
+  - uid: 1263
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 1251
+  - uid: 1264
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 1252
+  - uid: 1265
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 1253
+  - uid: 1266
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 1254
+  - uid: 1267
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 1255
+  - uid: 1268
     components:
     - type: Transform
       pos: -11.5,16.5
       parent: 1
-  - uid: 1256
+  - uid: 1269
     components:
     - type: Transform
       pos: -10.5,17.5
       parent: 1
-  - uid: 1257
+  - uid: 1270
     components:
     - type: Transform
       pos: -9.5,17.5
       parent: 1
-  - uid: 1258
+  - uid: 1271
     components:
     - type: Transform
       pos: 10.5,17.5
       parent: 1
-  - uid: 1259
+  - uid: 1272
     components:
     - type: Transform
       pos: 11.5,17.5
       parent: 1
-  - uid: 1260
+  - uid: 1273
     components:
     - type: Transform
       pos: -7.5,18.5
       parent: 1
-  - uid: 1261
+  - uid: 1274
     components:
     - type: Transform
       pos: -11.5,21.5
       parent: 1
-  - uid: 1262
+  - uid: 1275
     components:
     - type: Transform
       pos: -10.5,21.5
       parent: 1
-  - uid: 1264
+  - uid: 1276
     components:
     - type: Transform
       pos: -15.5,16.5
       parent: 1
-  - uid: 1265
+  - uid: 1277
     components:
     - type: Transform
       pos: -16.5,16.5
       parent: 1
-  - uid: 1267
+  - uid: 1278
     components:
     - type: Transform
       pos: -17.5,20.5
       parent: 1
-  - uid: 1268
+  - uid: 1279
     components:
     - type: Transform
       pos: -15.5,20.5
       parent: 1
-  - uid: 1269
+  - uid: 1280
     components:
     - type: Transform
       pos: -14.5,11.5
       parent: 1
-  - uid: 1270
+  - uid: 1281
     components:
     - type: Transform
       pos: -12.5,21.5
       parent: 1
-  - uid: 1271
+  - uid: 1282
     components:
     - type: Transform
       pos: -12.5,20.5
       parent: 1
-  - uid: 1272
+  - uid: 1283
     components:
     - type: Transform
       pos: -12.5,22.5
       parent: 1
-  - uid: 1273
+  - uid: 1284
     components:
     - type: Transform
       pos: -12.5,27.5
       parent: 1
-  - uid: 1274
+  - uid: 1285
     components:
     - type: Transform
       pos: -13.5,20.5
       parent: 1
-  - uid: 1275
+  - uid: 1286
     components:
     - type: Transform
       pos: -12.5,19.5
       parent: 1
-  - uid: 1276
+  - uid: 1287
     components:
     - type: Transform
       pos: -12.5,25.5
       parent: 1
-  - uid: 1277
+  - uid: 1288
     components:
     - type: Transform
       pos: -12.5,24.5
       parent: 1
-  - uid: 1278
+  - uid: 1289
     components:
     - type: Transform
       pos: 8.5,18.5
       parent: 1
-  - uid: 1279
+  - uid: 1290
     components:
     - type: Transform
       pos: -14.5,26.5
       parent: 1
-  - uid: 1280
+  - uid: 1291
     components:
     - type: Transform
       pos: -15.5,26.5
       parent: 1
-  - uid: 1281
+  - uid: 1292
     components:
     - type: Transform
       pos: -12.5,16.5
       parent: 1
-  - uid: 1282
+  - uid: 1293
     components:
     - type: Transform
       pos: -12.5,15.5
       parent: 1
-  - uid: 1283
+  - uid: 1294
     components:
     - type: Transform
       pos: -13.5,15.5
       parent: 1
-  - uid: 1284
+  - uid: 1295
     components:
     - type: Transform
       pos: -13.5,14.5
       parent: 1
-  - uid: 1285
+  - uid: 1296
     components:
     - type: Transform
       pos: -13.5,13.5
       parent: 1
-  - uid: 1286
+  - uid: 1297
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 1
-  - uid: 1287
+  - uid: 1298
     components:
     - type: Transform
       pos: -13.5,10.5
       parent: 1
-  - uid: 1288
+  - uid: 1299
     components:
     - type: Transform
       pos: -12.5,9.5
       parent: 1
-  - uid: 1289
+  - uid: 1300
     components:
     - type: Transform
       pos: -12.5,8.5
       parent: 1
-  - uid: 1290
+  - uid: 1301
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 1291
+  - uid: 1302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,24.5
       parent: 1
-  - uid: 1292
+  - uid: 1303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,26.5
       parent: 1
-  - uid: 1293
+  - uid: 1304
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 1294
+  - uid: 1305
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 1
-  - uid: 1295
+  - uid: 1306
     components:
     - type: Transform
       pos: -24.5,8.5
       parent: 1
-  - uid: 1296
+  - uid: 1307
     components:
     - type: Transform
       pos: -24.5,9.5
       parent: 1
-  - uid: 1297
+  - uid: 1308
     components:
     - type: Transform
       pos: -25.5,9.5
       parent: 1
-  - uid: 1298
+  - uid: 1309
     components:
     - type: Transform
       pos: -23.5,9.5
       parent: 1
-  - uid: 1299
+  - uid: 1310
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 1
-  - uid: 1300
+  - uid: 1311
     components:
     - type: Transform
       pos: -24.5,6.5
       parent: 1
-  - uid: 1301
+  - uid: 1312
     components:
     - type: Transform
       pos: -23.5,6.5
       parent: 1
-  - uid: 1302
+  - uid: 1313
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 1
-  - uid: 1303
+  - uid: 1314
     components:
     - type: Transform
       pos: -16.5,3.5
       parent: 1
-  - uid: 1304
+  - uid: 1315
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 1
-  - uid: 1305
+  - uid: 1316
     components:
     - type: Transform
       pos: -13.5,3.5
       parent: 1
-  - uid: 1306
+  - uid: 1317
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 1
-  - uid: 1307
+  - uid: 1318
     components:
     - type: Transform
       pos: -31.5,13.5
       parent: 1
-  - uid: 1308
+  - uid: 1319
     components:
     - type: Transform
       pos: -22.5,-0.5
       parent: 1
-  - uid: 1309
+  - uid: 1320
     components:
     - type: Transform
       pos: -22.5,-1.5
       parent: 1
-  - uid: 1311
+  - uid: 1321
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 1312
+  - uid: 1322
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 1313
+  - uid: 1323
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 1314
+  - uid: 1324
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 1315
+  - uid: 1325
     components:
     - type: Transform
       pos: -12.5,-10.5
       parent: 1
-  - uid: 1316
+  - uid: 1326
     components:
     - type: Transform
       pos: -13.5,-10.5
       parent: 1
-  - uid: 1317
+  - uid: 1327
     components:
     - type: Transform
       pos: -15.5,-8.5
       parent: 1
-  - uid: 1318
+  - uid: 1328
     components:
     - type: Transform
       pos: -15.5,-7.5
       parent: 1
-  - uid: 1319
+  - uid: 1329
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 1
-  - uid: 1320
+  - uid: 1330
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 1
-  - uid: 1321
+  - uid: 1331
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 1
-  - uid: 1322
+  - uid: 1332
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 1
-  - uid: 1323
+  - uid: 1333
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 1
-  - uid: 1324
+  - uid: 1334
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 1
-  - uid: 1325
+  - uid: 1335
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 1
-  - uid: 1326
+  - uid: 1336
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 1327
+  - uid: 1337
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 1328
+  - uid: 1338
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 1
-  - uid: 1329
+  - uid: 1339
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 1
-  - uid: 1330
+  - uid: 1340
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 1
-  - uid: 1331
+  - uid: 1341
     components:
     - type: Transform
       pos: -9.5,-8.5
       parent: 1
-  - uid: 1332
+  - uid: 1342
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 1333
+  - uid: 1343
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 1334
+  - uid: 1344
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 1335
+  - uid: 1345
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 1336
+  - uid: 1346
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 1337
+  - uid: 1347
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 1338
+  - uid: 1348
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 1339
+  - uid: 1349
     components:
     - type: Transform
       pos: 11.5,46.5
       parent: 1
-  - uid: 1340
+  - uid: 1350
     components:
     - type: Transform
       pos: 11.5,45.5
       parent: 1
-  - uid: 1341
+  - uid: 1351
     components:
     - type: Transform
       pos: 9.5,48.5
       parent: 1
-  - uid: 1342
+  - uid: 1352
     components:
     - type: Transform
       pos: 8.5,48.5
       parent: 1
-  - uid: 1343
+  - uid: 1353
     components:
     - type: Transform
       pos: 6.5,46.5
       parent: 1
-  - uid: 1344
+  - uid: 1354
     components:
     - type: Transform
       pos: 6.5,45.5
       parent: 1
-  - uid: 1345
+  - uid: 1355
     components:
     - type: Transform
       pos: 9.5,44.5
       parent: 1
-  - uid: 1346
+  - uid: 1356
     components:
     - type: Transform
       pos: 8.5,45.5
       parent: 1
-  - uid: 1347
+  - uid: 1357
     components:
     - type: Transform
       pos: 8.5,44.5
       parent: 1
-  - uid: 1348
+  - uid: 1358
     components:
     - type: Transform
       pos: 9.5,46.5
       parent: 1
-  - uid: 1349
+  - uid: 1359
     components:
     - type: Transform
       pos: 8.5,43.5
       parent: 1
-  - uid: 1350
+  - uid: 1360
     components:
     - type: Transform
       pos: 8.5,42.5
       parent: 1
-  - uid: 1351
+  - uid: 1361
     components:
     - type: Transform
       pos: 9.5,41.5
       parent: 1
-  - uid: 1352
+  - uid: 1362
     components:
     - type: Transform
       pos: 9.5,40.5
       parent: 1
-  - uid: 1353
+  - uid: 1363
     components:
     - type: Transform
       pos: 8.5,38.5
       parent: 1
-  - uid: 1354
+  - uid: 1364
     components:
     - type: Transform
       pos: -15.5,41.5
       parent: 1
-  - uid: 1355
+  - uid: 1365
     components:
     - type: Transform
       pos: -14.5,41.5
       parent: 1
-  - uid: 1356
+  - uid: 1366
     components:
     - type: Transform
       pos: -17.5,39.5
       parent: 1
-  - uid: 1357
+  - uid: 1367
     components:
     - type: Transform
       pos: -17.5,38.5
       parent: 1
-  - uid: 1358
+  - uid: 1368
     components:
     - type: Transform
       pos: -15.5,38.5
       parent: 1
-  - uid: 1359
+  - uid: 1369
     components:
     - type: Transform
       pos: -15.5,39.5
       parent: 1
-  - uid: 1360
+  - uid: 1370
     components:
     - type: Transform
       pos: -14.5,38.5
       parent: 1
-  - uid: 1361
+  - uid: 1371
     components:
     - type: Transform
       pos: -14.5,37.5
       parent: 1
-  - uid: 1362
+  - uid: 1372
     components:
     - type: Transform
       pos: -14.5,34.5
       parent: 1
-  - uid: 1363
+  - uid: 1373
     components:
     - type: Transform
       pos: -14.5,33.5
       parent: 1
-  - uid: 1364
+  - uid: 1374
     components:
     - type: Transform
       pos: -15.5,33.5
       parent: 1
-  - uid: 1365
+  - uid: 1375
     components:
     - type: Transform
       pos: -9.5,-1.5
       parent: 1
-  - uid: 1366
+  - uid: 1376
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
-  - uid: 1367
+  - uid: 1377
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 1
-  - uid: 1368
+  - uid: 1378
     components:
     - type: Transform
       pos: 20.5,2.5
       parent: 1
-  - uid: 1369
+  - uid: 1379
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 1
-  - uid: 1370
+  - uid: 1380
     components:
     - type: Transform
       pos: 20.5,0.5
       parent: 1
-  - uid: 1371
+  - uid: 1381
     components:
     - type: Transform
       pos: 19.5,2.5
       parent: 1
-  - uid: 1372
+  - uid: 1382
     components:
     - type: Transform
       pos: 19.5,1.5
       parent: 1
-  - uid: 1373
+  - uid: 1383
     components:
     - type: Transform
       pos: 19.5,0.5
       parent: 1
-  - uid: 1374
+  - uid: 1384
     components:
     - type: Transform
       pos: 18.5,2.5
       parent: 1
-  - uid: 1375
+  - uid: 1385
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 1
-  - uid: 1376
+  - uid: 1386
     components:
     - type: Transform
       pos: 18.5,0.5
       parent: 1
-  - uid: 1377
+  - uid: 1387
     components:
     - type: Transform
       pos: -22.5,-2.5
       parent: 1
-  - uid: 1378
+  - uid: 1388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,24.5
       parent: 1
-  - uid: 1379
+  - uid: 1389
     components:
     - type: Transform
       pos: -31.5,12.5
       parent: 1
-  - uid: 1380
+  - uid: 1390
     components:
     - type: Transform
       pos: -31.5,11.5
       parent: 1
-  - uid: 1381
+  - uid: 1391
     components:
     - type: Transform
       pos: -32.5,13.5
       parent: 1
-  - uid: 1382
+  - uid: 1392
     components:
     - type: Transform
       pos: -32.5,12.5
       parent: 1
-  - uid: 1383
+  - uid: 1393
     components:
     - type: Transform
       pos: -32.5,11.5
       parent: 1
-  - uid: 1384
+  - uid: 1394
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 1
-  - uid: 1385
+  - uid: 1395
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 1
-  - uid: 1386
+  - uid: 1396
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 1
-  - uid: 1387
+  - uid: 1397
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 1
-  - uid: 1388
+  - uid: 1398
     components:
     - type: Transform
       pos: -24.5,-1.5
       parent: 1
-  - uid: 1389
+  - uid: 1399
     components:
     - type: Transform
       pos: -24.5,-2.5
       parent: 1
-  - uid: 1390
+  - uid: 1400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,26.5
       parent: 1
-  - uid: 1391
+  - uid: 1401
     components:
     - type: Transform
       pos: -12.5,26.5
       parent: 1
-  - uid: 1392
+  - uid: 1402
     components:
     - type: Transform
       pos: -13.5,0.5
       parent: 1
-  - uid: 1393
+  - uid: 1403
     components:
     - type: Transform
       pos: -13.5,11.5
       parent: 1
-  - uid: 1394
+  - uid: 1404
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 1395
+  - uid: 1405
     components:
     - type: Transform
       pos: -4.5,11.5
       parent: 1
-  - uid: 1396
+  - uid: 1406
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 1397
+  - uid: 1407
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
-  - uid: 1398
+  - uid: 1408
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 1399
+  - uid: 1409
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 1400
+  - uid: 1410
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 1401
+  - uid: 1411
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 1402
+  - uid: 1412
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 1403
+  - uid: 1413
     components:
     - type: Transform
       pos: -6.5,12.5
       parent: 1
-  - uid: 1404
+  - uid: 1414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 1405
+  - uid: 1415
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 1406
+  - uid: 1416
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 1407
+  - uid: 1417
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 1
-  - uid: 1408
+  - uid: 1418
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 1409
+  - uid: 1419
     components:
     - type: Transform
       pos: -10.5,11.5
       parent: 1
-  - uid: 1411
+  - uid: 1420
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 1
-  - uid: 1412
+  - uid: 1421
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 1
-  - uid: 1413
+  - uid: 1422
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 1414
+  - uid: 1423
     components:
     - type: Transform
       pos: -6.5,13.5
       parent: 1
-  - uid: 1415
+  - uid: 1424
     components:
     - type: Transform
       pos: -6.5,14.5
       parent: 1
-  - uid: 1416
+  - uid: 1425
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
-  - uid: 1417
+  - uid: 1426
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 1418
+  - uid: 1427
     components:
     - type: Transform
       pos: -5.5,14.5
       parent: 1
-  - uid: 1419
+  - uid: 1428
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 1420
+  - uid: 1429
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 1
-  - uid: 1422
+  - uid: 1430
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 1423
+  - uid: 1431
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 1424
+  - uid: 1432
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 1425
+  - uid: 1433
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 1427
+  - uid: 1434
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 1428
+  - uid: 1435
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 1429
+  - uid: 1436
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 1430
+  - uid: 1437
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 1431
+  - uid: 1438
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 1432
+  - uid: 1439
     components:
     - type: Transform
       pos: 9.5,35.5
       parent: 1
-  - uid: 1433
+  - uid: 1440
     components:
     - type: Transform
       pos: 8.5,34.5
       parent: 1
-  - uid: 1434
+  - uid: 1441
     components:
     - type: Transform
       pos: 9.5,34.5
       parent: 1
-  - uid: 1435
+  - uid: 1442
     components:
     - type: Transform
       pos: 9.5,33.5
       parent: 1
-  - uid: 1436
+  - uid: 1443
     components:
     - type: Transform
       pos: 7.5,33.5
       parent: 1
-  - uid: 1437
+  - uid: 1444
     components:
     - type: Transform
       pos: 6.5,33.5
       parent: 1
-  - uid: 1438
+  - uid: 1445
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 1
-  - uid: 1439
+  - uid: 1446
     components:
     - type: Transform
       pos: 1.5,33.5
       parent: 1
-  - uid: 1440
+  - uid: 1447
     components:
     - type: Transform
       pos: 1.5,34.5
       parent: 1
-  - uid: 1441
+  - uid: 1448
     components:
     - type: Transform
       pos: 0.5,34.5
       parent: 1
-  - uid: 1442
+  - uid: 1449
     components:
     - type: Transform
       pos: -1.5,33.5
       parent: 1
-  - uid: 1443
+  - uid: 1450
     components:
     - type: Transform
       pos: -3.5,34.5
       parent: 1
-  - uid: 1444
+  - uid: 1451
     components:
     - type: Transform
       pos: -4.5,33.5
       parent: 1
-  - uid: 1445
+  - uid: 1452
     components:
     - type: Transform
       pos: -5.5,31.5
       parent: 1
-  - uid: 1446
+  - uid: 1453
     components:
     - type: Transform
       pos: -6.5,31.5
       parent: 1
-  - uid: 1447
+  - uid: 1454
     components:
     - type: Transform
       pos: -9.5,31.5
       parent: 1
-  - uid: 1448
+  - uid: 1455
     components:
     - type: Transform
       pos: -10.5,31.5
       parent: 1
-  - uid: 1449
+  - uid: 1456
     components:
     - type: Transform
       pos: -11.5,31.5
       parent: 1
-  - uid: 1450
+  - uid: 1457
     components:
     - type: Transform
       pos: -12.5,31.5
       parent: 1
-  - uid: 1451
+  - uid: 1458
     components:
     - type: Transform
       pos: -13.5,31.5
       parent: 1
-  - uid: 1452
+  - uid: 1459
     components:
     - type: Transform
       pos: -12.5,29.5
       parent: 1
-  - uid: 1453
+  - uid: 1460
     components:
     - type: Transform
       pos: -14.5,30.5
       parent: 1
-  - uid: 1454
+  - uid: 1461
     components:
     - type: Transform
       pos: -15.5,30.5
       parent: 1
-  - uid: 1455
+  - uid: 1462
     components:
     - type: Transform
       pos: 10.5,31.5
       parent: 1
-  - uid: 1456
+  - uid: 1463
     components:
     - type: Transform
       pos: 10.5,30.5
       parent: 1
-  - uid: 1457
+  - uid: 1464
     components:
     - type: Transform
       pos: 10.5,29.5
       parent: 1
-  - uid: 1458
+  - uid: 1465
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 1
-  - uid: 1459
+  - uid: 1466
     components:
     - type: Transform
       pos: 10.5,27.5
       parent: 1
-  - uid: 1460
+  - uid: 1467
     components:
     - type: Transform
       pos: 10.5,26.5
       parent: 1
-  - uid: 1461
+  - uid: 1468
     components:
     - type: Transform
       pos: 10.5,25.5
       parent: 1
-  - uid: 1462
+  - uid: 1469
     components:
     - type: Transform
       pos: 10.5,23.5
       parent: 1
-  - uid: 1463
+  - uid: 1470
     components:
     - type: Transform
       pos: 10.5,22.5
       parent: 1
-  - uid: 1464
+  - uid: 1471
     components:
     - type: Transform
       pos: 10.5,24.5
       parent: 1
-  - uid: 1465
+  - uid: 1472
     components:
     - type: Transform
       pos: 9.5,22.5
       parent: 1
-  - uid: 1466
+  - uid: 1473
     components:
     - type: Transform
       pos: 8.5,22.5
       parent: 1
-  - uid: 1467
+  - uid: 1474
     components:
     - type: Transform
       pos: 8.5,21.5
       parent: 1
-  - uid: 1468
+  - uid: 1475
     components:
     - type: Transform
       pos: 8.5,20.5
       parent: 1
-  - uid: 1469
+  - uid: 1476
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 1
-  - uid: 1470
+  - uid: 1477
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 1
-  - uid: 1471
+  - uid: 1478
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 1
-  - uid: 1472
+  - uid: 1479
     components:
     - type: Transform
       pos: -2.5,31.5
       parent: 1
-  - uid: 1473
+  - uid: 1480
     components:
     - type: Transform
       pos: 23.5,22.5
       parent: 1
-  - uid: 1474
+  - uid: 1481
     components:
     - type: Transform
       pos: 25.5,22.5
       parent: 1
-  - uid: 1475
+  - uid: 1482
     components:
     - type: Transform
       pos: 25.5,18.5
       parent: 1
-  - uid: 1476
+  - uid: 1483
     components:
     - type: Transform
       pos: 26.5,22.5
       parent: 1
-  - uid: 1477
+  - uid: 1484
     components:
     - type: Transform
       pos: 25.5,23.5
       parent: 1
-  - uid: 1478
+  - uid: 1485
     components:
     - type: Transform
       pos: 23.5,24.5
       parent: 1
-  - uid: 1479
+  - uid: 1486
     components:
     - type: Transform
       pos: 23.5,25.5
       parent: 1
-  - uid: 1480
+  - uid: 1487
     components:
     - type: Transform
       pos: 25.5,21.5
       parent: 1
-  - uid: 1481
+  - uid: 1488
     components:
     - type: Transform
       pos: 25.5,25.5
       parent: 1
-  - uid: 1482
+  - uid: 1489
     components:
     - type: Transform
       pos: 23.5,23.5
       parent: 1
-  - uid: 1483
+  - uid: 1490
     components:
     - type: Transform
       pos: 25.5,19.5
       parent: 1
-  - uid: 1484
+  - uid: 1491
     components:
     - type: Transform
       pos: 25.5,20.5
       parent: 1
-  - uid: 1485
+  - uid: 1492
     components:
     - type: Transform
       pos: 25.5,24.5
       parent: 1
-  - uid: 1486
+  - uid: 1493
     components:
     - type: Transform
       pos: 22.5,22.5
       parent: 1
-  - uid: 1487
+  - uid: 1494
     components:
     - type: Transform
       pos: 24.5,22.5
       parent: 1
-  - uid: 1488
+  - uid: 1495
     components:
     - type: Transform
       pos: 38.5,14.5
       parent: 1
-  - uid: 1489
+  - uid: 1496
     components:
     - type: Transform
       pos: 38.5,13.5
       parent: 1
-  - uid: 1490
+  - uid: 1497
     components:
     - type: Transform
       pos: 39.5,15.5
       parent: 1
-  - uid: 1491
+  - uid: 1498
     components:
     - type: Transform
       pos: 39.5,13.5
       parent: 1
-  - uid: 1492
+  - uid: 1499
     components:
     - type: Transform
       pos: 38.5,15.5
       parent: 1
-  - uid: 1493
+  - uid: 1500
     components:
     - type: Transform
       pos: 39.5,14.5
       parent: 1
-  - uid: 1494
+  - uid: 1501
     components:
     - type: Transform
       pos: 37.5,13.5
       parent: 1
-  - uid: 1495
+  - uid: 1502
     components:
     - type: Transform
       pos: 37.5,14.5
       parent: 1
-  - uid: 1496
+  - uid: 1503
     components:
     - type: Transform
       pos: 37.5,15.5
       parent: 1
-  - uid: 1497
+  - uid: 1504
     components:
     - type: Transform
       pos: 39.5,21.5
       parent: 1
-  - uid: 1498
+  - uid: 1505
     components:
     - type: Transform
       pos: 39.5,22.5
       parent: 1
-  - uid: 1499
+  - uid: 1506
     components:
     - type: Transform
       pos: 39.5,23.5
       parent: 1
-  - uid: 1500
+  - uid: 1507
     components:
     - type: Transform
       pos: 38.5,21.5
       parent: 1
-  - uid: 1501
+  - uid: 1508
     components:
     - type: Transform
       pos: 38.5,22.5
       parent: 1
-  - uid: 1502
+  - uid: 1509
     components:
     - type: Transform
       pos: 38.5,23.5
       parent: 1
-  - uid: 1503
+  - uid: 1510
     components:
     - type: Transform
       pos: 37.5,21.5
       parent: 1
-  - uid: 1504
+  - uid: 1511
     components:
     - type: Transform
       pos: 37.5,22.5
       parent: 1
-  - uid: 1505
-    components:
-    - type: Transform
-      pos: 37.5,23.5
-      parent: 1
-  - uid: 1506
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,35.5
-      parent: 1
-  - uid: 1507
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,35.5
-      parent: 1
-  - uid: 1508
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,12.5
-      parent: 1
-  - uid: 1509
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,17.5
-      parent: 1
-  - uid: 1510
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,13.5
-      parent: 1
-  - uid: 1511
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,17.5
-      parent: 1
   - uid: 1512
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,12.5
+      pos: 37.5,23.5
       parent: 1
   - uid: 1513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 23.5,12.5
+      pos: 23.5,35.5
       parent: 1
   - uid: 1514
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 16.5,17.5
+      pos: 22.5,35.5
       parent: 1
   - uid: 1515
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 26.5,12.5
+      pos: 21.5,12.5
       parent: 1
   - uid: 1516
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 28.5,12.5
+      pos: 14.5,17.5
       parent: 1
   - uid: 1517
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 30.5,12.5
+      pos: 21.5,13.5
       parent: 1
   - uid: 1518
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 29.5,12.5
+      pos: 13.5,17.5
       parent: 1
   - uid: 1519
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 31.5,12.5
+      pos: 22.5,12.5
       parent: 1
   - uid: 1520
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 24.5,12.5
+      pos: 23.5,12.5
       parent: 1
   - uid: 1521
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 27.5,12.5
+      pos: 16.5,17.5
       parent: 1
   - uid: 1522
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,39.5
+      pos: 26.5,12.5
       parent: 1
   - uid: 1523
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,38.5
+      pos: 28.5,12.5
       parent: 1
   - uid: 1524
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,39.5
+      pos: 30.5,12.5
       parent: 1
   - uid: 1525
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,39.5
+      pos: 29.5,12.5
       parent: 1
   - uid: 1526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -0.5,39.5
+      pos: 31.5,12.5
       parent: 1
   - uid: 1527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,38.5
+      pos: 24.5,12.5
       parent: 1
   - uid: 1528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,38.5
+      pos: 27.5,12.5
       parent: 1
   - uid: 1529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -22.5,26.5
+      pos: -2.5,39.5
       parent: 1
   - uid: 1530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -23.5,24.5
+      pos: -3.5,38.5
       parent: 1
   - uid: 1531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -22.5,24.5
+      pos: -1.5,39.5
       parent: 1
   - uid: 1532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -22.5,25.5
+      pos: -3.5,39.5
       parent: 1
   - uid: 1533
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -23.5,25.5
+      pos: -0.5,39.5
       parent: 1
   - uid: 1534
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,38.5
       parent: 1
   - uid: 1535
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,38.5
       parent: 1
   - uid: 1536
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,17.5
+      pos: -22.5,26.5
       parent: 1
   - uid: 1537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,16.5
+      pos: -23.5,24.5
       parent: 1
   - uid: 1538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,14.5
+      pos: -22.5,24.5
       parent: 1
   - uid: 1539
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 18.5,14.5
+      pos: -22.5,25.5
       parent: 1
   - uid: 1540
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,14.5
+      pos: -23.5,25.5
       parent: 1
   - uid: 1541
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,14.5
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-1.5
       parent: 1
   - uid: 1542
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 35.5,12.5
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-0.5
       parent: 1
   - uid: 1543
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -21.5,25.5
+      pos: 17.5,17.5
       parent: 1
   - uid: 1544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 22.5,36.5
+      pos: 17.5,16.5
       parent: 1
   - uid: 1545
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 22.5,37.5
+      pos: 17.5,14.5
       parent: 1
   - uid: 1546
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 21.5,37.5
+      pos: 18.5,14.5
       parent: 1
   - uid: 1547
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 21.5,36.5
+      pos: 19.5,14.5
       parent: 1
   - uid: 1548
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 21.5,35.5
+      pos: 20.5,14.5
       parent: 1
   - uid: 1549
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 20.5,35.5
+      pos: 35.5,12.5
       parent: 1
   - uid: 1550
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 20.5,36.5
+      pos: -21.5,25.5
       parent: 1
   - uid: 1551
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 20.5,37.5
+      pos: 22.5,36.5
       parent: 1
   - uid: 1552
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,37.5
+      pos: 22.5,37.5
       parent: 1
   - uid: 1553
     components:
     - type: Transform
-      pos: 17.5,1.5
+      rot: 3.141592653589793 rad
+      pos: 21.5,37.5
       parent: 1
   - uid: 1554
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 21.5,36.5
       parent: 1
   - uid: 1555
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,13.5
+      rot: 3.141592653589793 rad
+      pos: 21.5,35.5
       parent: 1
   - uid: 1556
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,12.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,35.5
       parent: 1
   - uid: 1557
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,11.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,36.5
       parent: 1
   - uid: 1558
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 20.5,37.5
       parent: 1
   - uid: 1559
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,38.5
+      pos: 19.5,37.5
       parent: 1
   - uid: 1560
+    components:
+    - type: Transform
+      pos: 17.5,1.5
+      parent: 1
+  - uid: 1561
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,10.5
+      parent: 1
+  - uid: 1562
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,13.5
+      parent: 1
+  - uid: 1563
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,12.5
+      parent: 1
+  - uid: 1564
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,11.5
+      parent: 1
+  - uid: 1565
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,14.5
+      parent: 1
+  - uid: 1566
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,38.5
+      parent: 1
+  - uid: 1567
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,39.5
       parent: 1
-  - uid: 1561
+  - uid: 1568
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,40.5
       parent: 1
-  - uid: 1562
+  - uid: 1569
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,40.5
       parent: 1
-  - uid: 1563
+  - uid: 1570
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,40.5
       parent: 1
-  - uid: 1564
+  - uid: 1571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,12.5
       parent: 1
-  - uid: 1565
+  - uid: 1572
     components:
     - type: Transform
       pos: -30.5,-1.5
       parent: 1
-  - uid: 1566
+  - uid: 1573
     components:
     - type: Transform
       pos: -35.5,4.5
       parent: 1
-  - uid: 1567
+  - uid: 1574
     components:
     - type: Transform
       pos: 29.5,3.5
       parent: 1
-  - uid: 1568
+  - uid: 1575
     components:
     - type: Transform
       pos: -32.5,18.5
       parent: 1
-  - uid: 1569
+  - uid: 1576
     components:
     - type: Transform
       pos: -8.5,41.5
       parent: 1
-  - uid: 1570
+  - uid: 1577
     components:
     - type: Transform
       pos: -21.5,31.5
       parent: 1
-  - uid: 1571
+  - uid: 1578
     components:
     - type: Transform
       pos: 16.5,40.5
       parent: 1
-  - uid: 1572
+  - uid: 1579
     components:
     - type: Transform
       pos: 37.5,8.5
       parent: 1
-  - uid: 1573
+  - uid: 1580
     components:
     - type: Transform
       pos: 39.5,18.5
       parent: 1
-  - uid: 1574
+  - uid: 1581
     components:
     - type: Transform
       pos: 37.5,30.5
       parent: 1
-  - uid: 1575
+  - uid: 1582
     components:
     - type: Transform
       pos: 29.5,35.5
       parent: 1
-  - uid: 4797
+  - uid: 1583
     components:
     - type: Transform
       pos: -16.5,20.5
       parent: 1
 - proto: CatwalkMono
   entities:
-  - uid: 1266
+  - uid: 1584
     components:
     - type: Transform
       pos: -17.5,21.5
       parent: 1
-  - uid: 4796
+  - uid: 1585
     components:
     - type: Transform
       pos: -15.5,21.5
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 1576
+  - uid: 1586
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10626,96 +10648,96 @@ entities:
       parent: 1
 - proto: ChairOfficeLight
   entities:
-  - uid: 1577
+  - uid: 1587
     components:
     - type: Transform
       pos: 4.4737463,-4.6138077
       parent: 1
-  - uid: 1578
+  - uid: 1588
     components:
     - type: Transform
       pos: 8.318181,-3.5341082
       parent: 1
 - proto: ChemDispenser
   entities:
-  - uid: 1579
+  - uid: 1589
     components:
     - type: Transform
       pos: -22.5,12.5
       parent: 1
-  - uid: 1580
+  - uid: 1590
     components:
     - type: Transform
       pos: -19.5,19.5
       parent: 1
-  - uid: 1581
+  - uid: 1591
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 1
 - proto: ChemistryHotplate
   entities:
-  - uid: 1582
+  - uid: 1592
     components:
     - type: Transform
       pos: -22.5,14.5
       parent: 1
-  - uid: 1583
+  - uid: 1593
     components:
     - type: Transform
       pos: -18.5,15.5
       parent: 1
-  - uid: 1584
+  - uid: 1594
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
 - proto: ChemMaster
   entities:
-  - uid: 1585
+  - uid: 1595
     components:
     - type: Transform
       pos: -23.5,12.5
       parent: 1
-  - uid: 1586
+  - uid: 1596
     components:
     - type: Transform
       pos: -19.5,18.5
       parent: 1
-  - uid: 1587
+  - uid: 1597
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 1
 - proto: CigarGoldCase
   entities:
-  - uid: 1588
+  - uid: 1598
     components:
     - type: Transform
       pos: -10.510417,3.6875
       parent: 1
 - proto: CigPackGreen
   entities:
-  - uid: 1589
+  - uid: 1599
     components:
     - type: Transform
       pos: 15.429472,27.194477
       parent: 1
 - proto: ClosetChefFilled
   entities:
-  - uid: 1590
+  - uid: 1600
     components:
     - type: Transform
       pos: 18.5,20.5
       parent: 1
 - proto: ClosetFireFilled
   entities:
-  - uid: 1591
+  - uid: 1601
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 1592
+  - uid: 1602
     components:
     - type: Transform
       pos: 7.5,18.5
@@ -10738,26 +10760,26 @@ entities:
         - 0
         - 0
         - 0
-  - uid: 1593
+  - uid: 1603
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 1
 - proto: ClosetL3Filled
   entities:
-  - uid: 1594
+  - uid: 1604
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 1595
+  - uid: 1605
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
 - proto: ClosetO2N2Filled
   entities:
-  - uid: 1596
+  - uid: 1606
     components:
     - type: Transform
       pos: 6.5,18.5
@@ -10780,274 +10802,274 @@ entities:
         - 0
         - 0
         - 0
-  - uid: 1597
+  - uid: 1607
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 1598
+  - uid: 1608
     components:
     - type: Transform
       pos: -13.5,17.5
       parent: 1
-  - uid: 1599
+  - uid: 1609
     components:
     - type: Transform
       pos: -13.5,6.5
       parent: 1
-  - uid: 1600
+  - uid: 1610
     components:
     - type: Transform
       pos: -13.5,-4.5
       parent: 1
-  - uid: 1601
+  - uid: 1611
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 1602
+  - uid: 1612
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
 - proto: ClosetToolFilled
   entities:
-  - uid: 1603
+  - uid: 1613
     components:
     - type: Transform
       pos: 3.5,28.5
       parent: 1
 - proto: ClothingBeltPlantFilled
   entities:
-  - uid: 1604
+  - uid: 1614
     components:
     - type: Transform
       pos: 23.190155,18.619
       parent: 1
 - proto: CMSemioticAirlock
   entities:
-  - uid: 1605
+  - uid: 1615
     components:
     - type: Transform
       pos: 7.5,47.5
       parent: 1
-  - uid: 1606
+  - uid: 1616
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 1607
+  - uid: 1617
     components:
     - type: Transform
       pos: -14.5,-9.5
       parent: 1
-  - uid: 1608
+  - uid: 1618
     components:
     - type: Transform
       pos: -16.5,40.5
       parent: 1
-  - uid: 1609
+  - uid: 1619
     components:
     - type: Transform
       pos: 10.5,47.5
       parent: 1
 - proto: CMSemioticAmmunition
   entities:
-  - uid: 1610
+  - uid: 1620
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
 - proto: CMSemioticBathunisex
   entities:
-  - uid: 1611
+  - uid: 1621
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 1
 - proto: CMSemioticBiohazard
   entities:
-  - uid: 1612
+  - uid: 1622
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 1613
+  - uid: 1623
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
 - proto: CMSemioticBiolab
   entities:
-  - uid: 1614
+  - uid: 1624
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
 - proto: CMSemioticBulkhead_door
   entities:
-  - uid: 1615
+  - uid: 1625
     components:
     - type: Transform
       pos: -11.5,-3.5
       parent: 1
-  - uid: 1616
+  - uid: 1626
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
 - proto: CMSemioticChem_lab
   entities:
-  - uid: 1617
+  - uid: 1627
     components:
     - type: Transform
       pos: -20.5,12.5
       parent: 1
-  - uid: 1618
+  - uid: 1628
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1
 - proto: CMSemioticCryo
   entities:
-  - uid: 1619
+  - uid: 1629
     components:
     - type: Transform
       pos: -16.5,21.5
       parent: 1
 - proto: CMSemioticDistribution_pipes
   entities:
-  - uid: 1620
+  - uid: 1630
     components:
     - type: Transform
       pos: 0.5,26.5
       parent: 1
 - proto: CMSemioticElectronics
   entities:
-  - uid: 1621
+  - uid: 1631
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 1
-  - uid: 1622
+  - uid: 1632
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 1
 - proto: CMSemioticFire_haz
   entities:
-  - uid: 1623
+  - uid: 1633
     components:
     - type: Transform
       pos: 5.5,22.5
       parent: 1
 - proto: CMSemioticFlightcontrol
   entities:
-  - uid: 1624
+  - uid: 1634
     components:
     - type: Transform
       pos: -16.5,2.5
       parent: 1
 - proto: CMSemioticHigh_rad
   entities:
-  - uid: 1625
+  - uid: 1635
     components:
     - type: Transform
       pos: -1.5,24.5
       parent: 1
 - proto: CMSemioticHigh_voltage
   entities:
-  - uid: 1626
+  - uid: 1636
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1
-  - uid: 1627
+  - uid: 1637
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 1628
+  - uid: 1638
     components:
     - type: Transform
       pos: -2.5,32.5
       parent: 1
 - proto: CMSemioticLife_support
   entities:
-  - uid: 1629
+  - uid: 1639
     components:
     - type: Transform
       pos: 5.5,26.5
       parent: 1
 - proto: CMSemioticMed_cryo
   entities:
-  - uid: 1630
+  - uid: 1640
     components:
     - type: Transform
       pos: -21.5,8.5
       parent: 1
 - proto: CMSemioticMed_life_support
   entities:
-  - uid: 1631
+  - uid: 1641
     components:
     - type: Transform
       pos: -21.5,10.5
       parent: 1
 - proto: CMSemioticRefridgeration
   entities:
-  - uid: 1633
+  - uid: 1642
     components:
     - type: Transform
       pos: -19.5,17.5
       parent: 1
 - proto: CMSemioticRestrictedarea
   entities:
-  - uid: 1634
+  - uid: 1643
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 1635
+  - uid: 1644
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 1
 - proto: CMSemioticSecurity
   entities:
-  - uid: 1636
+  - uid: 1645
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 1
 - proto: CMSemioticStorage
   entities:
-  - uid: 1637
+  - uid: 1646
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 1638
+  - uid: 1647
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
 - proto: CMSemioticTerminal
   entities:
-  - uid: 1639
+  - uid: 1648
     components:
     - type: Transform
       pos: -21.5,4.5
       parent: 1
-  - uid: 1640
+  - uid: 1649
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
 - proto: ComputerContrabandPalletConsolePirate
   entities:
-  - uid: 1641
+  - uid: 1650
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11059,7 +11081,7 @@ entities:
       startingCharge: 0
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 1642
+  - uid: 1651
     components:
     - type: Transform
       pos: -7.5,26.5
@@ -11070,7 +11092,7 @@ entities:
       startingCharge: 0
 - proto: ComputerPalletConsoleNFNormalMarket
   entities:
-  - uid: 1643
+  - uid: 1652
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11082,7 +11104,7 @@ entities:
       startingCharge: 0
 - proto: ComputerPirateBounty
   entities:
-  - uid: 1644
+  - uid: 1653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11094,7 +11116,7 @@ entities:
       startingCharge: 0
 - proto: ComputerPirateBountyRedemption
   entities:
-  - uid: 1645
+  - uid: 1654
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11106,7 +11128,7 @@ entities:
       startingCharge: 0
 - proto: ComputerShipyardBlackMarket
   entities:
-  - uid: 1646
+  - uid: 1655
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11116,7 +11138,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1647
+  - uid: 1656
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11128,7 +11150,7 @@ entities:
       startingCharge: 0
 - proto: ComputerStationRecords
   entities:
-  - uid: 1648
+  - uid: 1657
     components:
     - type: Transform
       pos: -6.5,26.5
@@ -11139,21 +11161,21 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopBroken
   entities:
-  - uid: 1649
+  - uid: 1658
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
 - proto: ComputerTabletopCargoOrders
   entities:
-  - uid: 1650
+  - uid: 1659
     components:
     - type: Transform
       pos: 15.5,10.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1201:
+        1214:
         - - OrderSender
           - OrderReceiver
     - type: ApcPowerReceiver
@@ -11162,7 +11184,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopCrewMonitoring
   entities:
-  - uid: 1651
+  - uid: 1660
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11174,7 +11196,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopMarketConsoleNFNormal
   entities:
-  - uid: 1652
+  - uid: 1661
     components:
     - type: Transform
       pos: 14.5,10.5
@@ -11185,7 +11207,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopRadar
   entities:
-  - uid: 1653
+  - uid: 1662
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11197,7 +11219,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopResearchAndDevelopment
   entities:
-  - uid: 1654
+  - uid: 1663
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11207,7 +11229,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1655
+  - uid: 1664
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11219,7 +11241,7 @@ entities:
       startingCharge: 0
 - proto: ComputerWallmountAdvancedRadar
   entities:
-  - uid: 1656
+  - uid: 1665
     components:
     - type: Transform
       pos: -9.5,26.5
@@ -11228,7 +11250,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1657
+  - uid: 1666
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11240,7 +11262,7 @@ entities:
       startingCharge: 0
 - proto: ComputerWallmountBlackMarketBankATM
   entities:
-  - uid: 1658
+  - uid: 1667
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11250,7 +11272,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1659
+  - uid: 1668
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11260,7 +11282,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1660
+  - uid: 1669
     components:
     - type: Transform
       pos: -14.5,13.5
@@ -11269,7 +11291,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1661
+  - uid: 1670
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11279,7 +11301,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1662
+  - uid: 1671
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11289,7 +11311,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1663
+  - uid: 1672
     components:
     - type: Transform
       pos: 1.5,11.5
@@ -11298,7 +11320,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1664
+  - uid: 1673
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11308,7 +11330,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1665
+  - uid: 1674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11318,7 +11340,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1666
+  - uid: 1675
     components:
     - type: Transform
       pos: 1.5,-6.5
@@ -11327,7 +11349,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1667
+  - uid: 1676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11337,7 +11359,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1668
+  - uid: 1677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11347,7 +11369,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1669
+  - uid: 1678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11357,7 +11379,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1670
+  - uid: 1679
     components:
     - type: Transform
       pos: -3.5,4.5
@@ -11368,529 +11390,529 @@ entities:
       startingCharge: 0
 - proto: CondimentDispenser
   entities:
-  - uid: 1671
+  - uid: 1680
     components:
     - type: Transform
       pos: 19.5,29.5
       parent: 1
 - proto: ConstructionBox
   entities:
-  - uid: 1672
+  - uid: 1681
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
 - proto: ContrabandPalletPirate
   entities:
-  - uid: 1673
+  - uid: 1682
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 1674
+  - uid: 1683
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 1675
+  - uid: 1684
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 1676
+  - uid: 1685
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 1677
+  - uid: 1686
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 1678
+  - uid: 1687
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 1679
+  - uid: 1688
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 1680
+  - uid: 1689
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
 - proto: CrateEngineeringElectricalSupplies
   entities:
-  - uid: 1681
+  - uid: 1690
     components:
     - type: Transform
       pos: 0.5,28.5
       parent: 1
 - proto: CrateHydroponicsSeedsMedicinal
   entities:
-  - uid: 1682
+  - uid: 1691
     components:
     - type: Transform
       pos: 24.5,18.5
       parent: 1
 - proto: CrateMachine
   entities:
-  - uid: 1683
+  - uid: 1692
     components:
     - type: Transform
       pos: 15.5,7.5
       parent: 1
 - proto: CryoPod
   entities:
-  - uid: 1684
+  - uid: 1693
     components:
     - type: Transform
       pos: -23.5,10.5
       parent: 1
 - proto: CurtainsBlackOpen
   entities:
-  - uid: 1685
+  - uid: 1694
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 1
-  - uid: 1686
+  - uid: 1695
     components:
     - type: Transform
       pos: 11.5,26.5
       parent: 1
-  - uid: 1687
+  - uid: 1696
     components:
     - type: Transform
       pos: 11.5,28.5
       parent: 1
-  - uid: 1688
+  - uid: 1697
     components:
     - type: Transform
       pos: 11.5,29.5
       parent: 1
-  - uid: 1689
+  - uid: 1698
     components:
     - type: Transform
       pos: 11.5,27.5
       parent: 1
 - proto: DarkCatwalkMono
   entities:
-  - uid: 1263
+  - uid: 1699
     components:
     - type: Transform
       pos: -16.5,18.5
       parent: 1
-  - uid: 4728
+  - uid: 1700
     components:
     - type: Transform
       pos: 8.5,46.5
       parent: 1
-  - uid: 4729
+  - uid: 1701
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 4730
+  - uid: 1702
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 4731
+  - uid: 1703
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 1
-  - uid: 4732
+  - uid: 1704
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 4733
+  - uid: 1705
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 4734
+  - uid: 1706
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 4736
+  - uid: 1707
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 4737
+  - uid: 1708
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 4738
+  - uid: 1709
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 4739
+  - uid: 1710
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 4740
+  - uid: 1711
     components:
     - type: Transform
       pos: -10.5,-8.5
       parent: 1
-  - uid: 4741
+  - uid: 1712
     components:
     - type: Transform
       pos: -11.5,-8.5
       parent: 1
-  - uid: 4742
+  - uid: 1713
     components:
     - type: Transform
       pos: -13.5,-8.5
       parent: 1
-  - uid: 4743
+  - uid: 1714
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 1
-  - uid: 4744
+  - uid: 1715
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 1
-  - uid: 4745
+  - uid: 1716
     components:
     - type: Transform
       pos: -12.5,5.5
       parent: 1
-  - uid: 4746
+  - uid: 1717
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 1
-  - uid: 4747
+  - uid: 1718
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 1
-  - uid: 4748
+  - uid: 1719
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 1
-  - uid: 4753
+  - uid: 1720
     components:
     - type: Transform
       pos: -12.5,11.5
       parent: 1
-  - uid: 4754
+  - uid: 1721
     components:
     - type: Transform
       pos: -13.5,12.5
       parent: 1
-  - uid: 4755
+  - uid: 1722
     components:
     - type: Transform
       pos: -10.5,16.5
       parent: 1
-  - uid: 4756
+  - uid: 1723
     components:
     - type: Transform
       pos: -12.5,17.5
       parent: 1
-  - uid: 4757
+  - uid: 1724
     components:
     - type: Transform
       pos: -13.5,16.5
       parent: 1
-  - uid: 4758
+  - uid: 1725
     components:
     - type: Transform
       pos: -8.5,17.5
       parent: 1
-  - uid: 4759
+  - uid: 1726
     components:
     - type: Transform
       pos: -7.5,19.5
       parent: 1
-  - uid: 4760
+  - uid: 1727
     components:
     - type: Transform
       pos: -6.5,17.5
       parent: 1
-  - uid: 4761
+  - uid: 1728
     components:
     - type: Transform
       pos: -4.5,17.5
       parent: 1
-  - uid: 4762
+  - uid: 1729
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1
-  - uid: 4763
+  - uid: 1730
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 1
-  - uid: 4764
+  - uid: 1731
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 4765
+  - uid: 1732
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 4766
+  - uid: 1733
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 4767
+  - uid: 1734
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 1
-  - uid: 4768
+  - uid: 1735
     components:
     - type: Transform
       pos: -9.5,11.5
       parent: 1
-  - uid: 4769
+  - uid: 1736
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 1
-  - uid: 4770
+  - uid: 1737
     components:
     - type: Transform
       pos: 8.5,35.5
       parent: 1
-  - uid: 4771
+  - uid: 1738
     components:
     - type: Transform
       pos: 8.5,33.5
       parent: 1
-  - uid: 4772
+  - uid: 1739
     components:
     - type: Transform
       pos: 10.5,33.5
       parent: 1
-  - uid: 4773
+  - uid: 1740
     components:
     - type: Transform
       pos: 5.5,33.5
       parent: 1
-  - uid: 4774
+  - uid: 1741
     components:
     - type: Transform
       pos: 4.5,33.5
       parent: 1
-  - uid: 4775
+  - uid: 1742
     components:
     - type: Transform
       pos: 3.5,33.5
       parent: 1
-  - uid: 4776
+  - uid: 1743
     components:
     - type: Transform
       pos: -0.5,34.5
       parent: 1
-  - uid: 4777
+  - uid: 1744
     components:
     - type: Transform
       pos: -1.5,34.5
       parent: 1
-  - uid: 4778
+  - uid: 1745
     components:
     - type: Transform
       pos: -2.5,34.5
       parent: 1
-  - uid: 4779
+  - uid: 1746
     components:
     - type: Transform
       pos: -3.5,33.5
       parent: 1
-  - uid: 4780
+  - uid: 1747
     components:
     - type: Transform
       pos: -5.5,33.5
       parent: 1
-  - uid: 4781
+  - uid: 1748
     components:
     - type: Transform
       pos: -5.5,32.5
       parent: 1
-  - uid: 4782
+  - uid: 1749
     components:
     - type: Transform
       pos: -8.5,31.5
       parent: 1
-  - uid: 4783
+  - uid: 1750
     components:
     - type: Transform
       pos: -7.5,31.5
       parent: 1
-  - uid: 4784
+  - uid: 1751
     components:
     - type: Transform
       pos: -12.5,30.5
       parent: 1
-  - uid: 4785
+  - uid: 1752
     components:
     - type: Transform
       pos: -14.5,36.5
       parent: 1
-  - uid: 4786
+  - uid: 1753
     components:
     - type: Transform
       pos: -14.5,35.5
       parent: 1
-  - uid: 4787
+  - uid: 1754
     components:
     - type: Transform
       pos: -14.5,39.5
       parent: 1
-  - uid: 4788
+  - uid: 1755
     components:
     - type: Transform
       pos: 9.5,45.5
       parent: 1
-  - uid: 4789
+  - uid: 1756
     components:
     - type: Transform
       pos: 9.5,42.5
       parent: 1
-  - uid: 4794
+  - uid: 1757
     components:
     - type: Transform
       pos: -16.5,17.5
       parent: 1
-  - uid: 4795
+  - uid: 1758
     components:
     - type: Transform
       pos: -16.5,19.5
       parent: 1
-  - uid: 4814
+  - uid: 1759
     components:
     - type: Transform
       pos: -12.5,23.5
       parent: 1
 - proto: DefaultStationBeaconArmory
   entities:
-  - uid: 1690
+  - uid: 1760
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
 - proto: DefaultStationBeaconAtmospherics
   entities:
-  - uid: 1691
+  - uid: 1761
     components:
     - type: Transform
       pos: 6.5,25.5
       parent: 1
 - proto: DefaultStationBeaconBar
   entities:
-  - uid: 1692
+  - uid: 1762
     components:
     - type: Transform
       pos: 17.5,28.5
       parent: 1
 - proto: DefaultStationBeaconBotany
   entities:
-  - uid: 1693
+  - uid: 1763
     components:
     - type: Transform
       pos: 24.5,22.5
       parent: 1
 - proto: DefaultStationBeaconCargoBay
   entities:
-  - uid: 1694
+  - uid: 1764
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 1
 - proto: DefaultStationBeaconChemistry
   entities:
-  - uid: 1695
+  - uid: 1765
     components:
     - type: Transform
       pos: -20.5,15.5
       parent: 1
 - proto: DefaultStationBeaconCryonics
   entities:
-  - uid: 1696
+  - uid: 1766
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 1
 - proto: DefaultStationBeaconCryosleep
   entities:
-  - uid: 1697
+  - uid: 1767
     components:
     - type: Transform
       pos: -16.5,20.5
       parent: 1
 - proto: DefaultStationBeaconDorms
   entities:
-  - uid: 1698
+  - uid: 1768
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 1
 - proto: DefaultStationBeaconEngineering
   entities:
-  - uid: 1699
+  - uid: 1769
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 1
 - proto: DefaultStationBeaconFrontierShipyard
   entities:
-  - uid: 1700
+  - uid: 1770
     components:
     - type: Transform
       pos: -7.5,24.5
       parent: 1
 - proto: DefaultStationBeaconKitchen
   entities:
-  - uid: 1701
+  - uid: 1771
     components:
     - type: Transform
       pos: 18.5,22.5
       parent: 1
 - proto: DefaultStationBeaconMedbay
   entities:
-  - uid: 1702
+  - uid: 1772
     components:
     - type: Transform
       pos: -19.5,9.5
       parent: 1
 - proto: DefaultStationBeaconServerRoom
   entities:
-  - uid: 1703
+  - uid: 1773
     components:
     - type: Transform
       pos: -18.5,4.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 1704
+  - uid: 1774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,7.5
       parent: 1
-  - uid: 1705
+  - uid: 1775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11898,158 +11920,158 @@ entities:
       parent: 1
 - proto: DiseaseDiagnoser
   entities:
-  - uid: 1706
+  - uid: 1776
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
 - proto: DisposalBend
   entities:
-  - uid: 1707
+  - uid: 1777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,0.5
       parent: 1
-  - uid: 1708
+  - uid: 1778
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 1709
+  - uid: 1779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 1710
+  - uid: 1780
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 1
-  - uid: 1711
+  - uid: 1781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,10.5
       parent: 1
-  - uid: 1712
+  - uid: 1782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,15.5
       parent: 1
-  - uid: 1713
+  - uid: 1783
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,15.5
       parent: 1
-  - uid: 1714
+  - uid: 1784
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,31.5
       parent: 1
-  - uid: 1715
+  - uid: 1785
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,31.5
       parent: 1
-  - uid: 1716
+  - uid: 1786
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,33.5
       parent: 1
-  - uid: 1717
+  - uid: 1787
     components:
     - type: Transform
       pos: -4.5,34.5
       parent: 1
-  - uid: 1718
+  - uid: 1788
     components:
     - type: Transform
       pos: 17.5,24.5
       parent: 1
-  - uid: 1719
+  - uid: 1789
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,22.5
       parent: 1
-  - uid: 1720
+  - uid: 1790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,22.5
       parent: 1
-  - uid: 1721
+  - uid: 1791
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,22.5
       parent: 1
-  - uid: 1722
+  - uid: 1792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,13.5
       parent: 1
-  - uid: 1723
+  - uid: 1793
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,17.5
       parent: 1
-  - uid: 1724
+  - uid: 1794
     components:
     - type: Transform
       pos: 17.5,17.5
       parent: 1
-  - uid: 1725
+  - uid: 1795
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,14.5
       parent: 1
-  - uid: 1726
+  - uid: 1796
     components:
     - type: Transform
       pos: 21.5,14.5
       parent: 1
-  - uid: 1727
+  - uid: 1797
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,12.5
       parent: 1
-  - uid: 1728
+  - uid: 1798
     components:
     - type: Transform
       pos: 10.5,33.5
       parent: 1
 - proto: DisposalJunctionFlipped
   entities:
-  - uid: 1729
+  - uid: 1799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,8.5
       parent: 1
-  - uid: 1730
+  - uid: 1800
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,33.5
       parent: 1
-  - uid: 1731
+  - uid: 1801
     components:
     - type: Transform
       pos: 10.5,24.5
       parent: 1
-  - uid: 1732
+  - uid: 1802
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12057,730 +12079,730 @@ entities:
       parent: 1
 - proto: DisposalPipe
   entities:
-  - uid: 1733
+  - uid: 1803
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 1734
+  - uid: 1804
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 1735
+  - uid: 1805
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 1736
+  - uid: 1806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 1
-  - uid: 1737
+  - uid: 1807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 1
-  - uid: 1738
+  - uid: 1808
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,0.5
       parent: 1
-  - uid: 1739
+  - uid: 1809
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,0.5
       parent: 1
-  - uid: 1740
+  - uid: 1810
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,0.5
       parent: 1
-  - uid: 1741
+  - uid: 1811
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,0.5
       parent: 1
-  - uid: 1742
+  - uid: 1812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,1.5
       parent: 1
-  - uid: 1743
+  - uid: 1813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,2.5
       parent: 1
-  - uid: 1744
+  - uid: 1814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,3.5
       parent: 1
-  - uid: 1745
+  - uid: 1815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,4.5
       parent: 1
-  - uid: 1746
+  - uid: 1816
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,5.5
       parent: 1
-  - uid: 1747
+  - uid: 1817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,6.5
       parent: 1
-  - uid: 1748
+  - uid: 1818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,7.5
       parent: 1
-  - uid: 1749
+  - uid: 1819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,9.5
       parent: 1
-  - uid: 1750
+  - uid: 1820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,8.5
       parent: 1
-  - uid: 1751
-    components:
-    - type: Transform
-      pos: -5.5,32.5
-      parent: 1
-  - uid: 1752
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,31.5
-      parent: 1
-  - uid: 1753
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,31.5
-      parent: 1
-  - uid: 1754
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,31.5
-      parent: 1
-  - uid: 1755
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,31.5
-      parent: 1
-  - uid: 1756
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,31.5
-      parent: 1
-  - uid: 1757
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,31.5
-      parent: 1
-  - uid: 1758
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,30.5
-      parent: 1
-  - uid: 1759
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,29.5
-      parent: 1
-  - uid: 1760
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,28.5
-      parent: 1
-  - uid: 1761
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,27.5
-      parent: 1
-  - uid: 1762
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,26.5
-      parent: 1
-  - uid: 1763
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,25.5
-      parent: 1
-  - uid: 1764
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,24.5
-      parent: 1
-  - uid: 1765
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,23.5
-      parent: 1
-  - uid: 1766
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,22.5
-      parent: 1
-  - uid: 1767
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,21.5
-      parent: 1
-  - uid: 1768
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,20.5
-      parent: 1
-  - uid: 1769
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,19.5
-      parent: 1
-  - uid: 1770
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,17.5
-      parent: 1
-  - uid: 1771
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,16.5
-      parent: 1
-  - uid: 1772
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,14.5
-      parent: 1
-  - uid: 1773
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,13.5
-      parent: 1
-  - uid: 1774
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,12.5
-      parent: 1
-  - uid: 1775
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,11.5
-      parent: 1
-  - uid: 1776
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,9.5
-      parent: 1
-  - uid: 1777
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,18.5
-      parent: 1
-  - uid: 1778
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,33.5
-      parent: 1
-  - uid: 1779
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,33.5
-      parent: 1
-  - uid: 1780
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,33.5
-      parent: 1
-  - uid: 1781
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,33.5
-      parent: 1
-  - uid: 1782
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,33.5
-      parent: 1
-  - uid: 1783
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,33.5
-      parent: 1
-  - uid: 1784
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,33.5
-      parent: 1
-  - uid: 1785
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,33.5
-      parent: 1
-  - uid: 1786
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,33.5
-      parent: 1
-  - uid: 1787
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,33.5
-      parent: 1
-  - uid: 1788
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,33.5
-      parent: 1
-  - uid: 1789
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,33.5
-      parent: 1
-  - uid: 1790
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,33.5
-      parent: 1
-  - uid: 1791
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,33.5
-      parent: 1
-  - uid: 1792
-    components:
-    - type: Transform
-      pos: 10.5,32.5
-      parent: 1
-  - uid: 1793
-    components:
-    - type: Transform
-      pos: 10.5,31.5
-      parent: 1
-  - uid: 1794
-    components:
-    - type: Transform
-      pos: 10.5,30.5
-      parent: 1
-  - uid: 1795
-    components:
-    - type: Transform
-      pos: 10.5,29.5
-      parent: 1
-  - uid: 1796
-    components:
-    - type: Transform
-      pos: 10.5,27.5
-      parent: 1
-  - uid: 1797
-    components:
-    - type: Transform
-      pos: 10.5,26.5
-      parent: 1
-  - uid: 1798
-    components:
-    - type: Transform
-      pos: 10.5,25.5
-      parent: 1
-  - uid: 1799
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,24.5
-      parent: 1
-  - uid: 1800
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,24.5
-      parent: 1
-  - uid: 1801
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,24.5
-      parent: 1
-  - uid: 1802
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,24.5
-      parent: 1
-  - uid: 1803
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,24.5
-      parent: 1
-  - uid: 1804
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,24.5
-      parent: 1
-  - uid: 1805
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,23.5
-      parent: 1
-  - uid: 1806
-    components:
-    - type: Transform
-      pos: 0.5,14.5
-      parent: 1
-  - uid: 1807
-    components:
-    - type: Transform
-      pos: 0.5,15.5
-      parent: 1
-  - uid: 1808
-    components:
-    - type: Transform
-      pos: 0.5,16.5
-      parent: 1
-  - uid: 1809
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,17.5
-      parent: 1
-  - uid: 1810
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,17.5
-      parent: 1
-  - uid: 1811
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,17.5
-      parent: 1
-  - uid: 1812
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,17.5
-      parent: 1
-  - uid: 1813
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,17.5
-      parent: 1
-  - uid: 1814
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,17.5
-      parent: 1
-  - uid: 1815
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,17.5
-      parent: 1
-  - uid: 1816
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,17.5
-      parent: 1
-  - uid: 1817
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,17.5
-      parent: 1
-  - uid: 1818
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,17.5
-      parent: 1
-  - uid: 1819
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,17.5
-      parent: 1
-  - uid: 1820
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,17.5
-      parent: 1
   - uid: 1821
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,17.5
+      pos: -5.5,32.5
       parent: 1
   - uid: 1822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 15.5,17.5
+      pos: -6.5,31.5
       parent: 1
   - uid: 1823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 16.5,17.5
+      pos: -7.5,31.5
       parent: 1
   - uid: 1824
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,23.5
+      rot: -1.5707963267948966 rad
+      pos: -8.5,31.5
       parent: 1
   - uid: 1825
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,22.5
+      rot: -1.5707963267948966 rad
+      pos: -9.5,31.5
       parent: 1
   - uid: 1826
     components:
     - type: Transform
-      pos: 8.5,21.5
+      rot: -1.5707963267948966 rad
+      pos: -10.5,31.5
       parent: 1
   - uid: 1827
     components:
     - type: Transform
-      pos: 8.5,20.5
+      rot: -1.5707963267948966 rad
+      pos: -11.5,31.5
       parent: 1
   - uid: 1828
     components:
     - type: Transform
-      pos: 8.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -12.5,30.5
       parent: 1
   - uid: 1829
     components:
     - type: Transform
-      pos: 8.5,18.5
+      rot: 3.141592653589793 rad
+      pos: -12.5,29.5
       parent: 1
   - uid: 1830
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,16.5
+      pos: -12.5,28.5
       parent: 1
   - uid: 1831
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 17.5,15.5
+      pos: -12.5,27.5
       parent: 1
   - uid: 1832
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,26.5
+      parent: 1
+  - uid: 1833
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,25.5
+      parent: 1
+  - uid: 1834
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,24.5
+      parent: 1
+  - uid: 1835
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,23.5
+      parent: 1
+  - uid: 1836
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,22.5
+      parent: 1
+  - uid: 1837
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,21.5
+      parent: 1
+  - uid: 1838
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,20.5
+      parent: 1
+  - uid: 1839
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,19.5
+      parent: 1
+  - uid: 1840
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,17.5
+      parent: 1
+  - uid: 1841
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,16.5
+      parent: 1
+  - uid: 1842
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,14.5
+      parent: 1
+  - uid: 1843
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,13.5
+      parent: 1
+  - uid: 1844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,12.5
+      parent: 1
+  - uid: 1845
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,11.5
+      parent: 1
+  - uid: 1846
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,9.5
+      parent: 1
+  - uid: 1847
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,18.5
+      parent: 1
+  - uid: 1848
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,33.5
+      parent: 1
+  - uid: 1849
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,33.5
+      parent: 1
+  - uid: 1850
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,33.5
+      parent: 1
+  - uid: 1851
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,33.5
+      parent: 1
+  - uid: 1852
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,33.5
+      parent: 1
+  - uid: 1853
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,33.5
+      parent: 1
+  - uid: 1854
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,33.5
+      parent: 1
+  - uid: 1855
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,33.5
+      parent: 1
+  - uid: 1856
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,33.5
+      parent: 1
+  - uid: 1857
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,33.5
+      parent: 1
+  - uid: 1858
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,33.5
+      parent: 1
+  - uid: 1859
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,33.5
+      parent: 1
+  - uid: 1860
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,33.5
+      parent: 1
+  - uid: 1861
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,33.5
+      parent: 1
+  - uid: 1862
+    components:
+    - type: Transform
+      pos: 10.5,32.5
+      parent: 1
+  - uid: 1863
+    components:
+    - type: Transform
+      pos: 10.5,31.5
+      parent: 1
+  - uid: 1864
+    components:
+    - type: Transform
+      pos: 10.5,30.5
+      parent: 1
+  - uid: 1865
+    components:
+    - type: Transform
+      pos: 10.5,29.5
+      parent: 1
+  - uid: 1866
+    components:
+    - type: Transform
+      pos: 10.5,27.5
+      parent: 1
+  - uid: 1867
+    components:
+    - type: Transform
+      pos: 10.5,26.5
+      parent: 1
+  - uid: 1868
+    components:
+    - type: Transform
+      pos: 10.5,25.5
+      parent: 1
+  - uid: 1869
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,24.5
+      parent: 1
+  - uid: 1870
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,24.5
+      parent: 1
+  - uid: 1871
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,24.5
+      parent: 1
+  - uid: 1872
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,24.5
+      parent: 1
+  - uid: 1873
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,24.5
+      parent: 1
+  - uid: 1874
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,24.5
+      parent: 1
+  - uid: 1875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,23.5
+      parent: 1
+  - uid: 1876
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 1877
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 1878
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 1879
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 1880
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 1881
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 1882
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 1883
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 1884
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,17.5
+      parent: 1
+  - uid: 1885
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,17.5
+      parent: 1
+  - uid: 1886
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,17.5
+      parent: 1
+  - uid: 1887
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,17.5
+      parent: 1
+  - uid: 1888
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,17.5
+      parent: 1
+  - uid: 1889
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,17.5
+      parent: 1
+  - uid: 1890
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,17.5
+      parent: 1
+  - uid: 1891
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,17.5
+      parent: 1
+  - uid: 1892
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,17.5
+      parent: 1
+  - uid: 1893
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,17.5
+      parent: 1
+  - uid: 1894
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,23.5
+      parent: 1
+  - uid: 1895
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,22.5
+      parent: 1
+  - uid: 1896
+    components:
+    - type: Transform
+      pos: 8.5,21.5
+      parent: 1
+  - uid: 1897
+    components:
+    - type: Transform
+      pos: 8.5,20.5
+      parent: 1
+  - uid: 1898
+    components:
+    - type: Transform
+      pos: 8.5,19.5
+      parent: 1
+  - uid: 1899
+    components:
+    - type: Transform
+      pos: 8.5,18.5
+      parent: 1
+  - uid: 1900
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,16.5
+      parent: 1
+  - uid: 1901
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,15.5
+      parent: 1
+  - uid: 1902
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,14.5
       parent: 1
-  - uid: 1833
+  - uid: 1903
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,14.5
       parent: 1
-  - uid: 1834
+  - uid: 1904
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,14.5
       parent: 1
-  - uid: 1835
+  - uid: 1905
     components:
     - type: Transform
       pos: 21.5,13.5
       parent: 1
-  - uid: 1836
+  - uid: 1906
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,12.5
       parent: 1
-  - uid: 1837
+  - uid: 1907
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,12.5
       parent: 1
-  - uid: 1838
+  - uid: 1908
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,12.5
       parent: 1
-  - uid: 1839
+  - uid: 1909
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,12.5
       parent: 1
-  - uid: 1840
+  - uid: 1910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,12.5
       parent: 1
-  - uid: 1841
+  - uid: 1911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,12.5
       parent: 1
-  - uid: 1842
+  - uid: 1912
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,12.5
       parent: 1
-  - uid: 1843
+  - uid: 1913
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,12.5
       parent: 1
-  - uid: 1844
+  - uid: 1914
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,12.5
       parent: 1
-  - uid: 1845
+  - uid: 1915
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,12.5
       parent: 1
-  - uid: 1846
+  - uid: 1916
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,12.5
       parent: 1
-  - uid: 1847
+  - uid: 1917
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,12.5
       parent: 1
-  - uid: 1848
+  - uid: 1918
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,12.5
       parent: 1
-  - uid: 1849
+  - uid: 1919
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 35.5,12.5
       parent: 1
-  - uid: 1850
+  - uid: 1920
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,12.5
       parent: 1
-  - uid: 1851
+  - uid: 1921
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 1
 - proto: DisposalTrunk
   entities:
-  - uid: 1852
+  - uid: 1922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,22.5
       parent: 1
-  - uid: 1853
+  - uid: 1923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 1
-  - uid: 1854
+  - uid: 1924
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
-  - uid: 1855
+  - uid: 1925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,8.5
       parent: 1
-  - uid: 1856
+  - uid: 1926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12788,283 +12810,283 @@ entities:
       parent: 1
 - proto: DisposalUnit
   entities:
-  - uid: 1857
+  - uid: 1927
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 1858
+  - uid: 1928
     components:
     - type: Transform
       pos: -5.5,34.5
       parent: 1
-  - uid: 1859
+  - uid: 1929
     components:
     - type: Transform
       pos: -14.5,8.5
       parent: 1
-  - uid: 1860
+  - uid: 1930
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 1861
+  - uid: 1931
     components:
     - type: Transform
       pos: 16.5,22.5
       parent: 1
 - proto: DresserFilled
   entities:
-  - uid: 1862
+  - uid: 1932
     components:
     - type: Transform
       pos: -8.5,14.5
       parent: 1
-  - uid: 1863
+  - uid: 1933
     components:
     - type: Transform
       pos: -2.5,15.5
       parent: 1
-  - uid: 1864
+  - uid: 1934
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 1
-  - uid: 1865
+  - uid: 1935
     components:
     - type: Transform
       pos: -10.5,5.5
       parent: 1
 - proto: DrinkAleBottleFull
   entities:
-  - uid: 1866
+  - uid: 1936
     components:
     - type: Transform
       pos: 15.627389,28.319477
       parent: 1
 - proto: DrinkBeerBottleFull
   entities:
-  - uid: 1867
+  - uid: 1937
     components:
     - type: Transform
       pos: 15.679472,29.454895
       parent: 1
-  - uid: 1868
+  - uid: 1938
     components:
     - type: Transform
       pos: 15.346139,29.017395
       parent: 1
 - proto: EmergencyLight
   entities:
-  - uid: 1869
+  - uid: 1939
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 1870
+  - uid: 1940
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,2.5
       parent: 1
-  - uid: 1871
+  - uid: 1941
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-8.5
       parent: 1
-  - uid: 1872
+  - uid: 1942
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 1873
+  - uid: 1943
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 1874
+  - uid: 1944
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 1875
+  - uid: 1945
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-1.5
       parent: 1
-  - uid: 1876
+  - uid: 1946
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 1877
+  - uid: 1947
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 1878
+  - uid: 1948
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
-  - uid: 1879
+  - uid: 1949
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 1
-  - uid: 1880
+  - uid: 1950
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,9.5
       parent: 1
-  - uid: 1881
+  - uid: 1951
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,14.5
       parent: 1
-  - uid: 1882
+  - uid: 1952
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,14.5
       parent: 1
-  - uid: 1883
+  - uid: 1953
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,15.5
       parent: 1
-  - uid: 1884
+  - uid: 1954
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,18.5
       parent: 1
-  - uid: 1885
+  - uid: 1955
     components:
     - type: Transform
       pos: -6.5,17.5
       parent: 1
-  - uid: 1886
+  - uid: 1956
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,12.5
       parent: 1
-  - uid: 1887
+  - uid: 1957
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,10.5
       parent: 1
-  - uid: 1888
+  - uid: 1958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,8.5
       parent: 1
-  - uid: 1889
+  - uid: 1959
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,8.5
       parent: 1
-  - uid: 1890
+  - uid: 1960
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,7.5
       parent: 1
-  - uid: 1891
+  - uid: 1961
     components:
     - type: Transform
       pos: -21.5,16.5
       parent: 1
-  - uid: 1892
+  - uid: 1962
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,18.5
       parent: 1
-  - uid: 1893
+  - uid: 1963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,18.5
       parent: 1
-  - uid: 1894
+  - uid: 1964
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,18.5
       parent: 1
-  - uid: 1895
+  - uid: 1965
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,5.5
       parent: 1
-  - uid: 1896
+  - uid: 1966
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,5.5
       parent: 1
-  - uid: 1897
+  - uid: 1967
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,4.5
       parent: 1
-  - uid: 1898
+  - uid: 1968
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-1.5
       parent: 1
-  - uid: 1899
+  - uid: 1969
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-0.5
       parent: 1
-  - uid: 1900
+  - uid: 1970
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 1901
+  - uid: 1971
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-1.5
       parent: 1
-  - uid: 1902
+  - uid: 1972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,22.5
       parent: 1
-  - uid: 1903
+  - uid: 1973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,23.5
       parent: 1
-  - uid: 1904
+  - uid: 1974
     components:
     - type: Transform
       pos: 8.5,22.5
       parent: 1
-  - uid: 1905
+  - uid: 1975
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13072,38 +13094,38 @@ entities:
       parent: 1
 - proto: FactionLathe
   entities:
-  - uid: 1906
+  - uid: 1976
     components:
     - type: Transform
       pos: -20.5,6.5
       parent: 1
 - proto: FaxMachineNFCove
   entities:
-  - uid: 1907
+  - uid: 1977
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
 - proto: filingCabinetDrawerRandom
   entities:
-  - uid: 1908
+  - uid: 1978
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 1909
+  - uid: 1979
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 1910
+  - uid: 1980
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 1911
+  - uid: 1981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13111,8 +13133,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1955
-  - uid: 1912
+      - 2025
+  - uid: 1982
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13120,10 +13142,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1939
-      - 1938
-      - 1937
-  - uid: 1913
+      - 2009
+      - 2008
+      - 2007
+  - uid: 1983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13131,11 +13153,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1940
-      - 1955
-      - 1954
-      - 1939
-  - uid: 1914
+      - 2010
+      - 2025
+      - 2024
+      - 2009
+  - uid: 1984
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13143,14 +13165,14 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1954
-      - 1956
-      - 1958
-      - 1957
-      - 1961
-      - 1950
-      - 1949
-  - uid: 1915
+      - 2024
+      - 2026
+      - 2028
+      - 2027
+      - 2031
+      - 2020
+      - 2019
+  - uid: 1985
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13158,8 +13180,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1958
-  - uid: 1916
+      - 2028
+  - uid: 1986
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13167,18 +13189,18 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1956
-  - uid: 1917
+      - 2026
+  - uid: 1987
     components:
     - type: Transform
       pos: -17.5,12.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1960
-      - 1957
-      - 1959
-  - uid: 1918
+      - 2030
+      - 2027
+      - 2029
+  - uid: 1988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13186,8 +13208,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1960
-  - uid: 1919
+      - 2030
+  - uid: 1989
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13195,8 +13217,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1959
-  - uid: 1920
+      - 2029
+  - uid: 1990
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13204,8 +13226,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1962
-  - uid: 1921
+      - 2032
+  - uid: 1991
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13213,20 +13235,20 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1962
-      - 1961
-      - 1963
-      - 1947
-  - uid: 1922
+      - 2032
+      - 2031
+      - 2033
+      - 2017
+  - uid: 1992
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1963
-      - 1943
-  - uid: 1923
+      - 2033
+      - 2013
+  - uid: 1993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13234,13 +13256,13 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1948
-      - 1967
-      - 1966
-      - 1951
-      - 1965
-      - 1964
-  - uid: 1924
+      - 2018
+      - 2037
+      - 2036
+      - 2021
+      - 2035
+      - 2034
+  - uid: 1994
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13248,9 +13270,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1967
-      - 1966
-  - uid: 1925
+      - 2037
+      - 2036
+  - uid: 1995
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13258,9 +13280,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1965
-      - 1964
-  - uid: 1926
+      - 2035
+      - 2034
+  - uid: 1996
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13268,13 +13290,13 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1936
-      - 1950
-      - 1949
+      - 2006
+      - 2020
+      - 2019
       - 119
       - 121
       - 120
-  - uid: 1927
+  - uid: 1997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13282,8 +13304,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1944
-  - uid: 1928
+      - 2014
+  - uid: 1998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13291,14 +13313,14 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1945
-      - 1947
-      - 1944
-      - 1936
-      - 1937
-      - 1943
-      - 1942
-  - uid: 1929
+      - 2015
+      - 2017
+      - 2014
+      - 2006
+      - 2007
+      - 2013
+      - 2012
+  - uid: 1999
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13306,15 +13328,15 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1946
-      - 1945
-  - uid: 1930
+      - 2016
+      - 2015
+  - uid: 2000
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 1931
+  - uid: 2001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13322,40 +13344,40 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1971
-      - 1953
-      - 1968
-      - 1970
-      - 1969
-  - uid: 1932
+      - 2041
+      - 2023
+      - 2038
+      - 2040
+      - 2039
+  - uid: 2002
     components:
     - type: Transform
       pos: 19.5,25.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1971
-      - 1972
-  - uid: 1933
+      - 2041
+      - 2042
+  - uid: 2003
     components:
     - type: Transform
       pos: 23.5,26.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1972
-  - uid: 1934
+      - 2042
+  - uid: 2004
     components:
     - type: Transform
       pos: 25.5,13.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1952
-      - 1973
+      - 2022
+      - 2043
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 1935
+  - uid: 2005
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13363,165 +13385,165 @@ entities:
       parent: 1
 - proto: Firelock
   entities:
-  - uid: 1936
+  - uid: 2006
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1928
+      - 1998
       - 19
-      - 1926
+      - 1996
       - 17
-  - uid: 1937
+  - uid: 2007
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1928
+      - 1998
       - 19
-      - 1912
+      - 1982
       - 3
-  - uid: 1938
+  - uid: 2008
     components:
     - type: Transform
       pos: 7.5,13.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1912
+      - 1982
       - 3
-  - uid: 1939
+  - uid: 2009
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1912
+      - 1982
       - 3
-      - 1913
+      - 1983
       - 4
-  - uid: 1940
+  - uid: 2010
     components:
     - type: Transform
       pos: 3.5,17.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1913
+      - 1983
       - 4
-  - uid: 1941
+  - uid: 2011
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 1942
+  - uid: 2012
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1928
+      - 1998
       - 19
-  - uid: 1943
+  - uid: 2013
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1928
+      - 1998
       - 19
-      - 1922
+      - 1992
       - 13
-  - uid: 1944
+  - uid: 2014
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1928
+      - 1998
       - 19
-      - 1927
+      - 1997
       - 18
-  - uid: 1945
+  - uid: 2015
     components:
     - type: Transform
       pos: -9.5,-0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1929
+      - 1999
       - 20
-      - 1928
+      - 1998
       - 19
-  - uid: 1946
+  - uid: 2016
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1929
+      - 1999
       - 20
-  - uid: 1947
+  - uid: 2017
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1928
+      - 1998
       - 19
-      - 1921
+      - 1991
       - 12
-  - uid: 1948
+  - uid: 2018
     components:
     - type: Transform
       pos: -12.5,29.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1923
+      - 1993
       - 14
-  - uid: 1949
+  - uid: 2019
     components:
     - type: Transform
       pos: -6.5,15.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1926
+      - 1996
       - 17
-      - 1914
-  - uid: 1950
+      - 1984
+  - uid: 2020
     components:
     - type: Transform
       pos: -11.5,11.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1926
+      - 1996
       - 17
-      - 1914
-  - uid: 1951
+      - 1984
+  - uid: 2021
     components:
     - type: Transform
       pos: 10.5,32.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1923
+      - 1993
       - 14
 - proto: FirelockGlass
   entities:
-  - uid: 1952
+  - uid: 2022
     components:
     - type: Transform
       pos: 32.5,12.5
@@ -13530,8 +13552,8 @@ entities:
       configurators:
       - invalid
       deviceLists:
-      - 1934
-  - uid: 1953
+      - 2004
+  - uid: 2023
     components:
     - type: Transform
       pos: 11.5,29.5
@@ -13539,162 +13561,162 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 24
-      - 1931
-  - uid: 1954
+      - 2001
+  - uid: 2024
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1913
+      - 1983
       - 4
-      - 1914
+      - 1984
       - 5
-  - uid: 1955
+  - uid: 2025
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1911
+      - 1981
       - 2
-      - 1913
+      - 1983
       - 4
-  - uid: 1956
+  - uid: 2026
     components:
     - type: Transform
       pos: -7.5,20.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1914
+      - 1984
       - 5
-      - 1916
+      - 1986
       - 7
-  - uid: 1957
+  - uid: 2027
     components:
     - type: Transform
       pos: -15.5,11.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1914
+      - 1984
       - 5
-      - 1917
+      - 1987
       - 9
-  - uid: 1958
+  - uid: 2028
     components:
     - type: Transform
       pos: -14.5,16.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1914
+      - 1984
       - 5
-      - 1915
+      - 1985
       - 6
-  - uid: 1959
+  - uid: 2029
     components:
     - type: Transform
       pos: -21.5,9.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1917
+      - 1987
       - 9
-      - 1919
+      - 1989
       - 10
-  - uid: 1960
+  - uid: 2030
     components:
     - type: Transform
       pos: -19.5,12.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1918
+      - 1988
       - 8
-      - 1917
+      - 1987
       - 9
-  - uid: 1961
+  - uid: 2031
     components:
     - type: Transform
       pos: -12.5,7.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1914
+      - 1984
       - 5
-      - 1921
+      - 1991
       - 12
-  - uid: 1962
+  - uid: 2032
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1920
+      - 1990
       - 11
-      - 1921
+      - 1991
       - 12
-  - uid: 1963
+  - uid: 2033
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1921
+      - 1991
       - 12
-      - 1922
+      - 1992
       - 13
-  - uid: 1964
+  - uid: 2034
     components:
     - type: Transform
       pos: 8.5,37.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1923
+      - 1993
       - 14
-      - 1925
+      - 1995
       - 15
-  - uid: 1965
+  - uid: 2035
     components:
     - type: Transform
       pos: 9.5,37.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1923
+      - 1993
       - 14
-      - 1925
+      - 1995
       - 15
-  - uid: 1966
+  - uid: 2036
     components:
     - type: Transform
       pos: -15.5,32.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1923
+      - 1993
       - 14
-      - 1924
+      - 1994
       - 16
-  - uid: 1967
+  - uid: 2037
     components:
     - type: Transform
       pos: -14.5,32.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1923
+      - 1993
       - 14
-      - 1924
+      - 1994
       - 16
-  - uid: 1968
+  - uid: 2038
     components:
     - type: Transform
       pos: 11.5,28.5
@@ -13702,8 +13724,8 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 24
-      - 1931
-  - uid: 1969
+      - 2001
+  - uid: 2039
     components:
     - type: Transform
       pos: 11.5,26.5
@@ -13711,8 +13733,8 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 24
-      - 1931
-  - uid: 1970
+      - 2001
+  - uid: 2040
     components:
     - type: Transform
       pos: 11.5,27.5
@@ -13720,30 +13742,30 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 24
-      - 1931
-  - uid: 1971
+      - 2001
+  - uid: 2041
     components:
     - type: Transform
       pos: 18.5,25.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1932
+      - 2002
       - 25
-      - 1931
+      - 2001
       - 24
-  - uid: 1972
+  - uid: 2042
     components:
     - type: Transform
       pos: 21.5,22.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1932
+      - 2002
       - 25
-      - 1933
+      - 2003
       - 26
-  - uid: 1973
+  - uid: 2043
     components:
     - type: Transform
       pos: 12.5,17.5
@@ -13752,101 +13774,101 @@ entities:
       configurators:
       - invalid
       deviceLists:
-      - 1934
+      - 2004
 - proto: Fireplace
   entities:
-  - uid: 1974
+  - uid: 2044
     components:
     - type: Transform
       pos: -8.5,5.5
       parent: 1
 - proto: FlippoEngravedLighter
   entities:
-  - uid: 1975
+  - uid: 2045
     components:
     - type: Transform
       pos: -10.53125,3.625
       parent: 1
 - proto: Floodlight
   entities:
-  - uid: 4151
+  - uid: 2046
     components:
     - type: Transform
       pos: 18.561232,10.440996
       parent: 1
 - proto: FloorDrain
   entities:
-  - uid: 1976
+  - uid: 2047
     components:
     - type: Transform
       pos: -21.5,15.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1977
+  - uid: 2048
     components:
     - type: Transform
       pos: -20.5,14.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1978
+  - uid: 2049
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1979
+  - uid: 2050
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1980
+  - uid: 2051
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1981
+  - uid: 2052
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1982
+  - uid: 2053
     components:
     - type: Transform
       pos: 17.5,27.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1983
+  - uid: 2054
     components:
     - type: Transform
       pos: 13.5,20.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1984
+  - uid: 2055
     components:
     - type: Transform
       pos: 17.5,29.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1985
+  - uid: 2056
     components:
     - type: Transform
       pos: 18.5,22.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1986
+  - uid: 2057
     components:
     - type: Transform
       pos: 23.5,20.5
@@ -13855,7 +13877,7 @@ entities:
       fixtures: {}
 - proto: GasFilter
   entities:
-  - uid: 1987
+  - uid: 2058
     components:
     - type: Transform
       pos: -23.5,8.5
@@ -13864,7 +13886,7 @@ entities:
       filteredGas: NitrousOxide
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 1988
+  - uid: 2059
     components:
     - type: Transform
       pos: -23.5,7.5
@@ -13875,21 +13897,21 @@ entities:
       color: '#DD0075FF'
 - proto: GasMinerNitrogenStationLarge
   entities:
-  - uid: 1989
+  - uid: 2060
     components:
     - type: Transform
       pos: 6.5,27.5
       parent: 1
 - proto: GasMinerOxygenStationLarge
   entities:
-  - uid: 1990
+  - uid: 2061
     components:
     - type: Transform
       pos: 8.5,25.5
       parent: 1
 - proto: GasMixerOnFlipped
   entities:
-  - uid: 1991
+  - uid: 2062
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13903,14 +13925,14 @@ entities:
       color: '#00AACCFF'
 - proto: GasPassiveGate
   entities:
-  - uid: 1992
+  - uid: 2063
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 1993
+  - uid: 2064
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13918,7 +13940,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 1994
+  - uid: 2065
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13928,53 +13950,53 @@ entities:
       color: '#00AACCFF'
 - proto: GasPassiveVent
   entities:
-  - uid: 1995
+  - uid: 2066
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,21.5
       parent: 1
-  - uid: 1996
+  - uid: 2067
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,24.5
       parent: 1
-  - uid: 1997
+  - uid: 2068
     components:
     - type: Transform
       pos: 5.5,27.5
       parent: 1
-  - uid: 1998
+  - uid: 2069
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,12.5
       parent: 1
-  - uid: 1999
+  - uid: 2070
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,14.5
       parent: 1
-  - uid: 2000
+  - uid: 2071
     components:
     - type: Transform
       pos: -9.5,13.5
       parent: 1
-  - uid: 2001
+  - uid: 2072
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,8.5
       parent: 1
-  - uid: 2002
+  - uid: 2073
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,7.5
       parent: 1
-  - uid: 2003
+  - uid: 2074
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13982,7 +14004,7 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 2004
+  - uid: 2075
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13990,7 +14012,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2005
+  - uid: 2076
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13998,7 +14020,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2006
+  - uid: 2077
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14006,7 +14028,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2007
+  - uid: 2078
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14014,7 +14036,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2008
+  - uid: 2079
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14022,25 +14044,25 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2009
+  - uid: 2080
     components:
     - type: Transform
       pos: 6.5,23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2010
+  - uid: 2081
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,24.5
       parent: 1
-  - uid: 2011
+  - uid: 2082
     components:
     - type: Transform
       pos: 6.5,25.5
       parent: 1
-  - uid: 2012
+  - uid: 2083
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14048,19 +14070,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2013
+  - uid: 2084
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,6.5
       parent: 1
-  - uid: 2014
+  - uid: 2085
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,6.5
       parent: 1
-  - uid: 2015
+  - uid: 2086
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14068,13 +14090,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2016
+  - uid: 2087
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,9.5
       parent: 1
-  - uid: 2017
+  - uid: 2088
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14082,7 +14104,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2018
+  - uid: 2089
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14090,7 +14112,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2019
+  - uid: 2090
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14098,7 +14120,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2020
+  - uid: 2091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14106,14 +14128,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2021
+  - uid: 2092
     components:
     - type: Transform
       pos: -20.5,13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2022
+  - uid: 2093
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14121,7 +14143,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2023
+  - uid: 2094
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14129,7 +14151,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2024
+  - uid: 2095
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14137,7 +14159,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2025
+  - uid: 2096
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14145,7 +14167,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2026
+  - uid: 2097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14153,7 +14175,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2027
+  - uid: 2098
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14161,14 +14183,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2028
+  - uid: 2099
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2029
+  - uid: 2100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14176,7 +14198,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2030
+  - uid: 2101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14184,7 +14206,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2031
+  - uid: 2102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14192,7 +14214,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2032
+  - uid: 2103
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14200,7 +14222,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2033
+  - uid: 2104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14208,7 +14230,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2034
+  - uid: 2105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14216,7 +14238,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2035
+  - uid: 2106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14224,7 +14246,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2036
+  - uid: 2107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14232,7 +14254,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2037
+  - uid: 2108
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14240,7 +14262,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2038
+  - uid: 2109
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14248,7 +14270,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2039
+  - uid: 2110
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14256,7 +14278,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2040
+  - uid: 2111
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14264,14 +14286,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2041
+  - uid: 2112
     components:
     - type: Transform
       pos: -16.5,18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2042
+  - uid: 2113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14279,7 +14301,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2043
+  - uid: 2114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14287,14 +14309,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2044
+  - uid: 2115
     components:
     - type: Transform
       pos: -7.5,18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2045
+  - uid: 2116
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14302,26 +14324,26 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2046
+  - uid: 2117
     components:
     - type: Transform
       pos: -4.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2047
+  - uid: 2118
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,10.5
       parent: 1
-  - uid: 2048
+  - uid: 2119
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,12.5
       parent: 1
-  - uid: 2049
+  - uid: 2120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14329,14 +14351,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2050
+  - uid: 2121
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2051
+  - uid: 2122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14344,7 +14366,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2052
+  - uid: 2123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14352,7 +14374,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2053
+  - uid: 2124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14360,7 +14382,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2054
+  - uid: 2125
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14368,7 +14390,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2055
+  - uid: 2126
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14376,7 +14398,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2056
+  - uid: 2127
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14384,7 +14406,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2057
+  - uid: 2128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14392,7 +14414,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2058
+  - uid: 2129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14400,7 +14422,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2059
+  - uid: 2130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14408,7 +14430,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2060
+  - uid: 2131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14416,7 +14438,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2061
+  - uid: 2132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14424,7 +14446,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2062
+  - uid: 2133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14432,7 +14454,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2063
+  - uid: 2134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14440,14 +14462,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2064
+  - uid: 2135
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2065
+  - uid: 2136
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14455,7 +14477,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2066
+  - uid: 2137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14463,7 +14485,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2067
+  - uid: 2138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14471,7 +14493,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2068
+  - uid: 2139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14479,7 +14501,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2069
+  - uid: 2140
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14487,7 +14509,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2070
+  - uid: 2141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14495,7 +14517,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2071
+  - uid: 2142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14503,7 +14525,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2072
+  - uid: 2143
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14511,7 +14533,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2073
+  - uid: 2144
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14519,7 +14541,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2074
+  - uid: 2145
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14527,7 +14549,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2075
+  - uid: 2146
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14535,7 +14557,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2076
+  - uid: 2147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14543,7 +14565,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2077
+  - uid: 2148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14551,7 +14573,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2078
+  - uid: 2149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14559,14 +14581,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2079
+  - uid: 2150
     components:
     - type: Transform
       pos: 20.5,24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2080
+  - uid: 2151
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14574,14 +14596,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2081
+  - uid: 2152
     components:
     - type: Transform
       pos: 18.5,28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2082
+  - uid: 2153
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14589,7 +14611,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2083
+  - uid: 2154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14597,21 +14619,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2084
+  - uid: 2155
     components:
     - type: Transform
       pos: 11.5,34.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2085
+  - uid: 2156
     components:
     - type: Transform
       pos: 19.5,23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2086
+  - uid: 2157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14619,21 +14641,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2087
+  - uid: 2158
     components:
     - type: Transform
       pos: 25.5,22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2088
+  - uid: 2159
     components:
     - type: Transform
       pos: 10.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2089
+  - uid: 2160
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14641,7 +14663,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2090
+  - uid: 2161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14651,40 +14673,40 @@ entities:
       color: '#00AACCFF'
 - proto: GasPipeFourway
   entities:
-  - uid: 2091
+  - uid: 2162
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2092
+  - uid: 2163
     components:
     - type: Transform
       pos: -24.5,9.5
       parent: 1
-  - uid: 2093
+  - uid: 2164
     components:
     - type: Transform
       pos: -13.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2094
+  - uid: 2165
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2095
+  - uid: 2166
     components:
     - type: Transform
       pos: -9.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2096
+  - uid: 2167
     components:
     - type: Transform
       pos: 8.5,33.5
@@ -14693,7 +14715,7 @@ entities:
       color: '#00AACCFF'
 - proto: GasPipeStraight
   entities:
-  - uid: 2097
+  - uid: 2168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14701,35 +14723,35 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2098
+  - uid: 2169
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2099
+  - uid: 2170
     components:
     - type: Transform
       pos: -0.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2100
+  - uid: 2171
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2101
+  - uid: 2172
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2102
+  - uid: 2173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14737,7 +14759,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2103
+  - uid: 2174
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14745,7 +14767,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2104
+  - uid: 2175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14753,7 +14775,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2105
+  - uid: 2176
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14761,7 +14783,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2106
+  - uid: 2177
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14769,7 +14791,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2107
+  - uid: 2178
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14777,18 +14799,18 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2108
+  - uid: 2179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,24.5
       parent: 1
-  - uid: 2109
+  - uid: 2180
     components:
     - type: Transform
       pos: 5.5,26.5
       parent: 1
-  - uid: 2110
+  - uid: 2181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14796,555 +14818,11 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2111
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2112
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2113
-    components:
-    - type: Transform
-      pos: -24.5,7.5
-      parent: 1
-  - uid: 2114
-    components:
-    - type: Transform
-      pos: -24.5,8.5
-      parent: 1
-  - uid: 2115
-    components:
-    - type: Transform
-      pos: -25.5,6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2116
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2117
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2118
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2119
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2120
-    components:
-    - type: Transform
-      pos: -19.5,14.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2121
-    components:
-    - type: Transform
-      pos: -19.5,13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2122
-    components:
-    - type: Transform
-      pos: -19.5,12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2123
-    components:
-    - type: Transform
-      pos: -19.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2124
-    components:
-    - type: Transform
-      pos: -19.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2125
-    components:
-    - type: Transform
-      pos: -19.5,9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2126
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2127
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2128
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -21.5,13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2129
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2130
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2131
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2132
-    components:
-    - type: Transform
-      pos: -16.5,9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2133
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2134
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2135
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2136
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2137
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2138
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2139
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2140
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2141
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2142
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2143
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,14.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2144
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,15.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2145
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2146
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,14.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2147
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,15.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2148
-    components:
-    - type: Transform
-      pos: -13.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2149
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2150
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2151
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2152
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2153
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2154
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2155
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2156
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2157
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2158
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2159
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2160
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2161
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2162
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2163
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2164
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2165
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2166
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2167
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2168
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2169
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,18.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2170
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2171
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,19.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2172
-    components:
-    - type: Transform
-      pos: -0.5,15.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2173
-    components:
-    - type: Transform
-      pos: 1.5,15.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2174
-    components:
-    - type: Transform
-      pos: 1.5,14.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2175
-    components:
-    - type: Transform
-      pos: -0.5,13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2176
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2177
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2178
-    components:
-    - type: Transform
-      pos: -0.5,12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2179
-    components:
-    - type: Transform
-      pos: -0.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2180
-    components:
-    - type: Transform
-      pos: -0.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2181
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
   - uid: 2182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,9.5
+      pos: -24.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -15352,11 +14830,555 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: -24.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2184
+    components:
+    - type: Transform
+      pos: -24.5,7.5
+      parent: 1
+  - uid: 2185
+    components:
+    - type: Transform
+      pos: -24.5,8.5
+      parent: 1
+  - uid: 2186
+    components:
+    - type: Transform
+      pos: -25.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2187
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2189
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2190
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2191
+    components:
+    - type: Transform
+      pos: -19.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2192
+    components:
+    - type: Transform
+      pos: -19.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2193
+    components:
+    - type: Transform
+      pos: -19.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2194
+    components:
+    - type: Transform
+      pos: -19.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2195
+    components:
+    - type: Transform
+      pos: -19.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2196
+    components:
+    - type: Transform
+      pos: -19.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2200
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2201
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2203
+    components:
+    - type: Transform
+      pos: -16.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2205
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2207
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2208
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2209
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2210
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2211
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2212
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2213
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2214
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2215
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2216
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2217
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2218
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2219
+    components:
+    - type: Transform
+      pos: -13.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2220
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2223
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2229
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2230
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2231
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2232
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2233
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2236
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2242
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,19.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2243
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2244
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2245
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2246
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2247
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2248
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2249
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2250
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2251
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2254
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 0.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2184
+  - uid: 2255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15364,7 +15386,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2185
+  - uid: 2256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15372,7 +15394,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2186
+  - uid: 2257
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15380,7 +15402,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2187
+  - uid: 2258
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15388,7 +15410,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2188
+  - uid: 2259
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15396,7 +15418,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2189
+  - uid: 2260
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15404,7 +15426,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2190
+  - uid: 2261
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15412,7 +15434,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2191
+  - uid: 2262
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15420,7 +15442,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2192
+  - uid: 2263
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15428,21 +15450,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2193
+  - uid: 2264
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2194
+  - uid: 2265
     components:
     - type: Transform
       pos: 9.5,12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2195
+  - uid: 2266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15450,7 +15472,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2196
+  - uid: 2267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15458,7 +15480,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2197
+  - uid: 2268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15466,7 +15488,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2198
+  - uid: 2269
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15474,7 +15496,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2199
+  - uid: 2270
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15482,7 +15504,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2200
+  - uid: 2271
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15490,7 +15512,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2201
+  - uid: 2272
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15498,7 +15520,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2202
+  - uid: 2273
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15506,7 +15528,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2203
+  - uid: 2274
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15514,7 +15536,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2204
+  - uid: 2275
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15522,126 +15544,126 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2205
+  - uid: 2276
     components:
     - type: Transform
       pos: 11.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2206
+  - uid: 2277
     components:
     - type: Transform
       pos: 11.5,12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2207
+  - uid: 2278
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2208
+  - uid: 2279
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2209
+  - uid: 2280
     components:
     - type: Transform
       pos: -12.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2210
+  - uid: 2281
     components:
     - type: Transform
       pos: -12.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2211
+  - uid: 2282
     components:
     - type: Transform
       pos: -12.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2212
+  - uid: 2283
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2213
+  - uid: 2284
     components:
     - type: Transform
       pos: -13.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2214
+  - uid: 2285
     components:
     - type: Transform
       pos: -13.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2215
+  - uid: 2286
     components:
     - type: Transform
       pos: -13.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2216
+  - uid: 2287
     components:
     - type: Transform
       pos: -13.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2217
+  - uid: 2288
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2218
+  - uid: 2289
     components:
     - type: Transform
       pos: -13.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2219
+  - uid: 2290
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2220
+  - uid: 2291
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2221
+  - uid: 2292
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2222
+  - uid: 2293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15649,7 +15671,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2223
+  - uid: 2294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15657,7 +15679,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2224
+  - uid: 2295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15665,7 +15687,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2225
+  - uid: 2296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15673,7 +15695,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2226
+  - uid: 2297
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15681,7 +15703,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2227
+  - uid: 2298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15689,7 +15711,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2228
+  - uid: 2299
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15697,7 +15719,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2229
+  - uid: 2300
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15705,7 +15727,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2230
+  - uid: 2301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15713,7 +15735,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2231
+  - uid: 2302
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15721,7 +15743,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2232
+  - uid: 2303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15729,119 +15751,119 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2233
+  - uid: 2304
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2234
+  - uid: 2305
     components:
     - type: Transform
       pos: -12.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2235
+  - uid: 2306
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2236
+  - uid: 2307
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2237
+  - uid: 2308
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2238
+  - uid: 2309
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2239
+  - uid: 2310
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2240
+  - uid: 2311
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2241
+  - uid: 2312
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2242
+  - uid: 2313
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2243
+  - uid: 2314
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2244
+  - uid: 2315
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2245
+  - uid: 2316
     components:
     - type: Transform
       pos: -13.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2246
+  - uid: 2317
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2247
+  - uid: 2318
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2248
+  - uid: 2319
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2249
+  - uid: 2320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15849,7 +15871,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2250
+  - uid: 2321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15857,7 +15879,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2251
+  - uid: 2322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15865,7 +15887,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2252
+  - uid: 2323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15873,7 +15895,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2253
+  - uid: 2324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15881,7 +15903,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2254
+  - uid: 2325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15889,7 +15911,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2255
+  - uid: 2326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15897,7 +15919,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2256
+  - uid: 2327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15905,7 +15927,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2257
+  - uid: 2328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15913,7 +15935,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2258
+  - uid: 2329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15921,7 +15943,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2259
+  - uid: 2330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15929,7 +15951,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2260
+  - uid: 2331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15937,7 +15959,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2261
+  - uid: 2332
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15945,7 +15967,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2262
+  - uid: 2333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15953,7 +15975,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2263
+  - uid: 2334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15961,7 +15983,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2264
+  - uid: 2335
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15969,7 +15991,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2265
+  - uid: 2336
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15977,7 +15999,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2266
+  - uid: 2337
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15985,7 +16007,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2267
+  - uid: 2338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15993,7 +16015,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2268
+  - uid: 2339
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16001,7 +16023,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2269
+  - uid: 2340
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16009,7 +16031,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2270
+  - uid: 2341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16017,7 +16039,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2271
+  - uid: 2342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16025,7 +16047,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2272
+  - uid: 2343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16033,7 +16055,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2273
+  - uid: 2344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16041,7 +16063,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2274
+  - uid: 2345
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16049,7 +16071,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2275
+  - uid: 2346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16057,7 +16079,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2276
+  - uid: 2347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16065,7 +16087,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2277
+  - uid: 2348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16073,7 +16095,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2278
+  - uid: 2349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16081,7 +16103,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2279
+  - uid: 2350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16089,7 +16111,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2280
+  - uid: 2351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16097,7 +16119,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2281
+  - uid: 2352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16105,7 +16127,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2282
+  - uid: 2353
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16113,7 +16135,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2283
+  - uid: 2354
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16121,7 +16143,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2284
+  - uid: 2355
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16129,7 +16151,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2285
+  - uid: 2356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16137,7 +16159,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2286
+  - uid: 2357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16145,7 +16167,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2287
+  - uid: 2358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16153,7 +16175,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2288
+  - uid: 2359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16161,7 +16183,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2289
+  - uid: 2360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16169,7 +16191,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2290
+  - uid: 2361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16177,7 +16199,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2291
+  - uid: 2362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16185,7 +16207,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2292
+  - uid: 2363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16193,7 +16215,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2293
+  - uid: 2364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16201,30 +16223,30 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2294
+  - uid: 2365
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 1
-  - uid: 2295
+  - uid: 2366
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,12.5
       parent: 1
-  - uid: 2296
+  - uid: 2367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,10.5
       parent: 1
-  - uid: 2297
+  - uid: 2368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,12.5
       parent: 1
-  - uid: 2298
+  - uid: 2369
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16232,13 +16254,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2299
+  - uid: 2370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,10.5
       parent: 1
-  - uid: 2300
+  - uid: 2371
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16246,7 +16268,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2301
+  - uid: 2372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16254,7 +16276,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2302
+  - uid: 2373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16262,7 +16284,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2303
+  - uid: 2374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16270,12 +16292,12 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2304
+  - uid: 2375
     components:
     - type: Transform
       pos: -9.5,9.5
       parent: 1
-  - uid: 2305
+  - uid: 2376
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16283,7 +16305,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2306
+  - uid: 2377
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16291,21 +16313,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2307
+  - uid: 2378
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2308
+  - uid: 2379
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2309
+  - uid: 2380
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16313,7 +16335,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2310
+  - uid: 2381
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16321,7 +16343,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2311
+  - uid: 2382
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16329,7 +16351,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2312
+  - uid: 2383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16337,7 +16359,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2313
+  - uid: 2384
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16345,7 +16367,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2314
+  - uid: 2385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16353,7 +16375,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2315
+  - uid: 2386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16361,7 +16383,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2316
+  - uid: 2387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16369,7 +16391,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2317
+  - uid: 2388
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16377,12 +16399,12 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2318
+  - uid: 2389
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 1
-  - uid: 2319
+  - uid: 2390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16390,7 +16412,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2320
+  - uid: 2391
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16398,7 +16420,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2321
+  - uid: 2392
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16406,12 +16428,12 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2322
+  - uid: 2393
     components:
     - type: Transform
       pos: -6.5,9.5
       parent: 1
-  - uid: 2323
+  - uid: 2394
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16419,7 +16441,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2324
+  - uid: 2395
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16427,7 +16449,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2325
+  - uid: 2396
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16435,7 +16457,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2326
+  - uid: 2397
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16443,7 +16465,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2327
+  - uid: 2398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16451,7 +16473,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2328
+  - uid: 2399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16459,557 +16481,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2329
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2330
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2331
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2332
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2333
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2334
-    components:
-    - type: Transform
-      pos: -1.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2335
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2336
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2337
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2338
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2339
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2340
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2341
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2342
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2343
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2344
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2345
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2346
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2347
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2348
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2349
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2350
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2351
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2352
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2353
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2354
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2355
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2356
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2357
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2358
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2359
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2360
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2361
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2362
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2363
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2364
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2365
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2366
-    components:
-    - type: Transform
-      pos: -3.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2367
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2368
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2369
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2370
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2371
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2372
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2373
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2374
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2375
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2376
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2377
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2378
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2379
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2380
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2381
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2382
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2383
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2384
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2385
-    components:
-    - type: Transform
-      pos: -12.5,18.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2386
-    components:
-    - type: Transform
-      pos: -12.5,19.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2387
-    components:
-    - type: Transform
-      pos: -12.5,20.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2388
-    components:
-    - type: Transform
-      pos: -12.5,21.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2389
-    components:
-    - type: Transform
-      pos: -12.5,22.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2390
-    components:
-    - type: Transform
-      pos: -12.5,23.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2391
-    components:
-    - type: Transform
-      pos: -12.5,24.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2392
-    components:
-    - type: Transform
-      pos: -12.5,25.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2393
-    components:
-    - type: Transform
-      pos: -12.5,26.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2394
-    components:
-    - type: Transform
-      pos: -12.5,27.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2395
-    components:
-    - type: Transform
-      pos: -12.5,28.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2396
-    components:
-    - type: Transform
-      pos: -12.5,29.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2397
-    components:
-    - type: Transform
-      pos: -12.5,30.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2398
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,31.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2399
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,31.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
   - uid: 2400
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,31.5
+      pos: -1.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
@@ -17017,11 +16492,558 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2402
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2403
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2405
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2406
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2407
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2409
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2411
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2412
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2414
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2415
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2417
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2418
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2419
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2421
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2422
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2423
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2424
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2425
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2426
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2427
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2429
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2430
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2431
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2432
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2433
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2434
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2435
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2436
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2437
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2438
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2439
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2440
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2442
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2443
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2444
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2445
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2446
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2447
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2448
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2449
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2450
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2451
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2452
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2453
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2454
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2455
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2456
+    components:
+    - type: Transform
+      pos: -12.5,18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2457
+    components:
+    - type: Transform
+      pos: -12.5,19.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2458
+    components:
+    - type: Transform
+      pos: -12.5,20.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2459
+    components:
+    - type: Transform
+      pos: -12.5,21.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2460
+    components:
+    - type: Transform
+      pos: -12.5,22.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2461
+    components:
+    - type: Transform
+      pos: -12.5,23.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2462
+    components:
+    - type: Transform
+      pos: -12.5,24.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2463
+    components:
+    - type: Transform
+      pos: -12.5,25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2464
+    components:
+    - type: Transform
+      pos: -12.5,26.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2465
+    components:
+    - type: Transform
+      pos: -12.5,27.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2466
+    components:
+    - type: Transform
+      pos: -12.5,28.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2467
+    components:
+    - type: Transform
+      pos: -12.5,29.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2468
+    components:
+    - type: Transform
+      pos: -12.5,30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2470
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2471
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 2472
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -7.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2402
+  - uid: 2473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17029,7 +17051,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2403
+  - uid: 2474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17037,14 +17059,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2404
+  - uid: 2475
     components:
     - type: Transform
       pos: -4.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2405
+  - uid: 2476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17052,7 +17074,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2406
+  - uid: 2477
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17060,7 +17082,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2407
+  - uid: 2478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17068,7 +17090,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2408
+  - uid: 2479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17076,7 +17098,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2409
+  - uid: 2480
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17084,7 +17106,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2410
+  - uid: 2481
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17092,7 +17114,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2411
+  - uid: 2482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17100,7 +17122,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2412
+  - uid: 2483
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17108,7 +17130,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2413
+  - uid: 2484
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17116,7 +17138,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2414
+  - uid: 2485
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17124,7 +17146,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2415
+  - uid: 2486
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17132,7 +17154,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2416
+  - uid: 2487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17140,28 +17162,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2417
+  - uid: 2488
     components:
     - type: Transform
       pos: -14.5,34.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2418
+  - uid: 2489
     components:
     - type: Transform
       pos: -14.5,33.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2419
+  - uid: 2490
     components:
     - type: Transform
       pos: -14.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2420
+  - uid: 2491
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17169,7 +17191,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2421
+  - uid: 2492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17177,7 +17199,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2422
+  - uid: 2493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17185,7 +17207,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2423
+  - uid: 2494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17193,7 +17215,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2424
+  - uid: 2495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17201,7 +17223,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2425
+  - uid: 2496
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17209,7 +17231,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2426
+  - uid: 2497
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17217,14 +17239,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2427
+  - uid: 2498
     components:
     - type: Transform
       pos: -13.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2428
+  - uid: 2499
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17232,7 +17254,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2429
+  - uid: 2500
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17240,7 +17262,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2430
+  - uid: 2501
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17248,7 +17270,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2431
+  - uid: 2502
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17256,7 +17278,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2432
+  - uid: 2503
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17264,7 +17286,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2433
+  - uid: 2504
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17272,7 +17294,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2434
+  - uid: 2505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17280,7 +17302,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2435
+  - uid: 2506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17288,7 +17310,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2436
+  - uid: 2507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17296,7 +17318,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2437
+  - uid: 2508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17304,7 +17326,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2438
+  - uid: 2509
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17312,7 +17334,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2439
+  - uid: 2510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17320,7 +17342,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2440
+  - uid: 2511
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17328,7 +17350,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2441
+  - uid: 2512
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17336,7 +17358,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2442
+  - uid: 2513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17344,35 +17366,35 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2443
+  - uid: 2514
     components:
     - type: Transform
       pos: -11.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2444
+  - uid: 2515
     components:
     - type: Transform
       pos: -11.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2445
+  - uid: 2516
     components:
     - type: Transform
       pos: -11.5,18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2446
+  - uid: 2517
     components:
     - type: Transform
       pos: -11.5,17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2447
+  - uid: 2518
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17380,7 +17402,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2448
+  - uid: 2519
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17388,7 +17410,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2449
+  - uid: 2520
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17396,7 +17418,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2450
+  - uid: 2521
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17404,7 +17426,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2451
+  - uid: 2522
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17412,7 +17434,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2452
+  - uid: 2523
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17420,7 +17442,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2453
+  - uid: 2524
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17428,7 +17450,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2454
+  - uid: 2525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17436,7 +17458,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2455
+  - uid: 2526
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17444,7 +17466,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2456
+  - uid: 2527
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17452,7 +17474,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2457
+  - uid: 2528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17460,7 +17482,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2458
+  - uid: 2529
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17468,7 +17490,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2459
+  - uid: 2530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17476,7 +17498,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2460
+  - uid: 2531
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17484,7 +17506,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2461
+  - uid: 2532
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17492,7 +17514,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2462
+  - uid: 2533
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17500,7 +17522,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2463
+  - uid: 2534
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17508,7 +17530,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2464
+  - uid: 2535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17516,7 +17538,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2465
+  - uid: 2536
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17524,7 +17546,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2466
+  - uid: 2537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17532,7 +17554,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2467
+  - uid: 2538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17540,7 +17562,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2468
+  - uid: 2539
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17548,7 +17570,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2469
+  - uid: 2540
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17556,7 +17578,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2470
+  - uid: 2541
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17564,7 +17586,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2471
+  - uid: 2542
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17572,7 +17594,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2472
+  - uid: 2543
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17580,7 +17602,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2473
+  - uid: 2544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17588,7 +17610,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2474
+  - uid: 2545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17596,7 +17618,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2475
+  - uid: 2546
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17604,35 +17626,35 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2476
+  - uid: 2547
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2477
+  - uid: 2548
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2478
+  - uid: 2549
     components:
     - type: Transform
       pos: -10.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2479
+  - uid: 2550
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2480
+  - uid: 2551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17640,7 +17662,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2481
+  - uid: 2552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17648,7 +17670,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2482
+  - uid: 2553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17656,7 +17678,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2483
+  - uid: 2554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17664,7 +17686,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2484
+  - uid: 2555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17672,7 +17694,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2485
+  - uid: 2556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17680,7 +17702,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2486
+  - uid: 2557
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17688,7 +17710,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2487
+  - uid: 2558
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17696,7 +17718,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2488
+  - uid: 2559
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17704,7 +17726,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2489
+  - uid: 2560
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17712,7 +17734,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2490
+  - uid: 2561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17720,7 +17742,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2491
+  - uid: 2562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17728,7 +17750,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2492
+  - uid: 2563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17736,7 +17758,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2493
+  - uid: 2564
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17744,7 +17766,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2494
+  - uid: 2565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17752,42 +17774,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2495
+  - uid: 2566
     components:
     - type: Transform
       pos: 11.5,29.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2496
+  - uid: 2567
     components:
     - type: Transform
       pos: 11.5,30.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2497
+  - uid: 2568
     components:
     - type: Transform
       pos: 11.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2498
+  - uid: 2569
     components:
     - type: Transform
       pos: 11.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2499
+  - uid: 2570
     components:
     - type: Transform
       pos: 11.5,33.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2500
+  - uid: 2571
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17795,7 +17817,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2501
+  - uid: 2572
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17803,7 +17825,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2502
+  - uid: 2573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17811,7 +17833,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2503
+  - uid: 2574
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17819,7 +17841,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2504
+  - uid: 2575
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17827,7 +17849,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2505
+  - uid: 2576
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17835,7 +17857,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2506
+  - uid: 2577
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17843,7 +17865,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2507
+  - uid: 2578
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17851,7 +17873,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2508
+  - uid: 2579
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17859,7 +17881,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2509
+  - uid: 2580
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17867,7 +17889,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2510
+  - uid: 2581
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17875,7 +17897,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2511
+  - uid: 2582
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17883,7 +17905,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2512
+  - uid: 2583
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17891,7 +17913,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2513
+  - uid: 2584
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17899,7 +17921,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2514
+  - uid: 2585
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17907,7 +17929,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2515
+  - uid: 2586
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17915,7 +17937,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2516
+  - uid: 2587
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17923,7 +17945,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2517
+  - uid: 2588
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17931,7 +17953,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2518
+  - uid: 2589
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17939,7 +17961,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2519
+  - uid: 2590
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17947,42 +17969,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2520
+  - uid: 2591
     components:
     - type: Transform
       pos: 10.5,27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2521
+  - uid: 2592
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2522
+  - uid: 2593
     components:
     - type: Transform
       pos: 10.5,29.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2523
+  - uid: 2594
     components:
     - type: Transform
       pos: 10.5,30.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2524
+  - uid: 2595
     components:
     - type: Transform
       pos: 10.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2525
+  - uid: 2596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17992,7 +18014,7 @@ entities:
       color: '#00AACCFF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 2526
+  - uid: 2597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18000,7 +18022,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2527
+  - uid: 2598
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18008,7 +18030,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2528
+  - uid: 2599
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18016,7 +18038,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2529
+  - uid: 2600
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18024,7 +18046,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2530
+  - uid: 2601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18032,7 +18054,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2531
+  - uid: 2602
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18040,7 +18062,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2532
+  - uid: 2603
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18048,14 +18070,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2533
+  - uid: 2604
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2534
+  - uid: 2605
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18063,7 +18085,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2535
+  - uid: 2606
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18071,7 +18093,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2536
+  - uid: 2607
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18079,7 +18101,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2537
+  - uid: 2608
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18087,13 +18109,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2538
+  - uid: 2609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,9.5
       parent: 1
-  - uid: 2539
+  - uid: 2610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18101,7 +18123,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2540
+  - uid: 2611
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18109,7 +18131,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2541
+  - uid: 2612
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18117,7 +18139,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2542
+  - uid: 2613
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18125,14 +18147,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2543
+  - uid: 2614
     components:
     - type: Transform
       pos: -18.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2544
+  - uid: 2615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18140,21 +18162,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2545
+  - uid: 2616
     components:
     - type: Transform
       pos: -13.5,17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2546
+  - uid: 2617
     components:
     - type: Transform
       pos: -12.5,16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2547
+  - uid: 2618
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18162,7 +18184,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2548
+  - uid: 2619
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18170,7 +18192,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2549
+  - uid: 2620
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18178,7 +18200,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2550
+  - uid: 2621
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18186,7 +18208,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2551
+  - uid: 2622
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18194,7 +18216,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2552
+  - uid: 2623
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18202,7 +18224,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2553
+  - uid: 2624
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18210,7 +18232,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2554
+  - uid: 2625
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18218,7 +18240,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2555
+  - uid: 2626
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18226,14 +18248,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2556
+  - uid: 2627
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2557
+  - uid: 2628
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18241,7 +18263,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2558
+  - uid: 2629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18249,7 +18271,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2559
+  - uid: 2630
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18257,7 +18279,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2560
+  - uid: 2631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18265,7 +18287,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2561
+  - uid: 2632
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18273,7 +18295,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2562
+  - uid: 2633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18281,7 +18303,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2563
+  - uid: 2634
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18289,7 +18311,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2564
+  - uid: 2635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18297,32 +18319,32 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2565
+  - uid: 2636
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2566
+  - uid: 2637
     components:
     - type: Transform
       pos: -6.5,12.5
       parent: 1
-  - uid: 2567
+  - uid: 2638
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,10.5
       parent: 1
-  - uid: 2568
+  - uid: 2639
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2569
+  - uid: 2640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18330,28 +18352,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2570
+  - uid: 2641
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2571
+  - uid: 2642
     components:
     - type: Transform
       pos: -8.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2572
+  - uid: 2643
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2573
+  - uid: 2644
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18359,28 +18381,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2574
+  - uid: 2645
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2575
+  - uid: 2646
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2576
+  - uid: 2647
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2577
+  - uid: 2648
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18388,28 +18410,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2578
+  - uid: 2649
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2579
+  - uid: 2650
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2580
+  - uid: 2651
     components:
     - type: Transform
       pos: -12.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2581
+  - uid: 2652
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18417,21 +18439,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2582
+  - uid: 2653
     components:
     - type: Transform
       pos: -13.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2583
+  - uid: 2654
     components:
     - type: Transform
       pos: -10.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2584
+  - uid: 2655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18439,19 +18461,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2585
+  - uid: 2656
     components:
     - type: Transform
       pos: 13.5,23.5
       parent: 1
-  - uid: 2586
+  - uid: 2657
     components:
     - type: Transform
       pos: 19.5,24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2587
+  - uid: 2658
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18459,7 +18481,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2588
+  - uid: 2659
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18467,7 +18489,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2589
+  - uid: 2660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18475,7 +18497,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2590
+  - uid: 2661
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18483,7 +18505,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2591
+  - uid: 2662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18493,19 +18515,19 @@ entities:
       color: '#00AACCFF'
 - proto: GasPort
   entities:
-  - uid: 2592
+  - uid: 2663
     components:
     - type: Transform
       pos: -25.5,10.5
       parent: 1
 - proto: GasThermoMachineFreezerEnabled
   entities:
-  - uid: 2593
+  - uid: 2664
     components:
     - type: Transform
       pos: -24.5,10.5
       parent: 1
-  - uid: 2594
+  - uid: 2665
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18513,7 +18535,7 @@ entities:
       parent: 1
     - type: GasThermoMachine
       targetTemperature: 235
-  - uid: 2595
+  - uid: 2666
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18523,7 +18545,7 @@ entities:
       targetTemperature: 235
 - proto: GasVentPump
   entities:
-  - uid: 2596
+  - uid: 2667
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18534,7 +18556,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2597
+  - uid: 2668
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18545,7 +18567,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2598
+  - uid: 2669
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18556,7 +18578,7 @@ entities:
       - 10
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2599
+  - uid: 2670
     components:
     - type: Transform
       pos: -22.5,14.5
@@ -18566,7 +18588,7 @@ entities:
       - 8
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2600
+  - uid: 2671
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18577,7 +18599,7 @@ entities:
       - 9
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2601
+  - uid: 2672
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18588,7 +18610,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2602
+  - uid: 2673
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18599,7 +18621,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2603
+  - uid: 2674
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18610,7 +18632,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2604
+  - uid: 2675
     components:
     - type: Transform
       pos: 9.5,13.5
@@ -18620,7 +18642,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2605
+  - uid: 2676
     components:
     - type: Transform
       pos: 5.5,13.5
@@ -18630,7 +18652,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2606
+  - uid: 2677
     components:
     - type: Transform
       pos: -19.5,5.5
@@ -18640,7 +18662,7 @@ entities:
       - 11
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2607
+  - uid: 2678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18651,7 +18673,7 @@ entities:
       - 12
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2608
+  - uid: 2679
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18662,7 +18684,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2609
+  - uid: 2680
     components:
     - type: Transform
       pos: -15.5,20.5
@@ -18672,7 +18694,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2610
+  - uid: 2681
     components:
     - type: Transform
       pos: -1.5,-7.5
@@ -18682,7 +18704,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2611
+  - uid: 2682
     components:
     - type: Transform
       pos: -11.5,-7.5
@@ -18692,7 +18714,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2612
+  - uid: 2683
     components:
     - type: Transform
       pos: -6.5,23.5
@@ -18702,7 +18724,7 @@ entities:
       - 7
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2613
+  - uid: 2684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18713,7 +18735,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2614
+  - uid: 2685
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18724,7 +18746,7 @@ entities:
       - 17
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2615
+  - uid: 2686
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18735,7 +18757,7 @@ entities:
       - 18
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2616
+  - uid: 2687
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18746,7 +18768,7 @@ entities:
       - 19
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2617
+  - uid: 2688
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18757,7 +18779,7 @@ entities:
       - 19
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2618
+  - uid: 2689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18765,7 +18787,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2619
+  - uid: 2690
     components:
     - type: Transform
       pos: 9.5,1.5
@@ -18773,7 +18795,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 23
-  - uid: 2620
+  - uid: 2691
     components:
     - type: Transform
       pos: 1.5,1.5
@@ -18781,7 +18803,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 22
-  - uid: 2621
+  - uid: 2692
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18792,7 +18814,7 @@ entities:
       - 14
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2622
+  - uid: 2693
     components:
     - type: Transform
       pos: 8.5,40.5
@@ -18802,7 +18824,7 @@ entities:
       - 15
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2623
+  - uid: 2694
     components:
     - type: Transform
       pos: -11.5,32.5
@@ -18812,7 +18834,7 @@ entities:
       - 14
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2624
+  - uid: 2695
     components:
     - type: Transform
       pos: -14.5,35.5
@@ -18822,7 +18844,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2625
+  - uid: 2696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18833,7 +18855,7 @@ entities:
       - 20
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2626
+  - uid: 2697
     components:
     - type: Transform
       pos: 16.5,27.5
@@ -18843,7 +18865,7 @@ entities:
       - 24
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2627
+  - uid: 2698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18854,7 +18876,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2628
+  - uid: 2699
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18867,7 +18889,7 @@ entities:
       color: '#00AACCFF'
 - proto: GasVentPumpFreezer
   entities:
-  - uid: 2629
+  - uid: 2700
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18880,7 +18902,7 @@ entities:
       color: '#00AACCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 2630
+  - uid: 2701
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18891,7 +18913,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2631
+  - uid: 2702
     components:
     - type: Transform
       pos: 5.5,24.5
@@ -18901,7 +18923,7 @@ entities:
       - 2
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2632
+  - uid: 2703
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18912,7 +18934,7 @@ entities:
       - 10
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2633
+  - uid: 2704
     components:
     - type: Transform
       pos: -17.5,9.5
@@ -18922,7 +18944,7 @@ entities:
       - 9
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2634
+  - uid: 2705
     components:
     - type: Transform
       pos: -19.5,15.5
@@ -18932,7 +18954,7 @@ entities:
       - 8
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2635
+  - uid: 2706
     components:
     - type: Transform
       pos: 0.5,17.5
@@ -18942,7 +18964,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2636
+  - uid: 2707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18953,7 +18975,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2637
+  - uid: 2708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18961,7 +18983,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2638
+  - uid: 2709
     components:
     - type: Transform
       pos: 3.5,13.5
@@ -18971,7 +18993,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2639
+  - uid: 2710
     components:
     - type: Transform
       pos: 11.5,13.5
@@ -18981,7 +19003,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2640
+  - uid: 2711
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18992,7 +19014,7 @@ entities:
       - 12
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2641
+  - uid: 2712
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19003,7 +19025,7 @@ entities:
       - 11
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2642
+  - uid: 2713
     components:
     - type: Transform
       pos: -8.5,17.5
@@ -19013,7 +19035,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2643
+  - uid: 2714
     components:
     - type: Transform
       pos: -17.5,20.5
@@ -19023,7 +19045,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2644
+  - uid: 2715
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19034,7 +19056,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2645
+  - uid: 2716
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19045,7 +19067,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2646
+  - uid: 2717
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19056,7 +19078,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2647
+  - uid: 2718
     components:
     - type: Transform
       pos: -8.5,22.5
@@ -19066,7 +19088,7 @@ entities:
       - 7
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2648
+  - uid: 2719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19077,7 +19099,7 @@ entities:
       - 18
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2649
+  - uid: 2720
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19088,7 +19110,7 @@ entities:
       - 17
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2650
+  - uid: 2721
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19099,7 +19121,7 @@ entities:
       - 19
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2651
+  - uid: 2722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19110,7 +19132,7 @@ entities:
       - 19
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2652
+  - uid: 2723
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19118,7 +19140,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2653
+  - uid: 2724
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19129,7 +19151,7 @@ entities:
       - 23
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2654
+  - uid: 2725
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19140,7 +19162,7 @@ entities:
       - 22
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2655
+  - uid: 2726
     components:
     - type: Transform
       pos: 9.5,40.5
@@ -19150,7 +19172,7 @@ entities:
       - 15
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2656
+  - uid: 2727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19161,7 +19183,7 @@ entities:
       - 14
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2657
+  - uid: 2728
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19172,7 +19194,7 @@ entities:
       - 14
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2658
+  - uid: 2729
     components:
     - type: Transform
       pos: -15.5,35.5
@@ -19182,7 +19204,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2659
+  - uid: 2730
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19193,7 +19215,7 @@ entities:
       - 20
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2660
+  - uid: 2731
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19204,7 +19226,7 @@ entities:
       - 24
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2661
+  - uid: 2732
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19215,7 +19237,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2662
+  - uid: 2733
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19228,7 +19250,7 @@ entities:
       color: '#DD0075FF'
 - proto: GasVentScrubberFreezer
   entities:
-  - uid: 2663
+  - uid: 2734
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19241,342 +19263,342 @@ entities:
       color: '#DD0075FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 2664
+  - uid: 2735
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 2665
+  - uid: 2736
     components:
     - type: Transform
       pos: -1.5,23.5
       parent: 1
-  - uid: 2666
+  - uid: 2737
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 1
-  - uid: 2667
+  - uid: 2738
     components:
     - type: Transform
       pos: 7.5,24.5
       parent: 1
-  - uid: 2668
+  - uid: 2739
     components:
     - type: Transform
       pos: 5.5,26.5
       parent: 1
-  - uid: 2669
+  - uid: 2740
     components:
     - type: Transform
       pos: 7.5,25.5
       parent: 1
-  - uid: 2670
+  - uid: 2741
     components:
     - type: Transform
       pos: 6.5,26.5
       parent: 1
-  - uid: 2671
+  - uid: 2742
     components:
     - type: Transform
       pos: -5.5,25.5
       parent: 1
-  - uid: 2672
+  - uid: 2743
     components:
     - type: Transform
       pos: -5.5,24.5
       parent: 1
-  - uid: 2673
+  - uid: 2744
     components:
     - type: Transform
       pos: -5.5,23.5
       parent: 1
-  - uid: 2674
+  - uid: 2745
     components:
     - type: Transform
       pos: -4.5,18.5
       parent: 1
-  - uid: 2675
+  - uid: 2746
     components:
     - type: Transform
       pos: -3.5,18.5
       parent: 1
-  - uid: 2676
+  - uid: 2747
     components:
     - type: Transform
       pos: -23.5,11.5
       parent: 1
-  - uid: 2677
+  - uid: 2748
     components:
     - type: Transform
       pos: -18.5,12.5
       parent: 1
-  - uid: 2678
+  - uid: 2749
     components:
     - type: Transform
       pos: -22.5,11.5
       parent: 1
-  - uid: 2679
+  - uid: 2750
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 1
-  - uid: 2680
+  - uid: 2751
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 2681
+  - uid: 2752
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 2682
+  - uid: 2753
     components:
     - type: Transform
       pos: -9.5,33.5
       parent: 1
-  - uid: 2683
+  - uid: 2754
     components:
     - type: Transform
       pos: -0.5,35.5
       parent: 1
-  - uid: 2684
+  - uid: 2755
     components:
     - type: Transform
       pos: -8.5,33.5
       parent: 1
-  - uid: 2685
+  - uid: 2756
     components:
     - type: Transform
       pos: -10.5,33.5
       parent: 1
-  - uid: 2686
+  - uid: 2757
     components:
     - type: Transform
       pos: -9.5,30.5
       parent: 1
-  - uid: 2687
+  - uid: 2758
     components:
     - type: Transform
       pos: -11.5,33.5
       parent: 1
-  - uid: 2688
+  - uid: 2759
     components:
     - type: Transform
       pos: -2.5,35.5
       parent: 1
-  - uid: 2689
+  - uid: 2760
     components:
     - type: Transform
       pos: -8.5,30.5
       parent: 1
-  - uid: 2690
+  - uid: 2761
     components:
     - type: Transform
       pos: -6.5,30.5
       parent: 1
-  - uid: 2691
+  - uid: 2762
     components:
     - type: Transform
       pos: -1.5,35.5
       parent: 1
-  - uid: 2692
+  - uid: 2763
     components:
     - type: Transform
       pos: -5.5,30.5
       parent: 1
-  - uid: 2693
+  - uid: 2764
     components:
     - type: Transform
       pos: 0.5,35.5
       parent: 1
-  - uid: 2694
+  - uid: 2765
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 1
-  - uid: 2695
+  - uid: 2766
     components:
     - type: Transform
       pos: 3.5,35.5
       parent: 1
-  - uid: 2696
+  - uid: 2767
     components:
     - type: Transform
       pos: 7.5,32.5
       parent: 1
-  - uid: 2697
+  - uid: 2768
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 1
-  - uid: 2698
+  - uid: 2769
     components:
     - type: Transform
       pos: 4.5,35.5
       parent: 1
-  - uid: 2699
+  - uid: 2770
     components:
     - type: Transform
       pos: 3.5,32.5
       parent: 1
-  - uid: 2700
+  - uid: 2771
     components:
     - type: Transform
       pos: 5.5,35.5
       parent: 1
-  - uid: 2701
+  - uid: 2772
     components:
     - type: Transform
       pos: 1.5,32.5
       parent: 1
-  - uid: 2702
+  - uid: 2773
     components:
     - type: Transform
       pos: 2.5,32.5
       parent: 1
-  - uid: 2703
+  - uid: 2774
     components:
     - type: Transform
       pos: 6.5,32.5
       parent: 1
-  - uid: 2704
+  - uid: 2775
     components:
     - type: Transform
       pos: 5.5,32.5
       parent: 1
-  - uid: 2705
+  - uid: 2776
     components:
     - type: Transform
       pos: 37.5,24.5
       parent: 1
-  - uid: 2706
+  - uid: 2777
     components:
     - type: Transform
       pos: 37.5,18.5
       parent: 1
-  - uid: 2707
+  - uid: 2778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-1.5
       parent: 1
-  - uid: 2708
+  - uid: 2779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,38.5
       parent: 1
-  - uid: 2709
+  - uid: 2780
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,40.5
       parent: 1
-  - uid: 2710
+  - uid: 2781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,33.5
       parent: 1
-  - uid: 2711
+  - uid: 2782
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,31.5
       parent: 1
-  - uid: 2712
+  - uid: 2783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,9.5
       parent: 1
-  - uid: 2713
+  - uid: 2784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,6.5
       parent: 1
-  - uid: 2714
+  - uid: 2785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,5.5
       parent: 1
-  - uid: 2715
+  - uid: 2786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,4.5
       parent: 1
-  - uid: 2716
+  - uid: 2787
     components:
     - type: Transform
       pos: 35.5,28.5
       parent: 1
-  - uid: 2717
+  - uid: 2788
     components:
     - type: Transform
       pos: 15.5,0.5
       parent: 1
-  - uid: 2718
+  - uid: 2789
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,7.5
       parent: 1
-  - uid: 2719
+  - uid: 2790
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,3.5
       parent: 1
-  - uid: 2720
+  - uid: 2791
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,0.5
       parent: 1
-  - uid: 2721
+  - uid: 2792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,31.5
       parent: 1
-  - uid: 2722
+  - uid: 2793
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,21.5
       parent: 1
-  - uid: 2723
+  - uid: 2794
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,17.5
       parent: 1
-  - uid: 2724
+  - uid: 2795
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,39.5
       parent: 1
-  - uid: 2725
+  - uid: 2796
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,39.5
       parent: 1
-  - uid: 2726
+  - uid: 2797
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,8.5
       parent: 1
-  - uid: 2727
+  - uid: 2798
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19584,7 +19606,7 @@ entities:
       parent: 1
 - proto: GunneryServerStationConsolesEnforced
   entities:
-  - uid: 2728
+  - uid: 2799
     components:
     - type: Transform
       pos: -8.5,26.5
@@ -19595,55 +19617,55 @@ entities:
       powerLoad: 50
 - proto: hydroponicsTrayAnchored
   entities:
-  - uid: 2729
+  - uid: 2800
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,24.5
       parent: 1
-  - uid: 2730
+  - uid: 2801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,25.5
       parent: 1
-  - uid: 2731
+  - uid: 2802
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,23.5
       parent: 1
-  - uid: 2732
+  - uid: 2803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,23.5
       parent: 1
-  - uid: 2733
+  - uid: 2804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,25.5
       parent: 1
-  - uid: 2734
+  - uid: 2805
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,23.5
       parent: 1
-  - uid: 2735
+  - uid: 2806
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,25.5
       parent: 1
-  - uid: 2736
+  - uid: 2807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,24.5
       parent: 1
-  - uid: 2737
+  - uid: 2808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19651,7 +19673,7 @@ entities:
       parent: 1
 - proto: JukeboxWallmount
   entities:
-  - uid: 2738
+  - uid: 2809
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19659,149 +19681,149 @@ entities:
       parent: 1
 - proto: KitchenAssembler
   entities:
-  - uid: 2739
+  - uid: 2810
     components:
     - type: Transform
       pos: 20.5,24.5
       parent: 1
 - proto: KitchenElectricGrill
   entities:
-  - uid: 2740
+  - uid: 2811
     components:
     - type: Transform
       pos: 20.5,23.5
       parent: 1
-  - uid: 2741
+  - uid: 2812
     components:
     - type: Transform
       pos: 16.5,23.5
       parent: 1
 - proto: KitchenElectricRange
   entities:
-  - uid: 2742
+  - uid: 2813
     components:
     - type: Transform
       pos: 20.5,21.5
       parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 2743
+  - uid: 2814
     components:
     - type: Transform
       pos: 17.5,24.5
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 2744
+  - uid: 2815
     components:
     - type: Transform
       pos: -23.5,15.5
       parent: 1
-  - uid: 2745
+  - uid: 2816
     components:
     - type: Transform
       pos: 9.5,-4.5
       parent: 1
-  - uid: 2746
+  - uid: 2817
     components:
     - type: Transform
       pos: 22.5,19.5
       parent: 1
-  - uid: 2747
+  - uid: 2818
     components:
     - type: Transform
       pos: 16.5,24.5
       parent: 1
 - proto: KitchenSpike
   entities:
-  - uid: 2748
+  - uid: 2819
     components:
     - type: Transform
       pos: 14.5,20.5
       parent: 1
-  - uid: 2749
+  - uid: 2820
     components:
     - type: Transform
       pos: 12.5,20.5
       parent: 1
 - proto: LampGold
   entities:
-  - uid: 2750
+  - uid: 2821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.4552286,-5.0675116
       parent: 1
-  - uid: 2751
+  - uid: 2822
     components:
     - type: Transform
       pos: -10.471387,14.842216
       parent: 1
 - proto: Lighter
   entities:
-  - uid: 2752
+  - uid: 2823
     components:
     - type: Transform
       pos: 15.658639,27.340311
       parent: 1
 - proto: LockerBoozeFilled
   entities:
-  - uid: 2753
+  - uid: 2824
     components:
     - type: Transform
       pos: 17.5,30.5
       parent: 1
 - proto: LockerBotanistFilled
   entities:
-  - uid: 2754
+  - uid: 2825
     components:
     - type: Transform
       pos: 26.5,21.5
       parent: 1
 - proto: LockerChemistryFilled
   entities:
-  - uid: 2755
+  - uid: 2826
     components:
     - type: Transform
       pos: -21.5,19.5
       parent: 1
-  - uid: 2756
+  - uid: 2827
     components:
     - type: Transform
       pos: -21.5,18.5
       parent: 1
 - proto: LockerElectricalSuppliesFilled
   entities:
-  - uid: 2757
+  - uid: 2828
     components:
     - type: Transform
       pos: 3.5,27.5
       parent: 1
 - proto: LockerMedicineFilled
   entities:
-  - uid: 2758
+  - uid: 2829
     components:
     - type: Transform
       pos: -19.5,8.5
       parent: 1
 - proto: LockerSteel
   entities:
-  - uid: 2759
+  - uid: 2830
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 1
-  - uid: 2760
+  - uid: 2831
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
-  - uid: 2761
+  - uid: 2832
     components:
     - type: Transform
       pos: -8.5,13.5
       parent: 1
-  - uid: 2762
+  - uid: 2833
     components:
     - type: Transform
       pos: -6.5,5.5
@@ -19826,7 +19848,7 @@ entities:
         - 0
 - proto: LockerWallMedicalFilled
   entities:
-  - uid: 2763
+  - uid: 2834
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19834,174 +19856,174 @@ entities:
       parent: 1
 - proto: LockerWeldingSuppliesFilled
   entities:
-  - uid: 2764
+  - uid: 2835
     components:
     - type: Transform
       pos: 0.5,27.5
       parent: 1
 - proto: MachineCentrifuge
   entities:
-  - uid: 2765
+  - uid: 2836
     components:
     - type: Transform
       pos: -22.5,15.5
       parent: 1
-  - uid: 2766
+  - uid: 2837
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
 - proto: MachineCryoSleepPod
   entities:
-  - uid: 2767
+  - uid: 2838
     components:
     - type: Transform
       pos: -17.5,22.5
       parent: 1
-  - uid: 2768
+  - uid: 2839
     components:
     - type: Transform
       pos: -15.5,22.5
       parent: 1
 - proto: MachineElectrolysisUnit
   entities:
-  - uid: 2769
+  - uid: 2840
     components:
     - type: Transform
       pos: -21.5,14.5
       parent: 1
-  - uid: 2770
+  - uid: 2841
     components:
     - type: Transform
       pos: -18.5,14.5
       parent: 1
-  - uid: 2771
+  - uid: 2842
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
 - proto: MachineOutpostCore
   entities:
-  - uid: 2772
+  - uid: 2843
     components:
     - type: Transform
       pos: -2.5,23.5
       parent: 1
 - proto: MedicalBed
   entities:
-  - uid: 2773
+  - uid: 2844
     components:
     - type: Transform
       pos: -18.5,8.5
       parent: 1
-  - uid: 2774
+  - uid: 2845
     components:
     - type: Transform
       pos: -20.5,8.5
       parent: 1
 - proto: MopBucketFull
   entities:
-  - uid: 2775
+  - uid: 2846
     components:
     - type: Transform
       pos: 24.552916,21.713972
       parent: 1
 - proto: MopItem
   entities:
-  - uid: 2776
+  - uid: 2847
     components:
     - type: Transform
       pos: 24.636248,21.630638
       parent: 1
 - proto: NFAshtray
   entities:
-  - uid: 2777
+  - uid: 2848
     components:
     - type: Transform
       pos: 15.471139,26.694477
       parent: 1
 - proto: OreBox
   entities:
-  - uid: 2778
+  - uid: 2849
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
 - proto: PaperBin20
   entities:
-  - uid: 2779
+  - uid: 2850
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 2780
+  - uid: 2851
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 1
-  - uid: 2781
+  - uid: 2852
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
 - proto: Pickaxe
   entities:
-  - uid: 3581
+  - uid: 2853
     components:
     - type: Transform
       pos: 20.644564,10.561366
       parent: 1
 - proto: PlastitaniumWindow
   entities:
-  - uid: 2782
+  - uid: 2854
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 1
-  - uid: 2783
+  - uid: 2855
     components:
     - type: Transform
       pos: 7.5,24.5
       parent: 1
-  - uid: 2784
+  - uid: 2856
     components:
     - type: Transform
       pos: 5.5,26.5
       parent: 1
-  - uid: 2785
+  - uid: 2857
     components:
     - type: Transform
       pos: 7.5,25.5
       parent: 1
-  - uid: 2786
+  - uid: 2858
     components:
     - type: Transform
       pos: 6.5,26.5
       parent: 1
 - proto: PottedPlant15
   entities:
-  - uid: 2787
+  - uid: 2859
     components:
     - type: Transform
       pos: -3.5,15.5
       parent: 1
 - proto: PottedPlant18
   entities:
-  - uid: 2788
+  - uid: 2860
     components:
     - type: Transform
       pos: -10.5,8.5
       parent: 1
 - proto: PottedPlant2
   entities:
-  - uid: 2789
+  - uid: 2861
     components:
     - type: Transform
       pos: 14.5,25.5
       parent: 1
 - proto: PottedPlant26
   entities:
-  - uid: 2790
+  - uid: 2862
     components:
     - type: MetaData
       name: Garry
@@ -20010,105 +20032,105 @@ entities:
       parent: 1
 - proto: PottedPlant4
   entities:
-  - uid: 2791
+  - uid: 2863
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
 - proto: PottedPlant5
   entities:
-  - uid: 2792
+  - uid: 2864
     components:
     - type: Transform
       pos: 12.5,25.5
       parent: 1
 - proto: PottedPlantBioluminscent
   entities:
-  - uid: 2793
+  - uid: 2865
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 1
 - proto: PowerCellRecharger
   entities:
-  - uid: 2794
+  - uid: 2866
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 2795
+  - uid: 2867
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 2796
+  - uid: 2868
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,22.5
       parent: 1
-  - uid: 2797
+  - uid: 2869
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 1
-  - uid: 2805
+  - uid: 2870
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,17.5
       parent: 1
-  - uid: 2812
+  - uid: 2871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-1.5
       parent: 1
-  - uid: 2813
+  - uid: 2872
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,13.5
       parent: 1
-  - uid: 2854
+  - uid: 2873
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 2859
+  - uid: 2874
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 2863
+  - uid: 2875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,5.5
       parent: 1
-  - uid: 4798
+  - uid: 2876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 1
-  - uid: 4803
+  - uid: 2877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,17.5
       parent: 1
-  - uid: 4804
+  - uid: 2878
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,18.5
       parent: 1
-  - uid: 4805
+  - uid: 2879
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20116,81 +20138,81 @@ entities:
       parent: 1
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 2798
+  - uid: 2880
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,26.5
       parent: 1
-  - uid: 2799
+  - uid: 2881
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,19.5
       parent: 1
-  - uid: 2800
+  - uid: 2882
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,19.5
       parent: 1
-  - uid: 2801
+  - uid: 2883
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,7.5
       parent: 1
-  - uid: 2802
+  - uid: 2884
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 2803
+  - uid: 2885
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,22.5
       parent: 1
-  - uid: 2804
+  - uid: 2886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,30.5
       parent: 1
-  - uid: 2806
+  - uid: 2887
     components:
     - type: Transform
       pos: -2.5,31.5
       parent: 1
-  - uid: 2807
+  - uid: 2888
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,25.5
       parent: 1
-  - uid: 2808
+  - uid: 2889
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 1
-  - uid: 2809
+  - uid: 2890
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,12.5
       parent: 1
-  - uid: 2810
+  - uid: 2891
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,12.5
       parent: 1
-  - uid: 2811
+  - uid: 2892
     components:
     - type: Transform
       pos: 19.5,14.5
       parent: 1
-  - uid: 2858
+  - uid: 2893
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20198,205 +20220,205 @@ entities:
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 2815
+  - uid: 2894
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-6.5
       parent: 1
-  - uid: 2817
+  - uid: 2895
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,6.5
       parent: 1
-  - uid: 2818
+  - uid: 2896
     components:
     - type: Transform
       pos: -9.5,14.5
       parent: 1
-  - uid: 2819
+  - uid: 2897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 1
-  - uid: 2820
+  - uid: 2898
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,7.5
       parent: 1
-  - uid: 2822
+  - uid: 2899
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-5.5
       parent: 1
-  - uid: 2823
+  - uid: 2900
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 2862
+  - uid: 2901
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
 - proto: PoweredlightBlue
   entities:
-  - uid: 2824
+  - uid: 2902
     components:
     - type: Transform
       pos: 13.5,30.5
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 2825
+  - uid: 2903
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,8.5
       parent: 1
-  - uid: 2826
+  - uid: 2904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,42.5
       parent: 1
-  - uid: 2827
+  - uid: 2905
     components:
     - type: Transform
       pos: -19.5,16.5
       parent: 1
-  - uid: 2828
+  - uid: 2906
     components:
     - type: Transform
       pos: -20.5,19.5
       parent: 1
-  - uid: 2830
+  - uid: 2907
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,4.5
       parent: 1
-  - uid: 2831
+  - uid: 2908
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,4.5
       parent: 1
-  - uid: 2832
+  - uid: 2909
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,16.5
       parent: 1
-  - uid: 2833
+  - uid: 2910
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,45.5
       parent: 1
-  - uid: 2834
+  - uid: 2911
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,38.5
       parent: 1
-  - uid: 2835
+  - uid: 2912
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,37.5
       parent: 1
-  - uid: 2836
+  - uid: 2913
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 1
-  - uid: 2837
+  - uid: 2914
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-2.5
       parent: 1
-  - uid: 2838
+  - uid: 2915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-4.5
       parent: 1
-  - uid: 2839
+  - uid: 2916
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 2840
+  - uid: 2917
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 2841
+  - uid: 2918
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,33.5
       parent: 1
-  - uid: 2842
+  - uid: 2919
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,31.5
       parent: 1
-  - uid: 2843
+  - uid: 2920
     components:
     - type: Transform
       pos: -13.5,31.5
       parent: 1
-  - uid: 2844
+  - uid: 2921
     components:
     - type: Transform
       pos: 19.5,24.5
       parent: 1
-  - uid: 2845
+  - uid: 2922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,22.5
       parent: 1
-  - uid: 2846
+  - uid: 2923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,21.5
       parent: 1
-  - uid: 2847
+  - uid: 2924
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,22.5
       parent: 1
-  - uid: 2850
+  - uid: 2925
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,7.5
       parent: 1
-  - uid: 2853
+  - uid: 2926
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,8.5
       parent: 1
-  - uid: 2856
+  - uid: 2927
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-8.5
       parent: 1
-  - uid: 2865
+  - uid: 2928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20404,7 +20426,7 @@ entities:
       parent: 1
 - proto: PoweredlightPink
   entities:
-  - uid: 2848
+  - uid: 2929
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20412,7 +20434,7 @@ entities:
       parent: 1
 - proto: PoweredlightSodium
   entities:
-  - uid: 2866
+  - uid: 2930
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20420,31 +20442,31 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 1632
+  - uid: 2931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,16.5
       parent: 1
-  - uid: 2816
+  - uid: 2932
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,12.5
       parent: 1
-  - uid: 2829
+  - uid: 2933
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,10.5
       parent: 1
-  - uid: 2851
+  - uid: 2934
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,15.5
       parent: 1
-  - uid: 2867
+  - uid: 2935
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20452,58 +20474,58 @@ entities:
       parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 2849
+  - uid: 2936
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 2857
+  - uid: 2937
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,8.5
       parent: 1
-  - uid: 2860
+  - uid: 2938
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,3.5
       parent: 1
-  - uid: 2864
+  - uid: 2939
     components:
     - type: Transform
       pos: 10.5,15.5
       parent: 1
-  - uid: 2868
+  - uid: 2940
     components:
     - type: Transform
       pos: 2.5,28.5
       parent: 1
-  - uid: 2869
+  - uid: 2941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 2870
+  - uid: 2942
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,4.5
       parent: 1
-  - uid: 2871
+  - uid: 2943
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,4.5
       parent: 1
-  - uid: 2872
+  - uid: 2944
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,20.5
       parent: 1
-  - uid: 4800
+  - uid: 2945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20511,249 +20533,249 @@ entities:
       parent: 1
 - proto: Rack
   entities:
-  - uid: 2873
+  - uid: 2946
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 2874
+  - uid: 2947
     components:
     - type: Transform
       pos: -17.5,2.5
       parent: 1
-  - uid: 2875
+  - uid: 2948
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 2876
+  - uid: 2949
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 1
-  - uid: 2877
+  - uid: 2950
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 2878
+  - uid: 2951
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 1
 - proto: Railing
   entities:
-  - uid: 1410
+  - uid: 2952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,10.5
       parent: 1
-  - uid: 2814
+  - uid: 2953
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-  - uid: 2821
+  - uid: 2954
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 1
-  - uid: 2852
+  - uid: 2955
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 1
-  - uid: 2861
+  - uid: 2956
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-0.5
       parent: 1
-  - uid: 2879
+  - uid: 2957
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,26.5
       parent: 1
-  - uid: 2880
+  - uid: 2958
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,25.5
       parent: 1
-  - uid: 2881
+  - uid: 2959
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,26.5
       parent: 1
-  - uid: 2882
+  - uid: 2960
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,22.5
       parent: 1
-  - uid: 2883
+  - uid: 2961
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,23.5
       parent: 1
-  - uid: 2884
+  - uid: 2962
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,23.5
       parent: 1
-  - uid: 2885
+  - uid: 2963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,36.5
       parent: 1
-  - uid: 2886
+  - uid: 2964
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,37.5
       parent: 1
-  - uid: 2887
+  - uid: 2965
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,37.5
       parent: 1
-  - uid: 2888
+  - uid: 2966
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,37.5
       parent: 1
-  - uid: 2889
+  - uid: 2967
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,22.5
       parent: 1
-  - uid: 2890
+  - uid: 2968
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,14.5
       parent: 1
-  - uid: 2891
+  - uid: 2969
     components:
     - type: Transform
       pos: 38.5,13.5
       parent: 1
-  - uid: 2892
+  - uid: 2970
     components:
     - type: Transform
       pos: 37.5,13.5
       parent: 1
-  - uid: 2893
+  - uid: 2971
     components:
     - type: Transform
       pos: 19.5,0.5
       parent: 1
-  - uid: 2894
+  - uid: 2972
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,1.5
       parent: 1
-  - uid: 2895
+  - uid: 2973
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,2.5
       parent: 1
-  - uid: 2896
+  - uid: 2974
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-0.5
       parent: 1
-  - uid: 2897
+  - uid: 2975
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 1
-  - uid: 2898
+  - uid: 2976
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-1.5
       parent: 1
-  - uid: 2899
+  - uid: 2977
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,13.5
       parent: 1
-  - uid: 2900
+  - uid: 2978
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,12.5
       parent: 1
-  - uid: 2901
+  - uid: 2979
     components:
     - type: Transform
       pos: -32.5,11.5
       parent: 1
-  - uid: 2902
+  - uid: 2980
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,40.5
       parent: 1
-  - uid: 4034
+  - uid: 2981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,11.5
       parent: 1
-  - uid: 4087
+  - uid: 2982
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,12.5
       parent: 1
-  - uid: 4160
+  - uid: 2983
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,13.5
       parent: 1
-  - uid: 4166
+  - uid: 2984
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,13.5
       parent: 1
-  - uid: 4799
+  - uid: 2985
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 4810
+  - uid: 2986
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,1.5
       parent: 1
-  - uid: 4811
+  - uid: 2987
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 1
-  - uid: 4812
+  - uid: 2988
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20761,135 +20783,135 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 2903
+  - uid: 2989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,26.5
       parent: 1
-  - uid: 2904
+  - uid: 2990
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,24.5
       parent: 1
-  - uid: 2905
+  - uid: 2991
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,37.5
       parent: 1
-  - uid: 2906
+  - uid: 2992
     components:
     - type: Transform
       pos: -22.5,-2.5
       parent: 1
-  - uid: 2907
+  - uid: 2993
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,35.5
       parent: 1
-  - uid: 2908
+  - uid: 2994
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,23.5
       parent: 1
-  - uid: 2909
+  - uid: 2995
     components:
     - type: Transform
       pos: 39.5,21.5
       parent: 1
-  - uid: 2910
+  - uid: 2996
     components:
     - type: Transform
       pos: 39.5,13.5
       parent: 1
-  - uid: 2911
+  - uid: 2997
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,15.5
       parent: 1
-  - uid: 2912
+  - uid: 2998
     components:
     - type: Transform
       pos: 20.5,0.5
       parent: 1
-  - uid: 2913
+  - uid: 2999
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,0.5
       parent: 1
-  - uid: 2914
+  - uid: 3000
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,1.5
       parent: 1
-  - uid: 2915
+  - uid: 3001
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-1.5
       parent: 1
-  - uid: 2916
+  - uid: 3002
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-2.5
       parent: 1
-  - uid: 2917
+  - uid: 3003
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,10.5
       parent: 1
-  - uid: 2918
+  - uid: 3004
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,11.5
       parent: 1
-  - uid: 2919
+  - uid: 3005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,13.5
       parent: 1
-  - uid: 2920
+  - uid: 3006
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,14.5
       parent: 1
-  - uid: 2921
+  - uid: 3007
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,39.5
       parent: 1
-  - uid: 2922
+  - uid: 3008
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,40.5
       parent: 1
-  - uid: 2923
+  - uid: 3009
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,40.5
       parent: 1
-  - uid: 2924
+  - uid: 3010
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,39.5
       parent: 1
-  - uid: 4031
+  - uid: 3011
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20897,18 +20919,18 @@ entities:
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 2925
+  - uid: 3012
     components:
     - type: Transform
       pos: 14.5,22.5
       parent: 1
-  - uid: 2926
+  - uid: 3013
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,22.5
       parent: 1
-  - uid: 3592
+  - uid: 3014
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20916,190 +20938,190 @@ entities:
       parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 2927
+  - uid: 3015
     components:
     - type: Transform
       pos: -9.5,33.5
       parent: 1
-  - uid: 2928
+  - uid: 3016
     components:
     - type: Transform
       pos: -8.5,33.5
       parent: 1
-  - uid: 2929
+  - uid: 3017
     components:
     - type: Transform
       pos: -11.5,33.5
       parent: 1
-  - uid: 2930
+  - uid: 3018
     components:
     - type: Transform
       pos: -1.5,23.5
       parent: 1
-  - uid: 2931
+  - uid: 3019
     components:
     - type: Transform
       pos: -3.5,18.5
       parent: 1
-  - uid: 2932
+  - uid: 3020
     components:
     - type: Transform
       pos: -4.5,18.5
       parent: 1
-  - uid: 2933
+  - uid: 3021
     components:
     - type: Transform
       pos: -5.5,25.5
       parent: 1
-  - uid: 2934
+  - uid: 3022
     components:
     - type: Transform
       pos: -5.5,24.5
       parent: 1
-  - uid: 2935
+  - uid: 3023
     components:
     - type: Transform
       pos: -5.5,23.5
       parent: 1
-  - uid: 2936
+  - uid: 3024
     components:
     - type: Transform
       pos: -9.5,30.5
       parent: 1
-  - uid: 2937
+  - uid: 3025
     components:
     - type: Transform
       pos: -8.5,30.5
       parent: 1
-  - uid: 2938
+  - uid: 3026
     components:
     - type: Transform
       pos: 7.5,32.5
       parent: 1
-  - uid: 2939
+  - uid: 3027
     components:
     - type: Transform
       pos: -1.5,35.5
       parent: 1
-  - uid: 2940
+  - uid: 3028
     components:
     - type: Transform
       pos: 6.5,32.5
       parent: 1
-  - uid: 2941
+  - uid: 3029
     components:
     - type: Transform
       pos: 3.5,32.5
       parent: 1
-  - uid: 2942
+  - uid: 3030
     components:
     - type: Transform
       pos: -2.5,35.5
       parent: 1
-  - uid: 2943
+  - uid: 3031
     components:
     - type: Transform
       pos: -10.5,33.5
       parent: 1
-  - uid: 2944
+  - uid: 3032
     components:
     - type: Transform
       pos: 1.5,32.5
       parent: 1
-  - uid: 2945
+  - uid: 3033
     components:
     - type: Transform
       pos: 5.5,32.5
       parent: 1
-  - uid: 2946
+  - uid: 3034
     components:
     - type: Transform
       pos: 2.5,32.5
       parent: 1
-  - uid: 2947
+  - uid: 3035
     components:
     - type: Transform
       pos: 0.5,35.5
       parent: 1
-  - uid: 2948
+  - uid: 3036
     components:
     - type: Transform
       pos: 3.5,35.5
       parent: 1
-  - uid: 2949
+  - uid: 3037
     components:
     - type: Transform
       pos: -0.5,35.5
       parent: 1
-  - uid: 2950
+  - uid: 3038
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 1
-  - uid: 2951
+  - uid: 3039
     components:
     - type: Transform
       pos: 4.5,35.5
       parent: 1
-  - uid: 2952
+  - uid: 3040
     components:
     - type: Transform
       pos: 5.5,35.5
       parent: 1
-  - uid: 2953
+  - uid: 3041
     components:
     - type: Transform
       pos: -6.5,30.5
       parent: 1
-  - uid: 2954
+  - uid: 3042
     components:
     - type: Transform
       pos: -5.5,30.5
       parent: 1
 - proto: ReinforcedWindow
   entities:
-  - uid: 2955
+  - uid: 3043
     components:
     - type: Transform
       pos: -18.5,12.5
       parent: 1
-  - uid: 2956
+  - uid: 3044
     components:
     - type: Transform
       pos: -23.5,11.5
       parent: 1
-  - uid: 2957
+  - uid: 3045
     components:
     - type: Transform
       pos: -22.5,11.5
       parent: 1
-  - uid: 2958
+  - uid: 3046
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 1
-  - uid: 2959
+  - uid: 3047
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 1
-  - uid: 2960
+  - uid: 3048
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 2961
+  - uid: 3049
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 2962
+  - uid: 3050
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,8.5
       parent: 1
-  - uid: 2963
+  - uid: 3051
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21107,21 +21129,21 @@ entities:
       parent: 1
 - proto: ResearchAndDevelopmentServerRogues
   entities:
-  - uid: 2964
+  - uid: 3052
     components:
     - type: Transform
       pos: -18.5,6.5
       parent: 1
 - proto: SeedExtractor
   entities:
-  - uid: 2965
+  - uid: 3053
     components:
     - type: Transform
       pos: 26.5,20.5
       parent: 1
 - proto: ShelfBar
   entities:
-  - uid: 2966
+  - uid: 3054
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21129,7 +21151,7 @@ entities:
       parent: 1
 - proto: ShelfKitchen
   entities:
-  - uid: 2967
+  - uid: 3055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21137,13 +21159,13 @@ entities:
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 2855
+  - uid: 3056
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,9.5
       parent: 1
-  - uid: 4801
+  - uid: 3057
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21151,49 +21173,49 @@ entities:
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 2968
+  - uid: 3058
     components:
     - type: Transform
       pos: 1.5,26.5
       parent: 1
-  - uid: 2969
+  - uid: 3059
     components:
     - type: Transform
       pos: 2.5,26.5
       parent: 1
-  - uid: 2970
+  - uid: 3060
     components:
     - type: Transform
       pos: 11.5,12.5
       parent: 1
-  - uid: 2971
+  - uid: 3061
     components:
     - type: Transform
       pos: 10.5,12.5
       parent: 1
-  - uid: 2972
+  - uid: 3062
     components:
     - type: Transform
       pos: 9.5,12.5
       parent: 1
-  - uid: 2973
+  - uid: 3063
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 2974
+  - uid: 3064
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 2975
+  - uid: 3065
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
 - proto: SignalButtonDirectional
   entities:
-  - uid: 2976
+  - uid: 3066
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21201,45 +21223,45 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2969:
+        3059:
         - - Pressed
           - Toggle
-        2968:
+        3058:
         - - Pressed
           - Toggle
-  - uid: 2977
+  - uid: 3067
     components:
     - type: Transform
       pos: 12.5,12.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2972:
+        3062:
         - - Pressed
           - Toggle
-        2971:
+        3061:
         - - Pressed
           - Toggle
-        2970:
+        3060:
         - - Pressed
           - Toggle
-  - uid: 2978
+  - uid: 3068
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2975:
+        3065:
         - - Pressed
           - Toggle
-        2974:
+        3064:
         - - Pressed
           - Toggle
-        2973:
+        3063:
         - - Pressed
           - Toggle
-  - uid: 4802
+  - uid: 3069
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21247,52 +21269,52 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2855:
+        3056:
         - - Pressed
           - Toggle
-        4801:
+        3057:
         - - Pressed
           - Toggle
 - proto: SignSecureSmall
   entities:
-  - uid: 2979
+  - uid: 3070
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 2980
+  - uid: 3071
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,13.5
       parent: 1
-  - uid: 2981
+  - uid: 3072
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 1
-  - uid: 2982
+  - uid: 3073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-3.5
       parent: 1
-  - uid: 2983
+  - uid: 3074
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,26.5
       parent: 1
-  - uid: 2984
+  - uid: 3075
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,21.5
       parent: 1
-  - uid: 2985
+  - uid: 3076
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21300,43 +21322,43 @@ entities:
       parent: 1
 - proto: SmartFridge
   entities:
-  - uid: 2986
+  - uid: 3077
     components:
     - type: Transform
       pos: -18.5,16.5
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 2987
+  - uid: 3078
     components:
     - type: Transform
       pos: 0.5,24.5
       parent: 1
-  - uid: 2988
+  - uid: 3079
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 2989
+  - uid: 3080
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
-  - uid: 2990
+  - uid: 3081
     components:
     - type: Transform
       pos: 10.5,18.5
       parent: 1
-  - uid: 2991
+  - uid: 3082
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 1
 - proto: SodaDispenser
   entities:
-  - uid: 2992
+  - uid: 3083
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21344,210 +21366,210 @@ entities:
       parent: 1
 - proto: SpawnPointPirate
   entities:
-  - uid: 2993
+  - uid: 3084
     components:
     - type: Transform
       pos: -15.5,21.5
       parent: 1
-  - uid: 2994
+  - uid: 3085
     components:
     - type: Transform
       pos: -17.5,21.5
       parent: 1
-  - uid: 4815
+  - uid: 3086
     components:
     - type: Transform
       pos: 10.5,14.5
       parent: 1
-  - uid: 4818
+  - uid: 3087
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 4820
+  - uid: 3088
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 4821
+  - uid: 3089
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 4822
+  - uid: 3090
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 1
-  - uid: 4827
+  - uid: 3091
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 4828
+  - uid: 3092
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
-  - uid: 4829
+  - uid: 3093
     components:
     - type: Transform
       pos: 13.5,29.5
       parent: 1
-  - uid: 4830
+  - uid: 3094
     components:
     - type: Transform
       pos: 13.5,26.5
       parent: 1
-  - uid: 4831
+  - uid: 3095
     components:
     - type: Transform
       pos: 19.5,23.5
       parent: 1
-  - uid: 4836
+  - uid: 3096
     components:
     - type: Transform
       pos: 25.5,22.5
       parent: 1
-  - uid: 4837
+  - uid: 3097
     components:
     - type: Transform
       pos: -17.5,10.5
       parent: 1
-  - uid: 4842
+  - uid: 3098
     components:
     - type: Transform
       pos: -19.5,9.5
       parent: 1
 - proto: SpawnPointPirateCaptain
   entities:
-  - uid: 2995
+  - uid: 3099
     components:
     - type: Transform
       pos: -15.5,21.5
       parent: 1
-  - uid: 2996
+  - uid: 3100
     components:
     - type: Transform
       pos: -17.5,21.5
       parent: 1
-  - uid: 2997
+  - uid: 3101
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 1
-  - uid: 4817
+  - uid: 3102
     components:
     - type: Transform
       pos: 9.5,14.5
       parent: 1
-  - uid: 4825
+  - uid: 3103
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 1
-  - uid: 4826
+  - uid: 3104
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 1
-  - uid: 4832
+  - uid: 3105
     components:
     - type: Transform
       pos: 17.5,21.5
       parent: 1
-  - uid: 4833
+  - uid: 3106
     components:
     - type: Transform
       pos: 13.5,28.5
       parent: 1
-  - uid: 4839
+  - uid: 3107
     components:
     - type: Transform
       pos: -19.5,10.5
       parent: 1
-  - uid: 4840
+  - uid: 3108
     components:
     - type: Transform
       pos: -17.5,9.5
       parent: 1
 - proto: SpawnPointPirateFirstMate
   entities:
-  - uid: 2998
+  - uid: 3109
     components:
     - type: Transform
       pos: -15.5,21.5
       parent: 1
-  - uid: 2999
+  - uid: 3110
     components:
     - type: Transform
       pos: -17.5,21.5
       parent: 1
-  - uid: 4816
+  - uid: 3111
     components:
     - type: Transform
       pos: 11.5,14.5
       parent: 1
-  - uid: 4819
+  - uid: 3112
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 4823
+  - uid: 3113
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 4824
+  - uid: 3114
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 1
-  - uid: 4834
+  - uid: 3115
     components:
     - type: Transform
       pos: 17.5,28.5
       parent: 1
-  - uid: 4835
+  - uid: 3116
     components:
     - type: Transform
       pos: 18.5,22.5
       parent: 1
-  - uid: 4838
+  - uid: 3117
     components:
     - type: Transform
       pos: -18.5,10.5
       parent: 1
-  - uid: 4841
+  - uid: 3118
     components:
     - type: Transform
       pos: -18.5,9.5
       parent: 1
 - proto: StairStageDark
   entities:
-  - uid: 1310
+  - uid: 3119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,0.5
       parent: 1
-  - uid: 1421
+  - uid: 3120
     components:
     - type: Transform
       pos: -8.5,1.5
       parent: 1
-  - uid: 1426
+  - uid: 3121
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 4735
+  - uid: 3122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 4813
+  - uid: 3123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21555,14 +21577,14 @@ entities:
       parent: 1
 - proto: StasisBed
   entities:
-  - uid: 3000
+  - uid: 3124
     components:
     - type: Transform
       pos: -16.5,10.5
       parent: 1
 - proto: StationMap
   entities:
-  - uid: 3001
+  - uid: 3125
     components:
     - type: Transform
       pos: -0.5,26.5
@@ -21571,7 +21593,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3002
+  - uid: 3126
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21581,7 +21603,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3003
+  - uid: 3127
     components:
     - type: Transform
       pos: -4.5,-6.5
@@ -21590,7 +21612,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3004
+  - uid: 3128
     components:
     - type: Transform
       pos: -9.5,18.5
@@ -21599,7 +21621,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3005
+  - uid: 3129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21609,7 +21631,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3006
+  - uid: 3130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21619,7 +21641,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3007
+  - uid: 3131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21629,7 +21651,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3008
+  - uid: 3132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21639,7 +21661,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3009
+  - uid: 3133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21649,7 +21671,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 4790
+  - uid: 3134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21659,7 +21681,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 4806
+  - uid: 3135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21669,7 +21691,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 4807
+  - uid: 3136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21679,7 +21701,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 4808
+  - uid: 3137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21689,7 +21711,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 4809
+  - uid: 3138
     components:
     - type: Transform
       pos: -11.5,22.5
@@ -21700,25 +21722,25 @@ entities:
       startingCharge: 0
 - proto: StoolBar
   entities:
-  - uid: 3010
+  - uid: 3139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,28.5
       parent: 1
-  - uid: 3011
+  - uid: 3140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,29.5
       parent: 1
-  - uid: 3012
+  - uid: 3141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,27.5
       parent: 1
-  - uid: 3013
+  - uid: 3142
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21726,8667 +21748,8667 @@ entities:
       parent: 1
 - proto: StructureGunRack
   entities:
-  - uid: 3014
+  - uid: 3143
     components:
     - type: Transform
       pos: -18.5,2.5
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 3015
+  - uid: 3144
     components:
     - type: Transform
       pos: 3.5,22.5
       parent: 1
-  - uid: 3016
+  - uid: 3145
     components:
     - type: Transform
       pos: 11.5,18.5
       parent: 1
-  - uid: 3017
+  - uid: 3146
     components:
     - type: Transform
       pos: -15.5,26.5
       parent: 1
-  - uid: 3018
+  - uid: 3147
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 3019
+  - uid: 3148
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,3.5
       parent: 1
-  - uid: 3020
+  - uid: 3149
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,15.5
       parent: 1
-  - uid: 3021
+  - uid: 3150
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 3022
+  - uid: 3151
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
 - proto: SuitStorageEVAPirate
   entities:
-  - uid: 3023
-    components:
-    - type: Transform
-      pos: -9.5,-5.5
-      parent: 1
-  - uid: 3024
+  - uid: 3153
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 1
-- proto: SuitStoragePirateCap
-  entities:
-  - uid: 3025
+  - uid: 3154
     components:
     - type: Transform
       pos: -10.5,-5.5
       parent: 1
+- proto: SuitStorageSyndieCommander
+  entities:
+  - uid: 3152
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 1
 - proto: SyringeCaseAltFilled
   entities:
-  - uid: 3026
+  - uid: 3155
     components:
     - type: Transform
       pos: 10.632307,-0.45730066
       parent: 1
-  - uid: 3027
+  - uid: 3156
     components:
     - type: Transform
       pos: 10.428603,-0.45730066
       parent: 1
 - proto: TableCounterWood
   entities:
-  - uid: 3028
+  - uid: 3157
     components:
     - type: Transform
       pos: 15.5,29.5
       parent: 1
-  - uid: 3029
+  - uid: 3158
     components:
     - type: Transform
       pos: 15.5,26.5
       parent: 1
-  - uid: 3030
+  - uid: 3159
     components:
     - type: Transform
       pos: 15.5,27.5
       parent: 1
-  - uid: 3031
+  - uid: 3160
     components:
     - type: Transform
       pos: 15.5,28.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 3032
+  - uid: 3161
     components:
     - type: Transform
       pos: 15.5,10.5
       parent: 1
-  - uid: 3033
+  - uid: 3162
     components:
     - type: Transform
       pos: 14.5,10.5
       parent: 1
-  - uid: 3034
+  - uid: 3163
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 3035
+  - uid: 3164
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 3036
+  - uid: 3165
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 3037
+  - uid: 3166
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 3038
+  - uid: 3167
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 3039
+  - uid: 3168
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-  - uid: 3040
+  - uid: 3169
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 1
-  - uid: 3041
+  - uid: 3170
     components:
     - type: Transform
       pos: -17.5,8.5
       parent: 1
-  - uid: 3042
+  - uid: 3171
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 1
-  - uid: 3043
+  - uid: 3172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,14.5
       parent: 1
-  - uid: 3044
+  - uid: 3173
     components:
     - type: Transform
       pos: -22.5,14.5
       parent: 1
-  - uid: 3045
+  - uid: 3174
     components:
     - type: Transform
       pos: -22.5,15.5
       parent: 1
-  - uid: 3046
+  - uid: 3175
     components:
     - type: Transform
       pos: -23.5,15.5
       parent: 1
-  - uid: 3047
+  - uid: 3176
     components:
     - type: Transform
       pos: -21.5,14.5
       parent: 1
-  - uid: 3048
+  - uid: 3177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,15.5
       parent: 1
-  - uid: 3049
+  - uid: 3178
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 1
-  - uid: 3050
+  - uid: 3179
     components:
     - type: Transform
       pos: -19.5,4.5
       parent: 1
-  - uid: 3051
+  - uid: 3180
     components:
     - type: Transform
       pos: -20.5,4.5
       parent: 1
-  - uid: 3052
+  - uid: 3181
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 3053
+  - uid: 3182
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 3054
+  - uid: 3183
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 1
-  - uid: 3055
+  - uid: 3184
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
-  - uid: 3056
+  - uid: 3185
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 3057
+  - uid: 3186
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 3058
+  - uid: 3187
     components:
     - type: Transform
       pos: 9.5,-4.5
       parent: 1
-  - uid: 3059
+  - uid: 3188
     components:
     - type: Transform
       pos: 17.5,24.5
       parent: 1
-  - uid: 3060
+  - uid: 3189
     components:
     - type: Transform
       pos: 16.5,24.5
       parent: 1
-  - uid: 3061
+  - uid: 3190
     components:
     - type: Transform
       pos: 20.5,24.5
       parent: 1
-  - uid: 3062
+  - uid: 3191
     components:
     - type: Transform
       pos: 20.5,23.5
       parent: 1
-  - uid: 3063
+  - uid: 3192
     components:
     - type: Transform
       pos: 22.5,19.5
       parent: 1
-  - uid: 3064
+  - uid: 3193
     components:
     - type: Transform
       pos: 22.5,18.5
       parent: 1
-  - uid: 3065
+  - uid: 3194
     components:
     - type: Transform
       pos: 23.5,18.5
       parent: 1
-  - uid: 3066
+  - uid: 3195
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,23.5
       parent: 1
-  - uid: 3067
+  - uid: 3196
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
 - proto: TableWood
   entities:
-  - uid: 3068
+  - uid: 3197
     components:
     - type: Transform
       pos: -3.5,15.5
       parent: 1
-  - uid: 3069
+  - uid: 3198
     components:
     - type: Transform
       pos: -10.5,14.5
       parent: 1
-  - uid: 3070
+  - uid: 3199
     components:
     - type: Transform
       pos: -10.5,8.5
       parent: 1
 - proto: TableWoodReinforced
   entities:
-  - uid: 3071
+  - uid: 3200
     components:
     - type: Transform
       pos: -10.5,3.5
       parent: 1
-  - uid: 3072
+  - uid: 3201
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 1
-  - uid: 3073
+  - uid: 3202
     components:
     - type: Transform
       pos: 19.5,27.5
       parent: 1
-  - uid: 3074
+  - uid: 3203
     components:
     - type: Transform
       pos: 19.5,29.5
       parent: 1
-  - uid: 3075
+  - uid: 3204
     components:
     - type: Transform
       pos: 19.5,28.5
       parent: 1
 - proto: TelecomServerFilledFreelance
   entities:
-  - uid: 3076
+  - uid: 3205
     components:
     - type: Transform
       pos: -17.5,6.5
       parent: 1
 - proto: ToiletDirtyWater
   entities:
-  - uid: 3077
+  - uid: 3206
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,7.5
       parent: 1
-  - uid: 3078
+  - uid: 3207
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 3079
+  - uid: 3208
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 4098
+  - uid: 3209
     components:
     - type: Transform
       pos: 21.320492,10.416215
       parent: 1
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 4005
+  - uid: 3210
     components:
     - type: Transform
       pos: 21.462467,10.761894
       parent: 1
 - proto: Vaccinator
   entities:
-  - uid: 3080
+  - uid: 3211
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
 - proto: VendingMachineAmmoPOIMercenary
   entities:
-  - uid: 3081
+  - uid: 3212
     components:
     - type: Transform
       pos: 10.5,15.5
       parent: 1
 - proto: VendingMachineAstroVendPOI
   entities:
-  - uid: 3082
+  - uid: 3213
     components:
     - type: Transform
       pos: 9.5,15.5
       parent: 1
 - proto: VendingMachineBooze
   entities:
-  - uid: 3083
+  - uid: 3214
     components:
     - type: Transform
       pos: 18.5,30.5
       parent: 1
 - proto: VendingMachineChefvend
   entities:
-  - uid: 3084
+  - uid: 3215
     components:
     - type: Transform
       pos: 17.5,20.5
       parent: 1
 - proto: VendingMachineCiviMedPlus
   entities:
-  - uid: 3085
+  - uid: 3216
     components:
     - type: Transform
       pos: -20.5,11.5
       parent: 1
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 3086
+  - uid: 3217
     components:
     - type: Transform
       pos: 16.5,20.5
       parent: 1
 - proto: VendingMachineEngivend
   entities:
-  - uid: 3087
+  - uid: 3218
     components:
     - type: Transform
       pos: 12.5,14.5
       parent: 1
 - proto: VendingMachineFuelVend
   entities:
-  - uid: 3088
+  - uid: 3219
     components:
     - type: Transform
       pos: 11.5,15.5
       parent: 1
-  - uid: 3089
+  - uid: 3220
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
 - proto: VendingMachineNutri
   entities:
-  - uid: 3090
+  - uid: 3221
     components:
     - type: Transform
       pos: 26.5,18.5
       parent: 1
 - proto: VendingMachineRestockSeeds
   entities:
-  - uid: 3091
+  - uid: 3222
     components:
     - type: Transform
       pos: 22.50046,19.010017
       parent: 1
-  - uid: 3092
+  - uid: 3223
     components:
     - type: Transform
       pos: 22.407867,19.108782
       parent: 1
 - proto: VendingMachineSeedsUnlocked
   entities:
-  - uid: 3093
+  - uid: 3224
     components:
     - type: Transform
       pos: 26.5,19.5
       parent: 1
 - proto: VendingMachineTankDispenserEVAPOI
   entities:
-  - uid: 3094
+  - uid: 3225
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 1
 - proto: VendingMachineYouTool
   entities:
-  - uid: 3095
+  - uid: 3226
     components:
     - type: Transform
       pos: 12.5,13.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 3096
+  - uid: 3227
     components:
     - type: Transform
       pos: 38.5,25.5
       parent: 1
-  - uid: 3097
+  - uid: 3228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,24.5
       parent: 1
-  - uid: 3098
+  - uid: 3229
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,30.5
       parent: 1
-  - uid: 3099
+  - uid: 3230
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,20.5
       parent: 1
-  - uid: 3100
+  - uid: 3231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,40.5
       parent: 1
-  - uid: 3101
+  - uid: 3232
     components:
     - type: Transform
       pos: 4.5,41.5
       parent: 1
-  - uid: 3102
+  - uid: 3233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,31.5
       parent: 1
-  - uid: 3103
+  - uid: 3234
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,23.5
       parent: 1
-  - uid: 3104
+  - uid: 3235
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,10.5
       parent: 1
-  - uid: 3105
+  - uid: 3236
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 3106
+  - uid: 3237
     components:
     - type: Transform
       pos: 7.5,36.5
       parent: 1
-  - uid: 3107
+  - uid: 3238
     components:
     - type: Transform
       pos: -6.5,34.5
       parent: 1
-  - uid: 3108
+  - uid: 3239
     components:
     - type: Transform
       pos: -7.5,33.5
       parent: 1
-  - uid: 3109
+  - uid: 3240
     components:
     - type: Transform
       pos: 7.5,35.5
       parent: 1
-  - uid: 3110
+  - uid: 3241
     components:
     - type: Transform
       pos: -5.5,35.5
       parent: 1
-  - uid: 3111
+  - uid: 3242
     components:
     - type: Transform
       pos: 10.5,34.5
       parent: 1
-  - uid: 3112
+  - uid: 3243
     components:
     - type: Transform
       pos: 10.5,35.5
       parent: 1
-  - uid: 3113
+  - uid: 3244
     components:
     - type: Transform
       pos: 10.5,36.5
       parent: 1
-  - uid: 3114
+  - uid: 3245
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 3115
+  - uid: 3246
     components:
     - type: Transform
       pos: -6.5,33.5
       parent: 1
-  - uid: 3116
+  - uid: 3247
     components:
     - type: Transform
       pos: -3.5,22.5
       parent: 1
-  - uid: 3117
+  - uid: 3248
     components:
     - type: Transform
       pos: -2.5,22.5
       parent: 1
-  - uid: 3118
+  - uid: 3249
     components:
     - type: Transform
       pos: -3.5,23.5
       parent: 1
-  - uid: 3119
+  - uid: 3250
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1
-  - uid: 3120
+  - uid: 3251
     components:
     - type: Transform
       pos: -3.5,24.5
       parent: 1
-  - uid: 3121
+  - uid: 3252
     components:
     - type: Transform
       pos: -1.5,21.5
       parent: 1
-  - uid: 3122
+  - uid: 3253
     components:
     - type: Transform
       pos: -2.5,24.5
       parent: 1
-  - uid: 3123
+  - uid: 3254
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 1
-  - uid: 3124
+  - uid: 3255
     components:
     - type: Transform
       pos: -1.5,24.5
       parent: 1
-  - uid: 3125
+  - uid: 3256
     components:
     - type: Transform
       pos: -1.5,25.5
       parent: 1
-  - uid: 3126
+  - uid: 3257
     components:
     - type: Transform
       pos: -1.5,26.5
       parent: 1
-  - uid: 3127
+  - uid: 3258
     components:
     - type: Transform
       pos: -0.5,26.5
       parent: 1
-  - uid: 3128
+  - uid: 3259
     components:
     - type: Transform
       pos: -0.5,27.5
       parent: 1
-  - uid: 3129
+  - uid: 3260
     components:
     - type: Transform
       pos: -0.5,28.5
       parent: 1
-  - uid: 3130
+  - uid: 3261
     components:
     - type: Transform
       pos: -0.5,29.5
       parent: 1
-  - uid: 3131
+  - uid: 3262
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 1
-  - uid: 3132
+  - uid: 3263
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 1
-  - uid: 3133
+  - uid: 3264
     components:
     - type: Transform
       pos: 2.5,21.5
       parent: 1
-  - uid: 3134
+  - uid: 3265
     components:
     - type: Transform
       pos: -0.5,20.5
       parent: 1
-  - uid: 3135
+  - uid: 3266
     components:
     - type: Transform
       pos: 3.5,21.5
       parent: 1
-  - uid: 3136
+  - uid: 3267
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 1
-  - uid: 3137
+  - uid: 3268
     components:
     - type: Transform
       pos: 5.5,20.5
       parent: 1
-  - uid: 3138
+  - uid: 3269
     components:
     - type: Transform
       pos: 4.5,21.5
       parent: 1
-  - uid: 3139
+  - uid: 3270
     components:
     - type: Transform
       pos: 6.5,20.5
       parent: 1
-  - uid: 3140
+  - uid: 3271
     components:
     - type: Transform
       pos: 5.5,21.5
       parent: 1
-  - uid: 3141
+  - uid: 3272
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 1
-  - uid: 3142
+  - uid: 3273
     components:
     - type: Transform
       pos: 7.5,20.5
       parent: 1
-  - uid: 3143
+  - uid: 3274
     components:
     - type: Transform
       pos: 5.5,22.5
       parent: 1
-  - uid: 3144
+  - uid: 3275
     components:
     - type: Transform
       pos: 7.5,21.5
       parent: 1
-  - uid: 3145
+  - uid: 3276
     components:
     - type: Transform
       pos: 7.5,22.5
       parent: 1
-  - uid: 3146
+  - uid: 3277
     components:
     - type: Transform
       pos: 0.5,29.5
       parent: 1
-  - uid: 3147
+  - uid: 3278
     components:
     - type: Transform
       pos: 7.5,23.5
       parent: 1
-  - uid: 3148
+  - uid: 3279
     components:
     - type: Transform
       pos: 4.5,26.5
       parent: 1
-  - uid: 3149
+  - uid: 3280
     components:
     - type: Transform
       pos: 1.5,29.5
       parent: 1
-  - uid: 3150
+  - uid: 3281
     components:
     - type: Transform
       pos: 8.5,23.5
       parent: 1
-  - uid: 3151
+  - uid: 3282
     components:
     - type: Transform
       pos: 4.5,27.5
       parent: 1
-  - uid: 3152
+  - uid: 3283
     components:
     - type: Transform
       pos: 2.5,29.5
       parent: 1
-  - uid: 3153
+  - uid: 3284
     components:
     - type: Transform
       pos: 9.5,23.5
       parent: 1
-  - uid: 3154
+  - uid: 3285
     components:
     - type: Transform
       pos: 4.5,28.5
       parent: 1
-  - uid: 3155
+  - uid: 3286
     components:
     - type: Transform
       pos: 3.5,29.5
       parent: 1
-  - uid: 3156
+  - uid: 3287
     components:
     - type: Transform
       pos: 9.5,24.5
       parent: 1
-  - uid: 3157
+  - uid: 3288
     components:
     - type: Transform
       pos: 7.5,26.5
       parent: 1
-  - uid: 3158
+  - uid: 3289
     components:
     - type: Transform
       pos: 5.5,28.5
       parent: 1
-  - uid: 3159
+  - uid: 3290
     components:
     - type: Transform
       pos: 4.5,29.5
       parent: 1
-  - uid: 3160
+  - uid: 3291
     components:
     - type: Transform
       pos: 9.5,25.5
       parent: 1
-  - uid: 3161
+  - uid: 3292
     components:
     - type: Transform
       pos: 8.5,26.5
       parent: 1
-  - uid: 3162
+  - uid: 3293
     components:
     - type: Transform
       pos: 7.5,27.5
       parent: 1
-  - uid: 3163
+  - uid: 3294
     components:
     - type: Transform
       pos: 6.5,28.5
       parent: 1
-  - uid: 3164
+  - uid: 3295
     components:
     - type: Transform
       pos: 9.5,26.5
       parent: 1
-  - uid: 3165
+  - uid: 3296
     components:
     - type: Transform
       pos: 7.5,28.5
       parent: 1
-  - uid: 3166
+  - uid: 3297
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 1
-  - uid: 3167
+  - uid: 3298
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 3168
+  - uid: 3299
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 3169
+  - uid: 3300
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 3170
+  - uid: 3301
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 3171
+  - uid: 3302
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 3172
+  - uid: 3303
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 3173
+  - uid: 3304
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 3174
+  - uid: 3305
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 3175
+  - uid: 3306
     components:
     - type: Transform
       pos: -6.5,20.5
       parent: 1
-  - uid: 3176
+  - uid: 3307
     components:
     - type: Transform
       pos: -6.5,21.5
       parent: 1
-  - uid: 3177
+  - uid: 3308
     components:
     - type: Transform
       pos: -5.5,21.5
       parent: 1
-  - uid: 3178
+  - uid: 3309
     components:
     - type: Transform
       pos: -5.5,22.5
       parent: 1
-  - uid: 3179
+  - uid: 3310
     components:
     - type: Transform
       pos: -5.5,26.5
       parent: 1
-  - uid: 3180
+  - uid: 3311
     components:
     - type: Transform
       pos: -5.5,27.5
       parent: 1
-  - uid: 3181
+  - uid: 3312
     components:
     - type: Transform
       pos: -6.5,27.5
       parent: 1
-  - uid: 3182
+  - uid: 3313
     components:
     - type: Transform
       pos: -7.5,27.5
       parent: 1
-  - uid: 3183
+  - uid: 3314
     components:
     - type: Transform
       pos: -8.5,27.5
       parent: 1
-  - uid: 3184
+  - uid: 3315
     components:
     - type: Transform
       pos: -9.5,27.5
       parent: 1
-  - uid: 3185
+  - uid: 3316
     components:
     - type: Transform
       pos: -9.5,26.5
       parent: 1
-  - uid: 3186
+  - uid: 3317
     components:
     - type: Transform
       pos: -10.5,26.5
       parent: 1
-  - uid: 3187
+  - uid: 3318
     components:
     - type: Transform
       pos: -11.5,26.5
       parent: 1
-  - uid: 3188
+  - uid: 3319
     components:
     - type: Transform
       pos: -11.5,25.5
       parent: 1
-  - uid: 3189
+  - uid: 3320
     components:
     - type: Transform
       pos: -11.5,24.5
       parent: 1
-  - uid: 3190
+  - uid: 3321
     components:
     - type: Transform
       pos: -11.5,23.5
       parent: 1
-  - uid: 3191
+  - uid: 3322
     components:
     - type: Transform
       pos: -11.5,22.5
       parent: 1
-  - uid: 3192
+  - uid: 3323
     components:
     - type: Transform
       pos: -10.5,22.5
       parent: 1
-  - uid: 3193
+  - uid: 3324
     components:
     - type: Transform
       pos: -9.5,22.5
       parent: 1
-  - uid: 3194
+  - uid: 3325
     components:
     - type: Transform
       pos: -9.5,20.5
       parent: 1
-  - uid: 3195
+  - uid: 3326
     components:
     - type: Transform
       pos: -8.5,20.5
       parent: 1
-  - uid: 3196
+  - uid: 3327
     components:
     - type: Transform
       pos: -14.5,18.5
       parent: 1
-  - uid: 3197
+  - uid: 3328
     components:
     - type: Transform
       pos: -14.5,17.5
       parent: 1
-  - uid: 3198
+  - uid: 3329
     components:
     - type: Transform
       pos: -14.5,15.5
       parent: 1
-  - uid: 3199
+  - uid: 3330
     components:
     - type: Transform
       pos: -15.5,15.5
       parent: 1
-  - uid: 3200
+  - uid: 3331
     components:
     - type: Transform
       pos: -16.5,15.5
       parent: 1
-  - uid: 3201
+  - uid: 3332
     components:
     - type: Transform
       pos: -17.5,15.5
       parent: 1
-  - uid: 3202
+  - uid: 3333
     components:
     - type: Transform
       pos: -17.5,17.5
       parent: 1
-  - uid: 3203
+  - uid: 3334
     components:
     - type: Transform
       pos: -17.5,16.5
       parent: 1
-  - uid: 3204
+  - uid: 3335
     components:
     - type: Transform
       pos: -18.5,17.5
       parent: 1
-  - uid: 3205
+  - uid: 3336
     components:
     - type: Transform
       pos: -18.5,18.5
       parent: 1
-  - uid: 3206
+  - uid: 3337
     components:
     - type: Transform
       pos: -18.5,19.5
       parent: 1
-  - uid: 3207
+  - uid: 3338
     components:
     - type: Transform
       pos: -18.5,20.5
       parent: 1
-  - uid: 3208
+  - uid: 3339
     components:
     - type: Transform
       pos: -18.5,21.5
       parent: 1
-  - uid: 3209
+  - uid: 3340
     components:
     - type: Transform
       pos: -18.5,22.5
       parent: 1
-  - uid: 3210
+  - uid: 3341
     components:
     - type: Transform
       pos: -18.5,23.5
       parent: 1
-  - uid: 3211
+  - uid: 3342
     components:
     - type: Transform
       pos: -17.5,23.5
       parent: 1
-  - uid: 3212
+  - uid: 3343
     components:
     - type: Transform
       pos: -16.5,23.5
       parent: 1
-  - uid: 3213
+  - uid: 3344
     components:
     - type: Transform
       pos: -16.5,22.5
       parent: 1
-  - uid: 3214
+  - uid: 3345
     components:
     - type: Transform
       pos: -16.5,21.5
       parent: 1
-  - uid: 3215
+  - uid: 3346
     components:
     - type: Transform
       pos: -15.5,23.5
       parent: 1
-  - uid: 3216
+  - uid: 3347
     components:
     - type: Transform
       pos: -14.5,23.5
       parent: 1
-  - uid: 3217
+  - uid: 3348
     components:
     - type: Transform
       pos: -14.5,22.5
       parent: 1
-  - uid: 3218
+  - uid: 3349
     components:
     - type: Transform
       pos: -14.5,21.5
       parent: 1
-  - uid: 3219
+  - uid: 3350
     components:
     - type: Transform
       pos: -14.5,19.5
       parent: 1
-  - uid: 3220
+  - uid: 3351
     components:
     - type: Transform
       pos: -16.5,33.5
       parent: 1
-  - uid: 3221
+  - uid: 3352
     components:
     - type: Transform
       pos: -16.5,32.5
       parent: 1
-  - uid: 3222
+  - uid: 3353
     components:
     - type: Transform
       pos: -16.5,34.5
       parent: 1
-  - uid: 3223
+  - uid: 3354
     components:
     - type: Transform
       pos: -13.5,32.5
       parent: 1
-  - uid: 3224
+  - uid: 3355
     components:
     - type: Transform
       pos: -16.5,36.5
       parent: 1
-  - uid: 3225
+  - uid: 3356
     components:
     - type: Transform
       pos: -16.5,35.5
       parent: 1
-  - uid: 3226
+  - uid: 3357
     components:
     - type: Transform
       pos: -16.5,37.5
       parent: 1
-  - uid: 3227
+  - uid: 3358
     components:
     - type: Transform
       pos: -14.5,-3.5
       parent: 1
-  - uid: 3228
+  - uid: 3359
     components:
     - type: Transform
       pos: -10.5,-9.5
       parent: 1
-  - uid: 3229
+  - uid: 3360
     components:
     - type: Transform
       pos: -14.5,-4.5
       parent: 1
-  - uid: 3230
+  - uid: 3361
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 1
-  - uid: 3231
+  - uid: 3362
     components:
     - type: Transform
       pos: -14.5,-6.5
       parent: 1
-  - uid: 3232
+  - uid: 3363
     components:
     - type: Transform
       pos: -15.5,-6.5
       parent: 1
-  - uid: 3233
+  - uid: 3364
     components:
     - type: Transform
       pos: -16.5,-6.5
       parent: 1
-  - uid: 3234
+  - uid: 3365
     components:
     - type: Transform
       pos: -16.5,-9.5
       parent: 1
-  - uid: 3235
+  - uid: 3366
     components:
     - type: Transform
       pos: -15.5,-9.5
       parent: 1
-  - uid: 3236
+  - uid: 3367
     components:
     - type: Transform
       pos: -14.5,-9.5
       parent: 1
-  - uid: 3237
+  - uid: 3368
     components:
     - type: Transform
       pos: -14.5,-10.5
       parent: 1
-  - uid: 3238
+  - uid: 3369
     components:
     - type: Transform
       pos: -14.5,-11.5
       parent: 1
-  - uid: 3239
+  - uid: 3370
     components:
     - type: Transform
       pos: -11.5,-11.5
       parent: 1
-  - uid: 3240
+  - uid: 3371
     components:
     - type: Transform
       pos: -11.5,-10.5
       parent: 1
-  - uid: 3241
+  - uid: 3372
     components:
     - type: Transform
       pos: -11.5,-9.5
       parent: 1
-  - uid: 3242
+  - uid: 3373
     components:
     - type: Transform
       pos: -9.5,-9.5
       parent: 1
-  - uid: 3243
+  - uid: 3374
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 1
-  - uid: 3244
+  - uid: 3375
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 1
-  - uid: 3245
+  - uid: 3376
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 1
-  - uid: 3246
+  - uid: 3377
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-  - uid: 3247
+  - uid: 3378
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 1
-  - uid: 3248
+  - uid: 3379
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 3249
+  - uid: 3380
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 3250
+  - uid: 3381
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 3251
+  - uid: 3382
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 3252
+  - uid: 3383
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 3253
+  - uid: 3384
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 3254
+  - uid: 3385
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 3255
+  - uid: 3386
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 3256
+  - uid: 3387
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 3257
+  - uid: 3388
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 3258
+  - uid: 3389
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 3259
+  - uid: 3390
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 3260
+  - uid: 3391
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 1
-  - uid: 3261
+  - uid: 3392
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 3262
+  - uid: 3393
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 3263
+  - uid: 3394
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 3264
+  - uid: 3395
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 3265
+  - uid: 3396
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 3266
+  - uid: 3397
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 3267
+  - uid: 3398
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 3268
+  - uid: 3399
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 3269
+  - uid: 3400
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 3270
+  - uid: 3401
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 3271
+  - uid: 3402
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 1
-  - uid: 3272
+  - uid: 3403
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 3273
+  - uid: 3404
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 3274
+  - uid: 3405
     components:
     - type: Transform
       pos: -7.5,-6.5
       parent: 1
-  - uid: 3275
+  - uid: 3406
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 1
-  - uid: 3276
+  - uid: 3407
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 1
-  - uid: 3277
+  - uid: 3408
     components:
     - type: Transform
       pos: -11.5,-6.5
       parent: 1
-  - uid: 3278
+  - uid: 3409
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 1
-  - uid: 3279
+  - uid: 3410
     components:
     - type: Transform
       pos: -11.5,-5.5
       parent: 1
-  - uid: 3280
+  - uid: 3411
     components:
     - type: Transform
       pos: -11.5,-4.5
       parent: 1
-  - uid: 3281
+  - uid: 3412
     components:
     - type: Transform
       pos: -11.5,-3.5
       parent: 1
-  - uid: 3282
+  - uid: 3413
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 1
-  - uid: 3283
+  - uid: 3414
     components:
     - type: Transform
       pos: -11.5,-1.5
       parent: 1
-  - uid: 3284
+  - uid: 3415
     components:
     - type: Transform
       pos: -11.5,-0.5
       parent: 1
-  - uid: 3285
+  - uid: 3416
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 1
-  - uid: 3286
+  - uid: 3417
     components:
     - type: Transform
       pos: 10.5,37.5
       parent: 1
-  - uid: 3287
+  - uid: 3418
     components:
     - type: Transform
       pos: 10.5,38.5
       parent: 1
-  - uid: 3288
+  - uid: 3419
     components:
     - type: Transform
       pos: 10.5,39.5
       parent: 1
-  - uid: 3289
+  - uid: 3420
     components:
     - type: Transform
       pos: 10.5,40.5
       parent: 1
-  - uid: 3290
+  - uid: 3421
     components:
     - type: Transform
       pos: 10.5,41.5
       parent: 1
-  - uid: 3291
+  - uid: 3422
     components:
     - type: Transform
       pos: 10.5,42.5
       parent: 1
-  - uid: 3292
+  - uid: 3423
     components:
     - type: Transform
       pos: 10.5,43.5
       parent: 1
-  - uid: 3293
+  - uid: 3424
     components:
     - type: Transform
       pos: 10.5,44.5
       parent: 1
-  - uid: 3294
+  - uid: 3425
     components:
     - type: Transform
       pos: 11.5,44.5
       parent: 1
-  - uid: 3295
+  - uid: 3426
     components:
     - type: Transform
       pos: 12.5,44.5
       parent: 1
-  - uid: 3296
+  - uid: 3427
     components:
     - type: Transform
       pos: 12.5,47.5
       parent: 1
-  - uid: 3297
+  - uid: 3428
     components:
     - type: Transform
       pos: 11.5,47.5
       parent: 1
-  - uid: 3298
+  - uid: 3429
     components:
     - type: Transform
       pos: 10.5,47.5
       parent: 1
-  - uid: 3299
+  - uid: 3430
     components:
     - type: Transform
       pos: 10.5,48.5
       parent: 1
-  - uid: 3300
+  - uid: 3431
     components:
     - type: Transform
       pos: 10.5,49.5
       parent: 1
-  - uid: 3301
+  - uid: 3432
     components:
     - type: Transform
       pos: 7.5,48.5
       parent: 1
-  - uid: 3302
+  - uid: 3433
     components:
     - type: Transform
       pos: 7.5,47.5
       parent: 1
-  - uid: 3303
+  - uid: 3434
     components:
     - type: Transform
       pos: 7.5,49.5
       parent: 1
-  - uid: 3304
+  - uid: 3435
     components:
     - type: Transform
       pos: 6.5,47.5
       parent: 1
-  - uid: 3305
+  - uid: 3436
     components:
     - type: Transform
       pos: 5.5,47.5
       parent: 1
-  - uid: 3306
+  - uid: 3437
     components:
     - type: Transform
       pos: 7.5,44.5
       parent: 1
-  - uid: 3307
+  - uid: 3438
     components:
     - type: Transform
       pos: 7.5,43.5
       parent: 1
-  - uid: 3308
+  - uid: 3439
     components:
     - type: Transform
       pos: 7.5,42.5
       parent: 1
-  - uid: 3309
+  - uid: 3440
     components:
     - type: Transform
       pos: 7.5,41.5
       parent: 1
-  - uid: 3310
+  - uid: 3441
     components:
     - type: Transform
       pos: 7.5,40.5
       parent: 1
-  - uid: 3311
+  - uid: 3442
     components:
     - type: Transform
       pos: 7.5,39.5
       parent: 1
-  - uid: 3312
+  - uid: 3443
     components:
     - type: Transform
       pos: 7.5,38.5
       parent: 1
-  - uid: 3313
+  - uid: 3444
     components:
     - type: Transform
       pos: 7.5,37.5
       parent: 1
-  - uid: 3314
+  - uid: 3445
     components:
     - type: Transform
       pos: 6.5,44.5
       parent: 1
-  - uid: 3315
+  - uid: 3446
     components:
     - type: Transform
       pos: 5.5,44.5
       parent: 1
-  - uid: 3316
+  - uid: 3447
     components:
     - type: Transform
       pos: -13.5,42.5
       parent: 1
-  - uid: 3317
+  - uid: 3448
     components:
     - type: Transform
       pos: -13.5,41.5
       parent: 1
-  - uid: 3318
+  - uid: 3449
     components:
     - type: Transform
       pos: -13.5,40.5
       parent: 1
-  - uid: 3319
+  - uid: 3450
     components:
     - type: Transform
       pos: -13.5,39.5
       parent: 1
-  - uid: 3320
+  - uid: 3451
     components:
     - type: Transform
       pos: -13.5,38.5
       parent: 1
-  - uid: 3321
+  - uid: 3452
     components:
     - type: Transform
       pos: -13.5,37.5
       parent: 1
-  - uid: 3322
+  - uid: 3453
     components:
     - type: Transform
       pos: -13.5,36.5
       parent: 1
-  - uid: 3323
+  - uid: 3454
     components:
     - type: Transform
       pos: -13.5,35.5
       parent: 1
-  - uid: 3324
+  - uid: 3455
     components:
     - type: Transform
       pos: -13.5,34.5
       parent: 1
-  - uid: 3325
+  - uid: 3456
     components:
     - type: Transform
       pos: -13.5,33.5
       parent: 1
-  - uid: 3326
+  - uid: 3457
     components:
     - type: Transform
       pos: -17.5,37.5
       parent: 1
-  - uid: 3327
+  - uid: 3458
     components:
     - type: Transform
       pos: -18.5,37.5
       parent: 1
-  - uid: 3328
+  - uid: 3459
     components:
     - type: Transform
       pos: -18.5,40.5
       parent: 1
-  - uid: 3329
+  - uid: 3460
     components:
     - type: Transform
       pos: -17.5,40.5
       parent: 1
-  - uid: 3330
+  - uid: 3461
     components:
     - type: Transform
       pos: -16.5,40.5
       parent: 1
-  - uid: 3331
+  - uid: 3462
     components:
     - type: Transform
       pos: -16.5,41.5
       parent: 1
-  - uid: 3332
+  - uid: 3463
     components:
     - type: Transform
       pos: -16.5,42.5
       parent: 1
-  - uid: 3333
+  - uid: 3464
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 3334
+  - uid: 3465
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 3335
+  - uid: 3466
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 3336
+  - uid: 3467
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 3337
+  - uid: 3468
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 3338
+  - uid: 3469
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 3339
+  - uid: 3470
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 3340
+  - uid: 3471
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 3341
+  - uid: 3472
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 3342
+  - uid: 3473
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 3343
+  - uid: 3474
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 3344
+  - uid: 3475
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 3345
+  - uid: 3476
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 3346
+  - uid: 3477
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 3347
+  - uid: 3478
     components:
     - type: Transform
       pos: 11.5,0.5
       parent: 1
-  - uid: 3348
+  - uid: 3479
     components:
     - type: Transform
       pos: 11.5,-1.5
       parent: 1
-  - uid: 3349
+  - uid: 3480
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 1
-  - uid: 3350
+  - uid: 3481
     components:
     - type: Transform
       pos: 11.5,-3.5
       parent: 1
-  - uid: 3351
+  - uid: 3482
     components:
     - type: Transform
       pos: 11.5,-2.5
       parent: 1
-  - uid: 3352
+  - uid: 3483
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 3353
+  - uid: 3484
     components:
     - type: Transform
       pos: 1.5,35.5
       parent: 1
-  - uid: 3354
+  - uid: 3485
     components:
     - type: Transform
       pos: -3.5,35.5
       parent: 1
-  - uid: 3355
+  - uid: 3486
     components:
     - type: Transform
       pos: -16.5,30.5
       parent: 1
-  - uid: 3356
+  - uid: 3487
     components:
     - type: Transform
       pos: -16.5,31.5
       parent: 1
-  - uid: 3357
+  - uid: 3488
     components:
     - type: Transform
       pos: -16.5,29.5
       parent: 1
-  - uid: 3358
+  - uid: 3489
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 3359
+  - uid: 3490
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 1
-  - uid: 3360
+  - uid: 3491
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 3361
+  - uid: 3492
     components:
     - type: Transform
       pos: 6.5,35.5
       parent: 1
-  - uid: 3362
+  - uid: 3493
     components:
     - type: Transform
       pos: -12.5,33.5
       parent: 1
-  - uid: 3363
+  - uid: 3494
     components:
     - type: Transform
       pos: -6.5,35.5
       parent: 1
-  - uid: 3364
+  - uid: 3495
     components:
     - type: Transform
       pos: -4.5,35.5
       parent: 1
-  - uid: 3365
+  - uid: 3496
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 3366
+  - uid: 3497
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 3367
+  - uid: 3498
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-  - uid: 3368
+  - uid: 3499
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 3369
+  - uid: 3500
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 3370
+  - uid: 3501
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
-  - uid: 3371
+  - uid: 3502
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 1
-  - uid: 3372
+  - uid: 3503
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 1
-  - uid: 3373
+  - uid: 3504
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
-  - uid: 3374
+  - uid: 3505
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 3375
+  - uid: 3506
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
-  - uid: 3376
+  - uid: 3507
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 3377
+  - uid: 3508
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 3378
+  - uid: 3509
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 3379
+  - uid: 3510
     components:
     - type: Transform
       pos: 10.5,-4.5
       parent: 1
-  - uid: 3380
+  - uid: 3511
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 1
-  - uid: 3381
+  - uid: 3512
     components:
     - type: Transform
       pos: 10.5,-5.5
       parent: 1
-  - uid: 3382
+  - uid: 3513
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 1
-  - uid: 3383
+  - uid: 3514
     components:
     - type: Transform
       pos: 8.5,-5.5
       parent: 1
-  - uid: 3384
+  - uid: 3515
     components:
     - type: Transform
       pos: 11.5,34.5
       parent: 1
-  - uid: 3385
+  - uid: 3516
     components:
     - type: Transform
       pos: 11.5,33.5
       parent: 1
-  - uid: 3386
+  - uid: 3517
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 3387
+  - uid: 3518
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 3388
+  - uid: 3519
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 3389
+  - uid: 3520
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 3390
+  - uid: 3521
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 3391
+  - uid: 3522
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 3392
+  - uid: 3523
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 3393
+  - uid: 3524
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 3394
+  - uid: 3525
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 1
-  - uid: 3395
+  - uid: 3526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,10.5
       parent: 1
-  - uid: 3396
+  - uid: 3527
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,7.5
       parent: 1
-  - uid: 3397
+  - uid: 3528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,13.5
       parent: 1
-  - uid: 3398
+  - uid: 3529
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 1
-  - uid: 3399
+  - uid: 3530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,11.5
       parent: 1
-  - uid: 3400
+  - uid: 3531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,40.5
       parent: 1
-  - uid: 3401
+  - uid: 3532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,21.5
       parent: 1
-  - uid: 3402
+  - uid: 3533
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,21.5
       parent: 1
-  - uid: 3403
+  - uid: 3534
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,22.5
       parent: 1
-  - uid: 3404
+  - uid: 3535
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,23.5
       parent: 1
-  - uid: 3405
+  - uid: 3536
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,18.5
       parent: 1
-  - uid: 3406
+  - uid: 3537
     components:
     - type: Transform
       pos: 37.5,27.5
       parent: 1
-  - uid: 3407
+  - uid: 3538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,17.5
       parent: 1
-  - uid: 3408
+  - uid: 3539
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,19.5
       parent: 1
-  - uid: 3409
+  - uid: 3540
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,20.5
       parent: 1
-  - uid: 3410
+  - uid: 3541
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,21.5
       parent: 1
-  - uid: 3411
+  - uid: 3542
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,19.5
       parent: 1
-  - uid: 3412
+  - uid: 3543
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,17.5
       parent: 1
-  - uid: 3413
+  - uid: 3544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,31.5
       parent: 1
-  - uid: 3414
+  - uid: 3545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,3.5
       parent: 1
-  - uid: 3415
+  - uid: 3546
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,1.5
       parent: 1
-  - uid: 3416
+  - uid: 3547
     components:
     - type: Transform
       pos: -31.5,16.5
       parent: 1
-  - uid: 3417
+  - uid: 3548
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-0.5
       parent: 1
-  - uid: 3418
+  - uid: 3549
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-2.5
       parent: 1
-  - uid: 3419
+  - uid: 3550
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-2.5
       parent: 1
-  - uid: 3420
+  - uid: 3551
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-3.5
       parent: 1
-  - uid: 3421
+  - uid: 3552
     components:
     - type: Transform
       pos: 22.5,2.5
       parent: 1
-  - uid: 3422
+  - uid: 3553
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-3.5
       parent: 1
-  - uid: 3423
+  - uid: 3554
     components:
     - type: Transform
       pos: 16.5,-0.5
       parent: 1
-  - uid: 3424
+  - uid: 3555
     components:
     - type: Transform
       pos: -11.5,39.5
       parent: 1
-  - uid: 3425
+  - uid: 3556
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,30.5
       parent: 1
-  - uid: 3426
+  - uid: 3557
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,39.5
       parent: 1
-  - uid: 3427
+  - uid: 3558
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,39.5
       parent: 1
-  - uid: 3428
+  - uid: 3559
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,39.5
       parent: 1
-  - uid: 3429
+  - uid: 3560
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,40.5
       parent: 1
-  - uid: 3430
+  - uid: 3561
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,5.5
       parent: 1
-  - uid: 3431
+  - uid: 3562
     components:
     - type: Transform
       pos: 25.5,35.5
       parent: 1
-  - uid: 3432
+  - uid: 3563
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,7.5
       parent: 1
-  - uid: 3433
+  - uid: 3564
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,9.5
       parent: 1
-  - uid: 3434
+  - uid: 3565
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,6.5
       parent: 1
-  - uid: 3435
+  - uid: 3566
     components:
     - type: Transform
       pos: 34.5,28.5
       parent: 1
-  - uid: 3436
+  - uid: 3567
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,3.5
       parent: 1
-  - uid: 3437
+  - uid: 3568
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,37.5
       parent: 1
-  - uid: 3438
+  - uid: 3569
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,13.5
       parent: 1
-  - uid: 3439
+  - uid: 3570
     components:
     - type: Transform
       pos: -20.5,-2.5
       parent: 1
-  - uid: 3440
+  - uid: 3571
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,29.5
       parent: 1
-  - uid: 3441
+  - uid: 3572
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,35.5
       parent: 1
-  - uid: 3442
+  - uid: 3573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,35.5
       parent: 1
-  - uid: 3443
+  - uid: 3574
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,34.5
       parent: 1
-  - uid: 3444
+  - uid: 3575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,34.5
       parent: 1
-  - uid: 3445
+  - uid: 3576
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,34.5
       parent: 1
-  - uid: 3446
+  - uid: 3577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,34.5
       parent: 1
-  - uid: 3447
+  - uid: 3578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,33.5
       parent: 1
-  - uid: 3448
+  - uid: 3579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,33.5
       parent: 1
-  - uid: 3449
+  - uid: 3580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,33.5
       parent: 1
-  - uid: 3450
+  - uid: 3581
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,32.5
       parent: 1
-  - uid: 3451
+  - uid: 3582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,32.5
       parent: 1
-  - uid: 3452
+  - uid: 3583
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,32.5
       parent: 1
-  - uid: 3453
+  - uid: 3584
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,32.5
       parent: 1
-  - uid: 3454
+  - uid: 3585
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,2.5
       parent: 1
-  - uid: 3455
+  - uid: 3586
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,3.5
       parent: 1
-  - uid: 3456
+  - uid: 3587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,3.5
       parent: 1
-  - uid: 3457
+  - uid: 3588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,4.5
       parent: 1
-  - uid: 3458
+  - uid: 3589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,4.5
       parent: 1
-  - uid: 3459
+  - uid: 3590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,4.5
       parent: 1
-  - uid: 3460
+  - uid: 3591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,4.5
       parent: 1
-  - uid: 3461
+  - uid: 3592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,4.5
       parent: 1
-  - uid: 3462
+  - uid: 3593
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,4.5
       parent: 1
-  - uid: 3463
+  - uid: 3594
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,5.5
       parent: 1
-  - uid: 3464
+  - uid: 3595
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,5.5
       parent: 1
-  - uid: 3465
+  - uid: 3596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,5.5
       parent: 1
-  - uid: 3466
+  - uid: 3597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,5.5
       parent: 1
-  - uid: 3467
+  - uid: 3598
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,6.5
       parent: 1
-  - uid: 3468
+  - uid: 3599
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,6.5
       parent: 1
-  - uid: 3469
+  - uid: 3600
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,7.5
       parent: 1
-  - uid: 3470
+  - uid: 3601
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,7.5
       parent: 1
-  - uid: 3471
+  - uid: 3602
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,9.5
       parent: 1
-  - uid: 3472
+  - uid: 3603
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,6.5
       parent: 1
-  - uid: 3473
+  - uid: 3604
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,8.5
       parent: 1
-  - uid: 3474
+  - uid: 3605
     components:
     - type: Transform
       pos: -27.5,-1.5
       parent: 1
-  - uid: 3475
+  - uid: 3606
     components:
     - type: Transform
       pos: 35.5,32.5
       parent: 1
-  - uid: 3476
+  - uid: 3607
     components:
     - type: Transform
       pos: 35.5,31.5
       parent: 1
-  - uid: 3477
+  - uid: 3608
     components:
     - type: Transform
       pos: 36.5,31.5
       parent: 1
-  - uid: 3478
+  - uid: 3609
     components:
     - type: Transform
       pos: 36.5,30.5
       parent: 1
-  - uid: 3479
+  - uid: 3610
     components:
     - type: Transform
       pos: 36.5,29.5
       parent: 1
-  - uid: 3480
+  - uid: 3611
     components:
     - type: Transform
       pos: 36.5,28.5
       parent: 1
-  - uid: 3481
+  - uid: 3612
     components:
     - type: Transform
       pos: 37.5,28.5
       parent: 1
-  - uid: 3482
+  - uid: 3613
     components:
     - type: Transform
       pos: -26.5,24.5
       parent: 1
-  - uid: 3483
+  - uid: 3614
     components:
     - type: Transform
       pos: 13.5,-1.5
       parent: 1
-  - uid: 3484
+  - uid: 3615
     components:
     - type: Transform
       pos: 15.5,-0.5
       parent: 1
-  - uid: 3485
+  - uid: 3616
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 1
-  - uid: 3486
+  - uid: 3617
     components:
     - type: Transform
       pos: 14.5,-1.5
       parent: 1
-  - uid: 3487
+  - uid: 3618
     components:
     - type: Transform
       pos: -17.5,-4.5
       parent: 1
-  - uid: 3488
+  - uid: 3619
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,8.5
       parent: 1
-  - uid: 3489
+  - uid: 3620
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,7.5
       parent: 1
-  - uid: 3490
+  - uid: 3621
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,7.5
       parent: 1
-  - uid: 3491
+  - uid: 3622
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,6.5
       parent: 1
-  - uid: 3492
+  - uid: 3623
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,5.5
       parent: 1
-  - uid: 3493
+  - uid: 3624
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,4.5
       parent: 1
-  - uid: 3494
+  - uid: 3625
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,3.5
       parent: 1
-  - uid: 3495
+  - uid: 3626
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,2.5
       parent: 1
-  - uid: 3496
+  - uid: 3627
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,1.5
       parent: 1
-  - uid: 3497
+  - uid: 3628
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,1.5
       parent: 1
-  - uid: 3498
+  - uid: 3629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,0.5
       parent: 1
-  - uid: 3499
+  - uid: 3630
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,0.5
       parent: 1
-  - uid: 3500
+  - uid: 3631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-0.5
       parent: 1
-  - uid: 3501
+  - uid: 3632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-0.5
       parent: 1
-  - uid: 3502
+  - uid: 3633
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-0.5
       parent: 1
-  - uid: 3503
+  - uid: 3634
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-0.5
       parent: 1
-  - uid: 3504
+  - uid: 3635
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-0.5
       parent: 1
-  - uid: 3505
+  - uid: 3636
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-1.5
       parent: 1
-  - uid: 3506
+  - uid: 3637
     components:
     - type: Transform
       pos: 37.5,11.5
       parent: 1
-  - uid: 3507
+  - uid: 3638
     components:
     - type: Transform
       pos: 13.5,41.5
       parent: 1
-  - uid: 3508
+  - uid: 3639
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,33.5
       parent: 1
-  - uid: 3509
+  - uid: 3640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,33.5
       parent: 1
-  - uid: 3510
+  - uid: 3641
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,32.5
       parent: 1
-  - uid: 3511
+  - uid: 3642
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,39.5
       parent: 1
-  - uid: 3512
+  - uid: 3643
     components:
     - type: Transform
       pos: -6.5,40.5
       parent: 1
-  - uid: 3513
+  - uid: 3644
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,40.5
       parent: 1
-  - uid: 3514
+  - uid: 3645
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,40.5
       parent: 1
-  - uid: 3515
+  - uid: 3646
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,40.5
       parent: 1
-  - uid: 3516
+  - uid: 3647
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,40.5
       parent: 1
-  - uid: 3517
+  - uid: 3648
     components:
     - type: Transform
       pos: 17.5,39.5
       parent: 1
-  - uid: 3518
+  - uid: 3649
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,38.5
       parent: 1
-  - uid: 3519
+  - uid: 3650
     components:
     - type: Transform
       pos: -20.5,28.5
       parent: 1
-  - uid: 3520
+  - uid: 3651
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,40.5
       parent: 1
-  - uid: 3521
+  - uid: 3652
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,40.5
       parent: 1
-  - uid: 3522
+  - uid: 3653
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,41.5
       parent: 1
-  - uid: 3523
+  - uid: 3654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,38.5
       parent: 1
-  - uid: 3524
+  - uid: 3655
     components:
     - type: Transform
       pos: -19.5,34.5
       parent: 1
-  - uid: 3525
+  - uid: 3656
     components:
     - type: Transform
       pos: 1.5,40.5
       parent: 1
 - proto: WallPlastitaniumOutpost
   entities:
-  - uid: 3526
+  - uid: 3657
     components:
     - type: Transform
       pos: 38.5,24.5
       parent: 1
-  - uid: 3527
+  - uid: 3658
     components:
     - type: Transform
       pos: 38.5,20.5
       parent: 1
-  - uid: 3528
+  - uid: 3659
     components:
     - type: Transform
       pos: 38.5,19.5
       parent: 1
-  - uid: 3529
+  - uid: 3660
     components:
     - type: Transform
       pos: 38.5,18.5
       parent: 1
-  - uid: 3530
+  - uid: 3661
     components:
     - type: Transform
       pos: 38.5,17.5
       parent: 1
-  - uid: 3531
+  - uid: 3662
     components:
     - type: Transform
       pos: 38.5,16.5
       parent: 1
-  - uid: 3532
+  - uid: 3663
     components:
     - type: Transform
       pos: 36.5,18.5
       parent: 1
-  - uid: 3533
+  - uid: 3664
     components:
     - type: Transform
       pos: 36.5,24.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 3534
+  - uid: 3665
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,5.5
       parent: 1
-  - uid: 3535
+  - uid: 3666
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 1
-  - uid: 3536
+  - uid: 3667
     components:
     - type: Transform
       pos: 0.5,26.5
       parent: 1
-  - uid: 3537
+  - uid: 3668
     components:
     - type: Transform
       pos: 4.5,23.5
       parent: 1
-  - uid: 3538
+  - uid: 3669
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 3539
+  - uid: 3670
     components:
     - type: Transform
       pos: 4.5,25.5
       parent: 1
-  - uid: 3540
+  - uid: 3671
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 1
-  - uid: 3541
+  - uid: 3672
     components:
     - type: Transform
       pos: 12.5,12.5
       parent: 1
-  - uid: 3542
+  - uid: 3673
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 3543
+  - uid: 3674
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 3544
+  - uid: 3675
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 3545
+  - uid: 3676
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 3546
+  - uid: 3677
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 1
-  - uid: 3547
+  - uid: 3678
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 1
-  - uid: 3548
+  - uid: 3679
     components:
     - type: Transform
       pos: 13.5,10.5
       parent: 1
-  - uid: 3549
+  - uid: 3680
     components:
     - type: Transform
       pos: 13.5,7.5
       parent: 1
-  - uid: 3550
+  - uid: 3681
     components:
     - type: Transform
       pos: 7.5,19.5
       parent: 1
-  - uid: 3551
+  - uid: 3682
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 1
-  - uid: 3552
+  - uid: 3683
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 1
-  - uid: 3553
+  - uid: 3684
     components:
     - type: Transform
       pos: -11.5,20.5
       parent: 1
-  - uid: 3554
+  - uid: 3685
     components:
     - type: Transform
       pos: -10.5,20.5
       parent: 1
-  - uid: 3555
+  - uid: 3686
     components:
     - type: Transform
       pos: -11.5,19.5
       parent: 1
-  - uid: 3556
+  - uid: 3687
     components:
     - type: Transform
       pos: -13.5,19.5
       parent: 1
-  - uid: 3557
+  - uid: 3688
     components:
     - type: Transform
       pos: -13.5,21.5
       parent: 1
-  - uid: 3558
+  - uid: 3689
     components:
     - type: Transform
       pos: -13.5,22.5
       parent: 1
-  - uid: 3559
+  - uid: 3690
     components:
     - type: Transform
       pos: -11.5,27.5
       parent: 1
-  - uid: 3560
+  - uid: 3691
     components:
     - type: Transform
       pos: -13.5,23.5
       parent: 1
-  - uid: 3561
+  - uid: 3692
     components:
     - type: Transform
       pos: -13.5,24.5
       parent: 1
-  - uid: 3562
+  - uid: 3693
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,19.5
       parent: 1
-  - uid: 3563
+  - uid: 3694
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,13.5
       parent: 1
-  - uid: 3564
+  - uid: 3695
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,13.5
       parent: 1
-  - uid: 3565
+  - uid: 3696
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,15.5
       parent: 1
-  - uid: 3566
+  - uid: 3697
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,13.5
       parent: 1
-  - uid: 3567
+  - uid: 3698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,16.5
       parent: 1
-  - uid: 3568
+  - uid: 3699
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,16.5
       parent: 1
-  - uid: 3569
+  - uid: 3700
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,16.5
       parent: 1
-  - uid: 3570
+  - uid: 3701
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,16.5
       parent: 1
-  - uid: 3571
+  - uid: 3702
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,11.5
       parent: 1
-  - uid: 3572
+  - uid: 3703
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,13.5
       parent: 1
-  - uid: 3573
+  - uid: 3704
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,13.5
       parent: 1
-  - uid: 3574
+  - uid: 3705
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,11.5
       parent: 1
-  - uid: 3575
+  - uid: 3706
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,15.5
       parent: 1
-  - uid: 3576
+  - uid: 3707
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,15.5
       parent: 1
-  - uid: 3577
+  - uid: 3708
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,15.5
       parent: 1
-  - uid: 3578
+  - uid: 3709
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,11.5
       parent: 1
-  - uid: 3579
+  - uid: 3710
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,13.5
       parent: 1
-  - uid: 3582
+  - uid: 3711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,13.5
       parent: 1
-  - uid: 3583
+  - uid: 3712
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,13.5
       parent: 1
-  - uid: 3584
+  - uid: 3713
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,11.5
       parent: 1
-  - uid: 3585
+  - uid: 3714
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,11.5
       parent: 1
-  - uid: 3588
+  - uid: 3715
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,13.5
       parent: 1
-  - uid: 3589
+  - uid: 3716
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,15.5
       parent: 1
-  - uid: 3590
+  - uid: 3717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,11.5
       parent: 1
-  - uid: 3591
+  - uid: 3718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,11.5
       parent: 1
-  - uid: 3594
+  - uid: 3719
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,15.5
       parent: 1
-  - uid: 3595
+  - uid: 3720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,13.5
       parent: 1
-  - uid: 3596
+  - uid: 3721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,13.5
       parent: 1
-  - uid: 3597
+  - uid: 3722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,16.5
       parent: 1
-  - uid: 3598
+  - uid: 3723
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,17.5
       parent: 1
-  - uid: 3599
+  - uid: 3724
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,13.5
       parent: 1
-  - uid: 3600
+  - uid: 3725
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,16.5
       parent: 1
-  - uid: 3601
+  - uid: 3726
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,13.5
       parent: 1
-  - uid: 3602
+  - uid: 3727
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,14.5
       parent: 1
-  - uid: 3603
+  - uid: 3728
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,18.5
       parent: 1
-  - uid: 3604
+  - uid: 3729
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,11.5
       parent: 1
-  - uid: 3605
+  - uid: 3730
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,18.5
       parent: 1
-  - uid: 3606
+  - uid: 3731
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,18.5
       parent: 1
-  - uid: 3607
+  - uid: 3732
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,11.5
       parent: 1
-  - uid: 3608
+  - uid: 3733
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,18.5
       parent: 1
-  - uid: 3609
+  - uid: 3734
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,11.5
       parent: 1
-  - uid: 3610
+  - uid: 3735
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,18.5
       parent: 1
-  - uid: 3611
+  - uid: 3736
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,11.5
       parent: 1
-  - uid: 3612
+  - uid: 3737
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,11.5
       parent: 1
-  - uid: 3613
+  - uid: 3738
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,18.5
       parent: 1
-  - uid: 3614
+  - uid: 3739
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,14.5
       parent: 1
-  - uid: 4120
+  - uid: 3740
     components:
     - type: Transform
       pos: 16.5,12.5
       parent: 1
 - proto: WallReinforcedOutpost
   entities:
-  - uid: 3615
+  - uid: 3741
     components:
     - type: Transform
       pos: -8.5,15.5
       parent: 1
-  - uid: 3616
+  - uid: 3742
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 3617
+  - uid: 3743
     components:
     - type: Transform
       pos: 9.5,20.5
       parent: 1
-  - uid: 3618
+  - uid: 3744
     components:
     - type: Transform
       pos: 4.5,32.5
       parent: 1
-  - uid: 3619
+  - uid: 3745
     components:
     - type: Transform
       pos: -0.5,32.5
       parent: 1
-  - uid: 3620
+  - uid: 3746
     components:
     - type: Transform
       pos: 0.5,32.5
       parent: 1
-  - uid: 3621
+  - uid: 3747
     components:
     - type: Transform
       pos: -2.5,32.5
       parent: 1
-  - uid: 3622
+  - uid: 3748
     components:
     - type: Transform
       pos: -3.5,32.5
       parent: 1
-  - uid: 3623
+  - uid: 3749
     components:
     - type: Transform
       pos: -3.5,31.5
       parent: 1
-  - uid: 3624
+  - uid: 3750
     components:
     - type: Transform
       pos: -3.5,30.5
       parent: 1
-  - uid: 3625
+  - uid: 3751
     components:
     - type: Transform
       pos: -2.5,29.5
       parent: 1
-  - uid: 3626
+  - uid: 3752
     components:
     - type: Transform
       pos: -1.5,29.5
       parent: 1
-  - uid: 3627
+  - uid: 3753
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 1
-  - uid: 3628
+  - uid: 3754
     components:
     - type: Transform
       pos: -0.5,30.5
       parent: 1
-  - uid: 3629
+  - uid: 3755
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 1
-  - uid: 3630
+  - uid: 3756
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 1
-  - uid: 3631
+  - uid: 3757
     components:
     - type: Transform
       pos: -5.5,15.5
       parent: 1
-  - uid: 3632
+  - uid: 3758
     components:
     - type: Transform
       pos: 9.5,21.5
       parent: 1
-  - uid: 3633
+  - uid: 3759
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 1
-  - uid: 3634
+  - uid: 3760
     components:
     - type: Transform
       pos: 11.5,23.5
       parent: 1
-  - uid: 3635
+  - uid: 3761
     components:
     - type: Transform
       pos: 11.5,24.5
       parent: 1
-  - uid: 3636
+  - uid: 3762
     components:
     - type: Transform
       pos: 10.5,21.5
       parent: 1
-  - uid: 3637
+  - uid: 3763
     components:
     - type: Transform
       pos: 11.5,21.5
       parent: 1
-  - uid: 3638
+  - uid: 3764
     components:
     - type: Transform
       pos: 11.5,22.5
       parent: 1
-  - uid: 3639
+  - uid: 3765
     components:
     - type: Transform
       pos: -4.5,30.5
       parent: 1
-  - uid: 3640
+  - uid: 3766
     components:
     - type: Transform
       pos: -10.5,15.5
       parent: 1
-  - uid: 3641
+  - uid: 3767
     components:
     - type: Transform
       pos: -7.5,15.5
       parent: 1
-  - uid: 3642
+  - uid: 3768
     components:
     - type: Transform
       pos: -11.5,28.5
       parent: 1
-  - uid: 3643
+  - uid: 3769
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 3644
+  - uid: 3770
     components:
     - type: Transform
       pos: -7.5,9.5
       parent: 1
-  - uid: 3645
+  - uid: 3771
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 1
-  - uid: 3646
+  - uid: 3772
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 3647
+  - uid: 3773
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 3648
+  - uid: 3774
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 3649
+  - uid: 3775
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 3650
+  - uid: 3776
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 1
-  - uid: 3651
+  - uid: 3777
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 3652
+  - uid: 3778
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 3653
+  - uid: 3779
     components:
     - type: Transform
       pos: -4.5,15.5
       parent: 1
-  - uid: 3654
+  - uid: 3780
     components:
     - type: Transform
       pos: -0.5,18.5
       parent: 1
-  - uid: 3655
+  - uid: 3781
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 3656
+  - uid: 3782
     components:
     - type: Transform
       pos: 3.5,18.5
       parent: 1
-  - uid: 3657
+  - uid: 3783
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 3658
+  - uid: 3784
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
-  - uid: 3659
+  - uid: 3785
     components:
     - type: Transform
       pos: -4.5,16.5
       parent: 1
-  - uid: 3660
+  - uid: 3786
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 1
-  - uid: 3661
+  - uid: 3787
     components:
     - type: Transform
       pos: -2.5,16.5
       parent: 1
-  - uid: 3662
+  - uid: 3788
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 1
-  - uid: 3663
+  - uid: 3789
     components:
     - type: Transform
       pos: -5.5,18.5
       parent: 1
-  - uid: 3664
+  - uid: 3790
     components:
     - type: Transform
       pos: -1.5,18.5
       parent: 1
-  - uid: 3665
+  - uid: 3791
     components:
     - type: Transform
       pos: -0.5,19.5
       parent: 1
-  - uid: 3666
+  - uid: 3792
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 1
-  - uid: 3667
+  - uid: 3793
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 1
-  - uid: 3668
+  - uid: 3794
     components:
     - type: Transform
       pos: 5.5,16.5
       parent: 1
-  - uid: 3669
+  - uid: 3795
     components:
     - type: Transform
       pos: 4.5,16.5
       parent: 1
-  - uid: 3670
+  - uid: 3796
     components:
     - type: Transform
       pos: 3.5,16.5
       parent: 1
-  - uid: 3671
+  - uid: 3797
     components:
     - type: Transform
       pos: 12.5,18.5
       parent: 1
-  - uid: 3672
+  - uid: 3798
     components:
     - type: Transform
       pos: 8.5,16.5
       parent: 1
-  - uid: 3673
+  - uid: 3799
     components:
     - type: Transform
       pos: 8.5,15.5
       parent: 1
-  - uid: 3674
+  - uid: 3800
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 3675
+  - uid: 3801
     components:
     - type: Transform
       pos: 9.5,16.5
       parent: 1
-  - uid: 3676
+  - uid: 3802
     components:
     - type: Transform
       pos: 10.5,16.5
       parent: 1
-  - uid: 3677
+  - uid: 3803
     components:
     - type: Transform
       pos: 11.5,16.5
       parent: 1
-  - uid: 3678
+  - uid: 3804
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 3679
+  - uid: 3805
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 3680
+  - uid: 3806
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 3681
+  - uid: 3807
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 3682
+  - uid: 3808
     components:
     - type: Transform
       pos: 13.5,12.5
       parent: 1
-  - uid: 3683
+  - uid: 3809
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 1
-  - uid: 3684
+  - uid: 3810
     components:
     - type: Transform
       pos: 8.5,13.5
       parent: 1
-  - uid: 3685
+  - uid: 3811
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 1
-  - uid: 3686
+  - uid: 3812
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 1
-  - uid: 3687
+  - uid: 3813
     components:
     - type: Transform
       pos: 6.5,13.5
       parent: 1
-  - uid: 3688
+  - uid: 3814
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
-  - uid: 3689
+  - uid: 3815
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 3690
+  - uid: 3816
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 3691
+  - uid: 3817
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 3692
+  - uid: 3818
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 3693
+  - uid: 3819
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
-  - uid: 3694
+  - uid: 3820
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 3695
+  - uid: 3821
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 3696
+  - uid: 3822
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 3697
+  - uid: 3823
     components:
     - type: Transform
       pos: 12.5,15.5
       parent: 1
-  - uid: 3698
+  - uid: 3824
     components:
     - type: Transform
       pos: 13.5,14.5
       parent: 1
-  - uid: 3699
+  - uid: 3825
     components:
     - type: Transform
       pos: 13.5,13.5
       parent: 1
-  - uid: 3700
+  - uid: 3826
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 3701
+  - uid: 3827
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 3702
+  - uid: 3828
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 3703
+  - uid: 3829
     components:
     - type: Transform
       pos: 13.5,11.5
       parent: 1
-  - uid: 3704
+  - uid: 3830
     components:
     - type: Transform
       pos: 14.5,6.5
       parent: 1
-  - uid: 3705
+  - uid: 3831
     components:
     - type: Transform
       pos: 16.5,6.5
       parent: 1
-  - uid: 3706
+  - uid: 3832
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 1
-  - uid: 3707
+  - uid: 3833
     components:
     - type: Transform
       pos: 16.5,7.5
       parent: 1
-  - uid: 3708
+  - uid: 3834
     components:
     - type: Transform
       pos: 13.5,6.5
       parent: 1
-  - uid: 3709
+  - uid: 3835
     components:
     - type: Transform
       pos: 13.5,5.5
       parent: 1
-  - uid: 3710
+  - uid: 3836
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
-  - uid: 3711
+  - uid: 3837
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 3712
+  - uid: 3838
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 1
-  - uid: 3713
+  - uid: 3839
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 1
-  - uid: 3714
+  - uid: 3840
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 3715
+  - uid: 3841
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 3716
+  - uid: 3842
     components:
     - type: Transform
       pos: 16.5,8.5
       parent: 1
-  - uid: 3717
+  - uid: 3843
     components:
     - type: Transform
       pos: 16.5,9.5
       parent: 1
-  - uid: 3718
+  - uid: 3844
     components:
     - type: Transform
       pos: 16.5,10.5
       parent: 1
-  - uid: 3719
+  - uid: 3845
     components:
     - type: Transform
       pos: 14.5,11.5
       parent: 1
-  - uid: 3720
+  - uid: 3846
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 1
-  - uid: 3721
+  - uid: 3847
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 1
-  - uid: 3722
+  - uid: 3848
     components:
     - type: Transform
       pos: 9.5,19.5
       parent: 1
-  - uid: 3723
+  - uid: 3849
     components:
     - type: Transform
       pos: 10.5,19.5
       parent: 1
-  - uid: 3724
+  - uid: 3850
     components:
     - type: Transform
       pos: 11.5,19.5
       parent: 1
-  - uid: 3725
+  - uid: 3851
     components:
     - type: Transform
       pos: 12.5,19.5
       parent: 1
-  - uid: 3726
+  - uid: 3852
     components:
     - type: Transform
       pos: 9.5,18.5
       parent: 1
-  - uid: 3727
+  - uid: 3853
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 3728
+  - uid: 3854
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 3729
+  - uid: 3855
     components:
     - type: Transform
       pos: -2.5,18.5
       parent: 1
-  - uid: 3730
+  - uid: 3856
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 3731
+  - uid: 3857
     components:
     - type: Transform
       pos: -8.5,18.5
       parent: 1
-  - uid: 3732
+  - uid: 3858
     components:
     - type: Transform
       pos: -6.5,19.5
       parent: 1
-  - uid: 3733
+  - uid: 3859
     components:
     - type: Transform
       pos: -6.5,18.5
       parent: 1
-  - uid: 3734
+  - uid: 3860
     components:
     - type: Transform
       pos: 13.5,15.5
       parent: 1
-  - uid: 3735
+  - uid: 3861
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 1
-  - uid: 3736
+  - uid: 3862
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 1
-  - uid: 3737
+  - uid: 3863
     components:
     - type: Transform
       pos: -8.5,9.5
       parent: 1
-  - uid: 3738
+  - uid: 3864
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 1
-  - uid: 3739
+  - uid: 3865
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 1
-  - uid: 3740
+  - uid: 3866
     components:
     - type: Transform
       pos: -9.5,18.5
       parent: 1
-  - uid: 3741
+  - uid: 3867
     components:
     - type: Transform
       pos: -10.5,18.5
       parent: 1
-  - uid: 3742
+  - uid: 3868
     components:
     - type: Transform
       pos: -11.5,18.5
       parent: 1
-  - uid: 3743
+  - uid: 3869
     components:
     - type: Transform
       pos: -11.5,15.5
       parent: 1
-  - uid: 3744
+  - uid: 3870
     components:
     - type: Transform
       pos: -9.5,15.5
       parent: 1
-  - uid: 3745
+  - uid: 3871
     components:
     - type: Transform
       pos: -8.5,19.5
       parent: 1
-  - uid: 3746
+  - uid: 3872
     components:
     - type: Transform
       pos: -11.5,14.5
       parent: 1
-  - uid: 3747
+  - uid: 3873
     components:
     - type: Transform
       pos: -11.5,13.5
       parent: 1
-  - uid: 3748
+  - uid: 3874
     components:
     - type: Transform
       pos: -11.5,12.5
       parent: 1
-  - uid: 3749
+  - uid: 3875
     components:
     - type: Transform
       pos: -13.5,18.5
       parent: 1
-  - uid: 3750
+  - uid: 3876
     components:
     - type: Transform
       pos: -14.5,14.5
       parent: 1
-  - uid: 3751
+  - uid: 3877
     components:
     - type: Transform
       pos: -14.5,13.5
       parent: 1
-  - uid: 3752
+  - uid: 3878
     components:
     - type: Transform
       pos: -22.5,4.5
       parent: 1
-  - uid: 3753
+  - uid: 3879
     components:
     - type: Transform
       pos: -11.5,10.5
       parent: 1
-  - uid: 3754
+  - uid: 3880
     components:
     - type: Transform
       pos: -15.5,27.5
       parent: 1
-  - uid: 3755
+  - uid: 3881
     components:
     - type: Transform
       pos: -16.5,25.5
       parent: 1
-  - uid: 3756
+  - uid: 3882
     components:
     - type: Transform
       pos: -13.5,27.5
       parent: 1
-  - uid: 3757
+  - uid: 3883
     components:
     - type: Transform
       pos: -16.5,27.5
       parent: 1
-  - uid: 3758
+  - uid: 3884
     components:
     - type: Transform
       pos: -16.5,26.5
       parent: 1
-  - uid: 3759
+  - uid: 3885
     components:
     - type: Transform
       pos: -14.5,25.5
       parent: 1
-  - uid: 3760
+  - uid: 3886
     components:
     - type: Transform
       pos: -15.5,25.5
       parent: 1
-  - uid: 3761
+  - uid: 3887
     components:
     - type: Transform
       pos: -14.5,6.5
       parent: 1
-  - uid: 3762
+  - uid: 3888
     components:
     - type: Transform
       pos: -13.5,25.5
       parent: 1
-  - uid: 3763
+  - uid: 3889
     components:
     - type: Transform
       pos: -14.5,27.5
       parent: 1
-  - uid: 3764
+  - uid: 3890
     components:
     - type: Transform
       pos: -11.5,9.5
       parent: 1
-  - uid: 3765
+  - uid: 3891
     components:
     - type: Transform
       pos: -11.5,8.5
       parent: 1
-  - uid: 3766
+  - uid: 3892
     components:
     - type: Transform
       pos: -11.5,7.5
       parent: 1
-  - uid: 3767
+  - uid: 3893
     components:
     - type: Transform
       pos: -13.5,7.5
       parent: 1
-  - uid: 3768
+  - uid: 3894
     components:
     - type: Transform
       pos: -14.5,7.5
       parent: 1
-  - uid: 3769
+  - uid: 3895
     components:
     - type: Transform
       pos: -15.5,10.5
       parent: 1
-  - uid: 3770
+  - uid: 3896
     components:
     - type: Transform
       pos: -15.5,13.5
       parent: 1
-  - uid: 3771
+  - uid: 3897
     components:
     - type: Transform
       pos: -15.5,12.5
       parent: 1
-  - uid: 3772
+  - uid: 3898
     components:
     - type: Transform
       pos: -26.5,9.5
       parent: 1
-  - uid: 3773
+  - uid: 3899
     components:
     - type: Transform
       pos: -23.5,4.5
       parent: 1
-  - uid: 3774
+  - uid: 3900
     components:
     - type: Transform
       pos: -21.5,5.5
       parent: 1
-  - uid: 3775
+  - uid: 3901
     components:
     - type: Transform
       pos: -26.5,8.5
       parent: 1
-  - uid: 3776
+  - uid: 3902
     components:
     - type: Transform
       pos: -26.5,6.5
       parent: 1
-  - uid: 3777
+  - uid: 3903
     components:
     - type: Transform
       pos: -17.5,12.5
       parent: 1
-  - uid: 3778
+  - uid: 3904
     components:
     - type: Transform
       pos: -16.5,12.5
       parent: 1
-  - uid: 3779
+  - uid: 3905
     components:
     - type: Transform
       pos: -26.5,5.5
       parent: 1
-  - uid: 3780
+  - uid: 3906
     components:
     - type: Transform
       pos: -20.5,7.5
       parent: 1
-  - uid: 3781
+  - uid: 3907
     components:
     - type: Transform
       pos: -21.5,10.5
       parent: 1
-  - uid: 3782
+  - uid: 3908
     components:
     - type: Transform
       pos: -21.5,8.5
       parent: 1
-  - uid: 3783
+  - uid: 3909
     components:
     - type: Transform
       pos: -21.5,11.5
       parent: 1
-  - uid: 3784
+  - uid: 3910
     components:
     - type: Transform
       pos: -26.5,7.5
       parent: 1
-  - uid: 3785
+  - uid: 3911
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 1
-  - uid: 3786
+  - uid: 3912
     components:
     - type: Transform
       pos: -22.5,17.5
       parent: 1
-  - uid: 3787
+  - uid: 3913
     components:
     - type: Transform
       pos: -19.5,7.5
       parent: 1
-  - uid: 3788
+  - uid: 3914
     components:
     - type: Transform
       pos: -21.5,6.5
       parent: 1
-  - uid: 3789
+  - uid: 3915
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 1
-  - uid: 3790
+  - uid: 3916
     components:
     - type: Transform
       pos: -26.5,4.5
       parent: 1
-  - uid: 3791
+  - uid: 3917
     components:
     - type: Transform
       pos: -24.5,4.5
       parent: 1
-  - uid: 3792
+  - uid: 3918
     components:
     - type: Transform
       pos: -15.5,7.5
       parent: 1
-  - uid: 3793
+  - uid: 3919
     components:
     - type: Transform
       pos: -21.5,7.5
       parent: 1
-  - uid: 3794
+  - uid: 3920
     components:
     - type: Transform
       pos: -18.5,7.5
       parent: 1
-  - uid: 3795
+  - uid: 3921
     components:
     - type: Transform
       pos: -19.5,17.5
       parent: 1
-  - uid: 3796
+  - uid: 3922
     components:
     - type: Transform
       pos: -24.5,14.5
       parent: 1
-  - uid: 3797
+  - uid: 3923
     components:
     - type: Transform
       pos: -24.5,17.5
       parent: 1
-  - uid: 3798
+  - uid: 3924
     components:
     - type: Transform
       pos: -24.5,11.5
       parent: 1
-  - uid: 3799
+  - uid: 3925
     components:
     - type: Transform
       pos: -17.5,14.5
       parent: 1
-  - uid: 3800
+  - uid: 3926
     components:
     - type: Transform
       pos: -25.5,11.5
       parent: 1
-  - uid: 3801
+  - uid: 3927
     components:
     - type: Transform
       pos: -24.5,13.5
       parent: 1
-  - uid: 3802
+  - uid: 3928
     components:
     - type: Transform
       pos: -24.5,12.5
       parent: 1
-  - uid: 3803
+  - uid: 3929
     components:
     - type: Transform
       pos: -17.5,7.5
       parent: 1
-  - uid: 3804
+  - uid: 3930
     components:
     - type: Transform
       pos: -26.5,11.5
       parent: 1
-  - uid: 3805
+  - uid: 3931
     components:
     - type: Transform
       pos: -26.5,10.5
       parent: 1
-  - uid: 3806
+  - uid: 3932
     components:
     - type: Transform
       pos: -23.5,17.5
       parent: 1
-  - uid: 3807
+  - uid: 3933
     components:
     - type: Transform
       pos: -24.5,16.5
       parent: 1
-  - uid: 3808
+  - uid: 3934
     components:
     - type: Transform
       pos: -24.5,15.5
       parent: 1
-  - uid: 3809
+  - uid: 3935
     components:
     - type: Transform
       pos: -21.5,20.5
       parent: 1
-  - uid: 3810
+  - uid: 3936
     components:
     - type: Transform
       pos: -22.5,19.5
       parent: 1
-  - uid: 3811
+  - uid: 3937
     components:
     - type: Transform
       pos: -22.5,20.5
       parent: 1
-  - uid: 3812
+  - uid: 3938
     components:
     - type: Transform
       pos: -20.5,12.5
       parent: 1
-  - uid: 3813
+  - uid: 3939
     components:
     - type: Transform
       pos: -17.5,13.5
       parent: 1
-  - uid: 3814
+  - uid: 3940
     components:
     - type: Transform
       pos: -19.5,20.5
       parent: 1
-  - uid: 3815
+  - uid: 3941
     components:
     - type: Transform
       pos: -20.5,20.5
       parent: 1
-  - uid: 3816
+  - uid: 3942
     components:
     - type: Transform
       pos: -21.5,12.5
       parent: 1
-  - uid: 3817
+  - uid: 3943
     components:
     - type: Transform
       pos: -22.5,18.5
       parent: 1
-  - uid: 3818
+  - uid: 3944
     components:
     - type: Transform
       pos: -21.5,17.5
       parent: 1
-  - uid: 3819
+  - uid: 3945
     components:
     - type: Transform
       pos: -21.5,4.5
       parent: 1
-  - uid: 3820
+  - uid: 3946
     components:
     - type: Transform
       pos: -14.5,4.5
       parent: 1
-  - uid: 3821
+  - uid: 3947
     components:
     - type: Transform
       pos: -15.5,4.5
       parent: 1
-  - uid: 3822
+  - uid: 3948
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 1
-  - uid: 3823
+  - uid: 3949
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 1
-  - uid: 3824
+  - uid: 3950
     components:
     - type: Transform
       pos: -14.5,1.5
       parent: 1
-  - uid: 3825
+  - uid: 3951
     components:
     - type: Transform
       pos: -11.5,1.5
       parent: 1
-  - uid: 3826
+  - uid: 3952
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 1
-  - uid: 3827
+  - uid: 3953
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 1
-  - uid: 3828
+  - uid: 3954
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 1
-  - uid: 3829
+  - uid: 3955
     components:
     - type: Transform
       pos: -11.5,5.5
       parent: 1
-  - uid: 3830
+  - uid: 3956
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 1
-  - uid: 3831
+  - uid: 3957
     components:
     - type: Transform
       pos: -16.5,6.5
       parent: 1
-  - uid: 3832
+  - uid: 3958
     components:
     - type: Transform
       pos: -16.5,5.5
       parent: 1
-  - uid: 3833
+  - uid: 3959
     components:
     - type: Transform
       pos: -16.5,4.5
       parent: 1
-  - uid: 3834
+  - uid: 3960
     components:
     - type: Transform
       pos: -16.5,2.5
       parent: 1
-  - uid: 3835
+  - uid: 3961
     components:
     - type: Transform
       pos: -16.5,1.5
       parent: 1
-  - uid: 3836
+  - uid: 3962
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 1
-  - uid: 3837
+  - uid: 3963
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 1
-  - uid: 3838
+  - uid: 3964
     components:
     - type: Transform
       pos: -19.5,1.5
       parent: 1
-  - uid: 3839
+  - uid: 3965
     components:
     - type: Transform
       pos: -20.5,1.5
       parent: 1
-  - uid: 3840
+  - uid: 3966
     components:
     - type: Transform
       pos: -21.5,1.5
       parent: 1
-  - uid: 3841
+  - uid: 3967
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 1
-  - uid: 3842
+  - uid: 3968
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 1
-  - uid: 3843
+  - uid: 3969
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 1
-  - uid: 3844
+  - uid: 3970
     components:
     - type: Transform
       pos: -14.5,-2.5
       parent: 1
-  - uid: 3845
+  - uid: 3971
     components:
     - type: Transform
       pos: -14.5,-1.5
       parent: 1
-  - uid: 3846
+  - uid: 3972
     components:
     - type: Transform
       pos: -14.5,-0.5
       parent: 1
-  - uid: 3847
+  - uid: 3973
     components:
     - type: Transform
       pos: -19.5,2.5
       parent: 1
-  - uid: 3848
+  - uid: 3974
     components:
     - type: Transform
       pos: -19.5,6.5
       parent: 1
-  - uid: 3849
+  - uid: 3975
     components:
     - type: Transform
       pos: 8.5,32.5
       parent: 1
-  - uid: 3850
+  - uid: 3976
     components:
     - type: Transform
       pos: -7.5,30.5
       parent: 1
-  - uid: 3851
+  - uid: 3977
     components:
     - type: Transform
       pos: 9.5,32.5
       parent: 1
-  - uid: 3852
+  - uid: 3978
     components:
     - type: Transform
       pos: -15.5,29.5
       parent: 1
-  - uid: 3853
+  - uid: 3979
     components:
     - type: Transform
       pos: -10.5,30.5
       parent: 1
-  - uid: 3854
+  - uid: 3980
     components:
     - type: Transform
       pos: -13.5,29.5
       parent: 1
-  - uid: 3855
+  - uid: 3981
     components:
     - type: Transform
       pos: -13.5,28.5
       parent: 1
-  - uid: 3856
+  - uid: 3982
     components:
     - type: Transform
       pos: -14.5,29.5
       parent: 1
-  - uid: 3857
+  - uid: 3983
     components:
     - type: Transform
       pos: -11.5,30.5
       parent: 1
-  - uid: 3858
+  - uid: 3984
     components:
     - type: Transform
       pos: -10.5,9.5
       parent: 1
-  - uid: 3859
+  - uid: 3985
     components:
     - type: Transform
       pos: -8.5,12.5
       parent: 1
-  - uid: 3860
+  - uid: 3986
     components:
     - type: Transform
       pos: -7.5,14.5
       parent: 1
-  - uid: 3861
+  - uid: 3987
     components:
     - type: Transform
       pos: -7.5,13.5
       parent: 1
-  - uid: 3862
+  - uid: 3988
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 3863
+  - uid: 3989
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 1
-  - uid: 3864
+  - uid: 3990
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 1
-  - uid: 3865
+  - uid: 3991
     components:
     - type: Transform
       pos: -8.5,6.5
       parent: 1
-  - uid: 3866
+  - uid: 3992
     components:
     - type: Transform
       pos: -10.5,12.5
       parent: 1
-  - uid: 3867
+  - uid: 3993
     components:
     - type: Transform
       pos: -7.5,12.5
       parent: 1
-  - uid: 3868
+  - uid: 3994
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
-  - uid: 3869
+  - uid: 3995
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 1
-  - uid: 3870
+  - uid: 3996
     components:
     - type: Transform
       pos: -7.5,8.5
       parent: 1
-  - uid: 3871
+  - uid: 3997
     components:
     - type: Transform
       pos: -9.5,6.5
       parent: 1
-  - uid: 3872
+  - uid: 3998
     components:
     - type: Transform
       pos: 11.5,25.5
       parent: 1
-  - uid: 3873
+  - uid: 3999
     components:
     - type: Transform
       pos: 11.5,30.5
       parent: 1
-  - uid: 3874
+  - uid: 4000
     components:
     - type: Transform
       pos: 9.5,31.5
       parent: 1
-  - uid: 3875
+  - uid: 4001
     components:
     - type: Transform
       pos: 9.5,28.5
       parent: 1
-  - uid: 3876
+  - uid: 4002
     components:
     - type: Transform
       pos: 9.5,30.5
       parent: 1
-  - uid: 3877
+  - uid: 4003
     components:
     - type: Transform
       pos: 9.5,27.5
       parent: 1
-  - uid: 3878
+  - uid: 4004
     components:
     - type: Transform
       pos: 9.5,29.5
       parent: 1
-  - uid: 3879
+  - uid: 4005
     components:
     - type: Transform
       pos: 11.5,31.5
       parent: 1
-  - uid: 3880
+  - uid: 4006
     components:
     - type: Transform
       pos: 11.5,32.5
       parent: 1
-  - uid: 3881
+  - uid: 4007
     components:
     - type: Transform
       pos: -11.5,29.5
       parent: 1
-  - uid: 3882
+  - uid: 4008
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-  - uid: 3883
+  - uid: 4009
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 1
-  - uid: 3884
+  - uid: 4010
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 1
-  - uid: 3885
+  - uid: 4011
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 3886
+  - uid: 4012
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 3887
+  - uid: 4013
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 3888
+  - uid: 4014
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 3889
+  - uid: 4015
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 3890
+  - uid: 4016
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 3891
+  - uid: 4017
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 1
-  - uid: 3892
+  - uid: 4018
     components:
     - type: Transform
       pos: 12.5,31.5
       parent: 1
-  - uid: 3893
+  - uid: 4019
     components:
     - type: Transform
       pos: 15.5,19.5
       parent: 1
-  - uid: 3894
+  - uid: 4020
     components:
     - type: Transform
       pos: 19.5,19.5
       parent: 1
-  - uid: 3895
+  - uid: 4021
     components:
     - type: Transform
       pos: 16.5,19.5
       parent: 1
-  - uid: 3896
+  - uid: 4022
     components:
     - type: Transform
       pos: 12.5,24.5
       parent: 1
-  - uid: 3897
+  - uid: 4023
     components:
     - type: Transform
       pos: 15.5,23.5
       parent: 1
-  - uid: 3898
+  - uid: 4024
     components:
     - type: Transform
       pos: 13.5,31.5
       parent: 1
-  - uid: 3899
+  - uid: 4025
     components:
     - type: Transform
       pos: 27.5,23.5
       parent: 1
-  - uid: 3900
+  - uid: 4026
     components:
     - type: Transform
       pos: 14.5,31.5
       parent: 1
-  - uid: 3901
+  - uid: 4027
     components:
     - type: Transform
       pos: 13.5,24.5
       parent: 1
-  - uid: 3902
+  - uid: 4028
     components:
     - type: Transform
       pos: 14.5,24.5
       parent: 1
-  - uid: 3903
+  - uid: 4029
     components:
     - type: Transform
       pos: 14.5,19.5
       parent: 1
-  - uid: 3904
+  - uid: 4030
     components:
     - type: Transform
       pos: 19.5,31.5
       parent: 1
-  - uid: 3905
+  - uid: 4031
     components:
     - type: Transform
       pos: 27.5,24.5
       parent: 1
-  - uid: 3906
+  - uid: 4032
     components:
     - type: Transform
       pos: 15.5,24.5
       parent: 1
-  - uid: 3907
+  - uid: 4033
     components:
     - type: Transform
       pos: 18.5,31.5
       parent: 1
-  - uid: 3908
+  - uid: 4034
     components:
     - type: Transform
       pos: 15.5,31.5
       parent: 1
-  - uid: 3909
+  - uid: 4035
     components:
     - type: Transform
       pos: 21.5,19.5
       parent: 1
-  - uid: 3910
+  - uid: 4036
     components:
     - type: Transform
       pos: 15.5,20.5
       parent: 1
-  - uid: 3911
+  - uid: 4037
     components:
     - type: Transform
       pos: 16.5,31.5
       parent: 1
-  - uid: 3912
+  - uid: 4038
     components:
     - type: Transform
       pos: 17.5,31.5
       parent: 1
-  - uid: 3913
+  - uid: 4039
     components:
     - type: Transform
       pos: 13.5,19.5
       parent: 1
-  - uid: 3914
+  - uid: 4040
     components:
     - type: Transform
       pos: 11.5,20.5
       parent: 1
-  - uid: 3915
+  - uid: 4041
     components:
     - type: Transform
       pos: 19.5,25.5
       parent: 1
-  - uid: 3916
+  - uid: 4042
     components:
     - type: Transform
       pos: 15.5,22.5
       parent: 1
-  - uid: 3917
+  - uid: 4043
     components:
     - type: Transform
       pos: 21.5,23.5
       parent: 1
-  - uid: 3918
+  - uid: 4044
     components:
     - type: Transform
       pos: 20.5,25.5
       parent: 1
-  - uid: 3919
+  - uid: 4045
     components:
     - type: Transform
       pos: 21.5,24.5
       parent: 1
-  - uid: 3920
+  - uid: 4046
     components:
     - type: Transform
       pos: 21.5,25.5
       parent: 1
-  - uid: 3921
+  - uid: 4047
     components:
     - type: Transform
       pos: 21.5,20.5
       parent: 1
-  - uid: 3922
+  - uid: 4048
     components:
     - type: Transform
       pos: 19.5,26.5
       parent: 1
-  - uid: 3923
+  - uid: 4049
     components:
     - type: Transform
       pos: 21.5,21.5
       parent: 1
-  - uid: 3924
+  - uid: 4050
     components:
     - type: Transform
       pos: 21.5,18.5
       parent: 1
-  - uid: 3925
+  - uid: 4051
     components:
     - type: Transform
       pos: 21.5,17.5
       parent: 1
-  - uid: 3926
+  - uid: 4052
     components:
     - type: Transform
       pos: 22.5,17.5
       parent: 1
-  - uid: 3927
+  - uid: 4053
     components:
     - type: Transform
       pos: 17.5,19.5
       parent: 1
-  - uid: 3928
+  - uid: 4054
     components:
     - type: Transform
       pos: 15.5,25.5
       parent: 1
-  - uid: 3929
+  - uid: 4055
     components:
     - type: Transform
       pos: 16.5,25.5
       parent: 1
-  - uid: 3930
+  - uid: 4056
     components:
     - type: Transform
       pos: 17.5,25.5
       parent: 1
-  - uid: 3931
+  - uid: 4057
     components:
     - type: Transform
       pos: 20.5,20.5
       parent: 1
-  - uid: 3932
+  - uid: 4058
     components:
     - type: Transform
       pos: 19.5,30.5
       parent: 1
-  - uid: 3933
+  - uid: 4059
     components:
     - type: Transform
       pos: 20.5,26.5
       parent: 1
-  - uid: 3934
+  - uid: 4060
     components:
     - type: Transform
       pos: 20.5,27.5
       parent: 1
-  - uid: 3935
+  - uid: 4061
     components:
     - type: Transform
       pos: 18.5,19.5
       parent: 1
-  - uid: 3936
+  - uid: 4062
     components:
     - type: Transform
       pos: 19.5,20.5
       parent: 1
-  - uid: 3937
+  - uid: 4063
     components:
     - type: Transform
       pos: 20.5,29.5
       parent: 1
-  - uid: 3938
+  - uid: 4064
     components:
     - type: Transform
       pos: 20.5,28.5
       parent: 1
-  - uid: 3939
+  - uid: 4065
     components:
     - type: Transform
       pos: 20.5,30.5
       parent: 1
-  - uid: 3940
+  - uid: 4066
     components:
     - type: Transform
       pos: 25.5,26.5
       parent: 1
-  - uid: 3941
+  - uid: 4067
     components:
     - type: Transform
       pos: 23.5,26.5
       parent: 1
-  - uid: 3942
+  - uid: 4068
     components:
     - type: Transform
       pos: 22.5,26.5
       parent: 1
-  - uid: 3943
+  - uid: 4069
     components:
     - type: Transform
       pos: 21.5,26.5
       parent: 1
-  - uid: 3944
+  - uid: 4070
     components:
     - type: Transform
       pos: 27.5,26.5
       parent: 1
-  - uid: 3945
+  - uid: 4071
     components:
     - type: Transform
       pos: 27.5,21.5
       parent: 1
-  - uid: 3946
+  - uid: 4072
     components:
     - type: Transform
       pos: 27.5,20.5
       parent: 1
-  - uid: 3947
+  - uid: 4073
     components:
     - type: Transform
       pos: 27.5,18.5
       parent: 1
-  - uid: 3948
+  - uid: 4074
     components:
     - type: Transform
       pos: 27.5,25.5
       parent: 1
-  - uid: 3949
+  - uid: 4075
     components:
     - type: Transform
       pos: 24.5,26.5
       parent: 1
-  - uid: 3950
+  - uid: 4076
     components:
     - type: Transform
       pos: 27.5,17.5
       parent: 1
-  - uid: 3951
+  - uid: 4077
     components:
     - type: Transform
       pos: 26.5,17.5
       parent: 1
-  - uid: 3952
+  - uid: 4078
     components:
     - type: Transform
       pos: 25.5,17.5
       parent: 1
-  - uid: 3953
+  - uid: 4079
     components:
     - type: Transform
       pos: 26.5,26.5
       parent: 1
-  - uid: 3954
+  - uid: 4080
     components:
     - type: Transform
       pos: 24.5,17.5
       parent: 1
-  - uid: 3955
+  - uid: 4081
     components:
     - type: Transform
       pos: 23.5,17.5
       parent: 1
-  - uid: 3956
+  - uid: 4082
     components:
     - type: Transform
       pos: 27.5,22.5
       parent: 1
 - proto: WallRock
   entities:
-  - uid: 3957
+  - uid: 4083
     components:
     - type: Transform
       pos: -19.5,26.5
       parent: 1
-  - uid: 3958
+  - uid: 4084
     components:
     - type: Transform
       pos: -18.5,28.5
       parent: 1
-  - uid: 3959
+  - uid: 4085
     components:
     - type: Transform
       pos: -30.5,12.5
       parent: 1
-  - uid: 3960
+  - uid: 4086
     components:
     - type: Transform
       pos: -30.5,13.5
       parent: 1
-  - uid: 3961
+  - uid: 4087
     components:
     - type: Transform
       pos: -30.5,11.5
       parent: 1
-  - uid: 3962
+  - uid: 4088
     components:
     - type: Transform
       pos: 24.5,33.5
       parent: 1
-  - uid: 3963
+  - uid: 4089
     components:
     - type: Transform
       pos: 25.5,32.5
       parent: 1
-  - uid: 3964
+  - uid: 4090
     components:
     - type: Transform
       pos: 26.5,32.5
       parent: 1
-  - uid: 3965
+  - uid: 4091
     components:
     - type: Transform
       pos: 19.5,36.5
       parent: 1
-  - uid: 3966
+  - uid: 4092
     components:
     - type: Transform
       pos: 23.5,34.5
       parent: 1
-  - uid: 3967
+  - uid: 4093
     components:
     - type: Transform
       pos: 19.5,35.5
       parent: 1
-  - uid: 3968
+  - uid: 4094
     components:
     - type: Transform
       pos: -17.5,34.5
       parent: 1
-  - uid: 3969
+  - uid: 4095
     components:
     - type: Transform
       pos: 36.5,19.5
       parent: 1
-  - uid: 3970
+  - uid: 4096
     components:
     - type: Transform
       pos: 36.5,23.5
       parent: 1
-  - uid: 3971
+  - uid: 4097
     components:
     - type: Transform
       pos: 36.5,22.5
       parent: 1
-  - uid: 3972
+  - uid: 4098
     components:
     - type: Transform
       pos: 36.5,25.5
       parent: 1
-  - uid: 3973
+  - uid: 4099
     components:
     - type: Transform
       pos: 36.5,13.5
       parent: 1
-  - uid: 3974
+  - uid: 4100
     components:
     - type: Transform
       pos: 36.5,14.5
       parent: 1
-  - uid: 3975
+  - uid: 4101
     components:
     - type: Transform
       pos: 36.5,16.5
       parent: 1
-  - uid: 3976
+  - uid: 4102
     components:
     - type: Transform
       pos: 36.5,21.5
       parent: 1
-  - uid: 3977
+  - uid: 4103
     components:
     - type: Transform
       pos: 36.5,20.5
       parent: 1
-  - uid: 3978
+  - uid: 4104
     components:
     - type: Transform
       pos: 36.5,17.5
       parent: 1
-  - uid: 3979
+  - uid: 4105
     components:
     - type: Transform
       pos: 23.5,14.5
       parent: 1
-  - uid: 3980
+  - uid: 4106
     components:
     - type: Transform
       pos: 25.5,9.5
       parent: 1
-  - uid: 3981
+  - uid: 4107
     components:
     - type: Transform
       pos: 25.5,14.5
       parent: 1
-  - uid: 3982
+  - uid: 4108
     components:
     - type: Transform
       pos: 25.5,8.5
       parent: 1
-  - uid: 3983
+  - uid: 4109
     components:
     - type: Transform
       pos: 26.5,14.5
       parent: 1
-  - uid: 3984
+  - uid: 4110
     components:
     - type: Transform
       pos: 24.5,10.5
       parent: 1
-  - uid: 3985
+  - uid: 4111
     components:
     - type: Transform
       pos: 25.5,10.5
       parent: 1
-  - uid: 3986
+  - uid: 4112
     components:
     - type: Transform
       pos: 24.5,14.5
       parent: 1
-  - uid: 3987
+  - uid: 4113
     components:
     - type: Transform
       pos: -5.5,37.5
       parent: 1
-  - uid: 3988
+  - uid: 4114
     components:
     - type: Transform
       pos: -7.5,37.5
       parent: 1
-  - uid: 3989
+  - uid: 4115
     components:
     - type: Transform
       pos: -9.5,36.5
       parent: 1
-  - uid: 3990
+  - uid: 4116
     components:
     - type: Transform
       pos: -8.5,36.5
       parent: 1
-  - uid: 3991
+  - uid: 4117
     components:
     - type: Transform
       pos: -1.5,36.5
       parent: 1
-  - uid: 3992
+  - uid: 4118
     components:
     - type: Transform
       pos: -6.5,36.5
       parent: 1
-  - uid: 3993
+  - uid: 4119
     components:
     - type: Transform
       pos: -7.5,36.5
       parent: 1
-  - uid: 3994
+  - uid: 4120
     components:
     - type: Transform
       pos: -8.5,37.5
       parent: 1
-  - uid: 3995
+  - uid: 4121
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 1
-  - uid: 3996
+  - uid: 4122
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 3997
+  - uid: 4123
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 1
-  - uid: 3998
+  - uid: 4124
     components:
     - type: Transform
       pos: -6.5,37.5
       parent: 1
-  - uid: 3999
+  - uid: 4125
     components:
     - type: Transform
       pos: -7.5,35.5
       parent: 1
-  - uid: 4000
+  - uid: 4126
     components:
     - type: Transform
       pos: -7.5,34.5
       parent: 1
-  - uid: 4001
+  - uid: 4127
     components:
     - type: Transform
       pos: -10.5,36.5
       parent: 1
-  - uid: 4002
+  - uid: 4128
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 1
-  - uid: 4003
+  - uid: 4129
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 1
-  - uid: 4004
+  - uid: 4130
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 4006
+  - uid: 4131
     components:
     - type: Transform
       pos: 20.5,8.5
       parent: 1
-  - uid: 4007
+  - uid: 4132
     components:
     - type: Transform
       pos: 20.5,7.5
       parent: 1
-  - uid: 4008
+  - uid: 4133
     components:
     - type: Transform
       pos: 20.5,6.5
       parent: 1
-  - uid: 4009
+  - uid: 4134
     components:
     - type: Transform
       pos: 15.5,14.5
       parent: 1
-  - uid: 4010
+  - uid: 4135
     components:
     - type: Transform
       pos: 15.5,15.5
       parent: 1
-  - uid: 4011
+  - uid: 4136
     components:
     - type: Transform
       pos: 14.5,12.5
       parent: 1
-  - uid: 4012
+  - uid: 4137
     components:
     - type: Transform
       pos: 14.5,13.5
       parent: 1
-  - uid: 4013
+  - uid: 4138
     components:
     - type: Transform
       pos: 22.5,28.5
       parent: 1
-  - uid: 4014
+  - uid: 4139
     components:
     - type: Transform
       pos: 12.5,33.5
       parent: 1
-  - uid: 4015
+  - uid: 4140
     components:
     - type: Transform
       pos: 12.5,32.5
       parent: 1
-  - uid: 4016
+  - uid: 4141
     components:
     - type: Transform
       pos: 0.5,30.5
       parent: 1
-  - uid: 4017
+  - uid: 4142
     components:
     - type: Transform
       pos: 2.5,31.5
       parent: 1
-  - uid: 4018
+  - uid: 4143
     components:
     - type: Transform
       pos: 2.5,30.5
       parent: 1
-  - uid: 4019
+  - uid: 4144
     components:
     - type: Transform
       pos: 3.5,31.5
       parent: 1
-  - uid: 4020
+  - uid: 4145
     components:
     - type: Transform
       pos: 3.5,30.5
       parent: 1
-  - uid: 4021
+  - uid: 4146
     components:
     - type: Transform
       pos: 4.5,30.5
       parent: 1
-  - uid: 4022
+  - uid: 4147
     components:
     - type: Transform
       pos: 5.5,30.5
       parent: 1
-  - uid: 4023
+  - uid: 4148
     components:
     - type: Transform
       pos: 4.5,31.5
       parent: 1
-  - uid: 4024
+  - uid: 4149
     components:
     - type: Transform
       pos: 5.5,31.5
       parent: 1
-  - uid: 4025
+  - uid: 4150
     components:
     - type: Transform
       pos: -5.5,28.5
       parent: 1
-  - uid: 4026
+  - uid: 4151
     components:
     - type: Transform
       pos: 12.5,34.5
       parent: 1
-  - uid: 4027
+  - uid: 4152
     components:
     - type: Transform
       pos: -6.5,28.5
       parent: 1
-  - uid: 4028
+  - uid: 4153
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 4029
+  - uid: 4154
     components:
     - type: Transform
       pos: 19.5,34.5
       parent: 1
-  - uid: 4030
+  - uid: 4155
     components:
     - type: Transform
       pos: 19.5,32.5
       parent: 1
-  - uid: 4032
+  - uid: 4156
     components:
     - type: Transform
       pos: 17.5,8.5
       parent: 1
-  - uid: 4033
+  - uid: 4157
     components:
     - type: Transform
       pos: 17.5,9.5
       parent: 1
-  - uid: 4035
+  - uid: 4158
     components:
     - type: Transform
       pos: 18.5,9.5
       parent: 1
-  - uid: 4036
+  - uid: 4159
     components:
     - type: Transform
       pos: 14.5,32.5
       parent: 1
-  - uid: 4037
+  - uid: 4160
     components:
     - type: Transform
       pos: 13.5,33.5
       parent: 1
-  - uid: 4038
+  - uid: 4161
     components:
     - type: Transform
       pos: 8.5,27.5
       parent: 1
-  - uid: 4039
+  - uid: 4162
     components:
     - type: Transform
       pos: -7.5,28.5
       parent: 1
-  - uid: 4040
+  - uid: 4163
     components:
     - type: Transform
       pos: 18.5,7.5
       parent: 1
-  - uid: 4041
+  - uid: 4164
     components:
     - type: Transform
       pos: 19.5,6.5
       parent: 1
-  - uid: 4042
+  - uid: 4165
     components:
     - type: Transform
       pos: 23.5,10.5
       parent: 1
-  - uid: 4043
+  - uid: 4166
     components:
     - type: Transform
       pos: 23.5,8.5
       parent: 1
-  - uid: 4044
+  - uid: 4167
     components:
     - type: Transform
       pos: 23.5,7.5
       parent: 1
-  - uid: 4045
+  - uid: 4168
     components:
     - type: Transform
       pos: 23.5,6.5
       parent: 1
-  - uid: 4046
+  - uid: 4169
     components:
     - type: Transform
       pos: 23.5,9.5
       parent: 1
-  - uid: 4047
+  - uid: 4170
     components:
     - type: Transform
       pos: 2.5,37.5
       parent: 1
-  - uid: 4048
+  - uid: 4171
     components:
     - type: Transform
       pos: 0.5,37.5
       parent: 1
-  - uid: 4049
+  - uid: 4172
     components:
     - type: Transform
       pos: 0.5,36.5
       parent: 1
-  - uid: 4050
+  - uid: 4173
     components:
     - type: Transform
       pos: -0.5,37.5
       parent: 1
-  - uid: 4051
+  - uid: 4174
     components:
     - type: Transform
       pos: 3.5,37.5
       parent: 1
-  - uid: 4052
+  - uid: 4175
     components:
     - type: Transform
       pos: 3.5,36.5
       parent: 1
-  - uid: 4053
+  - uid: 4176
     components:
     - type: Transform
       pos: 5.5,36.5
       parent: 1
-  - uid: 4054
+  - uid: 4177
     components:
     - type: Transform
       pos: 4.5,36.5
       parent: 1
-  - uid: 4055
+  - uid: 4178
     components:
     - type: Transform
       pos: 6.5,38.5
       parent: 1
-  - uid: 4056
+  - uid: 4179
     components:
     - type: Transform
       pos: 8.5,30.5
       parent: 1
-  - uid: 4057
+  - uid: 4180
     components:
     - type: Transform
       pos: 5.5,29.5
       parent: 1
-  - uid: 4058
+  - uid: 4181
     components:
     - type: Transform
       pos: 5.5,37.5
       parent: 1
-  - uid: 4059
+  - uid: 4182
     components:
     - type: Transform
       pos: 6.5,37.5
       parent: 1
-  - uid: 4060
+  - uid: 4183
     components:
     - type: Transform
       pos: 17.5,10.5
       parent: 1
-  - uid: 4061
+  - uid: 4184
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 1
-  - uid: 4062
+  - uid: 4185
     components:
     - type: Transform
       pos: 22.5,7.5
       parent: 1
-  - uid: 4063
+  - uid: 4186
     components:
     - type: Transform
       pos: 22.5,6.5
       parent: 1
-  - uid: 4064
+  - uid: 4187
     components:
     - type: Transform
       pos: 22.5,9.5
       parent: 1
-  - uid: 4065
+  - uid: 4188
     components:
     - type: Transform
       pos: 22.5,10.5
       parent: 1
-  - uid: 4066
+  - uid: 4189
     components:
     - type: Transform
       pos: 22.5,8.5
       parent: 1
-  - uid: 4067
+  - uid: 4190
     components:
     - type: Transform
       pos: 1.5,37.5
       parent: 1
-  - uid: 4068
+  - uid: 4191
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 1
-  - uid: 4069
+  - uid: 4192
     components:
     - type: Transform
       pos: 1.5,36.5
       parent: 1
-  - uid: 4070
+  - uid: 4193
     components:
     - type: Transform
       pos: -0.5,36.5
       parent: 1
-  - uid: 4071
+  - uid: 4194
     components:
     - type: Transform
       pos: 19.5,33.5
       parent: 1
-  - uid: 4072
+  - uid: 4195
     components:
     - type: Transform
       pos: 6.5,36.5
       parent: 1
-  - uid: 4073
+  - uid: 4196
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 4074
+  - uid: 4197
     components:
     - type: Transform
       pos: 4.5,37.5
       parent: 1
-  - uid: 4075
+  - uid: 4198
     components:
     - type: Transform
       pos: 8.5,28.5
       parent: 1
-  - uid: 4076
+  - uid: 4199
     components:
     - type: Transform
       pos: 8.5,29.5
       parent: 1
-  - uid: 4077
+  - uid: 4200
     components:
     - type: Transform
       pos: 7.5,29.5
       parent: 1
-  - uid: 4078
+  - uid: 4201
     components:
     - type: Transform
       pos: 6.5,29.5
       parent: 1
-  - uid: 4079
+  - uid: 4202
     components:
     - type: Transform
       pos: 11.5,36.5
       parent: 1
-  - uid: 4080
+  - uid: 4203
     components:
     - type: Transform
       pos: 21.5,28.5
       parent: 1
-  - uid: 4081
+  - uid: 4204
     components:
     - type: Transform
       pos: 21.5,27.5
       parent: 1
-  - uid: 4082
+  - uid: 4205
     components:
     - type: Transform
       pos: 22.5,30.5
       parent: 1
-  - uid: 4083
+  - uid: 4206
     components:
     - type: Transform
       pos: 13.5,32.5
       parent: 1
-  - uid: 4084
+  - uid: 4207
     components:
     - type: Transform
       pos: 13.5,34.5
       parent: 1
-  - uid: 4085
+  - uid: 4208
     components:
     - type: Transform
       pos: 14.5,33.5
       parent: 1
-  - uid: 4086
+  - uid: 4209
     components:
     - type: Transform
       pos: 18.5,8.5
       parent: 1
-  - uid: 4088
+  - uid: 4210
     components:
     - type: Transform
       pos: 17.5,6.5
       parent: 1
-  - uid: 4089
+  - uid: 4211
     components:
     - type: Transform
       pos: 17.5,7.5
       parent: 1
-  - uid: 4090
+  - uid: 4212
     components:
     - type: Transform
       pos: 6.5,30.5
       parent: 1
-  - uid: 4091
+  - uid: 4213
     components:
     - type: Transform
       pos: 7.5,31.5
       parent: 1
-  - uid: 4092
+  - uid: 4214
     components:
     - type: Transform
       pos: 7.5,30.5
       parent: 1
-  - uid: 4093
+  - uid: 4215
     components:
     - type: Transform
       pos: -4.5,28.5
       parent: 1
-  - uid: 4094
+  - uid: 4216
     components:
     - type: Transform
       pos: 6.5,31.5
       parent: 1
-  - uid: 4095
+  - uid: 4217
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 1
-  - uid: 4096
+  - uid: 4218
     components:
     - type: Transform
       pos: 21.5,6.5
       parent: 1
-  - uid: 4097
+  - uid: 4219
     components:
     - type: Transform
       pos: 21.5,8.5
       parent: 1
-  - uid: 4100
+  - uid: 4220
     components:
     - type: Transform
       pos: 15.5,13.5
       parent: 1
-  - uid: 4101
+  - uid: 4221
     components:
     - type: Transform
       pos: 22.5,29.5
       parent: 1
-  - uid: 4102
+  - uid: 4222
     components:
     - type: Transform
       pos: 22.5,27.5
       parent: 1
-  - uid: 4103
+  - uid: 4223
     components:
     - type: Transform
       pos: 14.5,14.5
       parent: 1
-  - uid: 4104
+  - uid: 4224
     components:
     - type: Transform
       pos: 8.5,31.5
       parent: 1
-  - uid: 4105
+  - uid: 4225
     components:
     - type: Transform
       pos: -5.5,36.5
       parent: 1
-  - uid: 4106
+  - uid: 4226
     components:
     - type: Transform
       pos: -4.5,36.5
       parent: 1
-  - uid: 4107
+  - uid: 4227
     components:
     - type: Transform
       pos: -3.5,36.5
       parent: 1
-  - uid: 4108
+  - uid: 4228
     components:
     - type: Transform
       pos: -2.5,37.5
       parent: 1
-  - uid: 4109
+  - uid: 4229
     components:
     - type: Transform
       pos: -4.5,37.5
       parent: 1
-  - uid: 4110
+  - uid: 4230
     components:
     - type: Transform
       pos: -2.5,36.5
       parent: 1
-  - uid: 4111
+  - uid: 4231
     components:
     - type: Transform
       pos: -3.5,37.5
       parent: 1
-  - uid: 4112
+  - uid: 4232
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 1
-  - uid: 4113
+  - uid: 4233
     components:
     - type: Transform
       pos: -1.5,37.5
       parent: 1
-  - uid: 4114
+  - uid: 4234
     components:
     - type: Transform
       pos: 21.5,7.5
       parent: 1
-  - uid: 4115
+  - uid: 4235
     components:
     - type: Transform
       pos: 21.5,30.5
       parent: 1
-  - uid: 4116
+  - uid: 4236
     components:
     - type: Transform
       pos: 21.5,29.5
       parent: 1
-  - uid: 4117
+  - uid: 4237
     components:
     - type: Transform
       pos: 15.5,12.5
       parent: 1
-  - uid: 4118
+  - uid: 4238
     components:
     - type: Transform
       pos: 21.5,5.5
       parent: 1
-  - uid: 4119
+  - uid: 4239
     components:
     - type: Transform
       pos: 19.5,18.5
       parent: 1
-  - uid: 4121
+  - uid: 4240
     components:
     - type: Transform
       pos: 19.5,16.5
       parent: 1
-  - uid: 4122
+  - uid: 4241
     components:
     - type: Transform
       pos: 19.5,17.5
       parent: 1
-  - uid: 4124
+  - uid: 4242
     components:
     - type: Transform
       pos: -1.5,20.5
       parent: 1
-  - uid: 4125
+  - uid: 4243
     components:
     - type: Transform
       pos: -1.5,19.5
       parent: 1
-  - uid: 4126
+  - uid: 4244
     components:
     - type: Transform
       pos: -2.5,20.5
       parent: 1
-  - uid: 4127
+  - uid: 4245
     components:
     - type: Transform
       pos: -2.5,19.5
       parent: 1
-  - uid: 4128
+  - uid: 4246
     components:
     - type: Transform
       pos: -3.5,20.5
       parent: 1
-  - uid: 4129
+  - uid: 4247
     components:
     - type: Transform
       pos: -3.5,19.5
       parent: 1
-  - uid: 4130
+  - uid: 4248
     components:
     - type: Transform
       pos: -4.5,20.5
       parent: 1
-  - uid: 4131
+  - uid: 4249
     components:
     - type: Transform
       pos: -4.5,19.5
       parent: 1
-  - uid: 4132
+  - uid: 4250
     components:
     - type: Transform
       pos: -5.5,20.5
       parent: 1
-  - uid: 4133
+  - uid: 4251
     components:
     - type: Transform
       pos: -5.5,19.5
       parent: 1
-  - uid: 4134
+  - uid: 4252
     components:
     - type: Transform
       pos: -4.5,21.5
       parent: 1
-  - uid: 4135
+  - uid: 4253
     components:
     - type: Transform
       pos: -3.5,21.5
       parent: 1
-  - uid: 4136
+  - uid: 4254
     components:
     - type: Transform
       pos: -2.5,21.5
       parent: 1
-  - uid: 4137
+  - uid: 4255
     components:
     - type: Transform
       pos: -4.5,22.5
       parent: 1
-  - uid: 4138
+  - uid: 4256
     components:
     - type: Transform
       pos: -4.5,23.5
       parent: 1
-  - uid: 4139
+  - uid: 4257
     components:
     - type: Transform
       pos: -4.5,24.5
       parent: 1
-  - uid: 4140
+  - uid: 4258
     components:
     - type: Transform
       pos: -4.5,25.5
       parent: 1
-  - uid: 4141
+  - uid: 4259
     components:
     - type: Transform
       pos: -4.5,26.5
       parent: 1
-  - uid: 4142
+  - uid: 4260
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 1
-  - uid: 4143
+  - uid: 4261
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-  - uid: 4144
+  - uid: 4262
     components:
     - type: Transform
       pos: -2.5,25.5
       parent: 1
-  - uid: 4145
+  - uid: 4263
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 1
-  - uid: 4146
+  - uid: 4264
     components:
     - type: Transform
       pos: -1.5,27.5
       parent: 1
-  - uid: 4147
+  - uid: 4265
     components:
     - type: Transform
       pos: -2.5,27.5
       parent: 1
-  - uid: 4148
+  - uid: 4266
     components:
     - type: Transform
       pos: -3.5,27.5
       parent: 1
-  - uid: 4149
+  - uid: 4267
     components:
     - type: Transform
       pos: -4.5,27.5
       parent: 1
-  - uid: 4150
+  - uid: 4268
     components:
     - type: Transform
       pos: -7.5,29.5
       parent: 1
-  - uid: 4152
+  - uid: 4269
     components:
     - type: Transform
       pos: 14.5,34.5
       parent: 1
-  - uid: 4153
+  - uid: 4270
     components:
     - type: Transform
       pos: -6.5,29.5
       parent: 1
-  - uid: 4154
+  - uid: 4271
     components:
     - type: Transform
       pos: 19.5,7.5
       parent: 1
-  - uid: 4155
+  - uid: 4272
     components:
     - type: Transform
       pos: -8.5,29.5
       parent: 1
-  - uid: 4156
+  - uid: 4273
     components:
     - type: Transform
       pos: -5.5,29.5
       parent: 1
-  - uid: 4157
+  - uid: 4274
     components:
     - type: Transform
       pos: 28.5,19.5
       parent: 1
-  - uid: 4158
+  - uid: 4275
     components:
     - type: Transform
       pos: -10.5,27.5
       parent: 1
-  - uid: 4159
+  - uid: 4276
     components:
     - type: Transform
       pos: 28.5,17.5
       parent: 1
-  - uid: 4161
+  - uid: 4277
     components:
     - type: Transform
       pos: -9.5,29.5
       parent: 1
-  - uid: 4162
+  - uid: 4278
     components:
     - type: Transform
       pos: -10.5,29.5
       parent: 1
-  - uid: 4163
+  - uid: 4279
     components:
     - type: Transform
       pos: 18.5,6.5
       parent: 1
-  - uid: 4164
+  - uid: 4280
     components:
     - type: Transform
       pos: -8.5,28.5
       parent: 1
-  - uid: 4165
+  - uid: 4281
     components:
     - type: Transform
       pos: -4.5,29.5
       parent: 1
-  - uid: 4167
+  - uid: 4282
     components:
     - type: Transform
       pos: 24.5,8.5
       parent: 1
-  - uid: 4168
+  - uid: 4283
     components:
     - type: Transform
       pos: 22.5,5.5
       parent: 1
-  - uid: 4169
+  - uid: 4284
     components:
     - type: Transform
       pos: 1.5,30.5
       parent: 1
-  - uid: 4170
+  - uid: 4285
     components:
     - type: Transform
       pos: 20.5,4.5
       parent: 1
-  - uid: 4171
+  - uid: 4286
     components:
     - type: Transform
       pos: 19.5,8.5
       parent: 1
-  - uid: 4172
+  - uid: 4287
     components:
     - type: Transform
       pos: 18.5,4.5
       parent: 1
-  - uid: 4173
+  - uid: 4288
     components:
     - type: Transform
       pos: 18.5,5.5
       parent: 1
-  - uid: 4174
+  - uid: 4289
     components:
     - type: Transform
       pos: 22.5,4.5
       parent: 1
-  - uid: 4175
+  - uid: 4290
     components:
     - type: Transform
       pos: 17.5,5.5
       parent: 1
-  - uid: 4176
+  - uid: 4291
     components:
     - type: Transform
       pos: 19.5,5.5
       parent: 1
-  - uid: 4177
+  - uid: 4292
     components:
     - type: Transform
       pos: 19.5,3.5
       parent: 1
-  - uid: 4178
+  - uid: 4293
     components:
     - type: Transform
       pos: 19.5,4.5
       parent: 1
-  - uid: 4179
+  - uid: 4294
     components:
     - type: Transform
       pos: 21.5,4.5
       parent: 1
-  - uid: 4180
+  - uid: 4295
     components:
     - type: Transform
       pos: -11.5,35.5
       parent: 1
-  - uid: 4181
+  - uid: 4296
     components:
     - type: Transform
       pos: 20.5,5.5
       parent: 1
-  - uid: 4182
+  - uid: 4297
     components:
     - type: Transform
       pos: 18.5,32.5
       parent: 1
-  - uid: 4183
+  - uid: 4298
     components:
     - type: Transform
       pos: 12.5,37.5
       parent: 1
-  - uid: 4184
+  - uid: 4299
     components:
     - type: Transform
       pos: 11.5,41.5
       parent: 1
-  - uid: 4185
+  - uid: 4300
     components:
     - type: Transform
       pos: -15.5,28.5
       parent: 1
-  - uid: 4186
+  - uid: 4301
     components:
     - type: Transform
       pos: 1.5,38.5
       parent: 1
-  - uid: 4187
+  - uid: 4302
     components:
     - type: Transform
       pos: 6.5,39.5
       parent: 1
-  - uid: 4188
+  - uid: 4303
     components:
     - type: Transform
       pos: 16.5,2.5
       parent: 1
-  - uid: 4189
+  - uid: 4304
     components:
     - type: Transform
       pos: 11.5,37.5
       parent: 1
-  - uid: 4190
+  - uid: 4305
     components:
     - type: Transform
       pos: 11.5,39.5
       parent: 1
-  - uid: 4191
+  - uid: 4306
     components:
     - type: Transform
       pos: 11.5,38.5
       parent: 1
-  - uid: 4192
+  - uid: 4307
     components:
     - type: Transform
       pos: -11.5,34.5
       parent: 1
-  - uid: 4193
+  - uid: 4308
     components:
     - type: Transform
       pos: 6.5,40.5
       parent: 1
-  - uid: 4194
+  - uid: 4309
     components:
     - type: Transform
       pos: 5.5,38.5
       parent: 1
-  - uid: 4195
+  - uid: 4310
     components:
     - type: Transform
       pos: -10.5,34.5
       parent: 1
-  - uid: 4196
+  - uid: 4311
     components:
     - type: Transform
       pos: 12.5,38.5
       parent: 1
-  - uid: 4197
+  - uid: 4312
     components:
     - type: Transform
       pos: 0.5,38.5
       parent: 1
-  - uid: 4198
+  - uid: 4313
     components:
     - type: Transform
       pos: -0.5,38.5
       parent: 1
-  - uid: 4199
+  - uid: 4314
     components:
     - type: Transform
       pos: 18.5,33.5
       parent: 1
-  - uid: 4200
+  - uid: 4315
     components:
     - type: Transform
       pos: -4.5,38.5
       parent: 1
-  - uid: 4201
+  - uid: 4316
     components:
     - type: Transform
       pos: 4.5,20.5
       parent: 1
-  - uid: 4202
+  - uid: 4317
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 4203
+  - uid: 4318
     components:
     - type: Transform
       pos: 3.5,20.5
       parent: 1
-  - uid: 4204
+  - uid: 4319
     components:
     - type: Transform
       pos: 3.5,19.5
       parent: 1
-  - uid: 4205
+  - uid: 4320
     components:
     - type: Transform
       pos: -10.5,19.5
       parent: 1
-  - uid: 4206
+  - uid: 4321
     components:
     - type: Transform
       pos: -9.5,19.5
       parent: 1
-  - uid: 4207
+  - uid: 4322
     components:
     - type: Transform
       pos: -14.5,24.5
       parent: 1
-  - uid: 4208
+  - uid: 4323
     components:
     - type: Transform
       pos: 15.5,34.5
       parent: 1
-  - uid: 4209
+  - uid: 4324
     components:
     - type: Transform
       pos: 0.5,31.5
       parent: 1
-  - uid: 4210
+  - uid: 4325
     components:
     - type: Transform
       pos: 1.5,31.5
       parent: 1
-  - uid: 4211
+  - uid: 4326
     components:
     - type: Transform
       pos: -10.5,28.5
       parent: 1
-  - uid: 4212
+  - uid: 4327
     components:
     - type: Transform
       pos: -9.5,28.5
       parent: 1
-  - uid: 4213
+  - uid: 4328
     components:
     - type: Transform
       pos: 28.5,22.5
       parent: 1
-  - uid: 4214
+  - uid: 4329
     components:
     - type: Transform
       pos: 28.5,20.5
       parent: 1
-  - uid: 4215
+  - uid: 4330
     components:
     - type: Transform
       pos: 15.5,32.5
       parent: 1
-  - uid: 4216
+  - uid: 4331
     components:
     - type: Transform
       pos: 15.5,33.5
       parent: 1
-  - uid: 4217
+  - uid: 4332
     components:
     - type: Transform
       pos: -5.5,38.5
       parent: 1
-  - uid: 4218
+  - uid: 4333
     components:
     - type: Transform
       pos: 24.5,9.5
       parent: 1
-  - uid: 4219
+  - uid: 4334
     components:
     - type: Transform
       pos: -15.5,24.5
       parent: 1
-  - uid: 4220
+  - uid: 4335
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 1
-  - uid: 4221
+  - uid: 4336
     components:
     - type: Transform
       pos: -16.5,14.5
       parent: 1
-  - uid: 4222
+  - uid: 4337
     components:
     - type: Transform
       pos: -24.5,18.5
       parent: 1
-  - uid: 4223
+  - uid: 4338
     components:
     - type: Transform
       pos: -24.5,19.5
       parent: 1
-  - uid: 4224
+  - uid: 4339
     components:
     - type: Transform
       pos: -24.5,20.5
       parent: 1
-  - uid: 4225
+  - uid: 4340
     components:
     - type: Transform
       pos: -23.5,18.5
       parent: 1
-  - uid: 4226
+  - uid: 4341
     components:
     - type: Transform
       pos: -23.5,19.5
       parent: 1
-  - uid: 4227
+  - uid: 4342
     components:
     - type: Transform
       pos: -23.5,20.5
       parent: 1
-  - uid: 4228
+  - uid: 4343
     components:
     - type: Transform
       pos: -15.5,14.5
       parent: 1
-  - uid: 4229
+  - uid: 4344
     components:
     - type: Transform
       pos: -25.5,18.5
       parent: 1
-  - uid: 4230
+  - uid: 4345
     components:
     - type: Transform
       pos: -25.5,17.5
       parent: 1
-  - uid: 4231
+  - uid: 4346
     components:
     - type: Transform
       pos: -25.5,16.5
       parent: 1
-  - uid: 4232
+  - uid: 4347
     components:
     - type: Transform
       pos: -25.5,15.5
       parent: 1
-  - uid: 4233
+  - uid: 4348
     components:
     - type: Transform
       pos: -26.5,17.5
       parent: 1
-  - uid: 4234
+  - uid: 4349
     components:
     - type: Transform
       pos: -23.5,21.5
       parent: 1
-  - uid: 4235
+  - uid: 4350
     components:
     - type: Transform
       pos: -22.5,21.5
       parent: 1
-  - uid: 4236
+  - uid: 4351
     components:
     - type: Transform
       pos: -22.5,22.5
       parent: 1
-  - uid: 4237
+  - uid: 4352
     components:
     - type: Transform
       pos: -22.5,23.5
       parent: 1
-  - uid: 4238
+  - uid: 4353
     components:
     - type: Transform
       pos: -21.5,21.5
       parent: 1
-  - uid: 4239
+  - uid: 4354
     components:
     - type: Transform
       pos: -21.5,22.5
       parent: 1
-  - uid: 4240
+  - uid: 4355
     components:
     - type: Transform
       pos: -21.5,23.5
       parent: 1
-  - uid: 4241
+  - uid: 4356
     components:
     - type: Transform
       pos: -20.5,21.5
       parent: 1
-  - uid: 4242
+  - uid: 4357
     components:
     - type: Transform
       pos: -20.5,22.5
       parent: 1
-  - uid: 4243
+  - uid: 4358
     components:
     - type: Transform
       pos: -20.5,23.5
       parent: 1
-  - uid: 4244
+  - uid: 4359
     components:
     - type: Transform
       pos: -20.5,24.5
       parent: 1
-  - uid: 4245
+  - uid: 4360
     components:
     - type: Transform
       pos: -19.5,21.5
       parent: 1
-  - uid: 4246
+  - uid: 4361
     components:
     - type: Transform
       pos: -19.5,22.5
       parent: 1
-  - uid: 4247
+  - uid: 4362
     components:
     - type: Transform
       pos: -19.5,23.5
       parent: 1
-  - uid: 4248
+  - uid: 4363
     components:
     - type: Transform
       pos: -19.5,24.5
       parent: 1
-  - uid: 4249
+  - uid: 4364
     components:
     - type: Transform
       pos: -16.5,24.5
       parent: 1
-  - uid: 4250
+  - uid: 4365
     components:
     - type: Transform
       pos: -17.5,24.5
       parent: 1
-  - uid: 4251
+  - uid: 4366
     components:
     - type: Transform
       pos: -18.5,24.5
       parent: 1
-  - uid: 4252
+  - uid: 4367
     components:
     - type: Transform
       pos: -23.5,23.5
       parent: 1
-  - uid: 4253
+  - uid: 4368
     components:
     - type: Transform
       pos: -20.5,25.5
       parent: 1
-  - uid: 4254
+  - uid: 4369
     components:
     - type: Transform
       pos: -19.5,25.5
       parent: 1
-  - uid: 4255
+  - uid: 4370
     components:
     - type: Transform
       pos: -18.5,25.5
       parent: 1
-  - uid: 4256
+  - uid: 4371
     components:
     - type: Transform
       pos: -18.5,26.5
       parent: 1
-  - uid: 4257
+  - uid: 4372
     components:
     - type: Transform
       pos: -18.5,27.5
       parent: 1
-  - uid: 4258
+  - uid: 4373
     components:
     - type: Transform
       pos: -17.5,25.5
       parent: 1
-  - uid: 4259
+  - uid: 4374
     components:
     - type: Transform
       pos: -17.5,26.5
       parent: 1
-  - uid: 4260
+  - uid: 4375
     components:
     - type: Transform
       pos: -17.5,27.5
       parent: 1
-  - uid: 4261
+  - uid: 4376
     components:
     - type: Transform
       pos: -17.5,31.5
       parent: 1
-  - uid: 4262
+  - uid: 4377
     components:
     - type: Transform
       pos: -17.5,32.5
       parent: 1
-  - uid: 4263
+  - uid: 4378
     components:
     - type: Transform
       pos: -17.5,33.5
       parent: 1
-  - uid: 4264
+  - uid: 4379
     components:
     - type: Transform
       pos: -17.5,28.5
       parent: 1
-  - uid: 4265
+  - uid: 4380
     components:
     - type: Transform
       pos: 13.5,35.5
       parent: 1
-  - uid: 4266
+  - uid: 4381
     components:
     - type: Transform
       pos: -2.5,28.5
       parent: 1
-  - uid: 4267
+  - uid: 4382
     components:
     - type: Transform
       pos: 13.5,36.5
       parent: 1
-  - uid: 4268
+  - uid: 4383
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 1
-  - uid: 4269
+  - uid: 4384
     components:
     - type: Transform
       pos: -18.5,29.5
       parent: 1
-  - uid: 4270
+  - uid: 4385
     components:
     - type: Transform
       pos: -17.5,29.5
       parent: 1
-  - uid: 4271
+  - uid: 4386
     components:
     - type: Transform
       pos: -17.5,30.5
       parent: 1
-  - uid: 4272
+  - uid: 4387
     components:
     - type: Transform
       pos: 12.5,36.5
       parent: 1
-  - uid: 4273
+  - uid: 4388
     components:
     - type: Transform
       pos: 12.5,35.5
       parent: 1
-  - uid: 4274
+  - uid: 4389
     components:
     - type: Transform
       pos: 11.5,35.5
       parent: 1
-  - uid: 4275
+  - uid: 4390
     components:
     - type: Transform
       pos: 28.5,21.5
       parent: 1
-  - uid: 4276
+  - uid: 4391
     components:
     - type: Transform
       pos: 17.5,34.5
       parent: 1
-  - uid: 4277
+  - uid: 4392
     components:
     - type: Transform
       pos: 20.5,19.5
       parent: 1
-  - uid: 4278
+  - uid: 4393
     components:
     - type: Transform
       pos: 28.5,18.5
       parent: 1
-  - uid: 4279
+  - uid: 4394
     components:
     - type: Transform
       pos: 17.5,33.5
       parent: 1
-  - uid: 4280
+  - uid: 4395
     components:
     - type: Transform
       pos: 17.5,32.5
       parent: 1
-  - uid: 4281
+  - uid: 4396
     components:
     - type: Transform
       pos: 16.5,33.5
       parent: 1
-  - uid: 4282
+  - uid: 4397
     components:
     - type: Transform
       pos: 16.5,34.5
       parent: 1
-  - uid: 4283
+  - uid: 4398
     components:
     - type: Transform
       pos: 16.5,32.5
       parent: 1
-  - uid: 4284
+  - uid: 4399
     components:
     - type: Transform
       pos: 18.5,34.5
       parent: 1
-  - uid: 4285
+  - uid: 4400
     components:
     - type: Transform
       pos: 10.5,20.5
       parent: 1
-  - uid: 4286
+  - uid: 4401
     components:
     - type: Transform
       pos: 17.5,4.5
       parent: 1
-  - uid: 4287
+  - uid: 4402
     components:
     - type: Transform
       pos: 16.5,4.5
       parent: 1
-  - uid: 4288
+  - uid: 4403
     components:
     - type: Transform
       pos: 15.5,5.5
       parent: 1
-  - uid: 4289
+  - uid: 4404
     components:
     - type: Transform
       pos: 16.5,5.5
       parent: 1
-  - uid: 4290
+  - uid: 4405
     components:
     - type: Transform
       pos: 15.5,4.5
       parent: 1
-  - uid: 4291
+  - uid: 4406
     components:
     - type: Transform
       pos: 14.5,4.5
       parent: 1
-  - uid: 4292
+  - uid: 4407
     components:
     - type: Transform
       pos: 14.5,5.5
       parent: 1
-  - uid: 4293
+  - uid: 4408
     components:
     - type: Transform
       pos: 17.5,3.5
       parent: 1
-  - uid: 4294
+  - uid: 4409
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 1
-  - uid: 4295
+  - uid: 4410
     components:
     - type: Transform
       pos: 20.5,3.5
       parent: 1
-  - uid: 4296
+  - uid: 4411
     components:
     - type: Transform
       pos: 18.5,3.5
       parent: 1
-  - uid: 4297
+  - uid: 4412
     components:
     - type: Transform
       pos: 15.5,3.5
       parent: 1
-  - uid: 4298
+  - uid: 4413
     components:
     - type: Transform
       pos: 17.5,2.5
       parent: 1
-  - uid: 4299
+  - uid: 4414
     components:
     - type: Transform
       pos: 15.5,2.5
       parent: 1
-  - uid: 4300
+  - uid: 4415
     components:
     - type: Transform
       pos: 16.5,3.5
       parent: 1
-  - uid: 4301
+  - uid: 4416
     components:
     - type: Transform
       pos: -7.5,38.5
       parent: 1
-  - uid: 4302
+  - uid: 4417
     components:
     - type: Transform
       pos: -6.5,38.5
       parent: 1
-  - uid: 4303
+  - uid: 4418
     components:
     - type: Transform
       pos: 2.5,38.5
       parent: 1
-  - uid: 4304
+  - uid: 4419
     components:
     - type: Transform
       pos: -14.5,28.5
       parent: 1
-  - uid: 4305
+  - uid: 4420
     components:
     - type: Transform
       pos: -9.5,35.5
       parent: 1
-  - uid: 4306
+  - uid: 4421
     components:
     - type: Transform
       pos: -9.5,34.5
       parent: 1
-  - uid: 4307
+  - uid: 4422
     components:
     - type: Transform
       pos: -10.5,35.5
       parent: 1
-  - uid: 4308
+  - uid: 4423
     components:
     - type: Transform
       pos: -8.5,35.5
       parent: 1
-  - uid: 4309
+  - uid: 4424
     components:
     - type: Transform
       pos: -16.5,28.5
       parent: 1
-  - uid: 4310
+  - uid: 4425
     components:
     - type: Transform
       pos: -8.5,34.5
       parent: 1
-  - uid: 4311
+  - uid: 4426
     components:
     - type: Transform
       pos: -12.5,35.5
       parent: 1
-  - uid: 4312
+  - uid: 4427
     components:
     - type: Transform
       pos: -12.5,34.5
       parent: 1
-  - uid: 4313
+  - uid: 4428
     components:
     - type: Transform
       pos: -15.5,-0.5
       parent: 1
-  - uid: 4314
+  - uid: 4429
     components:
     - type: Transform
       pos: -15.5,6.5
       parent: 1
-  - uid: 4315
+  - uid: 4430
     components:
     - type: Transform
       pos: -15.5,5.5
       parent: 1
-  - uid: 4316
+  - uid: 4431
     components:
     - type: Transform
       pos: -23.5,22.5
       parent: 1
-  - uid: 4317
+  - uid: 4432
     components:
     - type: Transform
       pos: -24.5,23.5
       parent: 1
-  - uid: 4318
+  - uid: 4433
     components:
     - type: Transform
       pos: -24.5,22.5
       parent: 1
-  - uid: 4319
+  - uid: 4434
     components:
     - type: Transform
       pos: -24.5,21.5
       parent: 1
-  - uid: 4320
+  - uid: 4435
     components:
     - type: Transform
       pos: -25.5,22.5
       parent: 1
-  - uid: 4321
+  - uid: 4436
     components:
     - type: Transform
       pos: -25.5,21.5
       parent: 1
-  - uid: 4322
+  - uid: 4437
     components:
     - type: Transform
       pos: -20.5,26.5
       parent: 1
-  - uid: 4323
+  - uid: 4438
     components:
     - type: Transform
       pos: -26.5,20.5
       parent: 1
-  - uid: 4324
+  - uid: 4439
     components:
     - type: Transform
       pos: -18.5,30.5
       parent: 1
-  - uid: 4325
+  - uid: 4440
     components:
     - type: Transform
       pos: -27.5,19.5
       parent: 1
-  - uid: 4326
+  - uid: 4441
     components:
     - type: Transform
       pos: -27.5,18.5
       parent: 1
-  - uid: 4327
+  - uid: 4442
     components:
     - type: Transform
       pos: -26.5,19.5
       parent: 1
-  - uid: 4328
+  - uid: 4443
     components:
     - type: Transform
       pos: -26.5,18.5
       parent: 1
-  - uid: 4329
+  - uid: 4444
     components:
     - type: Transform
       pos: -25.5,20.5
       parent: 1
-  - uid: 4330
+  - uid: 4445
     components:
     - type: Transform
       pos: -25.5,19.5
       parent: 1
-  - uid: 4331
+  - uid: 4446
     components:
     - type: Transform
       pos: -28.5,18.5
       parent: 1
-  - uid: 4332
+  - uid: 4447
     components:
     - type: Transform
       pos: -29.5,16.5
       parent: 1
-  - uid: 4333
+  - uid: 4448
     components:
     - type: Transform
       pos: -29.5,15.5
       parent: 1
-  - uid: 4334
+  - uid: 4449
     components:
     - type: Transform
       pos: -29.5,14.5
       parent: 1
-  - uid: 4335
+  - uid: 4450
     components:
     - type: Transform
       pos: -29.5,13.5
       parent: 1
-  - uid: 4336
+  - uid: 4451
     components:
     - type: Transform
       pos: -29.5,12.5
       parent: 1
-  - uid: 4337
+  - uid: 4452
     components:
     - type: Transform
       pos: -28.5,17.5
       parent: 1
-  - uid: 4338
+  - uid: 4453
     components:
     - type: Transform
       pos: -28.5,16.5
       parent: 1
-  - uid: 4339
+  - uid: 4454
     components:
     - type: Transform
       pos: -28.5,15.5
       parent: 1
-  - uid: 4340
+  - uid: 4455
     components:
     - type: Transform
       pos: -28.5,14.5
       parent: 1
-  - uid: 4341
+  - uid: 4456
     components:
     - type: Transform
       pos: -28.5,13.5
       parent: 1
-  - uid: 4342
+  - uid: 4457
     components:
     - type: Transform
       pos: -28.5,12.5
       parent: 1
-  - uid: 4343
+  - uid: 4458
     components:
     - type: Transform
       pos: -27.5,17.5
       parent: 1
-  - uid: 4344
+  - uid: 4459
     components:
     - type: Transform
       pos: -27.5,16.5
       parent: 1
-  - uid: 4345
+  - uid: 4460
     components:
     - type: Transform
       pos: -27.5,15.5
       parent: 1
-  - uid: 4346
+  - uid: 4461
     components:
     - type: Transform
       pos: -27.5,14.5
       parent: 1
-  - uid: 4347
+  - uid: 4462
     components:
     - type: Transform
       pos: -27.5,13.5
       parent: 1
-  - uid: 4348
+  - uid: 4463
     components:
     - type: Transform
       pos: -27.5,12.5
       parent: 1
-  - uid: 4349
+  - uid: 4464
     components:
     - type: Transform
       pos: -26.5,16.5
       parent: 1
-  - uid: 4350
+  - uid: 4465
     components:
     - type: Transform
       pos: -26.5,15.5
       parent: 1
-  - uid: 4351
+  - uid: 4466
     components:
     - type: Transform
       pos: -26.5,14.5
       parent: 1
-  - uid: 4352
+  - uid: 4467
     components:
     - type: Transform
       pos: -26.5,13.5
       parent: 1
-  - uid: 4353
+  - uid: 4468
     components:
     - type: Transform
       pos: -26.5,12.5
       parent: 1
-  - uid: 4354
+  - uid: 4469
     components:
     - type: Transform
       pos: -25.5,14.5
       parent: 1
-  - uid: 4355
+  - uid: 4470
     components:
     - type: Transform
       pos: -25.5,13.5
       parent: 1
-  - uid: 4356
+  - uid: 4471
     components:
     - type: Transform
       pos: -25.5,12.5
       parent: 1
-  - uid: 4357
+  - uid: 4472
     components:
     - type: Transform
       pos: -30.5,14.5
       parent: 1
-  - uid: 4358
+  - uid: 4473
     components:
     - type: Transform
       pos: -30.5,10.5
       parent: 1
-  - uid: 4359
+  - uid: 4474
     components:
     - type: Transform
       pos: -30.5,9.5
       parent: 1
-  - uid: 4360
+  - uid: 4475
     components:
     - type: Transform
       pos: -29.5,11.5
       parent: 1
-  - uid: 4361
+  - uid: 4476
     components:
     - type: Transform
       pos: -29.5,10.5
       parent: 1
-  - uid: 4362
+  - uid: 4477
     components:
     - type: Transform
       pos: -29.5,9.5
       parent: 1
-  - uid: 4363
+  - uid: 4478
     components:
     - type: Transform
       pos: -28.5,11.5
       parent: 1
-  - uid: 4364
+  - uid: 4479
     components:
     - type: Transform
       pos: -28.5,10.5
       parent: 1
-  - uid: 4365
+  - uid: 4480
     components:
     - type: Transform
       pos: -28.5,9.5
       parent: 1
-  - uid: 4366
+  - uid: 4481
     components:
     - type: Transform
       pos: -27.5,11.5
       parent: 1
-  - uid: 4367
+  - uid: 4482
     components:
     - type: Transform
       pos: -27.5,9.5
       parent: 1
-  - uid: 4368
+  - uid: 4483
     components:
     - type: Transform
       pos: -27.5,10.5
       parent: 1
-  - uid: 4369
+  - uid: 4484
     components:
     - type: Transform
       pos: -27.5,8.5
       parent: 1
-  - uid: 4370
+  - uid: 4485
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 1
-  - uid: 4371
+  - uid: 4486
     components:
     - type: Transform
       pos: -27.5,6.5
       parent: 1
-  - uid: 4372
+  - uid: 4487
     components:
     - type: Transform
       pos: -27.5,5.5
       parent: 1
-  - uid: 4373
+  - uid: 4488
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 1
-  - uid: 4374
+  - uid: 4489
     components:
     - type: Transform
       pos: -27.5,3.5
       parent: 1
-  - uid: 4375
+  - uid: 4490
     components:
     - type: Transform
       pos: -27.5,2.5
       parent: 1
-  - uid: 4376
+  - uid: 4491
     components:
     - type: Transform
       pos: -28.5,8.5
       parent: 1
-  - uid: 4377
+  - uid: 4492
     components:
     - type: Transform
       pos: -28.5,7.5
       parent: 1
-  - uid: 4378
+  - uid: 4493
     components:
     - type: Transform
       pos: -28.5,6.5
       parent: 1
-  - uid: 4379
+  - uid: 4494
     components:
     - type: Transform
       pos: -28.5,5.5
       parent: 1
-  - uid: 4380
+  - uid: 4495
     components:
     - type: Transform
       pos: -28.5,4.5
       parent: 1
-  - uid: 4381
+  - uid: 4496
     components:
     - type: Transform
       pos: -28.5,3.5
       parent: 1
-  - uid: 4382
+  - uid: 4497
     components:
     - type: Transform
       pos: -28.5,2.5
       parent: 1
-  - uid: 4383
+  - uid: 4498
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 1
-  - uid: 4384
+  - uid: 4499
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 1
-  - uid: 4385
+  - uid: 4500
     components:
     - type: Transform
       pos: -29.5,6.5
       parent: 1
-  - uid: 4386
+  - uid: 4501
     components:
     - type: Transform
       pos: -29.5,5.5
       parent: 1
-  - uid: 4387
+  - uid: 4502
     components:
     - type: Transform
       pos: -29.5,4.5
       parent: 1
-  - uid: 4388
+  - uid: 4503
     components:
     - type: Transform
       pos: -29.5,3.5
       parent: 1
-  - uid: 4389
+  - uid: 4504
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 1
-  - uid: 4390
+  - uid: 4505
     components:
     - type: Transform
       pos: -30.5,8.5
       parent: 1
-  - uid: 4391
+  - uid: 4506
     components:
     - type: Transform
       pos: -30.5,7.5
       parent: 1
-  - uid: 4392
+  - uid: 4507
     components:
     - type: Transform
       pos: -30.5,6.5
       parent: 1
-  - uid: 4393
+  - uid: 4508
     components:
     - type: Transform
       pos: -30.5,5.5
       parent: 1
-  - uid: 4394
+  - uid: 4509
     components:
     - type: Transform
       pos: -30.5,4.5
       parent: 1
-  - uid: 4395
+  - uid: 4510
     components:
     - type: Transform
       pos: -30.5,3.5
       parent: 1
-  - uid: 4396
+  - uid: 4511
     components:
     - type: Transform
       pos: -30.5,2.5
       parent: 1
-  - uid: 4397
+  - uid: 4512
     components:
     - type: Transform
       pos: -31.5,6.5
       parent: 1
-  - uid: 4398
+  - uid: 4513
     components:
     - type: Transform
       pos: -31.5,5.5
       parent: 1
-  - uid: 4399
+  - uid: 4514
     components:
     - type: Transform
       pos: -31.5,4.5
       parent: 1
-  - uid: 4400
+  - uid: 4515
     components:
     - type: Transform
       pos: -31.5,3.5
       parent: 1
-  - uid: 4401
+  - uid: 4516
     components:
     - type: Transform
       pos: -31.5,2.5
       parent: 1
-  - uid: 4402
+  - uid: 4517
     components:
     - type: Transform
       pos: -31.5,8.5
       parent: 1
-  - uid: 4403
+  - uid: 4518
     components:
     - type: Transform
       pos: -32.5,5.5
       parent: 1
-  - uid: 4404
+  - uid: 4519
     components:
     - type: Transform
       pos: -30.5,1.5
       parent: 1
-  - uid: 4405
+  - uid: 4520
     components:
     - type: Transform
       pos: -28.5,1.5
       parent: 1
-  - uid: 4406
+  - uid: 4521
     components:
     - type: Transform
       pos: -27.5,1.5
       parent: 1
-  - uid: 4407
+  - uid: 4522
     components:
     - type: Transform
       pos: -26.5,1.5
       parent: 1
-  - uid: 4408
+  - uid: 4523
     components:
     - type: Transform
       pos: -26.5,2.5
       parent: 1
-  - uid: 4409
+  - uid: 4524
     components:
     - type: Transform
       pos: -26.5,3.5
       parent: 1
-  - uid: 4410
+  - uid: 4525
     components:
     - type: Transform
       pos: -25.5,1.5
       parent: 1
-  - uid: 4411
+  - uid: 4526
     components:
     - type: Transform
       pos: -25.5,2.5
       parent: 1
-  - uid: 4412
+  - uid: 4527
     components:
     - type: Transform
       pos: -25.5,3.5
       parent: 1
-  - uid: 4413
+  - uid: 4528
     components:
     - type: Transform
       pos: -24.5,1.5
       parent: 1
-  - uid: 4414
+  - uid: 4529
     components:
     - type: Transform
       pos: -24.5,2.5
       parent: 1
-  - uid: 4415
+  - uid: 4530
     components:
     - type: Transform
       pos: -24.5,3.5
       parent: 1
-  - uid: 4416
+  - uid: 4531
     components:
     - type: Transform
       pos: -23.5,1.5
       parent: 1
-  - uid: 4417
+  - uid: 4532
     components:
     - type: Transform
       pos: -23.5,2.5
       parent: 1
-  - uid: 4418
+  - uid: 4533
     components:
     - type: Transform
       pos: -22.5,1.5
       parent: 1
-  - uid: 4419
+  - uid: 4534
     components:
     - type: Transform
       pos: -23.5,3.5
       parent: 1
-  - uid: 4420
+  - uid: 4535
     components:
     - type: Transform
       pos: -22.5,3.5
       parent: 1
-  - uid: 4421
+  - uid: 4536
     components:
     - type: Transform
       pos: -22.5,2.5
       parent: 1
-  - uid: 4422
+  - uid: 4537
     components:
     - type: Transform
       pos: -26.5,0.5
       parent: 1
-  - uid: 4423
+  - uid: 4538
     components:
     - type: Transform
       pos: -25.5,0.5
       parent: 1
-  - uid: 4424
+  - uid: 4539
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 1
-  - uid: 4425
+  - uid: 4540
     components:
     - type: Transform
       pos: -23.5,0.5
       parent: 1
-  - uid: 4426
+  - uid: 4541
     components:
     - type: Transform
       pos: -22.5,0.5
       parent: 1
-  - uid: 4427
+  - uid: 4542
     components:
     - type: Transform
       pos: -21.5,0.5
       parent: 1
-  - uid: 4428
+  - uid: 4543
     components:
     - type: Transform
       pos: -21.5,-0.5
       parent: 1
-  - uid: 4429
+  - uid: 4544
     components:
     - type: Transform
       pos: -20.5,0.5
       parent: 1
-  - uid: 4430
+  - uid: 4545
     components:
     - type: Transform
       pos: -20.5,-0.5
       parent: 1
-  - uid: 4431
+  - uid: 4546
     components:
     - type: Transform
       pos: -19.5,0.5
       parent: 1
-  - uid: 4432
+  - uid: 4547
     components:
     - type: Transform
       pos: -19.5,-0.5
       parent: 1
-  - uid: 4433
+  - uid: 4548
     components:
     - type: Transform
       pos: -18.5,0.5
       parent: 1
-  - uid: 4434
+  - uid: 4549
     components:
     - type: Transform
       pos: -17.5,-0.5
       parent: 1
-  - uid: 4435
+  - uid: 4550
     components:
     - type: Transform
       pos: -17.5,0.5
       parent: 1
-  - uid: 4436
+  - uid: 4551
     components:
     - type: Transform
       pos: -16.5,0.5
       parent: 1
-  - uid: 4437
+  - uid: 4552
     components:
     - type: Transform
       pos: -16.5,-0.5
       parent: 1
-  - uid: 4438
+  - uid: 4553
     components:
     - type: Transform
       pos: -16.5,-1.5
       parent: 1
-  - uid: 4439
+  - uid: 4554
     components:
     - type: Transform
       pos: -15.5,0.5
       parent: 1
-  - uid: 4440
+  - uid: 4555
     components:
     - type: Transform
       pos: -15.5,1.5
       parent: 1
-  - uid: 4441
+  - uid: 4556
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 1
-  - uid: 4442
+  - uid: 4557
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 1
-  - uid: 4443
+  - uid: 4558
     components:
     - type: Transform
       pos: -15.5,-3.5
       parent: 1
-  - uid: 4444
+  - uid: 4559
     components:
     - type: Transform
       pos: -1.5,28.5
       parent: 1
-  - uid: 4445
+  - uid: 4560
     components:
     - type: Transform
       pos: 21.5,16.5
       parent: 1
-  - uid: 4446
+  - uid: 4561
     components:
     - type: Transform
       pos: 20.5,18.5
       parent: 1
-  - uid: 4447
+  - uid: 4562
     components:
     - type: Transform
       pos: 20.5,17.5
       parent: 1
-  - uid: 4448
+  - uid: 4563
     components:
     - type: Transform
       pos: 20.5,16.5
       parent: 1
-  - uid: 4449
+  - uid: 4564
     components:
     - type: Transform
       pos: 28.5,16.5
       parent: 1
-  - uid: 4450
+  - uid: 4565
     components:
     - type: Transform
       pos: 14.5,36.5
       parent: 1
-  - uid: 4451
+  - uid: 4566
     components:
     - type: Transform
       pos: 14.5,35.5
       parent: 1
-  - uid: 4452
+  - uid: 4567
     components:
     - type: Transform
       pos: 15.5,36.5
       parent: 1
-  - uid: 4453
+  - uid: 4568
     components:
     - type: Transform
       pos: 15.5,35.5
       parent: 1
-  - uid: 4454
+  - uid: 4569
     components:
     - type: Transform
       pos: 16.5,36.5
       parent: 1
-  - uid: 4455
+  - uid: 4570
     components:
     - type: Transform
       pos: 16.5,35.5
       parent: 1
-  - uid: 4456
+  - uid: 4571
     components:
     - type: Transform
       pos: 17.5,36.5
       parent: 1
-  - uid: 4457
+  - uid: 4572
     components:
     - type: Transform
       pos: 17.5,35.5
       parent: 1
-  - uid: 4458
+  - uid: 4573
     components:
     - type: Transform
       pos: 18.5,36.5
       parent: 1
-  - uid: 4459
+  - uid: 4574
     components:
     - type: Transform
       pos: 18.5,35.5
       parent: 1
-  - uid: 4460
+  - uid: 4575
     components:
     - type: Transform
       pos: 20.5,34.5
       parent: 1
-  - uid: 4461
+  - uid: 4576
     components:
     - type: Transform
       pos: 20.5,33.5
       parent: 1
-  - uid: 4462
+  - uid: 4577
     components:
     - type: Transform
       pos: 20.5,32.5
       parent: 1
-  - uid: 4463
+  - uid: 4578
     components:
     - type: Transform
       pos: 20.5,31.5
       parent: 1
-  - uid: 4464
+  - uid: 4579
     components:
     - type: Transform
       pos: 16.5,37.5
       parent: 1
-  - uid: 4465
+  - uid: 4580
     components:
     - type: Transform
       pos: 22.5,34.5
       parent: 1
-  - uid: 4466
+  - uid: 4581
     components:
     - type: Transform
       pos: 22.5,33.5
       parent: 1
-  - uid: 4467
+  - uid: 4582
     components:
     - type: Transform
       pos: 22.5,32.5
       parent: 1
-  - uid: 4468
+  - uid: 4583
     components:
     - type: Transform
       pos: 22.5,31.5
       parent: 1
-  - uid: 4469
+  - uid: 4584
     components:
     - type: Transform
       pos: 21.5,34.5
       parent: 1
-  - uid: 4470
+  - uid: 4585
     components:
     - type: Transform
       pos: 21.5,33.5
       parent: 1
-  - uid: 4471
+  - uid: 4586
     components:
     - type: Transform
       pos: 21.5,32.5
       parent: 1
-  - uid: 4472
+  - uid: 4587
     components:
     - type: Transform
       pos: 21.5,31.5
       parent: 1
-  - uid: 4473
+  - uid: 4588
     components:
     - type: Transform
       pos: 27.5,16.5
       parent: 1
-  - uid: 4474
+  - uid: 4589
     components:
     - type: Transform
       pos: 23.5,30.5
       parent: 1
-  - uid: 4475
+  - uid: 4590
     components:
     - type: Transform
       pos: 23.5,31.5
       parent: 1
-  - uid: 4476
+  - uid: 4591
     components:
     - type: Transform
       pos: 24.5,30.5
       parent: 1
-  - uid: 4477
+  - uid: 4592
     components:
     - type: Transform
       pos: 24.5,31.5
       parent: 1
-  - uid: 4478
+  - uid: 4593
     components:
     - type: Transform
       pos: 25.5,30.5
       parent: 1
-  - uid: 4479
+  - uid: 4594
     components:
     - type: Transform
       pos: 25.5,31.5
       parent: 1
-  - uid: 4480
+  - uid: 4595
     components:
     - type: Transform
       pos: 24.5,32.5
       parent: 1
-  - uid: 4481
+  - uid: 4596
     components:
     - type: Transform
       pos: 23.5,32.5
       parent: 1
-  - uid: 4482
+  - uid: 4597
     components:
     - type: Transform
       pos: 23.5,33.5
       parent: 1
-  - uid: 4483
+  - uid: 4598
     components:
     - type: Transform
       pos: 18.5,37.5
       parent: 1
-  - uid: 4484
+  - uid: 4599
     components:
     - type: Transform
       pos: 17.5,37.5
       parent: 1
-  - uid: 4485
+  - uid: 4600
     components:
     - type: Transform
       pos: 14.5,37.5
       parent: 1
-  - uid: 4486
+  - uid: 4601
     components:
     - type: Transform
       pos: 13.5,37.5
       parent: 1
-  - uid: 4487
+  - uid: 4602
     components:
     - type: Transform
       pos: 22.5,16.5
       parent: 1
-  - uid: 4488
+  - uid: 4603
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 4489
+  - uid: 4604
     components:
     - type: Transform
       pos: 26.5,10.5
       parent: 1
-  - uid: 4490
+  - uid: 4605
     components:
     - type: Transform
       pos: 26.5,9.5
       parent: 1
-  - uid: 4491
+  - uid: 4606
     components:
     - type: Transform
       pos: 26.5,8.5
       parent: 1
-  - uid: 4492
+  - uid: 4607
     components:
     - type: Transform
       pos: 27.5,14.5
       parent: 1
-  - uid: 4493
+  - uid: 4608
     components:
     - type: Transform
       pos: 27.5,10.5
       parent: 1
-  - uid: 4494
+  - uid: 4609
     components:
     - type: Transform
       pos: 27.5,8.5
       parent: 1
-  - uid: 4495
+  - uid: 4610
     components:
     - type: Transform
       pos: 28.5,14.5
       parent: 1
-  - uid: 4496
+  - uid: 4611
     components:
     - type: Transform
       pos: 28.5,10.5
       parent: 1
-  - uid: 4497
+  - uid: 4612
     components:
     - type: Transform
       pos: 28.5,9.5
       parent: 1
-  - uid: 4498
+  - uid: 4613
     components:
     - type: Transform
       pos: 28.5,8.5
       parent: 1
-  - uid: 4499
+  - uid: 4614
     components:
     - type: Transform
       pos: 27.5,9.5
       parent: 1
-  - uid: 4500
+  - uid: 4615
     components:
     - type: Transform
       pos: 29.5,14.5
       parent: 1
-  - uid: 4501
+  - uid: 4616
     components:
     - type: Transform
       pos: 29.5,9.5
       parent: 1
-  - uid: 4502
+  - uid: 4617
     components:
     - type: Transform
       pos: 29.5,8.5
       parent: 1
-  - uid: 4503
+  - uid: 4618
     components:
     - type: Transform
       pos: 30.5,14.5
       parent: 1
-  - uid: 4504
+  - uid: 4619
     components:
     - type: Transform
       pos: 30.5,10.5
       parent: 1
-  - uid: 4505
+  - uid: 4620
     components:
     - type: Transform
       pos: 30.5,8.5
       parent: 1
-  - uid: 4506
+  - uid: 4621
     components:
     - type: Transform
       pos: 31.5,14.5
       parent: 1
-  - uid: 4507
+  - uid: 4622
     components:
     - type: Transform
       pos: 30.5,9.5
       parent: 1
-  - uid: 4508
+  - uid: 4623
     components:
     - type: Transform
       pos: 31.5,10.5
       parent: 1
-  - uid: 4509
+  - uid: 4624
     components:
     - type: Transform
       pos: 31.5,9.5
       parent: 1
-  - uid: 4510
+  - uid: 4625
     components:
     - type: Transform
       pos: 31.5,8.5
       parent: 1
-  - uid: 4511
+  - uid: 4626
     components:
     - type: Transform
       pos: 32.5,14.5
       parent: 1
-  - uid: 4512
+  - uid: 4627
     components:
     - type: Transform
       pos: 32.5,10.5
       parent: 1
-  - uid: 4513
+  - uid: 4628
     components:
     - type: Transform
       pos: 32.5,9.5
       parent: 1
-  - uid: 4514
+  - uid: 4629
     components:
     - type: Transform
       pos: 32.5,8.5
       parent: 1
-  - uid: 4515
+  - uid: 4630
     components:
     - type: Transform
       pos: 33.5,14.5
       parent: 1
-  - uid: 4516
+  - uid: 4631
     components:
     - type: Transform
       pos: 33.5,10.5
       parent: 1
-  - uid: 4517
+  - uid: 4632
     components:
     - type: Transform
       pos: 33.5,9.5
       parent: 1
-  - uid: 4518
+  - uid: 4633
     components:
     - type: Transform
       pos: 29.5,10.5
       parent: 1
-  - uid: 4519
+  - uid: 4634
     components:
     - type: Transform
       pos: 31.5,7.5
       parent: 1
-  - uid: 4520
+  - uid: 4635
     components:
     - type: Transform
       pos: 28.5,7.5
       parent: 1
-  - uid: 4521
+  - uid: 4636
     components:
     - type: Transform
       pos: 27.5,7.5
       parent: 1
-  - uid: 4522
+  - uid: 4637
     components:
     - type: Transform
       pos: 26.5,7.5
       parent: 1
-  - uid: 4523
+  - uid: 4638
     components:
     - type: Transform
       pos: 25.5,7.5
       parent: 1
-  - uid: 4524
+  - uid: 4639
     components:
     - type: Transform
       pos: 24.5,7.5
       parent: 1
-  - uid: 4525
+  - uid: 4640
     components:
     - type: Transform
       pos: 26.5,6.5
       parent: 1
-  - uid: 4526
+  - uid: 4641
     components:
     - type: Transform
       pos: 28.5,6.5
       parent: 1
-  - uid: 4527
+  - uid: 4642
     components:
     - type: Transform
       pos: 34.5,10.5
       parent: 1
-  - uid: 4528
+  - uid: 4643
     components:
     - type: Transform
       pos: 35.5,22.5
       parent: 1
-  - uid: 4529
+  - uid: 4644
     components:
     - type: Transform
       pos: 35.5,20.5
       parent: 1
-  - uid: 4530
+  - uid: 4645
     components:
     - type: Transform
       pos: 35.5,21.5
       parent: 1
-  - uid: 4531
+  - uid: 4646
     components:
     - type: Transform
       pos: 34.5,14.5
       parent: 1
-  - uid: 4532
+  - uid: 4647
     components:
     - type: Transform
       pos: 34.5,15.5
       parent: 1
-  - uid: 4533
+  - uid: 4648
     components:
     - type: Transform
       pos: 34.5,16.5
       parent: 1
-  - uid: 4534
+  - uid: 4649
     components:
     - type: Transform
       pos: 34.5,17.5
       parent: 1
-  - uid: 4535
+  - uid: 4650
     components:
     - type: Transform
       pos: 34.5,18.5
       parent: 1
-  - uid: 4536
+  - uid: 4651
     components:
     - type: Transform
       pos: 34.5,19.5
       parent: 1
-  - uid: 4537
+  - uid: 4652
     components:
     - type: Transform
       pos: 34.5,20.5
       parent: 1
-  - uid: 4538
+  - uid: 4653
     components:
     - type: Transform
       pos: 34.5,21.5
       parent: 1
-  - uid: 4539
+  - uid: 4654
     components:
     - type: Transform
       pos: 34.5,22.5
       parent: 1
-  - uid: 4540
+  - uid: 4655
     components:
     - type: Transform
       pos: 34.5,23.5
       parent: 1
-  - uid: 4541
+  - uid: 4656
     components:
     - type: Transform
       pos: 34.5,24.5
       parent: 1
-  - uid: 4542
+  - uid: 4657
     components:
     - type: Transform
       pos: 34.5,25.5
       parent: 1
-  - uid: 4543
+  - uid: 4658
     components:
     - type: Transform
       pos: 34.5,26.5
       parent: 1
-  - uid: 4544
+  - uid: 4659
     components:
     - type: Transform
       pos: 34.5,27.5
       parent: 1
-  - uid: 4545
+  - uid: 4660
     components:
     - type: Transform
       pos: 33.5,15.5
       parent: 1
-  - uid: 4546
+  - uid: 4661
     components:
     - type: Transform
       pos: 33.5,16.5
       parent: 1
-  - uid: 4547
+  - uid: 4662
     components:
     - type: Transform
       pos: 33.5,17.5
       parent: 1
-  - uid: 4548
+  - uid: 4663
     components:
     - type: Transform
       pos: 33.5,18.5
       parent: 1
-  - uid: 4549
+  - uid: 4664
     components:
     - type: Transform
       pos: 33.5,19.5
       parent: 1
-  - uid: 4550
+  - uid: 4665
     components:
     - type: Transform
       pos: 33.5,20.5
       parent: 1
-  - uid: 4551
+  - uid: 4666
     components:
     - type: Transform
       pos: 33.5,21.5
       parent: 1
-  - uid: 4552
+  - uid: 4667
     components:
     - type: Transform
       pos: 33.5,22.5
       parent: 1
-  - uid: 4553
+  - uid: 4668
     components:
     - type: Transform
       pos: 33.5,23.5
       parent: 1
-  - uid: 4554
+  - uid: 4669
     components:
     - type: Transform
       pos: 33.5,24.5
       parent: 1
-  - uid: 4555
+  - uid: 4670
     components:
     - type: Transform
       pos: 33.5,25.5
       parent: 1
-  - uid: 4556
+  - uid: 4671
     components:
     - type: Transform
       pos: 33.5,26.5
       parent: 1
-  - uid: 4557
+  - uid: 4672
     components:
     - type: Transform
       pos: 33.5,27.5
       parent: 1
-  - uid: 4558
+  - uid: 4673
     components:
     - type: Transform
       pos: 33.5,28.5
       parent: 1
-  - uid: 4559
+  - uid: 4674
     components:
     - type: Transform
       pos: 32.5,16.5
       parent: 1
-  - uid: 4560
+  - uid: 4675
     components:
     - type: Transform
       pos: 32.5,17.5
       parent: 1
-  - uid: 4561
+  - uid: 4676
     components:
     - type: Transform
       pos: 32.5,18.5
       parent: 1
-  - uid: 4562
+  - uid: 4677
     components:
     - type: Transform
       pos: 32.5,19.5
       parent: 1
-  - uid: 4563
+  - uid: 4678
     components:
     - type: Transform
       pos: 32.5,20.5
       parent: 1
-  - uid: 4564
+  - uid: 4679
     components:
     - type: Transform
       pos: 32.5,21.5
       parent: 1
-  - uid: 4565
+  - uid: 4680
     components:
     - type: Transform
       pos: 32.5,22.5
       parent: 1
-  - uid: 4566
+  - uid: 4681
     components:
     - type: Transform
       pos: 32.5,23.5
       parent: 1
-  - uid: 4567
+  - uid: 4682
     components:
     - type: Transform
       pos: 32.5,24.5
       parent: 1
-  - uid: 4568
+  - uid: 4683
     components:
     - type: Transform
       pos: 32.5,15.5
       parent: 1
-  - uid: 4569
+  - uid: 4684
     components:
     - type: Transform
       pos: 32.5,25.5
       parent: 1
-  - uid: 4570
+  - uid: 4685
     components:
     - type: Transform
       pos: 32.5,27.5
       parent: 1
-  - uid: 4571
+  - uid: 4686
     components:
     - type: Transform
       pos: 31.5,15.5
       parent: 1
-  - uid: 4572
+  - uid: 4687
     components:
     - type: Transform
       pos: 31.5,16.5
       parent: 1
-  - uid: 4573
+  - uid: 4688
     components:
     - type: Transform
       pos: 31.5,17.5
       parent: 1
-  - uid: 4574
+  - uid: 4689
     components:
     - type: Transform
       pos: 31.5,18.5
       parent: 1
-  - uid: 4575
+  - uid: 4690
     components:
     - type: Transform
       pos: 31.5,19.5
       parent: 1
-  - uid: 4576
+  - uid: 4691
     components:
     - type: Transform
       pos: 31.5,20.5
       parent: 1
-  - uid: 4577
+  - uid: 4692
     components:
     - type: Transform
       pos: 31.5,21.5
       parent: 1
-  - uid: 4578
+  - uid: 4693
     components:
     - type: Transform
       pos: 31.5,22.5
       parent: 1
-  - uid: 4579
+  - uid: 4694
     components:
     - type: Transform
       pos: 32.5,28.5
       parent: 1
-  - uid: 4580
+  - uid: 4695
     components:
     - type: Transform
       pos: 31.5,24.5
       parent: 1
-  - uid: 4581
+  - uid: 4696
     components:
     - type: Transform
       pos: 31.5,25.5
       parent: 1
-  - uid: 4582
+  - uid: 4697
     components:
     - type: Transform
       pos: 31.5,26.5
       parent: 1
-  - uid: 4583
+  - uid: 4698
     components:
     - type: Transform
       pos: 31.5,27.5
       parent: 1
-  - uid: 4584
+  - uid: 4699
     components:
     - type: Transform
       pos: 31.5,28.5
       parent: 1
-  - uid: 4585
+  - uid: 4700
     components:
     - type: Transform
       pos: 30.5,16.5
       parent: 1
-  - uid: 4586
+  - uid: 4701
     components:
     - type: Transform
       pos: 30.5,17.5
       parent: 1
-  - uid: 4587
+  - uid: 4702
     components:
     - type: Transform
       pos: 30.5,15.5
       parent: 1
-  - uid: 4588
+  - uid: 4703
     components:
     - type: Transform
       pos: 30.5,18.5
       parent: 1
-  - uid: 4589
+  - uid: 4704
     components:
     - type: Transform
       pos: 30.5,19.5
       parent: 1
-  - uid: 4590
+  - uid: 4705
     components:
     - type: Transform
       pos: 32.5,26.5
       parent: 1
-  - uid: 4591
+  - uid: 4706
     components:
     - type: Transform
       pos: 30.5,20.5
       parent: 1
-  - uid: 4592
+  - uid: 4707
     components:
     - type: Transform
       pos: 30.5,21.5
       parent: 1
-  - uid: 4593
+  - uid: 4708
     components:
     - type: Transform
       pos: 30.5,22.5
       parent: 1
-  - uid: 4594
+  - uid: 4709
     components:
     - type: Transform
       pos: 30.5,23.5
       parent: 1
-  - uid: 4595
+  - uid: 4710
     components:
     - type: Transform
       pos: 30.5,25.5
       parent: 1
-  - uid: 4596
+  - uid: 4711
     components:
     - type: Transform
       pos: 30.5,26.5
       parent: 1
-  - uid: 4597
+  - uid: 4712
     components:
     - type: Transform
       pos: 30.5,27.5
       parent: 1
-  - uid: 4598
+  - uid: 4713
     components:
     - type: Transform
       pos: 30.5,28.5
       parent: 1
-  - uid: 4599
+  - uid: 4714
     components:
     - type: Transform
       pos: 29.5,17.5
       parent: 1
-  - uid: 4600
+  - uid: 4715
     components:
     - type: Transform
       pos: 29.5,16.5
       parent: 1
-  - uid: 4601
+  - uid: 4716
     components:
     - type: Transform
       pos: 30.5,24.5
       parent: 1
-  - uid: 4602
+  - uid: 4717
     components:
     - type: Transform
       pos: 29.5,20.5
       parent: 1
-  - uid: 4603
+  - uid: 4718
     components:
     - type: Transform
       pos: 29.5,19.5
       parent: 1
-  - uid: 4604
+  - uid: 4719
     components:
     - type: Transform
       pos: 29.5,21.5
       parent: 1
-  - uid: 4605
+  - uid: 4720
     components:
     - type: Transform
       pos: 29.5,15.5
       parent: 1
-  - uid: 4606
+  - uid: 4721
     components:
     - type: Transform
       pos: 29.5,22.5
       parent: 1
-  - uid: 4607
+  - uid: 4722
     components:
     - type: Transform
       pos: 29.5,23.5
       parent: 1
-  - uid: 4608
+  - uid: 4723
     components:
     - type: Transform
       pos: 29.5,25.5
       parent: 1
-  - uid: 4609
+  - uid: 4724
     components:
     - type: Transform
       pos: 29.5,27.5
       parent: 1
-  - uid: 4610
+  - uid: 4725
     components:
     - type: Transform
       pos: 29.5,26.5
       parent: 1
-  - uid: 4611
+  - uid: 4726
     components:
     - type: Transform
       pos: 28.5,15.5
       parent: 1
-  - uid: 4612
+  - uid: 4727
     components:
     - type: Transform
       pos: 25.5,27.5
       parent: 1
-  - uid: 4613
+  - uid: 4728
     components:
     - type: Transform
       pos: 29.5,24.5
       parent: 1
-  - uid: 4614
+  - uid: 4729
     components:
     - type: Transform
       pos: 28.5,27.5
       parent: 1
-  - uid: 4615
+  - uid: 4730
     components:
     - type: Transform
       pos: 28.5,28.5
       parent: 1
-  - uid: 4616
+  - uid: 4731
     components:
     - type: Transform
       pos: 27.5,15.5
       parent: 1
-  - uid: 4617
+  - uid: 4732
     components:
     - type: Transform
       pos: 29.5,18.5
       parent: 1
-  - uid: 4618
+  - uid: 4733
     components:
     - type: Transform
       pos: 28.5,25.5
       parent: 1
-  - uid: 4619
+  - uid: 4734
     components:
     - type: Transform
       pos: 27.5,27.5
       parent: 1
-  - uid: 4620
+  - uid: 4735
     components:
     - type: Transform
       pos: 27.5,28.5
       parent: 1
-  - uid: 4621
+  - uid: 4736
     components:
     - type: Transform
       pos: 26.5,15.5
       parent: 1
-  - uid: 4622
+  - uid: 4737
     components:
     - type: Transform
       pos: 26.5,16.5
       parent: 1
-  - uid: 4623
+  - uid: 4738
     components:
     - type: Transform
       pos: 28.5,23.5
       parent: 1
-  - uid: 4624
+  - uid: 4739
     components:
     - type: Transform
       pos: 26.5,27.5
       parent: 1
-  - uid: 4625
+  - uid: 4740
     components:
     - type: Transform
       pos: 26.5,28.5
       parent: 1
-  - uid: 4626
+  - uid: 4741
     components:
     - type: Transform
       pos: 25.5,15.5
       parent: 1
-  - uid: 4627
+  - uid: 4742
     components:
     - type: Transform
       pos: 25.5,16.5
       parent: 1
-  - uid: 4628
+  - uid: 4743
     components:
     - type: Transform
       pos: 29.5,28.5
       parent: 1
-  - uid: 4629
+  - uid: 4744
     components:
     - type: Transform
       pos: 28.5,24.5
       parent: 1
-  - uid: 4630
+  - uid: 4745
     components:
     - type: Transform
       pos: 25.5,28.5
       parent: 1
-  - uid: 4631
+  - uid: 4746
     components:
     - type: Transform
       pos: 24.5,16.5
       parent: 1
-  - uid: 4632
+  - uid: 4747
     components:
     - type: Transform
       pos: 24.5,15.5
       parent: 1
-  - uid: 4633
+  - uid: 4748
     components:
     - type: Transform
       pos: 24.5,27.5
       parent: 1
-  - uid: 4634
+  - uid: 4749
     components:
     - type: Transform
       pos: 24.5,28.5
       parent: 1
-  - uid: 4635
+  - uid: 4750
     components:
     - type: Transform
       pos: 23.5,16.5
       parent: 1
-  - uid: 4636
+  - uid: 4751
     components:
     - type: Transform
       pos: 23.5,15.5
       parent: 1
-  - uid: 4637
+  - uid: 4752
     components:
     - type: Transform
       pos: 23.5,27.5
       parent: 1
-  - uid: 4638
+  - uid: 4753
     components:
     - type: Transform
       pos: 28.5,26.5
       parent: 1
-  - uid: 4639
+  - uid: 4754
     components:
     - type: Transform
       pos: 23.5,28.5
       parent: 1
-  - uid: 4640
+  - uid: 4755
     components:
     - type: Transform
       pos: 31.5,23.5
       parent: 1
-  - uid: 4641
+  - uid: 4756
     components:
     - type: Transform
       pos: 23.5,29.5
       parent: 1
-  - uid: 4642
+  - uid: 4757
     components:
     - type: Transform
       pos: 24.5,29.5
       parent: 1
-  - uid: 4643
+  - uid: 4758
     components:
     - type: Transform
       pos: 25.5,29.5
       parent: 1
-  - uid: 4644
+  - uid: 4759
     components:
     - type: Transform
       pos: 26.5,29.5
       parent: 1
-  - uid: 4645
+  - uid: 4760
     components:
     - type: Transform
       pos: 26.5,30.5
       parent: 1
-  - uid: 4646
+  - uid: 4761
     components:
     - type: Transform
       pos: 27.5,29.5
       parent: 1
-  - uid: 4647
+  - uid: 4762
     components:
     - type: Transform
       pos: 27.5,30.5
       parent: 1
-  - uid: 4648
+  - uid: 4763
     components:
     - type: Transform
       pos: 28.5,29.5
       parent: 1
-  - uid: 4649
+  - uid: 4764
     components:
     - type: Transform
       pos: 28.5,30.5
       parent: 1
-  - uid: 4650
+  - uid: 4765
     components:
     - type: Transform
       pos: 29.5,29.5
       parent: 1
-  - uid: 4651
+  - uid: 4766
     components:
     - type: Transform
       pos: 29.5,30.5
       parent: 1
-  - uid: 4652
+  - uid: 4767
     components:
     - type: Transform
       pos: 30.5,29.5
       parent: 1
-  - uid: 4653
+  - uid: 4768
     components:
     - type: Transform
       pos: 30.5,30.5
       parent: 1
-  - uid: 4654
+  - uid: 4769
     components:
     - type: Transform
       pos: 31.5,29.5
       parent: 1
-  - uid: 4655
+  - uid: 4770
     components:
     - type: Transform
       pos: 31.5,30.5
       parent: 1
-  - uid: 4656
+  - uid: 4771
     components:
     - type: Transform
       pos: 32.5,29.5
       parent: 1
-  - uid: 4657
+  - uid: 4772
     components:
     - type: Transform
       pos: 33.5,29.5
       parent: 1
-  - uid: 4658
+  - uid: 4773
     components:
     - type: Transform
       pos: 33.5,30.5
       parent: 1
-  - uid: 4659
+  - uid: 4774
     components:
     - type: Transform
       pos: 29.5,31.5
       parent: 1
-  - uid: 4660
+  - uid: 4775
     components:
     - type: Transform
       pos: 28.5,31.5
       parent: 1
-  - uid: 4661
+  - uid: 4776
     components:
     - type: Transform
       pos: 27.5,31.5
       parent: 1
-  - uid: 4662
+  - uid: 4777
     components:
     - type: Transform
       pos: 26.5,31.5
       parent: 1
-  - uid: 4663
+  - uid: 4778
     components:
     - type: Transform
       pos: 28.5,32.5
       parent: 1
-  - uid: 4664
+  - uid: 4779
     components:
     - type: Transform
       pos: 35.5,26.5
       parent: 1
-  - uid: 4665
+  - uid: 4780
     components:
     - type: Transform
       pos: 35.5,18.5
       parent: 1
-  - uid: 4666
+  - uid: 4781
     components:
     - type: Transform
       pos: 35.5,17.5
       parent: 1
-  - uid: 4667
+  - uid: 4782
     components:
     - type: Transform
       pos: 35.5,16.5
       parent: 1
-  - uid: 4668
+  - uid: 4783
     components:
     - type: Transform
       pos: 35.5,19.5
       parent: 1
-  - uid: 4669
+  - uid: 4784
     components:
     - type: Transform
       pos: 35.5,14.5
       parent: 1
-  - uid: 4670
+  - uid: 4785
     components:
     - type: Transform
       pos: 35.5,24.5
       parent: 1
-  - uid: 4671
+  - uid: 4786
     components:
     - type: Transform
       pos: 35.5,15.5
       parent: 1
-  - uid: 4672
+  - uid: 4787
     components:
     - type: Transform
       pos: 35.5,23.5
       parent: 1
-  - uid: 4673
+  - uid: 4788
     components:
     - type: Transform
       pos: 35.5,25.5
       parent: 1
-  - uid: 4674
+  - uid: 4789
     components:
     - type: Transform
       pos: 29.5,7.5
       parent: 1
-  - uid: 4675
+  - uid: 4790
     components:
     - type: Transform
       pos: 36.5,15.5
       parent: 1
-  - uid: 4676
+  - uid: 4791
     components:
     - type: Transform
       pos: -32.5,4.5
       parent: 1
-  - uid: 4677
+  - uid: 4792
     components:
     - type: Transform
       pos: 4.5,38.5
       parent: 1
-  - uid: 4678
+  - uid: 4793
     components:
     - type: Transform
       pos: 5.5,39.5
       parent: 1
-  - uid: 4679
+  - uid: 4794
     components:
     - type: Transform
       pos: -9.5,37.5
       parent: 1
-  - uid: 4680
+  - uid: 4795
     components:
     - type: Transform
       pos: -10.5,37.5
       parent: 1
-  - uid: 4681
+  - uid: 4796
     components:
     - type: Transform
       pos: -11.5,36.5
       parent: 1
-  - uid: 4682
+  - uid: 4797
     components:
     - type: Transform
       pos: -12.5,36.5
       parent: 1
 - proto: WarningAir
   entities:
-  - uid: 4683
+  - uid: 4798
     components:
     - type: Transform
       pos: 4.5,23.5
       parent: 1
 - proto: WarningN2
   entities:
-  - uid: 4684
+  - uid: 4799
     components:
     - type: Transform
       pos: 6.5,26.5
       parent: 1
 - proto: WarningO2
   entities:
-  - uid: 4685
+  - uid: 4800
     components:
     - type: Transform
       pos: 7.5,25.5
       parent: 1
 - proto: WarningWaste
   entities:
-  - uid: 4686
+  - uid: 4801
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 1
 - proto: WarpPointAdmin
   entities:
-  - uid: 4687
+  - uid: 4802
     components:
     - type: Transform
       pos: -5.5,17.5
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 4688
+  - uid: 4803
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 4689
+  - uid: 4804
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
 - proto: WeaponCaseAbielle
   entities:
-  - uid: 4690
+  - uid: 4805
     components:
     - type: Transform
       pos: -7.474353,-2.4843037
       parent: 1
-  - uid: 4691
+  - uid: 4806
     components:
     - type: Transform
       pos: -7.532335,-2.3755875
       parent: 1
 - proto: WeaponCaseLongLauncherChinaLake
   entities:
-  - uid: 4692
+  - uid: 4807
     components:
     - type: Transform
       pos: -5.490918,-2.4684525
       parent: 1
 - proto: WeaponCaseLongM90Expedition
   entities:
-  - uid: 4693
+  - uid: 4808
     components:
     - type: Transform
       pos: -6.486277,-2.5747533
       parent: 1
-  - uid: 4694
+  - uid: 4809
     components:
     - type: Transform
       pos: -6.4959407,-2.4732845
       parent: 1
 - proto: WeaponCaseMla73
   entities:
-  - uid: 4695
+  - uid: 4810
     components:
     - type: Transform
       pos: -5.5054135,-2.5940804
       parent: 1
 - proto: WeaponCaseMla79
   entities:
-  - uid: 4696
+  - uid: 4811
     components:
     - type: Transform
       pos: -7.519284,-5.4205327
       parent: 1
 - proto: WeaponCaseWspr
   entities:
-  - uid: 4697
+  - uid: 4812
     components:
     - type: Transform
       pos: -5.519909,-2.366984
       parent: 1
 - proto: WeaponTurretDravon
   entities:
-  - uid: 4698
+  - uid: 4813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,41.5
       parent: 1
-  - uid: 4699
+  - uid: 4814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,40.5
       parent: 1
-  - uid: 4700
+  - uid: 4815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,35.5
       parent: 1
-  - uid: 4701
+  - uid: 4816
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,30.5
       parent: 1
-  - uid: 4702
+  - uid: 4817
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,18.5
       parent: 1
-  - uid: 4703
+  - uid: 4818
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,8.5
       parent: 1
-  - uid: 4704
+  - uid: 4819
     components:
     - type: Transform
       pos: 29.5,3.5
       parent: 1
-  - uid: 4705
+  - uid: 4820
     components:
     - type: Transform
       pos: -30.5,-1.5
       parent: 1
-  - uid: 4706
+  - uid: 4821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,4.5
       parent: 1
-  - uid: 4707
+  - uid: 4822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,18.5
       parent: 1
-  - uid: 4708
+  - uid: 4823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30394,47 +30416,47 @@ entities:
       parent: 1
 - proto: WeaponTurretHades
   entities:
-  - uid: 4709
+  - uid: 4824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,36.5
       parent: 1
-  - uid: 4710
+  - uid: 4825
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,39.5
       parent: 1
-  - uid: 4711
+  - uid: 4826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,25.5
       parent: 1
-  - uid: 4712
+  - uid: 4827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,12.5
       parent: 1
-  - uid: 4713
+  - uid: 4828
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 1
-  - uid: 4714
+  - uid: 4829
     components:
     - type: Transform
       pos: 19.5,1.5
       parent: 1
-  - uid: 4715
+  - uid: 4830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 38.5,14.5
       parent: 1
-  - uid: 4716
+  - uid: 4831
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30442,66 +30464,66 @@ entities:
       parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 4717
+  - uid: 4832
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-5.5
       parent: 1
-  - uid: 4718
+  - uid: 4833
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 4719
+  - uid: 4834
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 1
-  - uid: 4720
+  - uid: 4835
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 4721
+  - uid: 4836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,29.5
       parent: 1
-  - uid: 4722
+  - uid: 4837
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 1
-  - uid: 4723
+  - uid: 4838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-5.5
       parent: 1
-  - uid: 4724
+  - uid: 4839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,7.5
       parent: 1
-  - uid: 4725
+  - uid: 4840
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 1
-  - uid: 4726
+  - uid: 4841
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,7.5
       parent: 1
-  - uid: 4727
+  - uid: 4842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/suit_storage.yml
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+# USSP
+
 - type: entity
   id: SuitStorageUssp
   parent: SuitStorageBase
@@ -14,7 +16,7 @@
         - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitUsspL27
         - id: ClothingMaskGasSecurity
-        - id: JetpackMiniFilled
+        - id: JetpackVoidFilled
         - id: ClothingShoesBootsMagSecurity
   - type: AccessReader
     access: [["USSP"]]
@@ -31,10 +33,12 @@
         - id: ClothingOuterHardsuitOfficerCombat
         - id: ClothingOuterHardsuitUsspL30
         - id: ClothingMaskGasSecurity
-        - id: JetpackMiniFilled
+        - id: JetpackVoidFilled
         - id: ClothingShoesBootsMagSecurity
   - type: AccessReader
     access: [["USSPCommand"]]
+
+# TSFMC
 
 - type: entity
   id: SuitStorageM82c
@@ -46,7 +50,8 @@
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
     - id: ClothingOuterHardsuitM82c
-    - id: JetpackMiniFilled
+    - id: JetpackSecurityFilled
+    - id: ClothingShoesBootsMagSecurity
   - type: AccessReader
     access: [["Security"]]
 
@@ -60,7 +65,8 @@
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
     - id: ClothingOuterHardsuitM82b
-    - id: JetpackMiniFilled
+    - id: JetpackSecurityFilled
+    - id: ClothingShoesBootsMagSecurity
   - type: AccessReader
     access: [["Security"]]
 
@@ -74,6 +80,39 @@
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
     - id: ClothingOuterHardsuitM86
-    - id: JetpackMiniFilled
+    - id: JetpackSecurityFilled
+    - id: ClothingShoesBootsMagSecurity
   - type: AccessReader
     access: [["Security"]]
+
+# Syndicate
+
+#Commander Blood-red hardsuit
+- type: entity
+  id: SuitStorageSyndieCommander
+  parent: SuitStorageBase
+  suffix: Syndicate Commander Hardsuit
+  components:
+  - type: StorageFill
+    contents:
+        - id: OxygenTankFilled
+        - id: NitrogenTankFilled
+        - id: ClothingOuterHardsuitSyndieCommander
+        - id: ClothingShoesBootsMagSyndie
+        - id: ClothingMaskGasSyndicate
+        - id: JetpackBlackFilled # Frontier
+
+#Blood-red medic hardsuit
+- type: entity
+  id: SuitStorageSyndieMedic
+  parent: SuitStorageBase
+  suffix: Syndicate Medic Hardsuit
+  components:
+  - type: StorageFill
+    contents:
+        - id: OxygenTankFilled
+        - id: NitrogenTankFilled
+        - id: ClothingOuterHardsuitSyndieMedic
+        - id: ClothingShoesBootsMagSyndie
+        - id: ClothingMaskGasSyndicate
+        - id: JetpackBlackFilled # Frontier

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/suit_storage.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Blu
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/equipment.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/equipment.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/equipment.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/equipment.yml
@@ -21,4 +21,4 @@
   - ClothingOuterHardsuitSyndieEliteRogue
   - ClothingOuterHardsuitJuggernautRogue
   - ClothingOuterHardsuitCybersunStealthRogue
-  - ClothingOuterHardsuitSyndieCommanderRogue
+# - ClothingOuterHardsuitSyndieCommanderRogue

--- a/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
@@ -75,7 +75,7 @@
   cost: 65000
   recipeUnlocks:
   - ClothingOuterHardsuitJuggernautRogue
-  - ClothingOuterHardsuitSyndieCommanderRogue
+# - ClothingOuterHardsuitSyndieCommanderRogue
   technologyPrerequisites:
   - RogueBasicEquipment
   - RogueAdvancedEquipment

--- a/Resources/Prototypes/_NF/Research/civilianservices.yml
+++ b/Resources/Prototypes/_NF/Research/civilianservices.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2024 chrome-cirrus
+# SPDX-FileCopyrightText: 2025 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2025 Redrover1760
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Tier 1
 
 - type: technology

--- a/Resources/Prototypes/_NF/Research/civilianservices.yml
+++ b/Resources/Prototypes/_NF/Research/civilianservices.yml
@@ -73,8 +73,6 @@
   - MedicalAssemblerMachineCircuitboard
   - HotplateMachineCircuitboard
 
-# Tier 3
-
 - type: technology
   id: AdvancedPersonalPropulsion
   name: research-technology-advanced-personal-propulsion
@@ -82,8 +80,8 @@
     sprite: Objects/Tanks/Jetpacks/void.rsi
     state: icon
   discipline: CivilianServices
-  tier: 3
-  cost: 15000
+  tier: 2 # 3->2 - Mono
+  cost: 7500 # 15000->7500 - Mono
   recipeUnlocks:
   - JetpackVoid
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Rogues can no longer can print commander hardsuits with tech. Rogues now start with a suit locker in rogue base that has one.

Fixes TSFMC suitstorages not having security jetpacks or magboots.

USSP suitstorages now have Void jetpacks.

Void jetpacks reduced to tier 2 civilian research and 7500 points.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Commander hardsuits is effectively a complete upgrade to other suits, its not very good and doesn't fit as the type of suit that can be endlessly printed. Besides, its a commander faction leadership type suit. No one else can't print leader-tier gear either.

I know other suits are somewhat this, but that will be resolved in the armor rebalance. As a consolation, rogues now start with one. 

TSFMC suitstorages was an oversight.

USSP could use a bit of love so they get void jetpacks in their suitstorages now.

Before void jetpacks were civ tier 3 15000 points for some reason, which is just too much.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Syndie commander suit removed from tech. One exists in rogue base now roundstart for the commander, don't lose it.
- tweak: TSFMC get proper security magboots and jetpacks in their lockers again.
- tweak: USSP Suitstorages get void jetpacks.
- tweak: Void jetpack tech moved to tier 2 civilian, cost reduced to 7500.
