### PR TITLE
Another Borer Fix

### DIFF
--- a/Content.Server/_Mono/CorticalBorer/CorticalBorerInfestedSystem.cs
+++ b/Content.Server/_Mono/CorticalBorer/CorticalBorerInfestedSystem.cs
@@ -84,7 +84,10 @@ public sealed class CorticalBorerInfestedSystem : EntitySystem
 
     private void OnMindRemoved(Entity<CorticalBorerInfestedComponent> infected, ref MindRemovedMessage args)
     {
-        if(infected.Comp.Borer.Comp.ControlingHost)
+        if (infected.Comp.Borer.Comp.ControlingHost)
+        {
             _borer.EndControl(infected.Comp.Borer);
+            _borer.TryEjectBorer(infected.Comp.Borer);
+        }
     }
 }

--- a/Content.Server/_Mono/CorticalBorer/CorticalBorerInfestedSystem.cs
+++ b/Content.Server/_Mono/CorticalBorer/CorticalBorerInfestedSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._Mono.CorticalBorer;
 using Content.Shared._Shitmed.Body.Events;
 using Content.Shared.Body.Part;
 using Content.Shared.Examine;
+using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Robust.Server.Containers;
 using Robust.Shared.Containers;
@@ -29,6 +30,7 @@ public sealed class CorticalBorerInfestedSystem : EntitySystem
 
         SubscribeLocalEvent<CorticalBorerInfestedComponent, BodyPartRemovedEvent>(OnBodyPartRemoved);
         SubscribeLocalEvent<CorticalBorerInfestedComponent, MobStateChangedEvent>(OnStateChange);
+        SubscribeLocalEvent<CorticalBorerInfestedComponent, MindRemovedMessage>(OnMindRemoved);
     }
 
     private void OnInit(Entity<CorticalBorerInfestedComponent> infested, ref MapInitEvent args)
@@ -78,5 +80,11 @@ public sealed class CorticalBorerInfestedSystem : EntitySystem
             _borer.EndControl(infected.Comp.Borer);
             _borer.TryEjectBorer(infected.Comp.Borer);
         }
+    }
+
+    private void OnMindRemoved(Entity<CorticalBorerInfestedComponent> infected, ref MindRemovedMessage args)
+    {
+        if(infected.Comp.Borer.Comp.ControlingHost)
+            _borer.EndControl(infected.Comp.Borer);
     }
 }

--- a/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
@@ -60,6 +60,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         SubscribeLocalEvent<InventoryComponent, InfestHostAttempt>(OnInfestHostAttempt);
         SubscribeLocalEvent<CorticalBorerComponent, CheckTargetedSpeechEvent>(OnSpeakEvent);
 
+        SubscribeLocalEvent<CorticalBorerComponent, MindRemovedMessage>(OnMindRemoved);
     }
 
     private void OnStartup(Entity<CorticalBorerComponent> ent, ref ComponentStartup args)
@@ -317,6 +318,8 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         {
             infestedComp.OrigininalMindId = null;
         }
+
+        comp.ControlingHost = true;
         _mind.TransferTo(wormMind, host);
 
         // add the end control and vomit egg action
@@ -328,8 +331,6 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
             if (_actions.AddAction(host, "ActionLayEggHost") is {} actionLay)
                 infestedComp.RemoveAbilities.Add(actionLay);
         }
-
-        comp.ControlingHost = true;
 
         var str = $"{ToPrettyString(worm)} has taken control over {ToPrettyString(host)}";
 
@@ -369,5 +370,11 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
 
         infestedComp.ControlTimeEnd = null;
         _container.CleanContainer(infestedComp.ControlContainer);
+    }
+
+    private void OnMindRemoved(Entity<CorticalBorerComponent> ent, ref MindRemovedMessage args)
+    {
+        if (!ent.Comp.ControlingHost)
+            TryEjectBorer(ent); // No storing them in hosts if you don't have a soul
     }
 }

--- a/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
@@ -313,6 +313,10 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
 
             _mind.TransferTo(controledMind, dummy);
         }
+        else
+        {
+            infestedComp.OrigininalMindId = null;
+        }
         _mind.TransferTo(wormMind, host);
 
         // add the end control and vomit egg action
@@ -348,6 +352,8 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         if (!comp.ControlingHost)
             return;
 
+        comp.ControlingHost = false;
+
         // remove all the actions set to remove
         foreach (var ability in infestedComp.RemoveAbilities)
         {
@@ -358,12 +364,10 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         // Return everyone to their own bodies
         if (!TerminatingOrDeleted(infestedComp.BorerMindId))
             _mind.TransferTo(infestedComp.BorerMindId, infestedComp.Borer);
-        if (!TerminatingOrDeleted(infestedComp.OrigininalMindId))
-            _mind.TransferTo(infestedComp.OrigininalMindId, host);
+        if (!TerminatingOrDeleted(infestedComp.OrigininalMindId) && infestedComp.OrigininalMindId.HasValue)
+            _mind.TransferTo(infestedComp.OrigininalMindId.Value, host);
 
         infestedComp.ControlTimeEnd = null;
         _container.CleanContainer(infestedComp.ControlContainer);
-
-        comp.ControlingHost = false;
     }
 }

--- a/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Coenx-flex
 // SPDX-FileCopyrightText: 2025 Cojoke
+// SPDX-FileCopyrightText: 2025 ScyronX
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Shared/_Mono/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
+++ b/Content.Shared/_Mono/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Coenx-flex
+// SPDX-FileCopyrightText: 2025 Cojoke
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Shared/_Mono/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
+++ b/Content.Shared/_Mono/CorticalBorer/Components/CorticalBorerInfestedComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class CorticalBorerInfestedComponent : Robust.Shared.GameO
     public TimeSpan? ControlTimeEnd;
 
     [ViewVariables]
-    public EntityUid OrigininalMindId;
+    public EntityUid? OrigininalMindId;
 
     [ViewVariables]
     public EntityUid BorerMindId;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes the bug where the worm can drag your soul back to your og body. Makes the borer eject from the host if it ghosts, should help out with some bugs.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugs
## How to test
<!-- Describe the way it can be tested -->
I couldn't test the first one because it requires 3 clients to pull off but it should be fixed... for the other one, just ghost while in a host.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/eca88f18-e0a2-40d2-93c6-e98306693133

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cortical Borers now eject from their host if they ghost

