### PR TITLE
Solar Panel Partial Obstruction

### DIFF
--- a/Content.Server/_NF/Solar/Components/NFSolarPanelComponent.cs
+++ b/Content.Server/_NF/Solar/Components/NFSolarPanelComponent.cs
@@ -23,6 +23,13 @@ public sealed partial class NFSolarPanelComponent : Component
     [DataField]
     public int MaxSupply = 1500;
 
+    // Mono
+    /// <summary>
+    /// Coverage to still have if there's a wall directly in front of us.
+    /// </summary>
+    [DataField]
+    public float ObstructedCoverage = 0.5f;
+
     /// <summary>
     /// Current coverage of this panel (from 0 to 1).
     /// This is updated by <see cref='PowerSolarSystem'/>.

--- a/Content.Server/_NF/Solar/Components/NFSolarPanelComponent.cs
+++ b/Content.Server/_NF/Solar/Components/NFSolarPanelComponent.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 Whatstone
 //

--- a/Content.Server/_NF/Solar/EntitySystems/NFPowerSolarSystem.cs
+++ b/Content.Server/_NF/Solar/EntitySystems/NFPowerSolarSystem.cs
@@ -2,8 +2,12 @@ using System.Linq;
 using Content.Server.Power.Components;
 using Content.Server._NF.Solar.Components;
 using Content.Shared.GameTicking;
+using Content.Shared.Light.Components; // Mono
+using Content.Shared.Light.EntitySystems; // Mono
 using Content.Shared.Physics;
 using JetBrains.Annotations;
+using Robust.Shared.Map; // Mono
+using Robust.Shared.Map.Components; // Mono
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
@@ -21,8 +25,10 @@ internal sealed class NFPowerSolarSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _robustRandom = default!;
     [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
+    [Dependency] private readonly SharedRoofSystem _roof = default!; // Mono
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!; // Frontier
+    [Dependency] private readonly IMapManager _mapMan = default!; // Mono
 
     /// <summary>
     /// Maximum panel angular velocity range - used to stop people rotating panels fast enough that the lag prevention becomes noticable
@@ -175,6 +181,16 @@ internal sealed class NFPowerSolarSystem : EntitySystem
         // and that's expected behavior.
         float coverage = (float)Math.Max(0, Math.Cos(panelRelativeToSun));
 
+        // Mono
+        var gridUid = xform.GridUid;
+        if (TryComp<RoofComponent>(gridUid, out var roofComp) && TryComp<MapGridComponent>(gridUid, out var gridComp))
+        {
+            var gridCoords = _transformSystem.WithEntityId(xform.Coordinates, gridUid.Value);
+            // drop coverage to 0 if the solar panel is roofed
+            if (_roof.IsRooved((gridUid.Value, gridComp, roofComp), gridCoords.ToVector2i(EntityManager, _mapMan, _transformSystem)))
+                coverage = 0f;
+        }
+
         if (coverage > 0)
         {
             // Determine if the solar panel is occluded, and zero out coverage if so.
@@ -185,7 +201,8 @@ internal sealed class NFPowerSolarSystem : EntitySystem
                 SunOcclusionCheckDistance,
                 e => !xform.Anchored || e == entity);
             if (rayCastResults.Any())
-                coverage = 0;
+                // Mono
+                coverage = MathHelper.Lerp(panel.Comp.ObstructedCoverage, 1f, rayCastResults.First().Distance / SunOcclusionCheckDistance);
         }
 
         // Total coverage calculated; apply it to the panel.

--- a/Content.Server/_NF/Solar/EntitySystems/NFPowerSolarSystem.cs
+++ b/Content.Server/_NF/Solar/EntitySystems/NFPowerSolarSystem.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.Server.Power.Components;
 using Content.Server._NF.Solar.Components;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- solar panels will now make from 50% to 100% of power if obstructed depending on distance to obstruction as opposed to always nothing if they see anything
- solar panels no longer make any power if roofed

## Why / Balance
currently solar panels are kinda bad and also worse in every way than RTG which is pretty easy to obtain
this makes them more bearable to use
also doesn't depower your ship the moment you dock to any POI because the POI obstructs all your panels

## How to test
test that roofed solar panel makes no power
test that unobstructed solar panel makes full power
test that obstructed solar panel makes partial power

## Media
<img width="435" height="285" alt="image" src="https://github.com/user-attachments/assets/e1bef03a-cfa5-4e36-86dd-ff1c73f13be4" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Solar panels now still make partial power if obstructed by walls.
