### PR TITLE
Movable Vgroid

### DIFF
--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -44,6 +44,7 @@
           inherent: true
         - type: IFF
         - type: LinkedLifecycleGridParent
+        # Mono - make it movable
         protos:
         - NFVGRoidBasalt
 

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -47,6 +47,14 @@
         - type: IFF
         - type: LinkedLifecycleGridParent
         # Mono - make it movable
+        #- type: ProtectedGrid
+        #  preventArtifactTriggers: true
+        #- type: PreventPilot
+        ## FIXME: the dungeon dosen't pass FTL events even though it should FTL in
+        ##        and we don't get a MapInitEvent, so this just forces static physics
+        #- type: Physics
+        #  bodyType: Static
+        #  bodyStatus: OnGround
         protos:
         - NFVGRoidBasalt
 

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -44,14 +44,6 @@
           inherent: true
         - type: IFF
         - type: LinkedLifecycleGridParent
-        - type: ProtectedGrid
-          preventArtifactTriggers: true
-        - type: PreventPilot
-        # FIXME: the dungeon dosen't pass FTL events even though it should FTL in
-        #        and we don't get a MapInitEvent, so this just forces static physics
-        - type: Physics
-          bodyType: Static
-          bodyStatus: OnGround
         protos:
         - NFVGRoidBasalt
 

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2024 Dvir
 # SPDX-FileCopyrightText: 2024 ErhardSteinhauer
 # SPDX-FileCopyrightText: 2025 GreaseMonk
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 significant harassment
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- you can now move and pilot the vgroid
- artifacts can now activate on vgroid

makes more sense with #1981 and works better with #1982

## Why / Balance
fun
it's probably fine since it requires an absurd amount of thrusters to move anyway
if people somehow abuse this just give them a decreased max speed or something
i tested ramming it into a poi with a lot of thrusters and it doesn't do much damage

## How to test
put shuttle console and like 30 thrusters and 30 gyros on vgroid
fly

## Media
\<image of vgroid flying\>
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: VGroids are no longer static and may be moved.
- tweak: Artifacts can now activate on VGroids.
