### PR TITLE
Fix Lathe Upgrade Kits

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -154,6 +154,7 @@
 # SPDX-FileCopyrightText: 2025 K-Dynamic
 # SPDX-FileCopyrightText: 2025 Myzumi
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 Southbridge
 # SPDX-FileCopyrightText: 2025 Velken
 # SPDX-FileCopyrightText: 2025 ark1368

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -405,6 +405,7 @@
     - NFScience # Frontier
     - NFPouches # Frontier
     - VoidBoots # Mono
+    - UpgradeKits # Mono
     - SMSurgery # Shitmed Change
     # WD EDIT START
     - VisionGoggles


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
they weren't in any lathes
added to protolathe

## Media
<img width="326" height="224" alt="image" src="https://github.com/user-attachments/assets/eb54a75a-b69d-411f-8746-1dc1cbf88d3b" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed lathe upgrade kits not being in any lathes - they now are in protolathe.
