### PR TITLE
Converts Virology Into a Proper RnD Lab

### DIFF
--- a/Resources/Maps/_Mono/POI/cove.yml
+++ b/Resources/Maps/_Mono/POI/cove.yml
@@ -28,8 +28,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/08/2025 00:54:46
-  entityCount: 4842
+  time: 08/18/2025 12:30:46
+  entityCount: 4809
 maps: []
 grids:
 - 1
@@ -44,6 +44,7 @@ tilemap:
   28: FloorConcreteMono
   11: FloorDark
   33: FloorDarkAlt
+  42: FloorDarkHerringbone
   5: FloorDarkMini
   7: FloorDarkMono
   32: FloorDarkMonoAlt
@@ -58,6 +59,7 @@ tilemap:
   36: FloorMaintMonoSterile
   41: FloorMaintSterile
   13: FloorMetalDiamond
+  43: FloorMiningDark
   2: FloorOldConcreteMono
   24: FloorRGlass
   15: FloorReinforcedHardened
@@ -108,7 +110,7 @@ entities:
           version: 7
         0,0:
           ind: 0,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAABAAAAAAAAAQAAAAAAAAFQAAAAAAAAAAAAAAAAAYAAAAAAMAGAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAADABgAAAAAAgAAAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAABUAAAAAAAAAAAAAAAAAGAAAAAABABgAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAABgAAAAAAQAYAAAAAAIAAAAAAAAAAAYAAAAAAAAGAAAAAAIABgAAAAAAAAYAAAAAAwAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAUABgAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAKAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAGAAAAAAYAAAAAAAAAAAAAAAAAAAASAAAAAAAAEwAAAAAAABMAAAAAAAATAAAAAAAAEwAAAAAAABIAAAAAAAASAAAAAAEAEwAAAAAAABMAAAAAAAATAAAAAAAAEwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAgAAAAAAAAAAEgAAAAAAAAsAAAAAAwALAAAAAAMACwAAAAABAAsAAAAAAAASAAAAAAEAEgAAAAACAAsAAAAAAgALAAAAAAEACwAAAAAAAAsAAAAAAwAAAAAAAAAABwAAAAADAAcAAAAAAAAIAAAAAAAAAAAAAAAAAAsAAAAAAQALAAAAAAMACwAAAAACAAsAAAAAAQALAAAAAAIAAAAAAAAAAAAAAAAAAAALAAAAAAMACwAAAAADAAsAAAAAAAALAAAAAAIAEgAAAAAAAAsAAAAAAQALAAAAAAMACAAAAAAAAAAAAAAAAAALAAAAAAMACwAAAAAAAAsAAAAAAQALAAAAAAIACwAAAAADABIAAAAAAwALAAAAAAAACwAAAAABAAsAAAAAAgALAAAAAAMACwAAAAABABIAAAAAAQALAAAAAAEACwAAAAACAAsAAAAAAgAAAAAAAAAACwAAAAADAAsAAAAAAwALAAAAAAAACwAAAAABAAsAAAAAAQASAAAAAAMACwAAAAADAAsAAAAAAAALAAAAAAMACwAAAAAAAAsAAAAAAQAAAAAAAAAAFAAAAAACABQAAAAAAwAAAAAAAAAAAAAAAAAAAAsAAAAAAAALAAAAAAEACwAAAAABAAsAAAAAAQALAAAAAAIAEgAAAAABAAsAAAAAAgALAAAAAAEACwAAAAAAAAsAAAAAAwALAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAUABgAAAAAAAAAAAAAAAAALAAAAAAMAAAAAAAAAAAgAAAAAAAALAAAAAAIACwAAAAADAAAAAAAAAAABAAAAAAAAAAAAAAAAAAgAAAAAAAALAAAAAAAACAAAAAAAAAcAAAAAAAAAAAAAAAAABgAAAAAAAAYAAAAAAAAAAAAAAAAABQAAAAACAAAAAAAAAAALAAAAAAIACAAAAAAAAAsAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACwAAAAABAAsAAAAAAQAHAAAAAAIAAAAAAAAAAAYAAAAAAAAGAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAAFAAAAAADABQAAAAAAQAHAAAAAAMAAAAAAAAAAAgAAAAAAAAAAAAAAAAABwAAAAADAAcAAAAAAQAHAAAAAAIAAAAAAAAAAAAAAAAAAAAGAAAAAAcABgAAAAAHAA==
+          tiles: AAAAAAAAABUAAAAAAAAVAAAAAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAAAAAVAAAAAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAABAAAAAAAAAQAAAAAAAAFQAAAAAAAAAAAAAAAAAVAAAAAAAAFQAAAAAAABUAAAAAAAAVAAAAAAAADgAAAAAAABUAAAAAAAAVAAAAAAAAFQAAAAAAABUAAAAAAAAAAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAABUAAAAAAAAAAAAAAAAAFQAAAAAAABUAAAAAAAAVAAAAAAAAFQAAAAAAAA4AAAAAAAAVAAAAAAAAFQAAAAAAABUAAAAAAAAVAAAAAAAAAAAAAAAAAAYAAAAAAAAGAAAAAAIABgAAAAAAAAYAAAAAAwAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAUABgAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAKAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAGAAAAAAYAAAAAAAAAAAAAAAAAAAASAAAAAAAAEwAAAAAAABMAAAAAAAATAAAAAAAAEwAAAAAAABIAAAAAAAASAAAAAAEAEwAAAAAAABMAAAAAAAATAAAAAAAAEwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAgAAAAAAAAAAEgAAAAAAAAsAAAAAAwALAAAAAAMACwAAAAABAAsAAAAAAAASAAAAAAEAEgAAAAACAAsAAAAAAgALAAAAAAEACwAAAAAAAAsAAAAAAwAAAAAAAAAABwAAAAADAAcAAAAAAAAIAAAAAAAAAAAAAAAAAAsAAAAAAQALAAAAAAMACwAAAAACAAsAAAAAAQALAAAAAAIAAAAAAAAAAAAAAAAAAAALAAAAAAMACwAAAAADAAsAAAAAAAALAAAAAAIAEgAAAAAAAAsAAAAAAQALAAAAAAMACAAAAAAAAAAAAAAAAAALAAAAAAMACwAAAAAAAAsAAAAAAQALAAAAAAIACwAAAAADABIAAAAAAwALAAAAAAAACwAAAAABAAsAAAAAAgALAAAAAAMACwAAAAABABIAAAAAAQALAAAAAAEACwAAAAACAAsAAAAAAgAAAAAAAAAACwAAAAADAAsAAAAAAwALAAAAAAAACwAAAAABAAsAAAAAAQASAAAAAAMACwAAAAADAAsAAAAAAAALAAAAAAMACwAAAAAAAAsAAAAAAQAAAAAAAAAAFAAAAAACABQAAAAAAwAAAAAAAAAAAAAAAAAAAAsAAAAAAAALAAAAAAEACwAAAAABAAsAAAAAAQALAAAAAAIAEgAAAAABAAsAAAAAAgALAAAAAAEACwAAAAAAAAsAAAAAAwALAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAUABgAAAAAAAAAAAAAAAAALAAAAAAMAAAAAAAAAAAgAAAAAAAALAAAAAAIACwAAAAADAAAAAAAAAAABAAAAAAAAAAAAAAAAAAgAAAAAAAALAAAAAAAACAAAAAAAAAcAAAAAAAAAAAAAAAAABgAAAAAAAAYAAAAAAAAAAAAAAAAABQAAAAACAAAAAAAAAAALAAAAAAIACAAAAAAAAAsAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACwAAAAABAAsAAAAAAQAHAAAAAAIAAAAAAAAAAAYAAAAAAAAGAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAAFAAAAAADABQAAAAAAQAHAAAAAAMAAAAAAAAAAAgAAAAAAAAAAAAAAAAABwAAAAADAAcAAAAAAQAHAAAAAAIAAAAAAAAAAAAAAAAAAAAGAAAAAAcABgAAAAAHAA==
           version: 7
         -1,0:
           ind: -1,0
@@ -144,7 +146,7 @@ entities:
           version: 7
         0,-1:
           ind: 0,-1
-          tiles: EAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAACwAAAAADAAsAAAAAAwAAAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAsAAAAAAgALAAAAAAIAAAAAAAAAABQAAAAAAgAUAAAAAAEAFAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAkAAAAAAAAKQAAAAAAAAEAAAAAAAAoAAAAAAAAKAAAAAAAACgAAAAAAAAoAAAAAAAAKAAAAAAAACgAAAAAAAAoAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACwAAAAACAAsAAAAAAQAAAAAAAAAAKAAAAAAAACgAAAAAAAAoAAAAAAAAKAAAAAAAAAcAAAAAAAAHAAAAAAMAKAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAoAAAAAAAAKAAAAAAAACgAAAAAAAAHAAAAAAEABwAAAAADACgAAAAAAAAHAAAAAAMAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAHAAAAAAIACwAAAAACAAsAAAAAAgAoAAAAAAAAKAAAAAAAACgAAAAAAAAoAAAAAAAAKAAAAAAAACgAAAAAAAAoAAAAAAAABwAAAAACAAAAAAAAAAAQAAAAAAAAFQAAAAAAABUAAAAAAAAQAAAAAAAABwAAAAADAAsAAAAAAwALAAAAAAAAKAAAAAAAACgAAAAAAAAoAAAAAAAAKAAAAAAAACgAAAAAAAAoAAAAAAAAKAAAAAAAABIAAAAAAwAAAAAAAAAAEAAAAAAAABAAAAAAAAAVAAAAAAAAFQAAAAAAAA==
+          tiles: EAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAEAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAACwAAAAADAAsAAAAAAwAAAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACQAAAAAAAAAAAAAAAAABwAAAAAAAAcAAAAAAAAHAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAkAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAAAsAAAAAAAALAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAABwAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAACoAAAAAAAAjAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAKwAAAAAAAAAAAAAAAAArAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKwAAAAAAAAAAAAAAAAArAAAAAAAAIwAAAAAAAAAAAAAAAAAQAAAAAAAAFQAAAAAAABUAAAAAAAAQAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAACwAAAAAAABUAAAAAAAAVAAAAAAAAFQAAAAAAAAsAAAAAAAAAAAAAAAAACwAAAAAAACMAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAVAAAAAAAAFQAAAAAAAA==
           version: 7
         0,3:
           ind: 0,3
@@ -194,6 +196,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
+      dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -220,6 +223,18 @@ entities:
             857: 18,20
             858: 17,27
             875: 17,29
+            1383: 0,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: BotGreyscale
+          decals:
+            1377: 5,-4
+            1378: 5,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: BotRightGreyscale
+          decals:
+            1353: 2,-4
         - node:
             color: '#FFFFFFFF'
             id: Box
@@ -380,7 +395,6 @@ entities:
           decals:
             267: -24,13
             289: -23,14
-            571: 6,-5
             747: 17,21
             841: 22,19
             869: 16,26
@@ -392,7 +406,6 @@ entities:
             id: BrickTileDarkInnerNw
           decals:
             266: -19,13
-            570: 9,-5
             711: 14,25
             748: 19,21
             842: 24,19
@@ -403,7 +416,6 @@ entities:
             id: BrickTileDarkInnerSe
           decals:
             268: -24,16
-            535: 6,-2
             713: 12,30
             746: 17,23
             843: 22,21
@@ -416,7 +428,6 @@ entities:
           decals:
             269: -19,16
             288: -20,15
-            572: 9,-2
             714: 14,30
             745: 19,23
             844: 24,21
@@ -443,8 +454,6 @@ entities:
             422: -16,35
             455: -3,14
             456: -7,4
-            529: 6,-3
-            530: 6,-4
             688: 19,29
             689: 19,28
             690: 19,27
@@ -463,6 +472,10 @@ entities:
             866: 16,29
             912: 12,26
             1160: -3,-1
+            1341: 1,-1
+            1343: 3,-1
+            1345: 7,-1
+            1347: 9,-1
         - node:
             color: '#FF5C5CFF'
             id: BrickTileDarkLineN
@@ -482,10 +495,7 @@ entities:
             453: -10,14
             454: -10,8
             519: -1,-6
-            520: 0,-6
             521: 1,-6
-            568: 7,-5
-            569: 8,-5
             709: 13,25
             710: 13,30
             742: 18,21
@@ -515,8 +525,6 @@ entities:
             522: -1,-4
             523: 0,-4
             524: 1,-4
-            527: 7,-2
-            528: 8,-2
             645: 3,34
             646: 4,34
             647: 5,34
@@ -554,8 +562,6 @@ entities:
             283: -20,14
             440: -11,4
             441: -4,14
-            566: 9,-3
-            567: 9,-4
             643: -5,31
             699: 14,29
             700: 14,28
@@ -573,6 +579,10 @@ entities:
             906: 12,26
             1051: 1,19
             1257: -14,8
+            1340: 9,-3
+            1342: 3,-1
+            1344: 7,-1
+            1346: 9,-1
         - node:
             color: '#D69949FF'
             id: BrickTileSteelCornerNe
@@ -604,11 +614,6 @@ entities:
             id: BrickTileSteelCornerSe
           decals:
             736: 19,21
-        - node:
-            color: '#9FED58FF'
-            id: BrickTileSteelCornerSw
-          decals:
-            538: 10,-1
         - node:
             color: '#D69949FF'
             id: BrickTileSteelCornerSw
@@ -658,12 +663,6 @@ entities:
             355: -21,10
             356: -21,9
         - node:
-            color: '#9FED58FF'
-            id: BrickTileSteelLineE
-          decals:
-            542: 2,-1
-            543: 2,-2
-        - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineE
           decals:
@@ -677,13 +676,6 @@ entities:
             352: -20,8
             353: -19,8
             354: -18,8
-        - node:
-            color: '#9FED58FF'
-            id: BrickTileSteelLineN
-          decals:
-            539: 3,-6
-            540: 4,-6
-            541: 5,-6
         - node:
             color: '#FFFFFFFF'
             id: BrickTileSteelLineN
@@ -791,10 +783,6 @@ entities:
             365: -19,6
             366: -21,6
             367: -21,2
-            544: 0,-1
-            545: 0,-2
-            613: 8,-3
-            614: 7,-4
             615: -8,-6
             616: -7,-6
             617: -6,-6
@@ -808,11 +796,27 @@ entities:
             856: 16,20
             1301: -16,22
             1302: -18,22
+            1338: 7,-5
+            1339: 9,-4
+            1370: 5,-6
+            1380: 3,-4
         - node:
             color: '#52B4E996'
             id: DeliveryGreyscale
           decals:
             326: -24,10
+        - node:
+            color: '#FFFFFFFF'
+            id: DeliveryGreyscale
+          decals:
+            1363: 10,-1
+            1364: 10,-2
+            1365: 10,-3
+            1371: 4,-1
+            1372: 5,-1
+            1373: 6,-1
+            1375: 7,-3
+            1376: 4,-6
         - node:
             color: '#FA750096'
             id: HalfTileOverlayGreyscale
@@ -1040,6 +1044,7 @@ entities:
             926: -5,32
             1165: -3,-1
             1180: -3,3
+            1331: 9,-3
         - node:
             color: '#FFFFFFFF'
             id: TechCornerW
@@ -1075,9 +1080,6 @@ entities:
             307: -26,6
             334: -17,9
             335: -17,10
-            578: 9,-2
-            579: 9,-3
-            580: 9,-4
             666: 15,29
             667: 15,28
             668: 15,27
@@ -1121,11 +1123,6 @@ entities:
             336: -20,11
             337: -19,11
             338: -18,11
-            573: 4,-1
-            574: 5,-1
-            575: 7,-1
-            576: 6,-1
-            577: 8,-1
             627: -10,-4
             628: -9,-4
             629: -8,-4
@@ -1169,7 +1166,6 @@ entities:
             257: -19,16
             308: -26,8
             342: -17,11
-            592: 9,-1
             626: -6,-4
             758: 20,24
             1168: -5,-1
@@ -1194,7 +1190,6 @@ entities:
             256: -24,16
             309: -23,8
             341: -21,11
-            591: 3,-1
             624: -11,-4
             765: 16,24
             1187: -3,0
@@ -1233,11 +1228,6 @@ entities:
             329: -20,8
             330: -19,8
             331: -18,8
-            584: 4,-5
-            585: 5,-5
-            586: 6,-5
-            587: 7,-5
-            588: 8,-5
             1173: -8,1
             1174: -7,1
             1175: -10,1
@@ -1249,6 +1239,7 @@ entities:
             1298: -10,-8
             1299: -11,-8
             1300: -12,-8
+            1329: 3,-6
         - node:
             color: '#FFFFFFFF'
             id: TechSE
@@ -1261,7 +1252,6 @@ entities:
             230: 0,7
             258: -19,13
             340: -17,8
-            589: 9,-5
             631: -6,-5
             759: 20,21
             1172: -6,1
@@ -1283,7 +1273,6 @@ entities:
             259: -24,13
             310: -23,10
             339: -21,8
-            590: 3,-5
             630: -11,-5
             894: 16,21
             914: -3,7
@@ -1293,6 +1282,7 @@ entities:
             1255: -13,12
             1288: 1,-8
             1289: -13,-8
+            1326: 2,-6
         - node:
             color: '#FFFFFFFF'
             id: TechW
@@ -1316,9 +1306,6 @@ entities:
             304: -23,6
             332: -21,9
             333: -21,10
-            581: 3,-2
-            582: 3,-3
-            583: 3,-4
             662: 15,29
             663: 15,28
             664: 15,27
@@ -1359,13 +1346,6 @@ entities:
           decals:
             281: -20,15
         - node:
-            color: '#439909FF'
-            id: TrimlineEast
-          decals:
-            610: 3,-2
-            611: 3,-3
-            612: 3,-4
-        - node:
             color: '#52B4E996'
             id: TrimlineEast
           decals:
@@ -1391,15 +1371,6 @@ entities:
             124: 2,9
             125: 2,8
             148: 9,8
-        - node:
-            color: '#439909FF'
-            id: TrimlineNorth
-          decals:
-            605: 8,-5
-            606: 7,-5
-            607: 6,-5
-            608: 5,-5
-            609: 4,-5
         - node:
             color: '#9FED58FF'
             id: TrimlineNorth
@@ -1432,11 +1403,6 @@ entities:
           decals:
             147: 9,9
         - node:
-            color: '#439909FF'
-            id: TrimlineNorthEastCorner
-          decals:
-            597: 3,-5
-        - node:
             color: '#52B4E996'
             id: TrimlineNorthEastCorner
           decals:
@@ -1464,11 +1430,6 @@ entities:
           decals:
             749: 17,23
         - node:
-            color: '#439909FF'
-            id: TrimlineNorthWestCorner
-          decals:
-            596: 9,-5
-        - node:
             color: '#9FED58FF'
             id: TrimlineNorthWestCorner
           decals:
@@ -1490,15 +1451,6 @@ entities:
             id: TrimlineNorthWestCorner
           decals:
             156: 5,13
-        - node:
-            color: '#439909FF'
-            id: TrimlineSouth
-          decals:
-            600: 8,-1
-            601: 7,-1
-            602: 6,-1
-            603: 5,-1
-            604: 4,-1
         - node:
             color: '#52B4E996'
             id: TrimlineSouth
@@ -1542,11 +1494,6 @@ entities:
           decals:
             752: 19,21
         - node:
-            color: '#439909FF'
-            id: TrimlineSouthEastCorner
-          decals:
-            598: 3,-1
-        - node:
             color: '#52B4E996'
             id: TrimlineSouthEastCorner
           decals:
@@ -1583,11 +1530,6 @@ entities:
           decals:
             751: 17,21
         - node:
-            color: '#439909FF'
-            id: TrimlineSouthWestCorner
-          decals:
-            599: 9,-1
-        - node:
             color: '#52B4E996'
             id: TrimlineSouthWestCorner
           decals:
@@ -1614,13 +1556,6 @@ entities:
           decals:
             153: 5,14
             154: 11,14
-        - node:
-            color: '#439909FF'
-            id: TrimlineWest
-          decals:
-            593: 9,-2
-            594: 9,-3
-            595: 9,-4
         - node:
             color: '#52B4E996'
             id: TrimlineWest
@@ -1671,8 +1606,6 @@ entities:
           decals:
             47: 13,9
             48: 13,8
-            1107: 1,-1
-            1108: 1,-2
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
@@ -1902,10 +1835,8 @@ entities:
           4,10:
             0: 1
             3: 2
-          0,-1:
-            0: 65419
           0,0:
-            0: 3680
+            0: 3812
           -1,0:
             0: 65527
           -1,1:
@@ -1916,16 +1847,20 @@ entities:
             0: 57343
           -1,2:
             0: 36590
-          1,0:
-            0: 3413
+          0,-1:
+            0: 61132
+            6: 1
           1,1:
             0: 65399
           1,2:
             0: 65527
           1,-1:
             0: 65535
+          1,0:
+            3: 544
+            0: 2176
           2,0:
-            0: 816
+            0: 817
           2,1:
             0: 65518
           2,2:
@@ -1965,8 +1900,7 @@ entities:
           -2,0:
             0: 47359
           -2,1:
-            0: 43163
-            6: 32
+            0: 43195
           -2,2:
             0: 65450
           -2,-1:
@@ -2085,9 +2019,7 @@ entities:
           -3,-3:
             0: 61440
           -3,-2:
-            0: 59407
-            8: 512
-            9: 1024
+            0: 60943
           -2,-3:
             0: 61440
           -2,-2:
@@ -2099,7 +2031,7 @@ entities:
           0,-3:
             0: 64716
           0,-2:
-            0: 64271
+            0: 64783
           1,-3:
             0: 28672
           1,-2:
@@ -2231,36 +2163,6 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.15
-          moles:
-          - 21.6852
-          - 81.57766
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
           temperature: 293.14996
           moles:
           - 21.824879
@@ -2276,10 +2178,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.1499
+          temperature: 293.15
           moles:
-          - 21.824879
-          - 82.10312
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -2551,30 +2453,6 @@ entities:
       - 2015
       - 2730
       - 2696
-  - uid: 21
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-3.5
-      parent: 1
-  - uid: 22
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 2725
-      - 2691
-  - uid: 23
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 2724
-      - 2690
   - uid: 24
     components:
     - type: Transform
@@ -2612,6 +2490,16 @@ entities:
       - 2042
       - 2733
       - 2699
+  - uid: 2445
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 2000
+      - 2132
+      - 50
 - proto: AirAlarmFreezer
   entities:
   - uid: 27
@@ -2735,54 +2623,6 @@ entities:
     - type: Transform
       pos: -14.5,40.5
       parent: 1
-  - uid: 48
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        49:
-        - - DoorStatus
-          - DoorBolt
-  - uid: 49
-    components:
-    - type: Transform
-      pos: 7.5,2.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        48:
-        - - DoorStatus
-          - DoorBolt
-  - uid: 50
-    components:
-    - type: Transform
-      pos: 3.5,2.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        51:
-        - - DoorStatus
-          - DoorBolt
-  - uid: 51
-    components:
-    - type: Transform
-      pos: 4.5,0.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        50:
-        - - DoorStatus
-          - DoorBolt
   - uid: 52
     components:
     - type: Transform
@@ -2823,13 +2663,18 @@ entities:
       pos: -8.5,2.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -517.1948
+      secondsUntilStateChange: -4455.745
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
 - proto: AirlockHatchRogueLocked
   entities:
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
   - uid: 57
     components:
     - type: Transform
@@ -2876,7 +2721,7 @@ entities:
       pos: 3.5,17.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -208.1618
+      secondsUntilStateChange: -4146.712
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2968,7 +2813,7 @@ entities:
       pos: -9.5,-0.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -514.22815
+      secondsUntilStateChange: -4452.7783
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2987,11 +2832,6 @@ entities:
     components:
     - type: Transform
       pos: -11.5,11.5
-      parent: 1
-  - uid: 86
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
       parent: 1
   - uid: 87
     components:
@@ -3014,16 +2854,11 @@ entities:
       pos: -4.5,14.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -64.128624
+      secondsUntilStateChange: -4002.6787
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
-  - uid: 91
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
   - uid: 92
     components:
     - type: Transform
@@ -3049,6 +2884,22 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,17.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 1411
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 2751
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
       parent: 1
 - proto: AirlockMedical
   entities:
@@ -3285,12 +3136,6 @@ entities:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 136
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-2.5
-      parent: 1
   - uid: 137
     components:
     - type: Transform
@@ -3334,6 +3179,12 @@ entities:
     components:
     - type: Transform
       pos: -14.5,27.5
+      parent: 1
+  - uid: 2650
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
@@ -3483,6 +3334,42 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 34.5,12.5
       parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 2422
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 2423
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 2451
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 2752
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,0.5
+      parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
   - uid: 170
@@ -3499,6 +3386,16 @@ entities:
     components:
     - type: Transform
       pos: 36.5,12.5
+      parent: 1
+  - uid: 1110
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 1112
+    components:
+    - type: Transform
+      pos: 5.5,1.5
       parent: 1
 - proto: AtmosFixFreezerMarker
   entities:
@@ -3600,20 +3497,33 @@ entities:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+- proto: Barricade
+  entities:
+  - uid: 1946
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
 - proto: BarricadeBlock
   entities:
-  - uid: 191
+  - uid: 592
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
 - proto: BarricadeDirectional
   entities:
-  - uid: 192
+  - uid: 1111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-4.5
+      pos: 0.5,-4.5
       parent: 1
 - proto: BarSign
   entities:
@@ -3652,16 +3562,6 @@ entities:
     components:
     - type: Transform
       pos: -10.5,13.5
-      parent: 1
-  - uid: 199
-    components:
-    - type: Transform
-      pos: 9.5,1.5
-      parent: 1
-  - uid: 200
-    components:
-    - type: Transform
-      pos: 1.5,1.5
       parent: 1
   - uid: 201
     components:
@@ -3709,17 +3609,35 @@ entities:
     - type: Transform
       pos: -10.5,13.5
       parent: 1
-- proto: BedsheetWhite
+- proto: BlastDoor
   entities:
-  - uid: 209
+  - uid: 91
     components:
     - type: Transform
-      pos: 1.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: 6.5,1.5
       parent: 1
-  - uid: 210
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 200
     components:
     - type: Transform
-      pos: 9.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 568
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 1106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
       parent: 1
 - proto: BoozeDispenser
   entities:
@@ -3736,6 +3654,20 @@ entities:
     - type: Transform
       pos: 5.5,15.5
       parent: 1
+- proto: BoxBeaker
+  entities:
+  - uid: 2453
+    components:
+    - type: Transform
+      pos: 8.452018,-4.3508196
+      parent: 1
+- proto: BoxSyringe
+  entities:
+  - uid: 596
+    components:
+    - type: Transform
+      pos: 8.952018,-4.3633194
+      parent: 1
 - proto: ButtonFrameCaution
   entities:
   - uid: 213
@@ -3747,6 +3679,18 @@ entities:
     components:
     - type: Transform
       pos: 12.5,12.5
+      parent: 1
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 584
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 2837
+    components:
+    - type: Transform
+      pos: 6.5,0.5
       parent: 1
 - proto: ButtonFrameGrey
   entities:
@@ -5468,15 +5412,10 @@ entities:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 558
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
   - uid: 559
     components:
     - type: Transform
-      pos: 0.5,-4.5
+      pos: 5.5,-4.5
       parent: 1
   - uid: 560
     components:
@@ -5518,225 +5457,25 @@ entities:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 568
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
   - uid: 569
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 570
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 571
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 572
-    components:
-    - type: Transform
-      pos: 4.5,-1.5
-      parent: 1
-  - uid: 573
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 574
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 575
-    components:
-    - type: Transform
-      pos: 8.5,-1.5
-      parent: 1
-  - uid: 576
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-  - uid: 577
+  - uid: 571
     components:
     - type: Transform
-      pos: 10.5,-1.5
+      pos: -0.5,-4.5
       parent: 1
-  - uid: 578
-    components:
-    - type: Transform
-      pos: 9.5,-2.5
-      parent: 1
-  - uid: 579
-    components:
-    - type: Transform
-      pos: 9.5,-3.5
-      parent: 1
-  - uid: 580
-    components:
-    - type: Transform
-      pos: 9.5,-4.5
-      parent: 1
-  - uid: 581
-    components:
-    - type: Transform
-      pos: 8.5,-4.5
-      parent: 1
-  - uid: 582
-    components:
-    - type: Transform
-      pos: 7.5,-4.5
-      parent: 1
-  - uid: 583
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
-      parent: 1
-  - uid: 584
-    components:
-    - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-  - uid: 585
-    components:
-    - type: Transform
-      pos: 4.5,-4.5
-      parent: 1
-  - uid: 586
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-  - uid: 587
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
-  - uid: 588
-    components:
-    - type: Transform
-      pos: 3.5,-2.5
-      parent: 1
-  - uid: 589
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 590
-    components:
-    - type: Transform
-      pos: 4.5,-0.5
-      parent: 1
-  - uid: 591
-    components:
-    - type: Transform
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 592
-    components:
-    - type: Transform
-      pos: 4.5,1.5
-      parent: 1
-  - uid: 593
-    components:
-    - type: Transform
-      pos: 4.5,2.5
-      parent: 1
-  - uid: 594
-    components:
-    - type: Transform
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 595
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
-  - uid: 596
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 597
-    components:
-    - type: Transform
-      pos: 9.5,2.5
-      parent: 1
-  - uid: 598
-    components:
-    - type: Transform
-      pos: 8.5,2.5
-      parent: 1
-  - uid: 599
-    components:
-    - type: Transform
-      pos: 7.5,2.5
-      parent: 1
-  - uid: 600
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 1
-  - uid: 601
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 1
-  - uid: 602
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 603
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 1
-  - uid: 604
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-  - uid: 605
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
-  - uid: 606
-    components:
-    - type: Transform
-      pos: 8.5,-0.5
-      parent: 1
-  - uid: 607
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 608
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 609
-    components:
-    - type: Transform
-      pos: 2.5,-0.5
-      parent: 1
-  - uid: 610
-    components:
-    - type: Transform
-      pos: 6.5,-2.5
-      parent: 1
-  - uid: 611
+  - uid: 572
     components:
     - type: Transform
       pos: 6.5,-3.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
       parent: 1
   - uid: 612
     components:
@@ -6572,6 +6311,126 @@ entities:
     components:
     - type: Transform
       pos: 9.5,37.5
+      parent: 1
+  - uid: 1113
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 1115
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 1116
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 1117
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 1594
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 1601
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 1624
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 1628
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 1663
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 1978
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 2052
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 2064
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 2065
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 2424
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 2428
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 2429
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 2432
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 2443
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 2449
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 2452
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 2647
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 2648
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 2690
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 2724
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
       parent: 1
 - proto: CableHV
   entities:
@@ -8212,72 +8071,12 @@ entities:
     - type: Transform
       pos: -2.5,31.5
       parent: 1
-  - uid: 1106
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
   - uid: 1107
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 1108
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 1109
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 1110
-    components:
-    - type: Transform
-      pos: 3.5,-2.5
-      parent: 1
-  - uid: 1111
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
-  - uid: 1112
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-  - uid: 1113
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 1114
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 1115
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-  - uid: 1116
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 1117
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-  - uid: 1118
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 1119
+  - uid: 1108
     components:
     - type: Transform
       pos: -2.5,-3.5
@@ -8426,11 +8225,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-3.5
-      parent: 1
-  - uid: 1149
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
       parent: 1
   - uid: 1150
     components:
@@ -8687,6 +8481,16 @@ entities:
     - type: Transform
       pos: -14.5,27.5
       parent: 1
+  - uid: 2446
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 2689
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
 - proto: CableTerminal
   entities:
   - uid: 1201
@@ -8800,6 +8604,21 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
   - uid: 1221
     components:
     - type: Transform
@@ -9750,21 +9569,6 @@ entities:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 1410
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 1
-  - uid: 1411
-    components:
-    - type: Transform
-      pos: 4.5,2.5
-      parent: 1
-  - uid: 1412
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 1
   - uid: 1413
     components:
     - type: Transform
@@ -9790,11 +9594,6 @@ entities:
     components:
     - type: Transform
       pos: -6.5,11.5
-      parent: 1
-  - uid: 1418
-    components:
-    - type: Transform
-      pos: 4.5,1.5
       parent: 1
   - uid: 1419
     components:
@@ -10680,6 +10479,51 @@ entities:
     - type: Transform
       pos: -16.5,20.5
       parent: 1
+  - uid: 1623
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 2133
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 2134
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 2135
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 2138
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 2420
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 2426
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 2430
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 2431
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
 - proto: CatwalkMono
   entities:
   - uid: 1584
@@ -10700,20 +10544,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5618813,9.752361
       parent: 1
-- proto: ChairOfficeLight
-  entities:
-  - uid: 1587
-    components:
-    - type: Transform
-      pos: 4.4737463,-4.6138077
-      parent: 1
-  - uid: 1588
-    components:
-    - type: Transform
-      pos: 8.318181,-3.5341082
-      parent: 1
 - proto: ChemDispenser
   entities:
+  - uid: 1149
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
   - uid: 1589
     components:
     - type: Transform
@@ -10723,11 +10560,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,19.5
-      parent: 1
-  - uid: 1591
-    components:
-    - type: Transform
-      pos: 10.5,-1.5
       parent: 1
 - proto: ChemistryHotplate
   entities:
@@ -10741,13 +10573,13 @@ entities:
     - type: Transform
       pos: -18.5,15.5
       parent: 1
-  - uid: 1594
-    components:
-    - type: Transform
-      pos: 8.5,-4.5
-      parent: 1
 - proto: ChemMaster
   entities:
+  - uid: 1410
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
   - uid: 1595
     components:
     - type: Transform
@@ -10757,11 +10589,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,18.5
-      parent: 1
-  - uid: 1597
-    components:
-    - type: Transform
-      pos: 10.5,-2.5
       parent: 1
 - proto: CigarGoldCase
   entities:
@@ -10777,6 +10604,13 @@ entities:
     - type: Transform
       pos: 15.429472,27.194477
       parent: 1
+- proto: CircuitImprinter
+  entities:
+  - uid: 1119
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
 - proto: ClosetChefFilled
   entities:
   - uid: 1600
@@ -10786,11 +10620,6 @@ entities:
       parent: 1
 - proto: ClosetFireFilled
   entities:
-  - uid: 1601
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 1
   - uid: 1602
     components:
     - type: Transform
@@ -10821,11 +10650,6 @@ entities:
       parent: 1
 - proto: ClosetL3Filled
   entities:
-  - uid: 1604
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
   - uid: 1605
     components:
     - type: Transform
@@ -10943,25 +10767,6 @@ entities:
     - type: Transform
       pos: -5.5,8.5
       parent: 1
-- proto: CMSemioticBiohazard
-  entities:
-  - uid: 1622
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 1623
-    components:
-    - type: Transform
-      pos: 7.5,0.5
-      parent: 1
-- proto: CMSemioticBiolab
-  entities:
-  - uid: 1624
-    components:
-    - type: Transform
-      pos: 2.5,-5.5
-      parent: 1
 - proto: CMSemioticBulkhead_door
   entities:
   - uid: 1625
@@ -10980,11 +10785,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,12.5
-      parent: 1
-  - uid: 1628
-    components:
-    - type: Transform
-      pos: 10.5,-3.5
       parent: 1
 - proto: CMSemioticCryo
   entities:
@@ -11116,11 +10916,36 @@ entities:
     - type: Transform
       pos: -21.5,4.5
       parent: 1
-  - uid: 1649
+- proto: ComputerAnalysisConsole
+  entities:
+  - uid: 2649
     components:
     - type: Transform
-      pos: 6.5,-5.5
+      pos: 4.5,-0.5
       parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        86:
+        - - ArtifactAnalyzerSender
+          - ArtifactAnalyzerReceiver
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+  - uid: 2691
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        49:
+        - - ArtifactAnalyzerSender
+          - ArtifactAnalyzerReceiver
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
 - proto: ComputerContrabandPalletConsolePirate
   entities:
   - uid: 1650
@@ -11175,6 +11000,17 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,7.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerResearchAndDevelopment
+  entities:
+  - uid: 2915
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 5
@@ -11282,16 +11118,6 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopResearchAndDevelopment
   entities:
-  - uid: 1663
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-5.5
-      parent: 1
-    - type: ApcPowerReceiver
-      powerLoad: 5
-    - type: Battery
-      startingCharge: 0
   - uid: 1664
     components:
     - type: Transform
@@ -11564,6 +11390,42 @@ entities:
       parent: 1
 - proto: DarkCatwalkMono
   entities:
+  - uid: 585
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 1114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
   - uid: 1699
     components:
     - type: Transform
@@ -11869,6 +11731,30 @@ entities:
     - type: Transform
       pos: -12.5,23.5
       parent: 1
+  - uid: 1945
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 2136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 2137
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 2425
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
 - proto: DefaultStationBeaconArmory
   entities:
   - uid: 1760
@@ -11980,13 +11866,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,7.5
-      parent: 1
-- proto: DiseaseDiagnoser
-  entities:
-  - uid: 1776
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
       parent: 1
 - proto: DisposalBend
   entities:
@@ -12970,28 +12849,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 1944
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-2.5
-      parent: 1
-  - uid: 1945
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-1.5
-      parent: 1
-  - uid: 1946
-    components:
-    - type: Transform
-      pos: 8.5,2.5
-      parent: 1
-  - uid: 1947
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
   - uid: 1948
     components:
     - type: Transform
@@ -13155,12 +13012,26 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 10.5,28.5
       parent: 1
+- proto: ExosuitFabricator
+  entities:
+  - uid: 2454
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
 - proto: FactionLathe
   entities:
   - uid: 1976
     components:
     - type: Transform
       pos: -20.5,6.5
+      parent: 1
+- proto: FaxMachineBase
+  entities:
+  - uid: 2725
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
       parent: 1
 - proto: FaxMachineNFCove
   entities:
@@ -13171,11 +13042,6 @@ entities:
       parent: 1
 - proto: filingCabinetDrawerRandom
   entities:
-  - uid: 1978
-    components:
-    - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
   - uid: 1979
     components:
     - type: Transform
@@ -13188,6 +13054,15 @@ entities:
       parent: 1
 - proto: FireAlarm
   entities:
+  - uid: 597
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 50
   - uid: 1981
     components:
     - type: Transform
@@ -13393,12 +13268,6 @@ entities:
       devices:
       - 2016
       - 2015
-  - uid: 2000
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-2.5
-      parent: 1
   - uid: 2001
     components:
     - type: Transform
@@ -13448,6 +13317,16 @@ entities:
       parent: 1
 - proto: Firelock
   entities:
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 597
+      - 2445
   - uid: 2006
     components:
     - type: Transform
@@ -13499,11 +13378,6 @@ entities:
       deviceLists:
       - 1983
       - 4
-  - uid: 2011
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
   - uid: 2012
     components:
     - type: Transform
@@ -13882,27 +13756,6 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 2050
-    components:
-    - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
-    - type: Fixtures
-      fixtures: {}
-  - uid: 2051
-    components:
-    - type: Transform
-      pos: 8.5,-2.5
-      parent: 1
-    - type: Fixtures
-      fixtures: {}
-  - uid: 2052
-    components:
-    - type: Transform
-      pos: 7.5,-3.5
-      parent: 1
-    - type: Fixtures
-      fixtures: {}
   - uid: 2053
     components:
     - type: Transform
@@ -13935,6 +13788,14 @@ entities:
     components:
     - type: Transform
       pos: 23.5,20.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 2421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
       parent: 1
     - type: Fixtures
       fixtures: {}
@@ -13986,6 +13847,18 @@ entities:
       targetPressure: 4500
     - type: AtmosPipeColor
       color: '#00AACCFF'
+- proto: GasOutletInjector
+  entities:
+  - uid: 583
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 1588
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
 - proto: GasPassiveGate
   entities:
   - uid: 2063
@@ -13995,24 +13868,18 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2064
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2065
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
 - proto: GasPassiveVent
   entities:
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
   - uid: 2066
     components:
     - type: Transform
@@ -14067,6 +13934,38 @@ entities:
       parent: 1
 - proto: GasPipeBend
   entities:
+  - uid: 1418
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 1944
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2011
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2050
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
   - uid: 2075
     components:
     - type: Transform
@@ -14445,46 +14344,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2125
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2126
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2127
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2128
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2129
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
   - uid: 2130
     components:
     - type: Transform
@@ -14501,61 +14360,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2132
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2133
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2134
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2135
-    components:
-    - type: Transform
-      pos: 8.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2136
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2137
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2138
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
   - uid: 2139
     components:
     - type: Transform
@@ -14734,6 +14538,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
+  - uid: 2450
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
 - proto: GasPipeFourway
   entities:
   - uid: 2162
@@ -14778,6 +14590,106 @@ entities:
       color: '#00AACCFF'
 - proto: GasPipeStraight
   entities:
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 577
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 580
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 582
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 1412
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 1591
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 1604
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
+  - uid: 1776
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2051
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
+  - uid: 2129
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
   - uid: 2168
     components:
     - type: Transform
@@ -16702,110 +16614,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2420
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2421
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2422
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2423
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2424
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2425
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2426
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2427
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2428
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2429
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2430
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2431
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2432
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
   - uid: 2433
     components:
     - type: Transform
@@ -16861,125 +16669,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2441
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2442
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2443
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2444
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2445
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2446
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2447
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2448
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2449
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2450
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2451
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2452
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2453
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2454
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2455
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
@@ -18458,35 +18147,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2647
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2648
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2649
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2650
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
   - uid: 2651
     components:
     - type: Transform
@@ -18578,10 +18238,58 @@ entities:
       color: '#00AACCFF'
 - proto: GasPort
   entities:
+  - uid: 578
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 1649
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
   - uid: 2663
     components:
     - type: Transform
       pos: -25.5,10.5
+      parent: 1
+- proto: GasPressurePump
+  entities:
+  - uid: 2125
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 2126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 2127
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 2455
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
       parent: 1
 - proto: GasThermoMachineFreezerEnabled
   entities:
@@ -18608,6 +18316,17 @@ entities:
       targetTemperature: 235
 - proto: GasVentPump
   entities:
+  - uid: 2000
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2445
+    - type: AtmosPipeColor
+      color: '#00AACCFF'
   - uid: 2667
     components:
     - type: Transform
@@ -18842,30 +18561,6 @@ entities:
       - 19
     - type: AtmosPipeColor
       color: '#00AACCFF'
-  - uid: 2689
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 2690
-    components:
-    - type: Transform
-      pos: 9.5,1.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 23
-  - uid: 2691
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 22
   - uid: 2692
     components:
     - type: Transform
@@ -18965,6 +18660,16 @@ entities:
       color: '#00AACCFF'
 - proto: GasVentScrubber
   entities:
+  - uid: 2132
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2445
+    - type: AtmosPipeColor
+      color: '#DD0075FF'
   - uid: 2701
     components:
     - type: Transform
@@ -19195,36 +18900,6 @@ entities:
       - 19
     - type: AtmosPipeColor
       color: '#DD0075FF'
-  - uid: 2723
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2724
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,1.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 23
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 2725
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,1.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 22
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
   - uid: 2726
     components:
     - type: Transform
@@ -19333,6 +19008,26 @@ entities:
       parent: 1
 - proto: Grille
   entities:
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 1587
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 2723
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
   - uid: 2736
     components:
     - type: Transform
@@ -19402,21 +19097,6 @@ entities:
     components:
     - type: Transform
       pos: -22.5,11.5
-      parent: 1
-  - uid: 2750
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-  - uid: 2751
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 2752
-    components:
-    - type: Transform
-      pos: 2.5,0.5
       parent: 1
   - uid: 2753
     components:
@@ -19492,11 +19172,6 @@ entities:
     components:
     - type: Transform
       pos: 7.5,32.5
-      parent: 1
-  - uid: 2768
-    components:
-    - type: Transform
-      pos: 9.5,0.5
       parent: 1
   - uid: 2769
     components:
@@ -19777,15 +19452,15 @@ entities:
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
+  - uid: 2441
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 1
   - uid: 2815
     components:
     - type: Transform
       pos: -23.5,15.5
-      parent: 1
-  - uid: 2816
-    components:
-    - type: Transform
-      pos: 9.5,-4.5
       parent: 1
   - uid: 2817
     components:
@@ -19811,12 +19486,6 @@ entities:
       parent: 1
 - proto: LampGold
   entities:
-  - uid: 2821
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.4552286,-5.0675116
-      parent: 1
   - uid: 2822
     components:
     - type: Transform
@@ -19829,6 +19498,34 @@ entities:
     - type: Transform
       pos: 15.658639,27.340311
       parent: 1
+- proto: LockableButtonPirate
+  entities:
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        568:
+        - - Pressed
+          - Toggle
+        1106:
+        - - Pressed
+          - Toggle
+  - uid: 2447
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        91:
+        - - Pressed
+          - Toggle
+        200:
+        - - Pressed
+          - Toggle
 - proto: LockerBoozeFilled
   entities:
   - uid: 2824
@@ -19935,17 +19632,24 @@ entities:
     - type: Transform
       pos: 0.5,27.5
       parent: 1
+- proto: MachineArtifactAnalyzer
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
 - proto: MachineCentrifuge
   entities:
   - uid: 2836
     components:
     - type: Transform
       pos: -22.5,15.5
-      parent: 1
-  - uid: 2837
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
       parent: 1
 - proto: MachineCryoSleepPod
   entities:
@@ -19970,11 +19674,6 @@ entities:
     components:
     - type: Transform
       pos: -18.5,14.5
-      parent: 1
-  - uid: 2842
-    components:
-    - type: Transform
-      pos: 7.5,-4.5
       parent: 1
 - proto: MachineOutpostCore
   entities:
@@ -20016,6 +19715,13 @@ entities:
     - type: Transform
       pos: 15.471139,26.694477
       parent: 1
+- proto: NodeScanner
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 2.4375334,-3.4244041
+      parent: 1
 - proto: OreBox
   entities:
   - uid: 2849
@@ -20025,10 +19731,11 @@ entities:
       parent: 1
 - proto: PaperBin20
   entities:
-  - uid: 2850
+  - uid: 191
     components:
     - type: Transform
-      pos: 5.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,-5.5
       parent: 1
   - uid: 2851
     components:
@@ -20039,6 +19746,13 @@ entities:
     components:
     - type: Transform
       pos: -2.5,9.5
+      parent: 1
+- proto: Pen
+  entities:
+  - uid: 590
+    components:
+    - type: Transform
+      pos: 3.5012271,-5.4000163
       parent: 1
 - proto: Pickaxe
   entities:
@@ -20212,6 +19926,16 @@ entities:
       parent: 1
 - proto: PoweredLEDSmallLight
   entities:
+  - uid: 2448
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 2768
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
   - uid: 2880
     components:
     - type: Transform
@@ -20348,6 +20072,30 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
+  - uid: 48
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 1947
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 2427
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 2816
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-4.5
+      parent: 1
   - uid: 2903
     components:
     - type: Transform
@@ -20405,34 +20153,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,37.5
-      parent: 1
-  - uid: 2913
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 2914
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-2.5
-      parent: 1
-  - uid: 2915
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-4.5
-      parent: 1
-  - uid: 2916
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 1
-  - uid: 2917
-    components:
-    - type: Transform
-      pos: 4.5,2.5
       parent: 1
   - uid: 2918
     components:
@@ -20605,8 +20325,20 @@ entities:
       rot: 3.141592653589793 rad
       pos: -4.5,-0.5
       parent: 1
+- proto: Protolathe
+  entities:
+  - uid: 1118
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
 - proto: Rack
   entities:
+  - uid: 1597
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
   - uid: 2946
     components:
     - type: Transform
@@ -20631,11 +20363,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,-2.5
-      parent: 1
-  - uid: 2951
-    components:
-    - type: Transform
-      pos: 10.5,-0.5
       parent: 1
 - proto: Railing
   entities:
@@ -21012,6 +20739,26 @@ entities:
       parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 1109
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 2842
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
   - uid: 3015
     components:
     - type: Transform
@@ -21168,26 +20915,6 @@ entities:
     components:
     - type: Transform
       pos: -22.5,11.5
-      parent: 1
-  - uid: 3046
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
-  - uid: 3047
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-  - uid: 3048
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 3049
-    components:
-    - type: Transform
-      pos: 1.5,0.5
       parent: 1
   - uid: 3050
     components:
@@ -21358,6 +21085,12 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
+  - uid: 591
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
   - uid: 3071
     components:
     - type: Transform
@@ -21369,12 +21102,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,8.5
-      parent: 1
-  - uid: 3073
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-3.5
       parent: 1
   - uid: 3074
     components:
@@ -21401,6 +21128,8 @@ entities:
     - type: Transform
       pos: -18.5,16.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4095.4297589
 - proto: SMESAdvanced
   entities:
   - uid: 3078
@@ -21805,6 +21534,23 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 14.5,26.5
       parent: 1
+- proto: StorageCanister
+  entities:
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
 - proto: StructureGunRack
   entities:
   - uid: 3143
@@ -21882,18 +21628,6 @@ entities:
     - type: Transform
       pos: -9.5,5.5
       parent: 1
-- proto: SyringeCaseAltFilled
-  entities:
-  - uid: 3155
-    components:
-    - type: Transform
-      pos: 10.632307,-0.45730066
-      parent: 1
-  - uid: 3156
-    components:
-    - type: Transform
-      pos: 10.428603,-0.45730066
-      parent: 1
 - proto: TableCounterWood
   entities:
   - uid: 3157
@@ -21918,6 +21652,30 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 2442
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 2821
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 2913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-5.5
+      parent: 1
   - uid: 3161
     components:
     - type: Transform
@@ -22019,41 +21777,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,4.5
-      parent: 1
-  - uid: 3181
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 1
-  - uid: 3182
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
-      parent: 1
-  - uid: 3183
-    components:
-    - type: Transform
-      pos: 7.5,-4.5
-      parent: 1
-  - uid: 3184
-    components:
-    - type: Transform
-      pos: 8.5,-4.5
-      parent: 1
-  - uid: 3185
-    components:
-    - type: Transform
-      pos: 4.5,-5.5
-      parent: 1
-  - uid: 3186
-    components:
-    - type: Transform
-      pos: 3.5,-5.5
-      parent: 1
-  - uid: 3187
-    components:
-    - type: Transform
-      pos: 9.5,-4.5
       parent: 1
   - uid: 3188
     components:
@@ -22160,16 +21883,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -6.5,7.5
       parent: 1
-  - uid: 3207
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 3208
-    components:
-    - type: Transform
-      pos: 9.5,2.5
-      parent: 1
 - proto: ToolboxElectricalFilled
   entities:
   - uid: 3209
@@ -22184,13 +21897,6 @@ entities:
     - type: Transform
       pos: 21.462467,10.761894
       parent: 1
-- proto: Vaccinator
-  entities:
-  - uid: 3211
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
 - proto: VendingMachineAmmoPOIMercenary
   entities:
   - uid: 3212
@@ -22198,6 +21904,8 @@ entities:
     - type: Transform
       pos: 10.5,15.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4399.4627472
 - proto: VendingMachineAstroVendPOI
   entities:
   - uid: 3213
@@ -22205,6 +21913,8 @@ entities:
     - type: Transform
       pos: 9.5,15.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 3991.4299129
 - proto: VendingMachineBooze
   entities:
   - uid: 3214
@@ -22212,6 +21922,8 @@ entities:
     - type: Transform
       pos: 18.5,30.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4060.4297969
 - proto: VendingMachineChefvend
   entities:
   - uid: 3215
@@ -22219,6 +21931,8 @@ entities:
     - type: Transform
       pos: 17.5,20.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4030.4298149
 - proto: VendingMachineCiviMedPlus
   entities:
   - uid: 3216
@@ -22226,6 +21940,8 @@ entities:
     - type: Transform
       pos: -20.5,11.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4130.4297369
 - proto: VendingMachineDinnerware
   entities:
   - uid: 3217
@@ -22233,6 +21949,8 @@ entities:
     - type: Transform
       pos: 16.5,20.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4310.4628902
 - proto: VendingMachineEngivend
   entities:
   - uid: 3218
@@ -22247,11 +21965,15 @@ entities:
     - type: Transform
       pos: 11.5,15.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4147.4296759
   - uid: 3220
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4219.4296979
 - proto: VendingMachineNutri
   entities:
   - uid: 3221
@@ -22259,6 +21981,8 @@ entities:
     - type: Transform
       pos: 26.5,18.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4505.4627472
 - proto: VendingMachineRestockSeeds
   entities:
   - uid: 3222
@@ -22278,6 +22002,8 @@ entities:
     - type: Transform
       pos: 26.5,19.5
       parent: 1
+    - type: Advertise
+      nextAdvertisementTime: 4078.3964936
 - proto: VendingMachineTankDispenserEVAPOI
   entities:
   - uid: 3225
@@ -22294,6 +22020,58 @@ entities:
       parent: 1
 - proto: WallPlastitanium
   entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 1622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 2850
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 2914
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
   - uid: 3227
     components:
     - type: Transform
@@ -22345,11 +22123,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,10.5
-      parent: 1
-  - uid: 3236
-    components:
-    - type: Transform
-      pos: 7.5,1.5
       parent: 1
   - uid: 3237
     components:
@@ -23506,40 +23279,10 @@ entities:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 3468
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 3469
-    components:
-    - type: Transform
-      pos: 3.5,1.5
-      parent: 1
-  - uid: 3470
-    components:
-    - type: Transform
-      pos: 5.5,0.5
-      parent: 1
-  - uid: 3471
-    components:
-    - type: Transform
-      pos: 5.5,2.5
-      parent: 1
-  - uid: 3472
-    components:
-    - type: Transform
-      pos: 5.5,1.5
-      parent: 1
   - uid: 3473
     components:
     - type: Transform
       pos: 1.5,-2.5
-      parent: 1
-  - uid: 3474
-    components:
-    - type: Transform
-      pos: 2.5,-2.5
       parent: 1
   - uid: 3475
     components:
@@ -23685,36 +23428,6 @@ entities:
     components:
     - type: Transform
       pos: -10.5,-0.5
-      parent: 1
-  - uid: 3504
-    components:
-    - type: Transform
-      pos: 10.5,2.5
-      parent: 1
-  - uid: 3505
-    components:
-    - type: Transform
-      pos: 10.5,1.5
-      parent: 1
-  - uid: 3506
-    components:
-    - type: Transform
-      pos: 10.5,0.5
-      parent: 1
-  - uid: 3507
-    components:
-    - type: Transform
-      pos: 7.5,0.5
-      parent: 1
-  - uid: 3508
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
-      parent: 1
-  - uid: 3509
-    components:
-    - type: Transform
-      pos: 2.5,-5.5
       parent: 1
   - uid: 3510
     components:
@@ -24551,6 +24264,20 @@ entities:
     components:
     - type: Transform
       pos: 1.5,40.5
+      parent: 1
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 2444
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 2750
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,2.5
       parent: 1
 - proto: WallPlastitaniumOutpost
   entities:

--- a/Resources/Maps/_Mono/POI/cove.yml
+++ b/Resources/Maps/_Mono/POI/cove.yml
@@ -28,8 +28,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/18/2025 12:30:46
-  entityCount: 4809
+  time: 08/18/2025 12:46:52
+  entityCount: 4810
 maps: []
 grids:
 - 1
@@ -205,6 +205,11 @@ entities:
       chunkCollection:
         version: 2
         nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            1392: 0,-5
         - node:
             color: '#FFFFFFFF'
             id: Bot
@@ -594,6 +599,7 @@ entities:
           decals:
             104: 2,7
             733: 19,23
+            1389: 0,-5
         - node:
             color: '#D69949FF'
             id: BrickTileSteelCornerNw
@@ -632,6 +638,11 @@ entities:
             80: 12,6
         - node:
             color: '#FFFFFFFF'
+            id: BrickTileSteelEndS
+          decals:
+            1390: 0,-6
+        - node:
+            color: '#FFFFFFFF'
             id: BrickTileSteelEndW
           decals:
             77: 3,6
@@ -656,6 +667,11 @@ entities:
             id: BrickTileSteelInnerSw
           decals:
             349: -17,11
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelInnerSw
+          decals:
+            1391: 0,-5
         - node:
             color: '#52B4E9FF'
             id: BrickTileSteelLineE
@@ -685,6 +701,7 @@ entities:
             83: 5,6
             84: 4,6
             739: 18,23
+            1384: -1,-5
         - node:
             color: '#52B4E9FF'
             id: BrickTileSteelLineS
@@ -701,6 +718,7 @@ entities:
             75: 10,6
             76: 11,6
             738: 18,21
+            1385: -1,-5
         - node:
             color: '#52B4E9FF'
             id: BrickTileSteelLineW
@@ -1346,6 +1364,24 @@ entities:
           decals:
             281: -20,15
         - node:
+            color: '#BE6BC3FF'
+            id: TrimWarnEast
+          decals:
+            1397: 6,2
+            1398: 6,1
+        - node:
+            color: '#BE6BC3FF'
+            id: TrimWarnSouth
+          decals:
+            1393: 2,0
+            1394: 8,0
+        - node:
+            color: '#BE6BC3FF'
+            id: TrimWarnWest
+          decals:
+            1395: 4,2
+            1396: 4,1
+        - node:
             color: '#52B4E996'
             id: TrimlineEast
           decals:
@@ -1848,8 +1884,7 @@ entities:
           -1,2:
             0: 36590
           0,-1:
-            0: 61132
-            6: 1
+            0: 61133
           1,1:
             0: 65399
           1,2:
@@ -1934,7 +1969,7 @@ entities:
             0: 1024
           8,3:
             0: 7
-            7: 8
+            6: 8
           5,5:
             0: 57308
           5,6:
@@ -2152,21 +2187,6 @@ entities:
           moles:
           - 27.225372
           - 102.419266
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.14996
-          moles:
-          - 21.824879
-          - 82.10312
           - 0
           - 0
           - 0
@@ -2663,7 +2683,7 @@ entities:
       pos: -8.5,2.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4455.745
+      secondsUntilStateChange: -4872.5464
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2721,7 +2741,7 @@ entities:
       pos: 3.5,17.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4146.712
+      secondsUntilStateChange: -4563.513
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2813,7 +2833,7 @@ entities:
       pos: -9.5,-0.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4452.7783
+      secondsUntilStateChange: -4869.5796
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2854,7 +2874,7 @@ entities:
       pos: -4.5,14.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4002.6787
+      secondsUntilStateChange: -4419.48
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2885,17 +2905,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 12.5,17.5
       parent: 1
-  - uid: 608
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 1411
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,0.5
-      parent: 1
   - uid: 2751
     components:
     - type: Transform
@@ -2919,6 +2928,18 @@ entities:
     components:
     - type: Transform
       pos: 15.5,30.5
+      parent: 1
+- proto: AirlockScienceGlass
+  entities:
+  - uid: 608
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 1411
+    components:
+    - type: Transform
+      pos: 8.5,0.5
       parent: 1
 - proto: AirlockShuttleSyndicateRogueLocked
   entities:
@@ -11845,6 +11866,13 @@ entities:
     components:
     - type: Transform
       pos: -19.5,9.5
+      parent: 1
+- proto: DefaultStationBeaconRND
+  entities:
+  - uid: 2916
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
       parent: 1
 - proto: DefaultStationBeaconServerRoom
   entities:
@@ -21129,7 +21157,7 @@ entities:
       pos: -18.5,16.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4095.4297589
+      nextAdvertisementTime: 744.999799
 - proto: SMESAdvanced
   entities:
   - uid: 3078
@@ -21905,7 +21933,7 @@ entities:
       pos: 10.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4399.4627472
+      nextAdvertisementTime: 911.999577
 - proto: VendingMachineAstroVendPOI
   entities:
   - uid: 3213
@@ -21914,7 +21942,7 @@ entities:
       pos: 9.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 3991.4299129
+      nextAdvertisementTime: 557.9912799
 - proto: VendingMachineBooze
   entities:
   - uid: 3214
@@ -21923,7 +21951,7 @@ entities:
       pos: 18.5,30.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4060.4297969
+      nextAdvertisementTime: 935.999552
 - proto: VendingMachineChefvend
   entities:
   - uid: 3215
@@ -21932,7 +21960,7 @@ entities:
       pos: 17.5,20.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4030.4298149
+      nextAdvertisementTime: 805.999767
 - proto: VendingMachineCiviMedPlus
   entities:
   - uid: 3216
@@ -21941,7 +21969,7 @@ entities:
       pos: -20.5,11.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4130.4297369
+      nextAdvertisementTime: 984.999518
 - proto: VendingMachineDinnerware
   entities:
   - uid: 3217
@@ -21950,7 +21978,7 @@ entities:
       pos: 16.5,20.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4310.4628902
+      nextAdvertisementTime: 933.999601
 - proto: VendingMachineEngivend
   entities:
   - uid: 3218
@@ -21966,14 +21994,14 @@ entities:
       pos: 11.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4147.4296759
+      nextAdvertisementTime: 695.9912799
   - uid: 3220
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4219.4296979
+      nextAdvertisementTime: 585.9912799
 - proto: VendingMachineNutri
   entities:
   - uid: 3221
@@ -21982,7 +22010,7 @@ entities:
       pos: 26.5,18.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4505.4627472
+      nextAdvertisementTime: 1052.999537
 - proto: VendingMachineRestockSeeds
   entities:
   - uid: 3222
@@ -22003,7 +22031,7 @@ entities:
       pos: 26.5,19.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 4078.3964936
+      nextAdvertisementTime: 1030.999525
 - proto: VendingMachineTankDispenserEVAPOI
   entities:
   - uid: 3225

--- a/Resources/Maps/_Mono/POI/cove.yml
+++ b/Resources/Maps/_Mono/POI/cove.yml
@@ -28,8 +28,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/18/2025 12:46:52
-  entityCount: 4810
+  time: 08/18/2025 12:54:06
+  entityCount: 4806
 maps: []
 grids:
 - 1
@@ -2683,7 +2683,7 @@ entities:
       pos: -8.5,2.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4872.5464
+      secondsUntilStateChange: -4942.435
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2741,7 +2741,7 @@ entities:
       pos: 3.5,17.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4563.513
+      secondsUntilStateChange: -4633.402
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2833,7 +2833,7 @@ entities:
       pos: -9.5,-0.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4869.5796
+      secondsUntilStateChange: -4939.4683
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2874,7 +2874,7 @@ entities:
       pos: -4.5,14.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4419.48
+      secondsUntilStateChange: -4489.3687
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -3355,35 +3355,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 34.5,12.5
       parent: 1
-  - uid: 587
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,2.5
-      parent: 1
-  - uid: 588
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,2.5
-      parent: 1
-  - uid: 2422
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,1.5
-      parent: 1
   - uid: 2423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
-      parent: 1
-  - uid: 2451
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,1.5
       parent: 1
   - uid: 2752
     components:
@@ -21157,7 +21133,7 @@ entities:
       pos: -18.5,16.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 744.999799
+      nextAdvertisementTime: 181.7993402
 - proto: SMESAdvanced
   entities:
   - uid: 3078
@@ -21933,7 +21909,7 @@ entities:
       pos: 10.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 911.999577
+      nextAdvertisementTime: 223.7993402
 - proto: VendingMachineAstroVendPOI
   entities:
   - uid: 3213
@@ -21942,7 +21918,7 @@ entities:
       pos: 9.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 557.9912799
+      nextAdvertisementTime: 176.7993402
 - proto: VendingMachineBooze
   entities:
   - uid: 3214
@@ -21951,7 +21927,7 @@ entities:
       pos: 18.5,30.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 935.999552
+      nextAdvertisementTime: 282.7993402
 - proto: VendingMachineChefvend
   entities:
   - uid: 3215
@@ -21960,7 +21936,7 @@ entities:
       pos: 17.5,20.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 805.999767
+      nextAdvertisementTime: 251.7993402
 - proto: VendingMachineCiviMedPlus
   entities:
   - uid: 3216
@@ -21969,7 +21945,7 @@ entities:
       pos: -20.5,11.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 984.999518
+      nextAdvertisementTime: 525.7993402
 - proto: VendingMachineDinnerware
   entities:
   - uid: 3217
@@ -21978,7 +21954,7 @@ entities:
       pos: 16.5,20.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 933.999601
+      nextAdvertisementTime: 401.7993402
 - proto: VendingMachineEngivend
   entities:
   - uid: 3218
@@ -21994,14 +21970,14 @@ entities:
       pos: 11.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 695.9912799
+      nextAdvertisementTime: 148.7993402
   - uid: 3220
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 585.9912799
+      nextAdvertisementTime: 245.7993402
 - proto: VendingMachineNutri
   entities:
   - uid: 3221
@@ -22010,7 +21986,7 @@ entities:
       pos: 26.5,18.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 1052.999537
+      nextAdvertisementTime: 514.7993402
 - proto: VendingMachineRestockSeeds
   entities:
   - uid: 3222
@@ -22031,7 +22007,7 @@ entities:
       pos: 26.5,19.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 1030.999525
+      nextAdvertisementTime: 592.7998872
 - proto: VendingMachineTankDispenserEVAPOI
   entities:
   - uid: 3225

--- a/Resources/Maps/_Mono/POI/cove.yml
+++ b/Resources/Maps/_Mono/POI/cove.yml
@@ -28,8 +28,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/18/2025 12:54:06
-  entityCount: 4806
+  time: 08/18/2025 13:14:00
+  entityCount: 4808
 maps: []
 grids:
 - 1
@@ -2683,7 +2683,7 @@ entities:
       pos: -8.5,2.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4942.435
+      secondsUntilStateChange: -5061.0684
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2741,7 +2741,7 @@ entities:
       pos: 3.5,17.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4633.402
+      secondsUntilStateChange: -4752.035
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2833,7 +2833,7 @@ entities:
       pos: -9.5,-0.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4939.4683
+      secondsUntilStateChange: -5058.1016
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2874,7 +2874,7 @@ entities:
       pos: -4.5,14.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4489.3687
+      secondsUntilStateChange: -4608.002
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -20370,6 +20370,16 @@ entities:
       parent: 1
 - proto: Railing
   entities:
+  - uid: 2422
+    components:
+    - type: Transform
+      pos: -18.5,6.5
+      parent: 1
+  - uid: 2451
+    components:
+    - type: Transform
+      pos: -17.5,6.5
+      parent: 1
   - uid: 2952
     components:
     - type: Transform
@@ -20932,6 +20942,13 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -15.5,9.5
       parent: 1
+- proto: ResearchAndDevelopmentServerFlatpack
+  entities:
+  - uid: 588
+    components:
+    - type: Transform
+      pos: -17.479393,6.5523887
+      parent: 1
 - proto: ResearchAndDevelopmentServerRogues
   entities:
   - uid: 3052
@@ -21133,7 +21150,7 @@ entities:
       pos: -18.5,16.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 181.7993402
+      nextAdvertisementTime: 446.5667075
 - proto: SMESAdvanced
   entities:
   - uid: 3078
@@ -21555,13 +21572,6 @@ entities:
     - type: Transform
       pos: 10.5,-2.5
       parent: 1
-- proto: StructureGunRack
-  entities:
-  - uid: 3143
-    components:
-    - type: Transform
-      pos: -18.5,2.5
-      parent: 1
 - proto: SubstationBasic
   entities:
   - uid: 3144
@@ -21874,10 +21884,10 @@ entities:
       parent: 1
 - proto: TelecomServerFilledFreelance
   entities:
-  - uid: 3205
+  - uid: 587
     components:
     - type: Transform
-      pos: -17.5,6.5
+      pos: -18.5,2.5
       parent: 1
 - proto: ToiletDirtyWater
   entities:
@@ -21909,7 +21919,7 @@ entities:
       pos: 10.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 223.7993402
+      nextAdvertisementTime: 450.5667075
 - proto: VendingMachineAstroVendPOI
   entities:
   - uid: 3213
@@ -21918,7 +21928,7 @@ entities:
       pos: 9.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 176.7993402
+      nextAdvertisementTime: 431.5667075
 - proto: VendingMachineBooze
   entities:
   - uid: 3214
@@ -21927,7 +21937,7 @@ entities:
       pos: 18.5,30.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 282.7993402
+      nextAdvertisementTime: 321.5667075
 - proto: VendingMachineChefvend
   entities:
   - uid: 3215
@@ -21936,7 +21946,7 @@ entities:
       pos: 17.5,20.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 251.7993402
+      nextAdvertisementTime: 542.5667075
 - proto: VendingMachineCiviMedPlus
   entities:
   - uid: 3216
@@ -21945,7 +21955,7 @@ entities:
       pos: -20.5,11.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 525.7993402
+      nextAdvertisementTime: 656.5999254
 - proto: VendingMachineDinnerware
   entities:
   - uid: 3217
@@ -21954,7 +21964,7 @@ entities:
       pos: 16.5,20.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 401.7993402
+      nextAdvertisementTime: 543.5999514
 - proto: VendingMachineEngivend
   entities:
   - uid: 3218
@@ -21970,14 +21980,14 @@ entities:
       pos: 11.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 148.7993402
+      nextAdvertisementTime: 335.5667075
   - uid: 3220
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 245.7993402
+      nextAdvertisementTime: 386.5667075
 - proto: VendingMachineNutri
   entities:
   - uid: 3221
@@ -21986,7 +21996,7 @@ entities:
       pos: 26.5,18.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 514.7993402
+      nextAdvertisementTime: 225.5667075
 - proto: VendingMachineRestockSeeds
   entities:
   - uid: 3222
@@ -22007,7 +22017,7 @@ entities:
       pos: 26.5,19.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 592.7998872
+      nextAdvertisementTime: 655.5998734
 - proto: VendingMachineTankDispenserEVAPOI
   entities:
   - uid: 3225

--- a/Resources/Maps/_Mono/POI/cove.yml
+++ b/Resources/Maps/_Mono/POI/cove.yml
@@ -28,8 +28,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/18/2025 13:14:00
-  entityCount: 4808
+  time: 08/19/2025 05:44:03
+  entityCount: 4810
 maps: []
 grids:
 - 1
@@ -2683,7 +2683,7 @@ entities:
       pos: -8.5,2.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -5061.0684
+      secondsUntilStateChange: -5241.607
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2741,7 +2741,7 @@ entities:
       pos: 3.5,17.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4752.035
+      secondsUntilStateChange: -4932.5737
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2833,7 +2833,7 @@ entities:
       pos: -9.5,-0.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -5058.1016
+      secondsUntilStateChange: -5238.64
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2874,7 +2874,7 @@ entities:
       pos: -4.5,14.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4608.002
+      secondsUntilStateChange: -4788.5405
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13803,6 +13803,20 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
+  - uid: 2917
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 2951
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: GasFilter
   entities:
   - uid: 2058
@@ -21150,7 +21164,7 @@ entities:
       pos: -18.5,16.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 446.5667075
+      nextAdvertisementTime: 329.6422244
 - proto: SMESAdvanced
   entities:
   - uid: 3078
@@ -21919,7 +21933,7 @@ entities:
       pos: 10.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 450.5667075
+      nextAdvertisementTime: 248.6422244
 - proto: VendingMachineAstroVendPOI
   entities:
   - uid: 3213
@@ -21928,7 +21942,7 @@ entities:
       pos: 9.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 431.5667075
+      nextAdvertisementTime: 773.666486
 - proto: VendingMachineBooze
   entities:
   - uid: 3214
@@ -21937,7 +21951,7 @@ entities:
       pos: 18.5,30.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 321.5667075
+      nextAdvertisementTime: 500.6422244
 - proto: VendingMachineChefvend
   entities:
   - uid: 3215
@@ -21946,7 +21960,7 @@ entities:
       pos: 17.5,20.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 542.5667075
+      nextAdvertisementTime: 587.6422244
 - proto: VendingMachineCiviMedPlus
   entities:
   - uid: 3216
@@ -21955,7 +21969,7 @@ entities:
       pos: -20.5,11.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 656.5999254
+      nextAdvertisementTime: 307.6422244
 - proto: VendingMachineDinnerware
   entities:
   - uid: 3217
@@ -21964,7 +21978,7 @@ entities:
       pos: 16.5,20.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 543.5999514
+      nextAdvertisementTime: 663.666564
 - proto: VendingMachineEngivend
   entities:
   - uid: 3218
@@ -21980,14 +21994,14 @@ entities:
       pos: 11.5,15.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 335.5667075
+      nextAdvertisementTime: 521.6422244
   - uid: 3220
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 386.5667075
+      nextAdvertisementTime: 447.6422244
 - proto: VendingMachineNutri
   entities:
   - uid: 3221
@@ -21996,7 +22010,7 @@ entities:
       pos: 26.5,18.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 225.5667075
+      nextAdvertisementTime: 661.666601
 - proto: VendingMachineRestockSeeds
   entities:
   - uid: 3222
@@ -22017,7 +22031,7 @@ entities:
       pos: 26.5,19.5
       parent: 1
     - type: Advertise
-      nextAdvertisementTime: 655.5998734
+      nextAdvertisementTime: 643.66656
 - proto: VendingMachineTankDispenserEVAPOI
   entities:
   - uid: 3225


### PR DESCRIPTION
## About the PR
Rogues only used this space for RnD purposes, so i converted it for that purpose, no more unused viro.

Added civilian RnD server.

## Why / Balance

## How to test

## Media

<img width="770" height="629" alt="image" src="https://github.com/user-attachments/assets/de1d5a06-021b-46cb-a905-901d11e2b035" />

<img width="337" height="375" alt="image" src="https://github.com/user-attachments/assets/527439e5-9461-468d-ba09-387e872d22fa" />

## Requirements

## Breaking changes

**Changelog**
:cl:
- tweak: Changed rogue viro into a RnD lab
- add: added civilian RnD server to Rogue outpost
