### PR TITLE
Fixes FillLevelSpriteExist's Fail

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Cooking/chemistry.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Cooking/chemistry.yml
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Blu
 # SPDX-FileCopyrightText: 2025 BlueHNT
-# SPDX-FileCopyrightText: 2025 monolith8319
+# SPDX-FileCopyrightText: 2025 Coenx-flex
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Cooking/chemistry.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Cooking/chemistry.yml
@@ -19,8 +19,8 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 1
     fillBaseName: teaspoon
+    inHandsFillBaseName: null
     # inHandsMaxFillLevels: 1 # TODO: Add inHandsMaxFillLevels
-    # inHandsFillBaseName: -fill-
   - type: SolutionContainerManager
     solutions:
       injector:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes an integration test error

## How to test
<!-- Describe the way it can be tested -->
Run the test, the issue was that it inherited the dropper's inHandsFillBaseName instead of setting it back to null

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
