### PR TITLE
Fix EVA Suit Bundle Testfail

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2025 LukeZurg22
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 dustylens
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # BASE
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/softsuits.yml
@@ -9,7 +9,7 @@
   components:
   - type: Item
     shape:
-    - 0,0,3,2
+    - 0,0,2,1
   - type: Armor
     modifiers:
       coefficients: # Made to have no protection - Mono


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
testfail because EVA suits were 4x3 and wouldnt fit in NF EVA bundles (since we added oxy and nitrogen tank instead of single air tank)
just makes EVA suits 3x2 to fix

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Frontier EVA suits are now 3x2 instead of 4x3.
- fix: Fixed EVA suit duffel bags not being able to fit all their contents.
