### PR TITLE
Disable CancelTilePry Tests

### DIFF
--- a/Content.IntegrationTests/Tests/DoAfter/DoAfterCancellationTests.cs
+++ b/Content.IntegrationTests/Tests/DoAfter/DoAfterCancellationTests.cs
@@ -1,3 +1,11 @@
+// SPDX-FileCopyrightText: 2023 TemporalOroboros
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2025 Coenx-flex
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.IntegrationTests.Tests.Construction.Interaction;
 using Content.IntegrationTests.Tests.Interaction;

--- a/Content.IntegrationTests/Tests/DoAfter/DoAfterCancellationTests.cs
+++ b/Content.IntegrationTests/Tests/DoAfter/DoAfterCancellationTests.cs
@@ -61,7 +61,8 @@ public sealed class DoAfterCancellationTests : InteractionTest
         AssertPrototype(WallConstruction.WallSolid);
     }
 
-    [Test]
+    // Mono Disable: Goob's instant pry means you can't even do this and a fix is pointless
+    // [Test]
     public async Task CancelTilePry()
     {
         await SetTile(Floor);
@@ -73,7 +74,8 @@ public sealed class DoAfterCancellationTests : InteractionTest
         await AssertTile(Plating);
     }
 
-    [Test]
+    // Mono Disable: Goob's instant pry means you can't even do this and their fix is pointless
+    // [Test]
     public async Task CancelRepeatedTilePry()
     {
         await SetTile(Floor);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Disables the integration tests for CancelTilePry and CancelRepeatedTilePry
## How to test
<!-- Describe the way it can be tested -->
Run tests and see they never run, Instant tile pry was ported from goob but the test fix was not... I don't see the point of their test fix since it just makes the tests tile-pry tests... which is pointless because that's already tested.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->