### PR TITLE
Fix Automation Upgrade Kit

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -407,6 +407,7 @@
     - NFPouches # Frontier
     - VoidBoots # Mono
     - UpgradeKits # Mono
+    - UpgradeKitAutomation # Mono
     - SMSurgery # Shitmed Change
     # WD EDIT START
     - VisionGoggles

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -407,7 +407,7 @@
     - NFPouches # Frontier
     - VoidBoots # Mono
     - UpgradeKits # Mono
-    - UpgradeKitAutomation # Mono
+    - UpgradeKits_Goob # Mono
     - SMSurgery # Shitmed Change
     # WD EDIT START
     - VisionGoggles


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
it also wasn't actually produceable in any lathes
added to protolathe
5 billion 1 line yaml fix PRs go

## Media
<img width="378" height="89" alt="image" src="https://github.com/user-attachments/assets/b81252fa-706b-4c79-b3c8-c500aac474ff" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed automation upgrade kit not being in any lathes. Is now in protolathe.
