### PR TITLE
Nerf Ballistic/Laser Turrets

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 chromiumboy
+# SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: BaseStructure
   id: BaseWeaponTurret

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
@@ -65,12 +65,12 @@
       task: TurretCompound
     blackboard:
       RotateSpeed: !type:Single
-        3.141
+        1.57 # Mono
       SoundTargetInLOS: !type:SoundPathSpecifier
         path: /Audio/Effects/double_beep.ogg
   - type: MouseRotator
     angleTolerance: 5
-    rotationSpeed: 180
+    rotationSpeed: 90 # Mono
     simple4DirMode: false
   - type: NoRotateOnInteract
   - type: NoRotateOnMove
@@ -90,6 +90,10 @@
   - type: Gun
     fireRate: 6
     projectileSpeed: 55
+    maxAngle: 15 # Mono
+    minAngle: 4 # Mono
+    angleIncrease: -1.2 # Mono
+    angleDecay: -4 # Mono
     selectedMode: FullAuto
     availableModes:
     - FullAuto
@@ -122,6 +126,10 @@
   - type: Gun
     projectileSpeed: 15
     fireRate: 1.5
+    maxAngle: 15 # Mono
+    minAngle: 4 # Mono
+    angleIncrease: -1.2 # Mono
+    angleDecay: -4 # Mono
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- halves rotation speed
- they now start off with bad accuracy and get more accurate as they fire

kinda needs #1993 or turrets become a joke

## Why / Balance
currently the only way to fight them is to kite them
with this they will no longer instantly snipe you when you get in range since the first few shots will be very inaccurate and you will have time to get away, plus it will have to spend time to rotate to you
also with the lowered rotation rate you could actually go up close and circle the turret to kill it

## How to test
obvious

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Halved ballistic and laser turret rotation speed.
- tweak: Ballistic and laser turrets now start off very inaccurate and get more accurate as they fire.
