### PR TITLE
Prevent Vgroids/Etc From Despawning with Players Nearby

### DIFF
--- a/Content.Server/_Mono/StationEvents/AutoExtendRuleComponent.cs
+++ b/Content.Server/_Mono/StationEvents/AutoExtendRuleComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System;
 
 namespace Content.Server._Mono.StationEvents;

--- a/Content.Server/_Mono/StationEvents/AutoExtendRuleComponent.cs
+++ b/Content.Server/_Mono/StationEvents/AutoExtendRuleComponent.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Content.Server._Mono.StationEvents;
+
+/// <summary>
+/// Causes this station event to automatically extend its duration if there's players near any of the specified entities.
+/// Also supports grids and automatically accounts for them potentially being big.
+/// Supposed to be used by other systems and not YML.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AutoExtendRuleComponent : Component
+{
+    /// <summary>
+    /// Entities for this to act on.
+    /// Supposed to be filled by whatever system added this component.
+    /// </summary>
+    [DataField]
+    public List<EntityUid> Entities = new();
+
+    /// <summary>
+    /// In what radius to check for players.
+    /// </summary
+    [DataField]
+    public float PlayerCheckRadius = 512f;
+
+    /// <summary>
+    /// Extend the event if less than this much is left.
+    /// </summary>
+    [DataField]
+    public TimeSpan ExtendAfterTime;
+
+    /// <summary>
+    /// By how much to extend the station event.
+    /// Keep this above the recheck delay.
+    /// </summary>
+    [DataField]
+    public TimeSpan ExtendBy;
+
+    /// <summary>
+    /// How often to perform the players-nearby check.
+    /// Try to keep this high for performance reasons, but it shouldn't matter too much.
+    /// </summary>
+    [DataField]
+    public TimeSpan RecheckDelay;
+
+    [ViewVariables]
+    public TimeSpan UpdateAccumulator = TimeSpan.FromSeconds(0);
+}

--- a/Content.Server/_Mono/StationEvents/AutoExtendRuleComponent.cs
+++ b/Content.Server/_Mono/StationEvents/AutoExtendRuleComponent.cs
@@ -10,6 +10,7 @@ namespace Content.Server._Mono.StationEvents;
 /// Causes this station event to automatically extend its duration if there's players near any of the specified entities.
 /// Also supports grids and automatically accounts for them potentially being big.
 /// Supposed to be used by other systems and not YML.
+/// Is removed once the event is ended.
 /// </summary>
 [RegisterComponent]
 public sealed partial class AutoExtendRuleComponent : Component

--- a/Content.Server/_Mono/StationEvents/AutoExtendRuleSystem.cs
+++ b/Content.Server/_Mono/StationEvents/AutoExtendRuleSystem.cs
@@ -1,0 +1,104 @@
+using Content.Server.StationEvents.Components;
+using Content.Shared.Ghost;
+using Content.Shared.Mobs.Systems;
+using Robust.Server.Player;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Timing;
+using System.Numerics;
+
+namespace Content.Server._Mono.StationEvents;
+
+public sealed class AutoExtendRuleSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<AutoExtendRuleComponent, StationEventComponent>();
+        while (query.MoveNext(out var ruleUid, out var extendRule, out var stationEv))
+        {
+            if (stationEv.EndTime == null)
+                continue;
+
+            // if we're too early to check then don't
+            if (_timing.CurTime < stationEv.EndTime.Value - extendRule.ExtendAfterTime)
+                continue;
+
+            extendRule.UpdateAccumulator += TimeSpan.FromSeconds(frameTime);
+            if (extendRule.UpdateAccumulator < extendRule.RecheckDelay)
+                continue;
+            extendRule.UpdateAccumulator -= extendRule.RecheckDelay;
+
+            var hasNearbyPlayer = false;
+            foreach (var entUid in extendRule.Entities)
+            {
+                // this is copypasted and modified from NPCSystem
+                var xform = Transform(entUid);
+                var ourCoords = xform.Coordinates;
+                // extend our check radius if we're a grid
+                var checkRadius = extendRule.PlayerCheckRadius;
+                if (TryComp<MapGridComponent>(entUid, out var gridComp))
+                {
+                    var gridAABB = gridComp.LocalAABB;
+                    checkRadius += MathF.Sqrt(gridAABB.Width*gridAABB.Width + gridAABB.Height*gridAABB.Height);
+                }
+
+                var allPlayerData = _player.GetAllPlayerData();
+                foreach (var playerData in allPlayerData)
+                {
+                    var exists = _player.TryGetSessionById(playerData.UserId, out var session);
+
+                    if (!exists || session == null
+                        || session.AttachedEntity is not { Valid: true } playerEnt
+                        || HasComp<GhostComponent>(playerEnt)
+                        || _mobState.IsDead(playerEnt))
+                        continue;
+
+                    var playerCoords = Transform(playerEnt).Coordinates;
+
+                    if (ourCoords.TryDistance(EntityManager, playerCoords, out var distance) &&
+                        distance <= checkRadius)
+                    {
+                        hasNearbyPlayer = true;
+                        break;
+                    }
+                }
+                if (hasNearbyPlayer)
+                    break;
+            }
+
+            if (hasNearbyPlayer)
+                stationEv.EndTime += extendRule.ExtendBy;
+        }
+    }
+
+    /// <summary>
+    /// Automatically apply and configure an AutoExtendRuleComponent to specified entities.
+    /// Can be used several times.
+    /// </summary>
+    public bool AutoExtend(Entity<StationEventComponent?> ent, List<EntityUid> entsWith, float portion = 0.125f)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return false;
+
+        if (ent.Comp.Duration == null)
+            return false;
+
+        var comp = EnsureComp<AutoExtendRuleComponent>(ent);
+        foreach (var entUid in entsWith)
+            comp.Entities.Add(entUid);
+
+        comp.ExtendAfterTime = ent.Comp.Duration.Value * portion;
+        comp.ExtendBy = ent.Comp.Duration.Value * portion;
+        comp.RecheckDelay = comp.ExtendBy * 0.5f;
+
+        return true;
+    }
+
+    public bool AutoExtend(Entity<StationEventComponent?> ent, EntityUid entWith, float portion = 0.125f)
+    {
+        return AutoExtend(ent, new List<EntityUid>() { entWith }, portion);
+    }
+}

--- a/Content.Server/_Mono/StationEvents/AutoExtendRuleSystem.cs
+++ b/Content.Server/_Mono/StationEvents/AutoExtendRuleSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.StationEvents.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Mobs.Systems;

--- a/Content.Server/_NF/StationEvents/Components/BluespaceErrorRuleComponent.cs
+++ b/Content.Server/_NF/StationEvents/Components/BluespaceErrorRuleComponent.cs
@@ -50,6 +50,13 @@ public sealed partial class BluespaceErrorRuleComponent : Component
     public bool DeleteGridsOnEnd = true;
 
     /// <summary>
+    /// Will actively extend the gamerule's duration as long as there's people near or on any of the rule's grids.
+    /// Prevents it being deleted from under you.
+    /// </summary>
+    [DataField]
+    public bool ExtendIfPopulated = true;
+
+    /// <summary>
     /// How much the grid is appraised at upon entering into existence, set after starting the event
     /// </summary>
     public double StartingValue = 0;

--- a/Content.Server/_NF/StationEvents/Components/BluespaceErrorRuleComponent.cs
+++ b/Content.Server/_NF/StationEvents/Components/BluespaceErrorRuleComponent.cs
@@ -1,3 +1,13 @@
+// SPDX-FileCopyrightText: 2023 Cheackraze
+// SPDX-FileCopyrightText: 2024 Kill_Me_I_Noobs
+// SPDX-FileCopyrightText: 2024 Shroomerian
+// SPDX-FileCopyrightText: 2025 Dvir
+// SPDX-FileCopyrightText: 2025 GreaseMonk
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.StationEvents.Events;
 using Content.Server.Shuttles.Systems;
 using Content.Shared.Dataset;

--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -19,6 +19,7 @@ using Content.Server.StationEvents.Events;
 using Content.Server._NF.Station.Systems;
 using Content.Server._NF.StationEvents.Components;
 using Robust.Shared.EntitySerialization.Systems;
+using Content.Server._Mono.StationEvents;
 
 namespace Content.Server._NF.StationEvents.Events;
 
@@ -40,6 +41,7 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
     [Dependency] private readonly StationRenameWarpsSystems _renameWarps = default!;
     [Dependency] private readonly BankSystem _bank = default!;
     [Dependency] private readonly SharedSalvageSystem _salvage = default!;
+    [Dependency] private readonly AutoExtendRuleSystem _autoExtend = default!;
 
     public override void Initialize()
     {
@@ -121,6 +123,9 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
                 EntityManager.AddComponents(spawned, group.AddComponents);
 
                 component.GridsUid.Add(spawned);
+
+                if (component.ExtendIfPopulated)
+                    _autoExtend.AutoExtend(uid, spawned);
             }
         }
 

--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -1,3 +1,16 @@
+// SPDX-FileCopyrightText: 2023 Cheackraze
+// SPDX-FileCopyrightText: 2024 Checkraze
+// SPDX-FileCopyrightText: 2024 Kill_Me_I_Noobs
+// SPDX-FileCopyrightText: 2024 Shroomerian
+// SPDX-FileCopyrightText: 2024 checkraze
+// SPDX-FileCopyrightText: 2025 Alkheemist
+// SPDX-FileCopyrightText: 2025 Dvir
+// SPDX-FileCopyrightText: 2025 GreaseMonk
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Numerics;
 using Content.Server.Cargo.Systems;
 using Robust.Server.GameObjects;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title
vgroids/UIVs/etc will no longer despawn as long as there's a player within 512m

## Why / Balance
no more vgroid despawning from under your legs for no reason
you can now take your time

## How to test
addgamerule BluespaceDungeonBasalt
fly near it
watch it not despawn
ghost
watch it despawn after a bit

## Media
<img width="1065" height="379" alt="image" src="https://github.com/user-attachments/assets/52d72164-4e09-4678-9c24-55d423fa41bf" />

was 3min increased itself to 4min over time

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: VGroids, unidentified vessels, and other temporary grids will no longer despawn with non-dead players on or near them.
