### PR TITLE
Try Optimise Advertise System

### DIFF
--- a/Content.Server/Advertise/Components/AdvertiseComponent.cs
+++ b/Content.Server/Advertise/Components/AdvertiseComponent.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2024 Tayrtahn
+// SPDX-FileCopyrightText: 2024 Wrexbe (Josh)
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Advertise.EntitySystems;
 using Content.Shared.Dataset;
 using Robust.Shared.Prototypes;

--- a/Content.Server/Advertise/Components/AdvertiseComponent.cs
+++ b/Content.Server/Advertise/Components/AdvertiseComponent.cs
@@ -42,6 +42,7 @@ public sealed partial class AdvertiseComponent : Component
     /// The next time an advertisement will be said.
     /// </summary>
     [DataField]
+    [Access(typeof(AdvertiseSystem))] // Mono - you really don't want to change this outside of AdvertiseSystem
     public TimeSpan NextAdvertisementTime { get; set; } = TimeSpan.Zero;
 
 }

--- a/Content.Server/Advertise/EntitySystems/AdvertiseSystem.cs
+++ b/Content.Server/Advertise/EntitySystems/AdvertiseSystem.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic; // Mono
 using Content.Server.Advertise.Components;
 using Content.Server.Chat.Systems;
 using Content.Server.Power.Components;
+using Content.Shared.Dataset;
 using Content.Shared.VendingMachines;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -8,6 +10,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Server.Advertise.EntitySystems;
 
+// Mono - update delay replaced with priority queue
 public sealed class AdvertiseSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -15,40 +18,43 @@ public sealed class AdvertiseSystem : EntitySystem
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
 
-    /// <summary>
-    /// The maximum amount of time between checking if advertisements should be displayed
-    /// </summary>
-    private readonly TimeSpan _maximumNextCheckDuration = TimeSpan.FromSeconds(15);
+    // Mono
+    private PriorityQueue<EntityUid, TimeSpan> _advertQueue = new();
 
-    /// <summary>
-    /// The next time the game will check if advertisements should be displayed
-    /// </summary>
-    private TimeSpan _nextCheckTime = TimeSpan.MinValue;
+    // Mono - cache dataset protos for performance reasons
+    private Dictionary<ProtoId<LocalizedDatasetPrototype>, LocalizedDatasetPrototype> _cachedDatasets = new();
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<AdvertiseComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<AdvertiseComponent, ComponentInit>(OnInit);
 
         SubscribeLocalEvent<ApcPowerReceiverComponent, AttemptAdvertiseEvent>(OnPowerReceiverAttemptAdvertiseEvent);
         SubscribeLocalEvent<VendingMachineComponent, AttemptAdvertiseEvent>(OnVendingAttemptAdvertiseEvent);
 
-        _nextCheckTime = TimeSpan.MinValue;
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnProtoReload); // Mono
     }
 
-    private void OnMapInit(EntityUid uid, AdvertiseComponent advert, MapInitEvent args)
+    // Mono - has to be ComponentInit so it doesn't break when loading again after MapInit
+    private void OnInit(EntityUid uid, AdvertiseComponent advert, ComponentInit args)
     {
         var prewarm = advert.Prewarm;
-        RandomizeNextAdvertTime(advert, prewarm);
-        _nextCheckTime = MathHelper.Min(advert.NextAdvertisementTime, _nextCheckTime);
+        RandomizeNextAdvertTime(uid, advert, prewarm);
     }
 
-    private void RandomizeNextAdvertTime(AdvertiseComponent advert, bool prewarm = false)
+    private void RandomizeNextAdvertTime(EntityUid uid, AdvertiseComponent advert, bool prewarm = false)
     {
         var minDuration = prewarm ? 0 : Math.Max(1, advert.MinimumWait);
         var maxDuration = Math.Max(minDuration, advert.MaximumWait);
         var waitDuration = TimeSpan.FromSeconds(_random.Next(minDuration, maxDuration));
 
         advert.NextAdvertisementTime = _gameTiming.CurTime + waitDuration;
+        _advertQueue.Enqueue(uid, advert.NextAdvertisementTime);
+    }
+
+    // Mono
+    private void OnProtoReload(PrototypesReloadedEventArgs ev)
+    {
+        _cachedDatasets.Clear();
     }
 
     public void SayAdvertisement(EntityUid uid, AdvertiseComponent? advert = null)
@@ -61,29 +67,47 @@ public sealed class AdvertiseSystem : EntitySystem
         if (attemptEvent.Cancelled)
             return;
 
-        if (_prototypeManager.TryIndex(advert.Pack, out var advertisements))
-            _chat.TrySendInGameICMessage(uid, Loc.GetString(_random.Pick(advertisements.Values)), InGameICChatType.Speak, hideChat: true);
+        // Mono
+        if (!_cachedDatasets.ContainsKey(advert.Pack))
+        {
+            if (!_prototypeManager.TryIndex(advert.Pack, out var advertisements))
+                return;
+
+            _cachedDatasets[advert.Pack] = advertisements;
+        }
+
+        // Mono
+        var adverts = _cachedDatasets[advert.Pack];
+        // TODO: investigate why TrySendInGameICMessage takes entire milliseconds
+        _chat.TrySendInGameICMessage(uid, Loc.GetString(_random.Pick(adverts.Values)), InGameICChatType.Speak, hideChat: true);
     }
 
     public override void Update(float frameTime)
     {
-        var currentGameTime = _gameTiming.CurTime;
-        if (_nextCheckTime > currentGameTime)
-            return;
-
-        // _nextCheckTime starts at TimeSpan.MinValue, so this has to SET the value, not just increment it.
-        _nextCheckTime = currentGameTime + _maximumNextCheckDuration;
-
-        var query = EntityQueryEnumerator<AdvertiseComponent>();
-        while (query.MoveNext(out var uid, out var advert))
+        var i = 0;
+        while (true)
         {
-            if (currentGameTime > advert.NextAdvertisementTime)
+            i++;
+            if (!_advertQueue.TryPeek(out var uid, out var time))
+                break;
+
+            // failsafe - something went wrong (evil admeme setting advertise delay to negative?) but don't freeze the server
+            if (i > _advertQueue.Count)
+                break;
+                                                                                                     // seems like it has changed
+            if (TerminatingOrDeleted(uid) || !TryComp<AdvertiseComponent>(uid, out var advertise) || advertise.NextAdvertisementTime != time)
             {
-                SayAdvertisement(uid, advert);
-                // The timer is always refreshed when it expires, to prevent mass advertising (ex: all the vending machines have no power, and get it back at the same time).
-                RandomizeNextAdvertTime(advert);
+                _advertQueue.Dequeue();
+                continue;
             }
-            _nextCheckTime = MathHelper.Min(advert.NextAdvertisementTime, _nextCheckTime);
+
+            // it's a priority queue so everything after this will be later
+            if (advertise.NextAdvertisementTime > _gameTiming.CurTime)
+                break;
+
+            _advertQueue.Dequeue();
+            SayAdvertisement(uid, advertise);
+            RandomizeNextAdvertTime(uid, advertise);
         }
     }
 

--- a/Content.Server/Advertise/EntitySystems/AdvertiseSystem.cs
+++ b/Content.Server/Advertise/EntitySystems/AdvertiseSystem.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2024 Tayrtahn
+// SPDX-FileCopyrightText: 2024 Wrexbe (Josh)
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Collections.Generic; // Mono
 using Content.Server.Advertise.Components;
 using Content.Server.Chat.Systems;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title
doesn't get rid of all the lag because apparently a big hotspot is chatsystem
after this PR it takes about 2ms per advertisement all of which is spent inside chatsystem
much more before

## Why / Balance
one of the laggiest systems

## How to test
use _timing.RealTime to measure how much it takes currently vs my implementation

## Media
vendomats still advertise fine ingame
<img width="211" height="143" alt="image" src="https://github.com/user-attachments/assets/9fdc52c2-2543-4934-b1ce-5cf4ce1abb96" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
not player-facing
even if i were to make CL telling players to watch for bugs, nobody would just stare at a vendomat to check if it advertises wrong