### PR TITLE
Scale Shuttle Max Speed From TWR

### DIFF
--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -176,8 +176,8 @@
                         <controls:SliderIntInput Name="MaximumShuttleSpeedValue"
                                                  Access="Public"
                                                  MinValue="0"
-                                                 MaxValue="140"
-                                                 Value="140"
+                                                 MaxValue="100"
+                                                 Value="100"
                                                  HorizontalExpand="True"/>
                     </controls:BoxContainer>
                 </controls:BoxContainer>

--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -176,8 +176,8 @@
                         <controls:SliderIntInput Name="MaximumShuttleSpeedValue"
                                                  Access="Public"
                                                  MinValue="0"
-                                                 MaxValue="60"
-                                                 Value="60"
+                                                 MaxValue="140"
+                                                 Value="140"
                                                  HorizontalExpand="True"/>
                     </controls:BoxContainer>
                 </controls:BoxContainer>

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -313,7 +313,7 @@ public sealed class MoverController : SharedMoverController
         var vertComp = vel.Y == 0 ? 0 : vel.Y * shuttle.BaseLinearThrust[vertIndex] / vertThrust; // Frontier: LinearThrust<BaseLinearThrust
 
         // Mono
-        return vel * MathF.Min(shuttle.BaseMaxLinearVelocity * twrMult / MathF.Sqrt(horizComp * horizComp + vertComp * vertComp), shuttle.UpperMaxVelocity);
+        return vel * MathF.Min(shuttle.BaseMaxLinearVelocity * twrMult / MathF.Sqrt(horizComp * horizComp + vertComp * vertComp), MathF.Min(shuttle.UpperMaxVelocity, shuttle.SetMaxVelocity));
     }
 
     private void HandleShuttleMovement(float frameTime)

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -300,8 +300,8 @@ public sealed class MoverController : SharedMoverController
         var vertIndex = vel.Y > 0 ? 2 : 0; // north else south
 
         // Mono
-        var horizThrust = shuttle.LinearThrust[horizIndex];
-        var vertThrust = shuttle.LinearThrust[vertIndex];
+        var horizThrust = vel.X * shuttle.LinearThrust[horizIndex];
+        var vertThrust = vel.Y * shuttle.LinearThrust[vertIndex];
 
         // Mono - scale max velocity depending on TWR
         var thrust = MathF.Sqrt(horizThrust * horizThrust + vertThrust * vertThrust);
@@ -309,8 +309,8 @@ public sealed class MoverController : SharedMoverController
         var twrMult = MathF.Pow(twr / shuttle.BaseMaxVelocityTWR, shuttle.MaxVelocityScalingExponent);
 
         // Mono - minor optimisation
-        var horizComp = vel.X * shuttle.BaseLinearThrust[horizIndex] / horizThrust; // Frontier: LinearThrust<BaseLinearThrust
-        var vertComp = vel.Y * shuttle.BaseLinearThrust[vertIndex] / vertThrust; // Frontier: LinearThrust<BaseLinearThrust
+        var horizComp = vel.X == 0 ? 0 : vel.X * shuttle.BaseLinearThrust[horizIndex] / horizThrust; // Frontier: LinearThrust<BaseLinearThrust
+        var vertComp = vel.Y == 0 ? 0 : vel.Y * shuttle.BaseLinearThrust[vertIndex] / vertThrust; // Frontier: LinearThrust<BaseLinearThrust
 
         // Mono
         return vel * MathF.Min(shuttle.BaseMaxLinearVelocity * twrMult / MathF.Sqrt(horizComp * horizComp + vertComp * vertComp), shuttle.UpperMaxVelocity);

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -282,10 +282,12 @@ public sealed class MoverController : SharedMoverController
     /// <summary>
     /// Helper function to extrapolate max velocity for a given Vector2 (really, its angle) and shuttle.
     /// </summary>
-    private Vector2 ObtainMaxVel(Vector2 vel, ShuttleComponent shuttle)
+    private Vector2 ObtainMaxVel(Vector2 vel, ShuttleComponent shuttle, PhysicsComponent body) // mono
     {
         if (vel.Length() == 0f)
             return Vector2.Zero;
+
+        vel.Normalize(); // Mono
 
         // this math could PROBABLY be simplified for performance
         // probably
@@ -296,10 +298,22 @@ public sealed class MoverController : SharedMoverController
 
         var horizIndex = vel.X > 0 ? 1 : 3; // east else west
         var vertIndex = vel.Y > 0 ? 2 : 0; // north else south
-        var horizComp = vel.X != 0 ? MathF.Pow(Vector2.Dot(vel, new (shuttle.BaseLinearThrust[horizIndex] / shuttle.LinearThrust[horizIndex], 0f)), 2) : 0; // Frontier: LinearThrust<BaseLinearThrust
-        var vertComp = vel.Y != 0 ? MathF.Pow(Vector2.Dot(vel, new (0f, shuttle.BaseLinearThrust[vertIndex] / shuttle.LinearThrust[vertIndex])), 2) : 0; // Frontier: LinearThrust<BaseLinearThrust
 
-        return shuttle.BaseMaxLinearVelocity * vel * MathF.ReciprocalSqrtEstimate(horizComp + vertComp);
+        // Mono
+        var horizThrust = shuttle.LinearThrust[horizIndex];
+        var vertThrust = shuttle.LinearThrust[vertIndex];
+
+        // Mono - scale max velocity depending on TWR
+        var thrust = MathF.Sqrt(horizThrust * horizThrust + vertThrust * vertThrust);
+        var twr = thrust / body.Mass;
+        var twrMult = MathF.Pow(twr / shuttle.BaseMaxVelocityTWR, shuttle.MaxVelocityScalingExponent);
+
+        // Mono - minor optimisation
+        var horizComp = vel.X * shuttle.BaseLinearThrust[horizIndex] / horizThrust; // Frontier: LinearThrust<BaseLinearThrust
+        var vertComp = vel.Y * shuttle.BaseLinearThrust[vertIndex] / vertThrust; // Frontier: LinearThrust<BaseLinearThrust
+
+        // Mono
+        return vel * MathF.Min(shuttle.BaseMaxLinearVelocity * twrMult / MathF.Sqrt(horizComp * horizComp + vertComp * vertComp), shuttle.UpperMaxVelocity);
     }
 
     private void HandleShuttleMovement(float frameTime)
@@ -557,8 +571,9 @@ public sealed class MoverController : SharedMoverController
                 var forceMul = frameTime * body.InvMass;
 
                 var localVel = (-shuttleNorthAngle).RotateVec(body.LinearVelocity);
-                var maxVelocity = ObtainMaxVel(localVel, shuttle); // max for current travel dir
-                var maxWishVelocity = ObtainMaxVel(totalForce, shuttle);
+                // Mono - ObtainMaxVel takes body
+                var maxVelocity = ObtainMaxVel(localVel, shuttle, body); // max for current travel dir
+                var maxWishVelocity = ObtainMaxVel(totalForce, shuttle, body);
                 var properAccel = (maxWishVelocity - localVel) / forceMul;
 
                 var finalForce = Vector2Dot(totalForce, properAccel.Normalized()) * properAccel.Normalized();

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -95,7 +95,7 @@ namespace Content.Server.Shuttles.Components
         /// Limit to max velocity set by a shuttle console.
         /// </summary>
         [DataField]
-        public float SetMaxVelocity = 140f;
+        public float SetMaxVelocity = 100f;
 
         /// <summary>
         /// At what Thrust-Weight-Ratio should this ship have the base max velocity as its maximum velocity.

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -95,7 +95,7 @@ namespace Content.Server.Shuttles.Components
         /// At what Thrust-Weight-Ratio should this ship have the base max velocity as its maximum velocity.
         /// </summary>
         [DataField]
-        public float BaseMaxVelocityTWR = 10f;
+        public float BaseMaxVelocityTWR = 4f;
 
         /// <summary>
         /// How much should TWR affect max velocity.

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -92,6 +92,12 @@ namespace Content.Server.Shuttles.Components
 
         // <Mono>
         /// <summary>
+        /// Limit to max velocity set by a shuttle console.
+        /// </summary>
+        [DataField]
+        public float SetMaxVelocity = 140f;
+
+        /// <summary>
         /// At what Thrust-Weight-Ratio should this ship have the base max velocity as its maximum velocity.
         /// </summary>
         [DataField]

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: 2024 Kesiath
 // SPDX-FileCopyrightText: 2024 checkraze
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Princess Cheeseballs
 // SPDX-FileCopyrightText: 2025 Redrover1760
 //

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -101,19 +101,19 @@ namespace Content.Server.Shuttles.Components
         /// At what Thrust-Weight-Ratio should this ship have the base max velocity as its maximum velocity.
         /// </summary>
         [DataField]
-        public float BaseMaxVelocityTWR = 4f;
+        public float BaseMaxVelocityTWR = 2f;
 
         /// <summary>
         /// How much should TWR affect max velocity.
         /// </summary>
         [DataField]
-        public float MaxVelocityScalingExponent = 0.33f; // 8x thrust = 2x max speed
+        public float MaxVelocityScalingExponent = 0.25f; // 16x thrust = 2x max speed
 
         /// <summary>
         /// Don't allow max velocity to go beyond this value.
         /// </summary>
         [DataField]
-        public float UpperMaxVelocity = 140f;
+        public float UpperMaxVelocity = 100f;
         // </Mono>
     }
 }

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -88,5 +88,25 @@ namespace Content.Server.Shuttles.Components
         /// </summary>
         [DataField]
         public float DampingModifier;
+
+        // <Mono>
+        /// <summary>
+        /// At what Thrust-Weight-Ratio should this ship have the base max velocity as its maximum velocity.
+        /// </summary>
+        [DataField]
+        public float BaseMaxVelocityTWR = 10f;
+
+        /// <summary>
+        /// How much should TWR affect max velocity.
+        /// </summary>
+        [DataField]
+        public float MaxVelocityScalingExponent = 0.5f; // 4x thrust = 2x max speed
+
+        /// <summary>
+        /// Don't allow max velocity to go beyond this value.
+        /// </summary>
+        [DataField]
+        public float UpperMaxVelocity = 140f;
+        // </Mono>
     }
 }

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -107,7 +107,7 @@ namespace Content.Server.Shuttles.Components
         /// How much should TWR affect max velocity.
         /// </summary>
         [DataField]
-        public float MaxVelocityScalingExponent = 0.5f; // 4x thrust = 2x max speed
+        public float MaxVelocityScalingExponent = 0.33f; // 8x thrust = 2x max speed
 
         /// <summary>
         /// Don't allow max velocity to go beyond this value.

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
@@ -89,15 +89,15 @@ public sealed partial class ShuttleSystem
             return;
         }
 
-        // Clamp the speed between 0 and 60
-        // TODO: Make this account for thruster upgrades
-        var maxSpeed = Math.Clamp(args.MaxSpeed, 0f, 60f);
+        // Mono - fix
+        var maxSpeed = Math.Max(args.MaxSpeed, 0f);
 
         // Don't do anything if the value didn't change
-        if (Math.Abs(shuttleComponent.BaseMaxLinearVelocity - maxSpeed) < 0.01f)
+        if (Math.Abs(shuttleComponent.SetMaxVelocity - maxSpeed) < 0.01f)
             return;
 
-        shuttleComponent.BaseMaxLinearVelocity = maxSpeed;
+        // Mono - fix
+        shuttleComponent.SetMaxVelocity = maxSpeed;
 
         // Refresh the shuttle consoles to update the UI
         _console.RefreshShuttleConsoles(transform.GridUid.Value);

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 neuPanda
 // SPDX-FileCopyrightText: 2025 Ark
 // SPDX-FileCopyrightText: 2025 Dvir
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 Whatstone
 // SPDX-FileCopyrightText: 2025 significant harassment

--- a/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
@@ -34,6 +34,7 @@
     powerLoad: 10000
   - type: Thruster
     thrust: 350
+    baseThrust: 350 # TODO: make doing this not needed
     burnShape: ["-0.3,0.5","0.2,1.6","0.8,1.6","1.3,0.5"]
     damage:
       types:

--- a/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2025 BoskiYourk
+# SPDX-FileCopyrightText: 2025 Honestly101
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
shuttle max speed now scales from square root of your TWR
from testing duran can go 35 and baeg can go 100
this means if 1 in 16 your tiles are a thruster you can go 100 speed
has a limit so max speed can never go beyond 140 ever

if wanted, exponent can be changed so TWR affects max speed less

## Why / Balance
makes sense

## How to test
count amount of ship thrusters and ship tiles and see max speed scale with square root of their ratio

## Media
insert video of baeg going 100 speed

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Shuttle max speed now scales with thrust-weight ratio.
