### PR TITLE
Vgroid Deep Gas Deposits

### DIFF
--- a/Content.Server/_NF/Atmos/Components/RandomGasDepositComponent.cs
+++ b/Content.Server/_NF/Atmos/Components/RandomGasDepositComponent.cs
@@ -17,6 +17,7 @@ public sealed partial class RandomGasDepositComponent : Component
     /// <summary>
     /// A scale factor on the deposit's size.
     /// After each gas is chosen from the deposit prototype, the scale factor is multiplied into the deposit size.
+    /// Is used as yield for deep deposits. Minimum yield is also multiplied by the square root of this.
     /// </summary>
     [DataField]
     public float Scale = 1.0f;

--- a/Content.Server/_NF/Atmos/Components/RandomGasDepositComponent.cs
+++ b/Content.Server/_NF/Atmos/Components/RandomGasDepositComponent.cs
@@ -23,7 +23,7 @@ public sealed partial class RandomGasDepositComponent : Component
     /// <summary>
     /// A scale factor on the deposit's size.
     /// After each gas is chosen from the deposit prototype, the scale factor is multiplied into the deposit size.
-    /// Is used as yield for deep deposits. Minimum yield is also multiplied by the square root of this.
+    /// Mono - Is used as yield for deep deposits. Minimum yield is also multiplied by the square root of this.
     /// </summary>
     [DataField]
     public float Scale = 1.0f;

--- a/Content.Server/_NF/Atmos/Components/RandomGasDepositComponent.cs
+++ b/Content.Server/_NF/Atmos/Components/RandomGasDepositComponent.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Milon
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server._NF.Atmos.Systems;
 using Content.Shared._NF.Atmos.Prototypes;
 using Robust.Shared.Prototypes;

--- a/Content.Server/_NF/Atmos/Systems/GasDepositScannerSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositScannerSystem.cs
@@ -168,7 +168,7 @@ public sealed class GasDepositScannerSystem : EntitySystem
                 return false;
             }
 
-            gasMixList = GenerateGasEntryArray(gasDeposit.Composition, gasDeposit.GasLeft);
+            gasMixList = GenerateGasEntryArray(gasDeposit.Composition, gasDeposit.GasLeft); // Mono
         }
 
         // Don't bother sending a UI message with no content, and stop updating I guess?
@@ -184,7 +184,8 @@ public sealed class GasDepositScannerSystem : EntitySystem
     /// <summary>
     /// Generates a GasEntry array for a given GasMixture.
     /// </summary>
-    private GasEntry[] GenerateGasEntryArray(GasMixture? mixture, float scale)
+    private GasEntry[] GenerateGasEntryArray(GasMixture? mixture,
+                                             float scale) // Mono
     {
         if (mixture == null)
             return [];
@@ -200,6 +201,7 @@ public sealed class GasDepositScannerSystem : EntitySystem
 
             var gasName = Loc.GetString(gas.Name);
             ApproximateGasDepositSize depositSize;
+            // Mono
             var gasCount = mixture[i] * scale;
             if (gasCount < 500.0)
                 depositSize = ApproximateGasDepositSize.Trace;

--- a/Content.Server/_NF/Atmos/Systems/GasDepositScannerSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositScannerSystem.cs
@@ -163,7 +163,7 @@ public sealed class GasDepositScannerSystem : EntitySystem
                 return false;
             }
 
-            gasMixList = GenerateGasEntryArray(gasDeposit.Deposit);
+            gasMixList = GenerateGasEntryArray(gasDeposit.Composition, gasDeposit.GasLeft);
         }
 
         // Don't bother sending a UI message with no content, and stop updating I guess?
@@ -179,7 +179,7 @@ public sealed class GasDepositScannerSystem : EntitySystem
     /// <summary>
     /// Generates a GasEntry array for a given GasMixture.
     /// </summary>
-    private GasEntry[] GenerateGasEntryArray(GasMixture? mixture)
+    private GasEntry[] GenerateGasEntryArray(GasMixture? mixture, float scale)
     {
         if (mixture == null)
             return [];
@@ -195,13 +195,14 @@ public sealed class GasDepositScannerSystem : EntitySystem
 
             var gasName = Loc.GetString(gas.Name);
             ApproximateGasDepositSize depositSize;
-            if (mixture[i] < 500.0)
+            var gasCount = mixture[i] * scale;
+            if (gasCount < 500.0)
                 depositSize = ApproximateGasDepositSize.Trace;
-            else if (mixture[i] < 3000.0)
+            else if (gasCount < 3000.0)
                 depositSize = ApproximateGasDepositSize.Small;
-            else if (mixture[i] < 10000.0)
+            else if (gasCount < 10000.0)
                 depositSize = ApproximateGasDepositSize.Medium;
-            else if (mixture[i] < 30000.0)
+            else if (gasCount < 30000.0)
                 depositSize = ApproximateGasDepositSize.Large;
             else
                 depositSize = ApproximateGasDepositSize.Enormous;

--- a/Content.Server/_NF/Atmos/Systems/GasDepositScannerSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositScannerSystem.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.Server._NF.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;

--- a/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
@@ -114,6 +114,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
             depositPrototype = (GasDepositPrototype)randomPrototype;
         }
 
+        // Mono
         var mix = new GasMixture();
 
         for (var i = 0; i < depositPrototype.Gases.Length && i < Atmospherics.TotalNumberOfGases; i++)
@@ -123,6 +124,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
             mix.SetMoles(i, gasAmount);
         }
 
+        // Mono
         var moleCount = mix.TotalMoles;
         deposit.Composition = mix;
         deposit.Composition.Multiply(1f / moleCount);
@@ -132,6 +134,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
         deposit.LowMoles = moleCount * LowMoleCoefficient;
     }
 
+    // Mono - changes throughout the method
     private void OnExtractorUpdate(Entity<GasDepositExtractorComponent> ent, ref AtmosDeviceUpdateEvent args)
     {
         if (!ent.Comp.Enabled

--- a/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
@@ -107,15 +107,22 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
             depositPrototype = (GasDepositPrototype)randomPrototype;
         }
 
+        var mix = new GasMixture();
+
         for (var i = 0; i < depositPrototype.Gases.Length && i < Atmospherics.TotalNumberOfGases; i++)
         {
             var gasRange = depositPrototype.Gases[i];
             var gasAmount = gasRange[0] + _random.NextFloat() * (gasRange[1] - gasRange[0]);
-            gasAmount *= ent.Comp.Scale;
-            deposit.Deposit.SetMoles(i, gasAmount);
+            mix.SetMoles(i, gasAmount);
         }
 
-        deposit.LowMoles = deposit.Deposit.TotalMoles * LowMoleCoefficient;
+        var moleCount = mix.TotalMoles;
+        deposit.Composition = mix;
+        deposit.Composition.Multiply(1f / moleCount);
+        deposit.Yield = ent.Comp.Scale;
+        deposit.MinYield *= MathF.Sqrt(ent.Comp.Scale);
+        deposit.GasLeft = moleCount * ent.Comp.Scale;
+        deposit.LowMoles = moleCount * LowMoleCoefficient;
     }
 
     private void OnExtractorUpdate(Entity<GasDepositExtractorComponent> ent, ref AtmosDeviceUpdateEvent args)
@@ -130,7 +137,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
             return;
         }
 
-        if (depositComp.Deposit.TotalMoles < Atmospherics.GasMinMoles)
+        if (!depositComp.YieldBased && depositComp.GasLeft < Atmospherics.GasMinMoles)
         {
             _ambientSound.SetAmbience(ent, false);
             SetDepositState(ent, GasDepositExtractorState.Empty);
@@ -145,12 +152,16 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
             return;
         }
 
+        var extractionRate = ent.Comp.ExtractionRate;
+        if (depositComp.YieldBased)
+            extractionRate *= depositComp.Yield;
+
         var targetPressure = float.Clamp(ent.Comp.TargetPressure, 0, ent.Comp.MaxTargetPressure);
 
         // How many moles could we theoretically spawn. Cap by pressure, amount, and extractor limit.
         var allowableMoles = (targetPressure - net.Air.Pressure) * net.Air.Volume /
                              (ent.Comp.OutputTemperature * Atmospherics.R);
-        allowableMoles = float.Min(allowableMoles, ent.Comp.ExtractionRate * args.dt);
+        allowableMoles = float.Min(allowableMoles, extractionRate * args.dt);
 
         if (allowableMoles < Atmospherics.GasMinMoles)
         {
@@ -159,12 +170,21 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
             return;
         }
 
-        var removed = depositComp.Deposit.Remove(allowableMoles);
-        removed.Temperature = ent.Comp.OutputTemperature;
-        _atmosphere.Merge(net.Air, removed);
+        var extracted = depositComp.Composition.Clone();
+        extracted.Multiply(allowableMoles);
+        extracted.Temperature = ent.Comp.OutputTemperature;
+
+        if (!depositComp.YieldBased)
+            depositComp.GasLeft -= allowableMoles;
+        else
+            depositComp.Yield = MathF.Max(depositComp.MinYield, depositComp.Yield - depositComp.YieldDrop * ent.Comp.ExtractionRate * args.dt);
+
+        _atmosphere.Merge(net.Air, extracted);
 
         _ambientSound.SetAmbience(ent, true);
-        if (depositComp.Deposit.TotalMoles <= depositComp.LowMoles)
+
+        var isLow = depositComp.YieldBased ? depositComp.Yield == depositComp.MinYield : depositComp.GasLeft <= depositComp.LowMoles;
+        if (isLow)
             SetDepositState(ent, GasDepositExtractorState.Low);
         else
             SetDepositState(ent, GasDepositExtractorState.On);

--- a/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
@@ -170,7 +170,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
 
         // How many moles could we theoretically spawn. Cap by pressure, amount, and extractor limit.
         var allowableMoles = (targetPressure - net.Air.Pressure) * net.Air.Volume /
-                             (ent.Comp.OutputTemperature * Atmospherics.R);
+                             (depositComp.OutputTemperature * Atmospherics.R);
         allowableMoles = float.Min(allowableMoles, extractionRate * args.dt);
 
         if (allowableMoles < Atmospherics.GasMinMoles)
@@ -182,7 +182,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
 
         var extracted = depositComp.Composition.Clone();
         extracted.Multiply(allowableMoles);
-        extracted.Temperature = ent.Comp.OutputTemperature;
+        extracted.Temperature = depositComp.OutputTemperature;
 
         if (!depositComp.YieldBased)
             depositComp.GasLeft -= allowableMoles;

--- a/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
@@ -1,3 +1,10 @@
+// SPDX-FileCopyrightText: 2025 Dvir
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Milon
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Numerics;
 using Content.Server._NF.Atmos.Components;
 using Content.Server.Administration.Logs;

--- a/Content.Shared/_NF/Atmos/Components/GasDepositComponent.cs
+++ b/Content.Shared/_NF/Atmos/Components/GasDepositComponent.cs
@@ -40,7 +40,7 @@ public sealed partial class GasDepositComponent : Component
     /// Minimum yield to never drop below.
     /// </summary>
     [DataField]
-    public float MinYield = 0.15f;
+    public float MinYield = 0.25f;
 
     /// <summary>
     /// Whether this deposit is yield-based.

--- a/Content.Shared/_NF/Atmos/Components/GasDepositComponent.cs
+++ b/Content.Shared/_NF/Atmos/Components/GasDepositComponent.cs
@@ -7,10 +7,42 @@ namespace Content.Shared._NF.Atmos.Components;
 public sealed partial class GasDepositComponent : Component
 {
     /// <summary>
-    /// Gases left in the deposit.
+    /// Gas composition in this deposit.
+    /// Gas amounts should add up to 1.
     /// </summary>
     [DataField]
-    public GasMixture Deposit = new();
+    public GasMixture Composition = new();
+
+    /// <summary>
+    /// Total moles of gas left in this deposit, for non-deep deposits.
+    /// </summary>
+    [DataField]
+    public float GasLeft = 0f;
+
+    /// <summary>
+    /// Yield, for deep deposits.
+    /// </summary>
+    [DataField]
+    public float Yield = 1f;
+
+    /// <summary>
+    /// How much to drop yield per second per mol/s base extraction rate.
+    /// </summary>
+    [DataField]
+    public float YieldDrop = 1f / 100f / 350f; // drop by 1% per 350mol extracted at 100% yield
+
+    /// <summary>
+    /// Minimum yield to never drop below.
+    /// </summary>
+    [DataField]
+    public float MinYield = 0.15f;
+
+    /// <summary>
+    /// Whether this deposit is yield-based.
+    /// Whether to operate based on yield rather than a fixed amount of moles.
+    /// </summary>
+    [DataField]
+    public bool YieldBased = false;
 
     /// <summary>
     /// The maximum number of moles for this deposit to be considered "mostly depleted".

--- a/Content.Shared/_NF/Atmos/Components/GasDepositComponent.cs
+++ b/Content.Shared/_NF/Atmos/Components/GasDepositComponent.cs
@@ -50,6 +50,12 @@ public sealed partial class GasDepositComponent : Component
     public bool YieldBased = false;
 
     /// <summary>
+    /// Temperature of the output gas mixture, in K.
+    /// </summary>
+    [DataField]
+    public float OutputTemperature = Atmospherics.T20C;
+
+    /// <summary>
     /// The maximum number of moles for this deposit to be considered "mostly depleted".
     /// </summary>
     [ViewVariables]

--- a/Content.Shared/_NF/Atmos/Components/GasDepositComponent.cs
+++ b/Content.Shared/_NF/Atmos/Components/GasDepositComponent.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Milon
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Atmos;
 using Content.Shared._NF.Atmos.Systems;
 

--- a/Content.Shared/_NF/Atmos/Components/GasDepositExtractorComponent.cs
+++ b/Content.Shared/_NF/Atmos/Components/GasDepositExtractorComponent.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Milon
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared._NF.Atmos.Systems;
 using Content.Shared._NF.Atmos.Visuals;
 using Content.Shared.Atmos;

--- a/Content.Shared/_NF/Atmos/Components/GasDepositExtractorComponent.cs
+++ b/Content.Shared/_NF/Atmos/Components/GasDepositExtractorComponent.cs
@@ -31,12 +31,6 @@ public sealed partial class GasDepositExtractorComponent : Component
     public float TargetPressure = Atmospherics.OneAtmosphere;
 
     /// <summary>
-    /// The output temperature, in K.
-    /// </summary>
-    [DataField]
-    public float OutputTemperature = Atmospherics.T20C;
-
-    /// <summary>
     /// The entity to be extracted from.
     /// </summary>
     [DataField]

--- a/Content.Shared/_NF/Atmos/Systems/SharedGasDepositSystem.cs
+++ b/Content.Shared/_NF/Atmos/Systems/SharedGasDepositSystem.cs
@@ -40,10 +40,21 @@ public abstract class SharedGasDepositSystem : EntitySystem
             ("pressure", ent.Comp.TargetPressure)));
         if (_net.IsServer && TryComp(ent.Comp.DepositEntity, out GasDepositComponent? deposit))
         {
-            float estimatedAmount = MathF.Round(deposit.Deposit.TotalMoles / DrillExamineAmountRound) * DrillExamineAmountRound;
-            args.PushMarkup(Loc.GetString("gas-deposit-drill-system-examined-amount",
-                ("statusColor", "lightblue"),
-                ("value", estimatedAmount)));
+            if (deposit.YieldBased)
+            {
+                var hitMinimum = deposit.Yield == deposit.MinYield;
+                args.PushMarkup(Loc.GetString("gas-deposit-drill-system-examined-yield",
+                    ("statusColor", "lightblue"),
+                    ("yield", deposit.Yield * 100f),
+                    ("hitMinimum", hitMinimum)));
+            }
+            else
+            {
+                float estimatedAmount = MathF.Round(deposit.GasLeft / DrillExamineAmountRound) * DrillExamineAmountRound;
+                args.PushMarkup(Loc.GetString("gas-deposit-drill-system-examined-amount",
+                    ("statusColor", "lightblue"),
+                    ("value", estimatedAmount)));
+            }
         }
     }
 

--- a/Content.Shared/_NF/Atmos/Systems/SharedGasDepositSystem.cs
+++ b/Content.Shared/_NF/Atmos/Systems/SharedGasDepositSystem.cs
@@ -46,6 +46,7 @@ public abstract class SharedGasDepositSystem : EntitySystem
             ("pressure", ent.Comp.TargetPressure)));
         if (_net.IsServer && TryComp(ent.Comp.DepositEntity, out GasDepositComponent? deposit))
         {
+            // Mono
             if (deposit.YieldBased)
             {
                 var hitMinimum = deposit.Yield == deposit.MinYield;

--- a/Content.Shared/_NF/Atmos/Systems/SharedGasDepositSystem.cs
+++ b/Content.Shared/_NF/Atmos/Systems/SharedGasDepositSystem.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Milon
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared._NF.Atmos.Components;
 using Content.Shared.Atmos.Piping.Binary.Components;
 using Content.Shared.Construction.Components;

--- a/Resources/Locale/en-US/_NF/atmos/gas-deposit.ftl
+++ b/Resources/Locale/en-US/_NF/atmos/gas-deposit.ftl
@@ -5,3 +5,8 @@ gas-deposit-drill-system-examined-amount = The extractor reports {
         [0] [color={$statusColor}]barely anything[/color] left.
         *[other] roughly [color={$statusColor}]{GASQUANTITY($value)}[/color] left.
     }
+gas-deposit-drill-system-examined-yield = The extractor reports that [color={$statusColor}]{NATURALFIXED($yield, 1)}%[/color]{
+    $hitMinimum ->
+        [false] yield remains.
+        *[other] yield remains, and deep reserves have been reached.
+    }

--- a/Resources/Prototypes/_Mono/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_Mono/Atmospherics/deposits.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: gasDeposit
   id: Frezon
   gases:

--- a/Resources/Prototypes/_Mono/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_Mono/Atmospherics/deposits.yml
@@ -1,0 +1,12 @@
+- type: gasDeposit
+  id: Frezon
+  gases:
+  -  4000, 10000  # oxygen
+  -   500,  2000  # nitrogen
+  -     0,     0  # carbon dioxide
+  -     0,  4000  # plasma
+  -   500,  2000  # tritium
+  -     0,  1500  # water vapor
+  -     0,     0  # ammonia
+  -  3000,  5000  # n2o
+  -  8000, 12000  # frezon

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
@@ -1,0 +1,14 @@
+- type: entityTable
+  id: VgroidGasDepositTable
+  table: !type:GroupSelector
+    children:
+      - id: DeepGasDepositVerySmall
+        weight: 0.1
+      - id: DeepGasDepositSmall
+        weight: 0.2
+      - id: DeepGasDeposit
+        weight: 0.4
+      - id: DeepGasDepositLarge
+        weight: 0.2
+      - id: DeepGasDepositVeryLarge
+        weight: 0.1

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
@@ -6,13 +6,103 @@
   id: VgroidGasDepositTable
   table: !type:GroupSelector
     children:
-      - id: DeepGasDepositVerySmall
-        weight: 0.1
-      - id: DeepGasDepositSmall
-        weight: 0.2
-      - id: DeepGasDeposit
-        weight: 0.4
-      - id: DeepGasDepositLarge
-        weight: 0.2
-      - id: DeepGasDepositVeryLarge
-        weight: 0.1
+    - !type:NestedSelector
+      tableId: DeepGasDepositVerySmall
+      weight: 0.1
+    - !type:NestedSelector
+      tableId: DeepGasDepositSmall
+      weight: 0.2
+    - !type:NestedSelector
+      tableId: DeepGasDeposit
+      weight: 0.4
+    - !type:NestedSelector
+      tableId: DeepGasDepositLarge
+      weight: 0.2
+    - !type:NestedSelector
+      tableId: DeepGasDepositVeryLarge
+      weight: 0.1
+
+- type: entityTable
+  id: DeepGasDepositVerySmall
+  table: !type:GroupSelector
+    children:
+    - id: DeepGasDepositOxygenVerySmall
+    - id: DeepGasDepositNitrogenVerySmall
+    - id: DeepGasDepositCarbonDioxideVerySmall
+    - id: DeepGasDepositPlasmaVerySmall
+    - id: DeepGasDepositAmmoniaVery Small
+    - id: DeepGasDepositWaterVaporVerySmall
+    - id: DeepGasDepositNitrousOxideVerySmall
+    - id: DeepGasDepositAirVerySmall
+    - id: DeepGasDepositMuddleEvenVerySmall
+    - id: DeepGasDepositMuddlePlasmaVerySmall
+    - id: DeepGasDepositFrezonVerySmall
+      weight: 0.5 # rare
+
+- type: entityTable
+  id: DeepGasDepositSmall
+  table: !type:GroupSelector
+    children:
+    - id: DeepGasDepositOxygenSmall
+    - id: DeepGasDepositNitrogenSmall
+    - id: DeepGasDepositCarbonDioxideSmall
+    - id: DeepGasDepositPlasmaSmall
+    - id: DeepGasDepositAmmoniaVery Small
+    - id: DeepGasDepositWaterVaporSmall
+    - id: DeepGasDepositNitrousOxideSmall
+    - id: DeepGasDepositAirSmall
+    - id: DeepGasDepositMuddleEvenSmall
+    - id: DeepGasDepositMuddlePlasmaSmall
+    - id: DeepGasDepositFrezonSmall
+      weight: 0.5 # rare
+
+- type: entityTable
+  id: DeepGasDeposit
+  table: !type:GroupSelector
+    children:
+    - id: DeepGasDepositOxygen
+    - id: DeepGasDepositNitrogen
+    - id: DeepGasDepositCarbonDioxide
+    - id: DeepGasDepositPlasma
+    - id: DeepGasDepositAmmoniaVery
+    - id: DeepGasDepositWaterVapor
+    - id: DeepGasDepositNitrousOxide
+    - id: DeepGasDepositAir
+    - id: DeepGasDepositMuddleEven
+    - id: DeepGasDepositMuddlePlasma
+    - id: DeepGasDepositFrezon
+      weight: 0.5 # rare
+
+- type: entityTable
+  id: DeepGasDepositLarge
+  table: !type:GroupSelector
+    children:
+    - id: DeepGasDepositOxygenLarge
+    - id: DeepGasDepositNitrogenLarge
+    - id: DeepGasDepositCarbonDioxideLarge
+    - id: DeepGasDepositPlasmaLarge
+    - id: DeepGasDepositAmmoniaVery Large
+    - id: DeepGasDepositWaterVaporLarge
+    - id: DeepGasDepositNitrousOxideLarge
+    - id: DeepGasDepositAirLarge
+    - id: DeepGasDepositMuddleEvenLarge
+    - id: DeepGasDepositMuddlePlasmaLarge
+    - id: DeepGasDepositFrezonLarge
+      weight: 0.5 # rare
+
+- type: entityTable
+  id: DeepGasDepositVeryLarge
+  table: !type:GroupSelector
+    children:
+    - id: DeepGasDepositOxygenVeryLarge
+    - id: DeepGasDepositNitrogenVeryLarge
+    - id: DeepGasDepositCarbonDioxideVeryLarge
+    - id: DeepGasDepositPlasmaVeryLarge
+    - id: DeepGasDepositAmmoniaVery VeryLarge
+    - id: DeepGasDepositWaterVaporVeryLarge
+    - id: DeepGasDepositNitrousOxideVeryLarge
+    - id: DeepGasDepositAirVeryLarge
+    - id: DeepGasDepositMuddleEvenVeryLarge
+    - id: DeepGasDepositMuddlePlasmaVeryLarge
+    - id: DeepGasDepositFrezonVeryLarge
+      weight: 0.5 # rare

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
@@ -30,7 +30,7 @@
     - id: DeepGasDepositNitrogenVerySmall
     - id: DeepGasDepositCarbonDioxideVerySmall
     - id: DeepGasDepositPlasmaVerySmall
-    - id: DeepGasDepositAmmoniaVery Small
+    - id: DeepGasDepositAmmoniaVerySmall
     - id: DeepGasDepositWaterVaporVerySmall
     - id: DeepGasDepositNitrousOxideVerySmall
     - id: DeepGasDepositAirVerySmall
@@ -47,7 +47,7 @@
     - id: DeepGasDepositNitrogenSmall
     - id: DeepGasDepositCarbonDioxideSmall
     - id: DeepGasDepositPlasmaSmall
-    - id: DeepGasDepositAmmoniaVery Small
+    - id: DeepGasDepositAmmoniaSmall
     - id: DeepGasDepositWaterVaporSmall
     - id: DeepGasDepositNitrousOxideSmall
     - id: DeepGasDepositAirSmall
@@ -64,7 +64,7 @@
     - id: DeepGasDepositNitrogen
     - id: DeepGasDepositCarbonDioxide
     - id: DeepGasDepositPlasma
-    - id: DeepGasDepositAmmoniaVery
+    - id: DeepGasDepositAmmonia
     - id: DeepGasDepositWaterVapor
     - id: DeepGasDepositNitrousOxide
     - id: DeepGasDepositAir
@@ -81,7 +81,7 @@
     - id: DeepGasDepositNitrogenLarge
     - id: DeepGasDepositCarbonDioxideLarge
     - id: DeepGasDepositPlasmaLarge
-    - id: DeepGasDepositAmmoniaVery Large
+    - id: DeepGasDepositAmmoniaLarge
     - id: DeepGasDepositWaterVaporLarge
     - id: DeepGasDepositNitrousOxideLarge
     - id: DeepGasDepositAirLarge
@@ -98,7 +98,7 @@
     - id: DeepGasDepositNitrogenVeryLarge
     - id: DeepGasDepositCarbonDioxideVeryLarge
     - id: DeepGasDepositPlasmaVeryLarge
-    - id: DeepGasDepositAmmoniaVery VeryLarge
+    - id: DeepGasDepositAmmoniaVeryLarge
     - id: DeepGasDepositWaterVaporVeryLarge
     - id: DeepGasDepositNitrousOxideVeryLarge
     - id: DeepGasDepositAirVeryLarge

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
@@ -106,3 +106,18 @@
     - id: DeepGasDepositMuddlePlasmaVeryLarge
     - id: DeepGasDepositFrezonVeryLarge
       weight: 0.5 # rare
+
+- type: entityTable
+  id: DeepGasDepositFrezon
+  table: !type:GroupSelector
+    children:
+    - id: DeepGasDepositFrezonVerySmall
+      weight: 0.1
+    - id: DeepGasDepositFrezonSmall
+      weight: 0.2
+    - id: DeepGasDepositFrezon
+      weight: 0.4
+    - id: DeepGasDepositFrezonLarge
+      weight: 0.2
+    - id: DeepGasDepositFrezonVeryLarge
+      weight: 0.1

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/gas_deposit.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entityTable
   id: VgroidGasDepositTable
   table: !type:GroupSelector

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -1,0 +1,437 @@
+# region Base Deposits
+- type: entity
+  id: BaseDeepGasDeposit
+  parent: BaseGasDeposit
+  name: deep gas deposit
+  description: Deep solidified reserves of an element, normally a gas at room temperature, can be drilled, heated and piped out. Should provide an unlimited supply once the easily reachable gas is depleted.
+  abstract: true
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: GasDeposit
+    yieldBased: true
+
+# endregion Base Deposits
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - BaseDeepGasDeposit
+  id: DeepGasDepositVerySmall
+  suffix: Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - BaseDeepGasDeposit
+  id: DeepGasDepositSmall
+  suffix: Small
+
+- type: entity
+  parent:
+  - BaseDeepGasDeposit
+  id: DeepGasDeposit
+  suffix: Normal
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - BaseDeepGasDeposit
+  id: DeepGasDepositLarge
+  suffix: Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - BaseDeepGasDeposit
+  id: DeepGasDepositVeryLarge
+  suffix: Very Large
+
+# region Standard Deposits
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositOxygen
+  suffix: Oxygen
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MostlyOxygen
+  - type: Sprite
+    color: "#DDDDEE"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositNitrogen
+  suffix: Nitrogen
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MostlyNitrogen
+  - type: Sprite
+    color: "#FFCCCC"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositCarbonDioxide
+  suffix: Carbon Dioxide
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MostlyCarbonDioxide
+  - type: Sprite
+    color: "#CCCCCC"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositPlasma
+  suffix: Plasma
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MostlyPlasma
+  - type: Sprite
+    color: "#FFCCFF"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositAmmonia
+  suffix: Ammonia
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MostlyAmmonia
+  - type: Sprite
+    color: "#FFFFCC"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositWaterVapor
+  suffix: Water Vapor
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MostlyWaterVapor
+  - type: Sprite
+    color: "#DDEEEE"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositNitrousOxide
+  suffix: Nitrous Oxide
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MostlyNitrousOxide
+  - type: Sprite
+    color: "#EEDDDD"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositAir
+  suffix: Air-like
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: AirLike
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositMuddleEven
+  suffix: Muddled
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MuddleEven
+  - type: Sprite
+    color: "#DDEEDD"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositMuddlePlasma
+  suffix: Muddled PL+
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: MuddlePlasma
+  - type: Sprite
+    color: "#F0DDF0"
+# endregion Standard Deposits
+
+# region Very Small Deposits
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositOxygen
+  id: DeepGasDepositOxygenVerySmall
+  suffix: Oxygen, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositNitrogen
+  id: DeepGasDepositNitrogenVerySmall
+  suffix: Nitrogen, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositCarbonDioxide
+  id: DeepGasDepositCarbonDioxideVerySmall
+  suffix: Carbon Dioxide, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositPlasma
+  id: DeepGasDepositPlasmaVerySmall
+  suffix: Plasma, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositAmmonia
+  id: DeepGasDepositAmmoniaVery Small
+  suffix: Ammonia, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositWaterVapor
+  id: DeepGasDepositWaterVaporVerySmall
+  suffix: Water Vapor, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositNitrousOxide
+  id: DeepGasDepositNitrousOxideVerySmall
+  suffix: Nitrous Oxide, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositAir
+  id: DeepGasDepositAirVerySmall
+  suffix: Air-like, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositMuddleEven
+  id: DeepGasDepositMuddleEvenVerySmall
+  suffix: Muddled, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositMuddlePlasma
+  id: DeepGasDepositMuddlePlasmaVerySmall
+  suffix: Muddled P+, Very Small
+# endregion Very Small Deposits
+
+# region Small Deposits
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositOxygen
+  id: DeepGasDepositOxygenSmall
+  suffix: Oxygen, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositNitrogen
+  id: DeepGasDepositNitrogenSmall
+  suffix: Nitrogen, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositCarbonDioxide
+  id: DeepGasDepositCarbonDioxideSmall
+  suffix: Carbon Dioxide, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositPlasma
+  id: DeepGasDepositPlasmaSmall
+  suffix: Plasma, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositAmmonia
+  id: DeepGasDepositAmmoniaSmall
+  suffix: Ammonia, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositWaterVapor
+  id: DeepGasDepositWaterVaporSmall
+  suffix: Water Vapor, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositNitrousOxide
+  id: DeepGasDepositNitrousOxideSmall
+  suffix: Nitrous Oxide, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositAir
+  id: DeepGasDepositAirSmall
+  suffix: Air-like, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositMuddleEven
+  id: DeepGasDepositMuddleEvenSmall
+  suffix: Muddled, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositMuddlePlasma
+  id: DeepGasDepositMuddlePlasmaSmall
+  suffix: Muddled P+, Small
+# endregion Small Deposits
+
+# region Large Deposits
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositOxygen
+  id: DeepGasDepositOxygenLarge
+  suffix: Oxygen, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositNitrogen
+  id: DeepGasDepositNitrogenLarge
+  suffix: Nitrogen, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositCarbonDioxide
+  id: DeepGasDepositCarbonDioxideLarge
+  suffix: Carbon Dioxide, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositPlasma
+  id: DeepGasDepositPlasmaLarge
+  suffix: Plasma, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositAmmonia
+  id: DeepGasDepositAmmoniaLarge
+  suffix: Ammonia, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositWaterVapor
+  id: DeepGasDepositWaterVaporLarge
+  suffix: Water Vapor, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositNitrousOxide
+  id: DeepGasDepositNitrousOxideLarge
+  suffix: Nitrous Oxide, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositAir
+  id: DeepGasDepositAirLarge
+  suffix: Air-like, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositMuddleEven
+  id: DeepGasDepositMuddleEvenLarge
+  suffix: Muddled, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositMuddlePlasma
+  id: DeepGasDepositMuddlePlasmaLarge
+  suffix: Muddled P+, Large
+# endregion Large Deposits
+
+# region Very Large Deposits
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositOxygen
+  id: DeepGasDepositOxygenVeryLarge
+  suffix: Oxygen, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositNitrogen
+  id: DeepGasDepositNitrogenVeryLarge
+  suffix: Nitrogen, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositCarbonDioxide
+  id: DeepGasDepositCarbonDioxideVeryLarge
+  suffix: Carbon Dioxide, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositPlasma
+  id: DeepGasDepositPlasmaVeryLarge
+  suffix: Plasma, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositAmmonia
+  id: DeepGasDepositAmmoniaVeryLarge
+  suffix: Ammonia, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositWaterVapor
+  id: DeepGasDepositWaterVaporVeryLarge
+  suffix: Water Vapor, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositNitrousOxide
+  id: DeepGasDepositNitrousOxideVeryLarge
+  suffix: Nitrous Oxide, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositAir
+  id: DeepGasDepositAirVeryLarge
+  suffix: Air-like, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositMuddleEven
+  id: DeepGasDepositMuddleEvenVeryLarge
+  suffix: Muddled, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositMuddlePlasma
+  id: DeepGasDepositMuddlePlasmaVeryLarge
+  suffix: Muddled P+, Very Large
+# endregion Very Large Deposits
+

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # region Base Deposits
 - type: entity
   id: BaseDeepGasDeposit

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -149,6 +149,18 @@
     depositPrototype: MuddlePlasma
   - type: Sprite
     color: "#F0DDF0"
+
+- type: entity
+  parent: BaseDeepGasDeposit
+  id: DeepGasDepositFrezon
+  suffix: Frezon
+  components:
+  - type: RandomGasDeposit
+    depositPrototype: Frezon
+  - type: GasDeposit
+    outputTemperature: 23.15 # naturally occuring frezon
+  - type: Sprite
+    color: "#AADDFF"
 # endregion Standard Deposits
 
 # region Very Small Deposits
@@ -221,6 +233,13 @@
   - DeepGasDepositMuddlePlasma
   id: DeepGasDepositMuddlePlasmaVerySmall
   suffix: Muddled P+, Very Small
+
+- type: entity
+  parent:
+  - BaseGasDepositVerySmall
+  - DeepGasDepositFrezon
+  id: DeepGasDepositFrezonVerySmall
+  suffix: Frezon, Very Small
 # endregion Very Small Deposits
 
 # region Small Deposits
@@ -293,6 +312,13 @@
   - DeepGasDepositMuddlePlasma
   id: DeepGasDepositMuddlePlasmaSmall
   suffix: Muddled P+, Small
+
+- type: entity
+  parent:
+  - BaseGasDepositSmall
+  - DeepGasDepositFrezon
+  id: DeepGasDepositFrezonSmall
+  suffix: Frezon, Small
 # endregion Small Deposits
 
 # region Large Deposits
@@ -365,6 +391,13 @@
   - DeepGasDepositMuddlePlasma
   id: DeepGasDepositMuddlePlasmaLarge
   suffix: Muddled P+, Large
+
+- type: entity
+  parent:
+  - BaseGasDepositLarge
+  - DeepGasDepositFrezon
+  id: DeepGasDepositFrezonLarge
+  suffix: Frezon, Large
 # endregion Large Deposits
 
 # region Very Large Deposits
@@ -437,5 +470,12 @@
   - DeepGasDepositMuddlePlasma
   id: DeepGasDepositMuddlePlasmaVeryLarge
   suffix: Muddled P+, Very Large
+
+- type: entity
+  parent:
+  - BaseGasDepositVeryLarge
+  - DeepGasDepositFrezon
+  id: DeepGasDepositFrezonVeryLarge
+  suffix: Frezon, Very Large
 # endregion Very Large Deposits
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Atmospherics/deposits.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Atmospherics/deposits.yml
@@ -196,7 +196,7 @@
   parent:
   - BaseGasDepositVerySmall
   - DeepGasDepositAmmonia
-  id: DeepGasDepositAmmoniaVery Small
+  id: DeepGasDepositAmmoniaVerySmall
   suffix: Ammonia, Very Small
 
 - type: entity

--- a/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
@@ -147,6 +147,11 @@
       count: 5
       minGroupSize: 1
       maxGroupSize: 1
+    - !type:EntityTableDunGen
+      minCount: 5
+      maxCount: 11
+      table: !type:NestedSelector
+        tableId: VgroidGasDepositTable
 
 # Configs
 - type: dungeonConfig

--- a/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
@@ -155,6 +155,7 @@
       count: 5
       minGroupSize: 1
       maxGroupSize: 1
+    # Mono
     - !type:EntityTableDunGen
       minCount: 5
       maxCount: 11

--- a/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 GreaseMonk
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Okay so my general thought is this:
 # 1. Generate the large mass
 # 2. Generate smaller masses offset

--- a/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
@@ -147,6 +147,11 @@
       count: 5
       minGroupSize: 1
       maxGroupSize: 1
+    - !type:EntityTableDunGen
+      minCount: 5
+      maxCount: 11
+      table: !type:NestedSelector
+        tableId: VgroidGasDepositTable
 
 # Configs
 - type: dungeonConfig

--- a/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
@@ -155,6 +155,7 @@
       count: 5
       minGroupSize: 1
       maxGroupSize: 1
+    # Mono
     - !type:EntityTableDunGen
       minCount: 5
       maxCount: 11

--- a/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 GreaseMonk
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Okay so my general thought is this:
 # 1. Generate the large mass
 # 2. Generate smaller masses offset

--- a/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
@@ -147,6 +147,11 @@
       count: 5
       minGroupSize: 1
       maxGroupSize: 1
+    - !type:EntityTableDunGen
+      minCount: 5
+      maxCount: 11
+      table: !type:NestedSelector
+        tableId: VgroidGasDepositTable
 
 # Configs
 - type: dungeonConfig

--- a/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
@@ -155,6 +155,7 @@
       count: 5
       minGroupSize: 1
       maxGroupSize: 1
+    # Mono
     - !type:EntityTableDunGen
       minCount: 5
       maxCount: 11

--- a/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 GreaseMonk
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Okay so my general thought is this:
 # 1. Generate the large mass
 # 2. Generate smaller masses offset

--- a/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
@@ -152,6 +152,12 @@
       count: 2
       minGroupSize: 1
       maxGroupSize: 1
+    # has less
+    - !type:EntityTableDunGen
+      minCount: 3
+      maxCount: 7
+      table: !type:NestedSelector
+        tableId: VgroidGasDepositTable
 
 # Configs
 - type: dungeonConfig

--- a/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
@@ -159,7 +159,7 @@
       count: 2
       minGroupSize: 1
       maxGroupSize: 1
-    # has less
+    # Mono - has less
     - !type:EntityTableDunGen
       minCount: 3
       maxCount: 7

--- a/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
@@ -165,6 +165,12 @@
       maxCount: 7
       table: !type:NestedSelector
         tableId: VgroidGasDepositTable
+    # but has guaranteed frezon deposit
+    - !type:EntityTableDunGen
+      minCount: 1
+      maxCount: 1
+      table: !type:NestedSelector
+        tableId: DeepGasDepositFrezon
 
 # Configs
 - type: dungeonConfig

--- a/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2025 GreaseMonk
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Okay so my general thought is this:
 # 1. Generate the large mass
 # 2. Generate smaller masses offset

--- a/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
@@ -168,6 +168,12 @@
       count: 1
       minGroupSize: 0
       maxGroupSize: 1
+    # has more
+    - !type:EntityTableDunGen
+      minCount: 7
+      maxCount: 12
+      table: !type:NestedSelector
+        tableId: VgroidGasDepositTable
 
 # Configs
 - type: dungeonConfig

--- a/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
@@ -177,7 +177,7 @@
       count: 1
       minGroupSize: 0
       maxGroupSize: 1
-    # has more
+    # Mono - has more
     - !type:EntityTableDunGen
       minCount: 7
       maxCount: 12

--- a/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
@@ -1,3 +1,12 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 AndresE55
+# SPDX-FileCopyrightText: 2025 GreaseMonk
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Okay so my general thought is this:
 # 1. Generate the large mass
 # 2. Generate smaller masses offset


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
vgroids now have deep gas deposits
they work like factorio oil, have yield which decreases based on base extraction rate
yield can never drop below a minimum so you can have infinite gas at a lower rate
also adds rare deep frezon deposits to vgroids only

## Why / Balance
more incentive to colonise vgroid
atmos colony gameplay that doesn't need gas miners
note that considering vgroids are large those will generally need long pipelines to actually get gas to your ship
makes gas deposit scanner actually useful
frezon deposits are probably fine since i gave them a reduced chance to appear and it doesn't yield that much frezon anyway

## How to test
`addgamerule BluespaceDungeonSnow`
fly to it
go around with gas deposit scanner
find deposit, mine it

## Media
<img width="887" height="398" alt="image" src="https://github.com/user-attachments/assets/089b9f79-fe83-43b2-89c9-87ac1c958dc2" />

<img width="503" height="266" alt="image" src="https://github.com/user-attachments/assets/ad8368e0-30b6-494f-ad90-d0f2dece0f2c" />

since screenshots were taken the `remains .` part was fixed

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: VGroids now have deep gas deposits, which can be gas mined indefinitely.
