### PR TITLE
Constructible Containment Field Gens

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -1,3 +1,21 @@
+# SPDX-FileCopyrightText: 2021 20kdc
+# SPDX-FileCopyrightText: 2021 Acruid
+# SPDX-FileCopyrightText: 2021 ShadowCommander
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2021 cyclowns
+# SPDX-FileCopyrightText: 2021 metalgearsloth
+# SPDX-FileCopyrightText: 2021 mirrorcult
+# SPDX-FileCopyrightText: 2022 Jacob Tong
+# SPDX-FileCopyrightText: 2022 keronshb
+# SPDX-FileCopyrightText: 2023 Kara
+# SPDX-FileCopyrightText: 2023 Naive817
+# SPDX-FileCopyrightText: 2023 c4llv07e
+# SPDX-FileCopyrightText: 2023 lzk
+# SPDX-FileCopyrightText: 2025 ArtisticRoomba
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: [BaseMachinePowered, ConstructibleMachine] # Monolith
   id: ContainmentFieldGenerator

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseStructure
+  parent: [BaseMachinePowered, ConstructibleMachine] # Monolith
   id: ContainmentFieldGenerator
   name: containment field generator
   description: A machine that generates a containment field when powered by an emitter. Keeps the Singularity docile.
@@ -15,6 +15,27 @@
         - FullTileMask
         layer:
         - WallLayer
+  # Monolith - durable
+  - type: Damageable
+    damageModifierSet: StructuralMetallicHeatReinforced
+  # Monolith - as durable as a normal wall
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1600
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 800
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
   - type: InteractionOutline
   - type: Anchorable
   - type: Sprite

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -88,6 +88,7 @@
   - PortableGeneratorSuperPacmanMachineCircuitboard
   - PortableGeneratorJrPacmanMachineCircuitboard
   - EmitterCircuitboard
+  - ContainmentFieldGeneratorCircuitboard # Mono
   - TelecomServerCircuitboard
   - SMESAdvancedMachineCircuitboard
   # - HolopadMachineCircuitboard # Frontier: use NF variant

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 beck-thompson
+# SPDX-FileCopyrightText: 2025 deltanedas
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ## Static
 
 - type: latheRecipePack

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -120,6 +120,7 @@
   - SolarControlComputerCircuitboard
   - SolarTrackerElectronics
   - EmitterCircuitboard
+  - ContainmentFieldGeneratorCircuitboard # Mono
 
 - type: technology
   id: AtmosphericTech

--- a/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Honestly101
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
@@ -24,3 +24,16 @@
     Blunt: 0.6
     Slash: 0.7
     Piercing: 0.7
+
+- type: damageModifierSet
+  id: StructuralMetallicHeatReinforced
+  coefficients:
+    Shock: 1.2
+    Heat: 1.2
+    Structural: 0.5
+  flatReductions:
+    Blunt: 10
+    Slash: 10
+    Piercing: 10
+    Heat: 17 # no damage from emitters
+    Structural: 10

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/misc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/misc.yml
@@ -16,3 +16,17 @@
       Manipulator: 2
     stackRequirements:
       Plasma: 2
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  id: ContainmentFieldGeneratorCircuitboard
+  name: containment field generator machine board
+  components:
+  - type: Sprite
+    state: engineering
+  - type: MachineBoard
+    prototype: ContainmentFieldGenerator
+    requirements:
+      Capacitor: 4
+    stackRequirements:
+      Plasteel: 4

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/electronics.yml
@@ -81,3 +81,8 @@
   parent: BaseCircuitboardRecipe
   id: CarpCallerMachineCircuitboard
   result: CarpCallerMachineCircuitboard
+
+- type: latheRecipe
+  parent: BaseGoldCircuitboardRecipe
+  id: ContainmentFieldGeneratorCircuitboard
+  result: ContainmentFieldGeneratorCircuitboard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- containment field generator is now researchable and constructible
- can be made whenever emitter board can be
- is now also destructible
- same durability as a solid wall but has bonus flat heat reduction to take 0 damage from emitter shots

## Why / Balance
more ways for people to get creative
you can use them for protection or as object yeeters

## How to test
research power generation -> build 2 CFGs -> power them up with emitters -> destroy one of the CFGs

## Media
<img width="402" height="107" alt="image" src="https://github.com/user-attachments/assets/94d45693-c382-461f-a0fc-66f00c06333e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now build containment field generators.
