### PR TITLE
Change Cortical Borer Control to 5 Minute Cooldown

### DIFF
--- a/Resources/Prototypes/_Mono/Actions/cortical_borer.yml
+++ b/Resources/Prototypes/_Mono/Actions/cortical_borer.yml
@@ -56,7 +56,7 @@
   - type: InstantAction
     icon: _Mono/Interface/Action/borer_control.png
     event: !type:CorticalTakeControlEvent
-    useDelay: 120
+    useDelay: 340 #5 minutes and 40 seconds
 
 - type: entity
   id: ActionEndControlHost


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Change Borer delay on using Take Control to 5 minutes and 40 seconds. 5 minute recharge + time controlling host, 2 minutes - time controlling host was too short.

## How to test
<!-- Describe the way it can be tested -->
Use the ability

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cortical Borer's Take Control now has a 5-minute cooldown
