### PR TITLE
Shuttle Mass Affects FTL Times.

### DIFF
--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -15,6 +15,7 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth
 // SPDX-FileCopyrightText: 2025 Dvir
 // SPDX-FileCopyrightText: 2025 GreaseMonk
+// SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 starch
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Salvage/SpawnSalvageMissionJob.cs
+++ b/Content.Server/Salvage/SpawnSalvageMissionJob.cs
@@ -90,7 +90,7 @@ public sealed class SpawnSalvageMissionJob : Job<bool>
     // End Frontier
 
     // Mono
-    private const float MassConstant = 50000f; // Arbitrary, at this value massMultiplier = 0.65
+    private const float MassConstant = 50f; // Arbitrary, at this value massMultiplier = 0.65
     private const float MassMultiplierMin = 0.5f;
     private const float MassMultiplierMax = 5f;
     private const float StartupTime = 5.5f;

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -265,7 +265,7 @@ public sealed partial class ShuttleConsoleSystem
             massAdjustedStartupTime = drive.StartupTime;
             return;
         }
-        var adjustedMass = shuttlePhysics.Mass / drive.DriveMassMultiplier;
+        var adjustedMass = shuttlePhysics.Mass * drive.DriveMassMultiplier;
         var massMultiplier = float.Log(float.Sqrt(adjustedMass / MassConstant + float.E));
         massMultiplier = float.Clamp(massMultiplier, MassMultiplierMin, MassMultiplierMax);
         massAdjustedStartupTime = drive.StartupTime * massMultiplier;

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -32,7 +32,7 @@ public sealed partial class ShuttleConsoleSystem
     private const float ShuttleFTLRange = 256f;
     private const float ShuttleFTLMassThreshold = 100f;
 
-    private const float MassConstant = 50000f; // Arbitrary, at this value massMultiplier = 0.65
+    private const float MassConstant = 50f; // Arbitrary, at this value massMultiplier = 0.65
     private const float MassMultiplierMin = 0.5f;
     private const float MassMultiplierMax = 5f;
     private void InitializeFTL()

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -242,8 +242,12 @@ public sealed partial class ShuttleConsoleSystem
 
         var ev = new ShuttleConsoleFTLTravelStartEvent(ent.Owner);
         RaiseLocalEvent(ref ev);
-        if(_sharedShuttle.TryGetFTLDrive(shuttleUid.Value, out _, out var drive))
+        if (_sharedShuttle.TryGetFTLDrive(shuttleUid.Value, out _, out var drive)) // Mono Begin
+        {
+            var massAdjustedStartupTime = drive.StartupTime * 5;
+            var massAdjustedHyperSpaceTime = drive.HyperSpaceTime * 5;
             _shuttle.FTLToCoordinates(shuttleUid.Value, shuttleComp, adjustedCoordinates, targetAngle, drive.StartupTime, drive.HyperSpaceTime);
+        }
     }
 
     private void UpdateConsoles(EntityUid uid, ShuttleComponent? component = null)

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -65,6 +65,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using FTLMapComponent = Content.Shared.Shuttles.Components.FTLMapComponent;
 using Content.Server.Salvage.Expeditions;
+using Content.Shared._Mono.Ships;
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -83,6 +84,10 @@ public sealed partial class ShuttleSystem
     {
         Params = AudioParams.Default.WithVolume(-5f),
     };
+
+    private const float MassConstant = 50000f; // Arbitrary, at this value massMultiplier = 0.65
+    private const float MassMultiplierMin = 0.5f;
+    private const float MassMultiplierMax = 5f;
 
     public float DefaultStartupTime;
     public float DefaultTravelTime;
@@ -712,6 +717,21 @@ public sealed partial class ShuttleSystem
         _console.RefreshShuttleConsoles(entity.Owner);
     }
 
+    // Mono Begin
+    private void MassAdjustFTLCooldown(PhysicsComponent shuttlePhysics, FTLDriveComponent drive, out float massAdjustedCooldown)
+    {
+        if (drive.MassAffectedDrive == false)
+        {
+            massAdjustedCooldown = drive.Cooldown;
+            return;
+        }
+        var adjustedMass = shuttlePhysics.Mass / drive.DriveMassMultiplier;
+        var massMultiplier = float.Log(float.Sqrt(adjustedMass / MassConstant + float.E));
+        massMultiplier = float.Clamp(massMultiplier, MassMultiplierMin, MassMultiplierMax);
+        massAdjustedCooldown = drive.Cooldown * massMultiplier;
+    }
+    // Mono End
+
     /// <summary>
     ///  Shuttle arrived.
     /// </summary>
@@ -729,7 +749,11 @@ public sealed partial class ShuttleSystem
         _dockSystem.SetDockBolts(entity, false);
 
         if (TryGetFTLDrive(entity, out _, out var globalDrive))
-            globalFtlCooldown = globalDrive.Cooldown;
+        {
+            MassAdjustFTLCooldown(body, globalDrive, out var massAdjustedCooldown);
+            globalFtlCooldown = massAdjustedCooldown;
+        }
+
 
         // Get all docked shuttles
         var dockedShuttles = new HashSet<EntityUid>();
@@ -841,6 +865,11 @@ public sealed partial class ShuttleSystem
                 var dockedShuttle = Comp<ShuttleComponent>(dockedUid);
                 _physics.SetLinearDamping(dockedUid, dockedBody, dockedShuttle.LinearDamping);
                 _physics.SetAngularDamping(dockedUid, dockedBody, dockedShuttle.AngularDamping);
+                if (TryGetFTLDrive(dockedUid, out _, out var drive))
+                {
+                    MassAdjustFTLCooldown(dockedBody, drive, out var massAdjustedCooldown);
+                    ftlCooldown = massAdjustedCooldown;
+                }
                 if (HasComp<MapGridComponent>(xform.MapUid))
                 {
                     Disable(dockedUid, component: dockedBody);
@@ -850,9 +879,6 @@ public sealed partial class ShuttleSystem
                     Enable(dockedUid, component: dockedBody, shuttle: dockedShuttle);
                 }
             }
-
-            if (TryGetFTLDrive(dockedUid, out _, out var drive))
-                ftlCooldown = drive.Cooldown;
 
             // Put linked shuttles in cooldown state instead of immediately removing the component
             if (ftlCooldown > 0f && TryComp<FTLComponent>(dockedUid, out var dockedFtl))

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -85,7 +85,7 @@ public sealed partial class ShuttleSystem
         Params = AudioParams.Default.WithVolume(-5f),
     };
 
-    private const float MassConstant = 50000f; // Arbitrary, at this value massMultiplier = 0.65
+    private const float MassConstant = 50f; // Arbitrary, at this value massMultiplier = 0.65
     private const float MassMultiplierMin = 0.5f;
     private const float MassMultiplierMax = 5f;
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -725,7 +725,7 @@ public sealed partial class ShuttleSystem
             massAdjustedCooldown = drive.Cooldown;
             return;
         }
-        var adjustedMass = shuttlePhysics.Mass / drive.DriveMassMultiplier;
+        var adjustedMass = shuttlePhysics.Mass * drive.DriveMassMultiplier;
         var massMultiplier = float.Log(float.Sqrt(adjustedMass / MassConstant + float.E));
         massMultiplier = float.Clamp(massMultiplier, MassMultiplierMin, MassMultiplierMax);
         massAdjustedCooldown = drive.Cooldown * massMultiplier;

--- a/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
+++ b/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
@@ -47,9 +47,8 @@ public sealed partial class FTLDriveComponent : Component
     public bool MassAffectedDrive = true;
 
     /// <summary>
-    /// A multiplier of the effective mass a ship will have from mass calculations.
-    /// Set MassAffectedDrive to false instead of setting this to Zero.
-    /// i.e. 2f = 2 times the mass for calculations.
+    /// A multiplier of the effective mass a ship will have for mass calculations.
+    /// Ships with mass zero will have half the FTL times.
     /// </summary>
     [DataField]
     [AutoNetworkedField]

--- a/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
+++ b/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Redrover1760
+// SPDX-FileCopyrightText: 2025 gus
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Mono.Ships;

--- a/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
+++ b/Content.Shared/_Mono/Ships/FTLDriveComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class FTLDriveComponent : Component
     public float Range = 512f;
 
     /// <summary>
-    /// The FTL drive's cooldown between jumps.
+    /// The FTL drive's cooldown between jumps before Mass Multiplier.
     /// </summary>
     [DataField]
     [AutoNetworkedField]
@@ -26,16 +26,32 @@ public sealed partial class FTLDriveComponent : Component
 
 
     /// <summary>
-    /// The FTL jump duration.
+    /// The FTL jump duration before Mass Multiplier.
     /// </summary>
     [DataField]
     [AutoNetworkedField]
     public float HyperSpaceTime = 20f;
 
     /// <summary>
-    /// The FTL duration until the jump starts.
+    /// The FTL duration until the jump starts before Mass Multiplier.
     /// </summary>
     [DataField]
     [AutoNetworkedField]
     public float StartupTime = 5.5f;
+
+    /// <summary>
+    /// Is the drive's FTL StartupTime, Travel Time, and Cooldown affected by the mass of the ship?
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public bool MassAffectedDrive = true;
+
+    /// <summary>
+    /// A multiplier of the effective mass a ship will have from mass calculations.
+    /// Set MassAffectedDrive to false instead of setting this to Zero.
+    /// i.e. 2f = 2 times the mass for calculations.
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public float DriveMassMultiplier = 1f;
 }

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/heavy_drive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/heavy_drive.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/heavy_drive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/heavy_drive.yml
@@ -36,6 +36,7 @@
     cooldown: 60
     hyperSpaceTime: 25
     startupTime: 6.4
+    DriveMassMultiplier: 0.25
   - type: ApcPowerReceiver
     powerLoad: 15000
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/heavy_drive.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/heavy_drive.yml
@@ -36,7 +36,7 @@
     cooldown: 60
     hyperSpaceTime: 25
     startupTime: 6.4
-    DriveMassMultiplier: 0.25
+    driveMassMultiplier: 0.25
   - type: ApcPowerReceiver
     powerLoad: 15000
   - type: ExtensionCableReceiver


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Multiplies the FTL startup, cooldown, and hyperspace time by a formula based off the mass of a ship.

Equation is done here.
https://www.desmos.com/calculator/s2kfdqrtkp

Shuttle with a mass of 0 will have 0.5x times FTL startup/cooldown/hyperspace times.

Shuttle with mass of 50 (MassConstant) will have 0.65x

Shuttle with mass of 123 (i.e. Tethys) will have 0.83x.

Shuttle with mass of 234  will have 1x.

Shuttle with mass of 312 (i.e. Europa) will have 1.12x.

Shuttle with mass of 898 (i.e. Vulture) will have 1.51x.

yes this stacks with upgraded FTL drives.

Technical side of things, adds two new datafields to FTL drives. One is an effective mass multiplier (a drive with a 0.25x multiplier considers a 800 mass ship as a 200 mass ship for calculations) and a toggle boolean to disable the effect of mass for a drive.

In addition, the Heavy CTLA-160 has a 0.25x mass multiplier, fitting for a heavy drive.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

https://discord.com/channels/1329292619834069034/1401343138303316039

Adds a heavy niche for smaller ships. Faster, quicker FTL usage.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Ship FTL times are now modified by ship mass.


