### PR TITLE
XLR-556 Buff

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -153,14 +153,15 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-0
       map: ["enum.GunVisualLayers.Mag"]
+  - type: GunRequiresWield
   - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -47
+    minAngle: 0
+    maxAngle: 0
   - type: Gun
-    minAngle: 23
-    maxAngle: 73
-    angleIncrease: 9
-    angleDecay: 20
+    minAngle: 0
+    maxAngle: 20
+    angleIncrease: 1
+    angleDecay: 8
     fireRate: 11 # 660 rpm
     shotsPerBurst: 3
     availableModes:
@@ -207,6 +208,9 @@
     vendPrice: 9000
   - type: PirateBountyItem
     id: ExperimentalFactionWeapon
+  - type: LaserPointer
+    targetedColor: "#00fff7"
+    defaultColor: "#0000ff"
 
 #Mercenary vulcan
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 Blu
 # SPDX-FileCopyrightText: 2025 BlueHNT
 # SPDX-FileCopyrightText: 2025 HungryCuban


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR simply buffs the accuracy of the XLR, as currently, it sprays and prays worse than an atriedes, but needs 2 hands

## Why / Balance
Its a T3 Faction tech that doesnt feel like a T3. This changes that, hopefully

## How to test
Laod up, spawn rifle, start firing

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The XLR-556 ICWS now actually feels like a T3 Tech rifle