### PR TITLE
Buildable Gaslocks and Gas Drills

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
@@ -231,6 +231,28 @@
     price: 2000
 
 - type: entity
+  parent: BaseNFFlatpack
+  id: GasMiningDrillFlatpack
+  name: gas mining drill flatpack
+  description: A flatpack used for constructing a gas mining drill.
+  components:
+  - type: Flatpack
+    entity: GasMiningDrill
+  - type: StaticPrice
+    price: 300
+
+- type: entity
+  parent: BaseNFFlatpack
+  id: GaslockFrameFlatpack
+  name: portable gaslock flatpack
+  description: A flatpack used for constructing a portable gaslock.
+  components:
+  - type: Flatpack
+    entity: GaslockFrame
+  - type: StaticPrice
+    price: 300
+
+- type: entity
   parent: BaseFlatpack
   id: LaserDrillFlatpack
   name: laser drill flatpack

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Blu
 # SPDX-FileCopyrightText: 2025 HungryCuban
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 SRV
 # SPDX-FileCopyrightText: 2025 SarahRaven

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/devices.yml
@@ -1,0 +1,17 @@
+- type: latheRecipe
+  id: GasMiningDrillFlatpack
+  result: GasMiningDrillFlatpack
+  completetime: 5
+  materials:
+    Steel: 1200
+    Silver: 200
+    Gold: 100
+
+- type: latheRecipe
+  id: GaslockFrameFlatpack
+  result: GaslockFrameFlatpack
+  completetime: 5
+  materials:
+    Steel: 1500
+    Silver: 250
+    Gold: 50

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/devices.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: latheRecipe
   id: GasMiningDrillFlatpack
   result: GasMiningDrillFlatpack

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
@@ -78,6 +78,8 @@
     - SolarControlComputerCircuitboard
     - SolarTrackerElectronics
     - SolarAssemblyFlatpack
+    - GasMiningDrillFlatpack # Mono
+    - GaslockFrameFlatpack # Mono
     - ShuttleConsoleCircuitboard
     - PortableGeneratorPacmanMachineCircuitboard
     - PortableGeneratorSuperPacmanMachineCircuitboard

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 Whatstone
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # The engineering techfab made into packs.
 # TODO: Reorganize these into common packs.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes portable gaslock and gas mining drill flatpacks makeable in engifab

## Why / Balance
why were they not makeable
don't have to sell your ship to get a replacement anymore
can also theoretically gas mine on other ships now
or transfer gas to any grid by putting gaslock on it

## How to test
make gaslock ans gas mining drill flatpack in engifab
unpack

## Media
<img width="500" height="216" alt="image" src="https://github.com/user-attachments/assets/51a114c0-8bb6-4755-ade7-fbdd97e1f039" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The engineering techfab can now make gas mining drill and portable gaslock flatpacks.
