### PR TITLE
Cleanup/Smoothify Radar Blips

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -12,6 +12,7 @@
 // SPDX-FileCopyrightText: 2025 Blu
 // SPDX-FileCopyrightText: 2025 BlueHNT
 // SPDX-FileCopyrightText: 2025 GreaseMonk
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 LukeZurg22
 // SPDX-FileCopyrightText: 2025 RikuTheKiller
 // SPDX-FileCopyrightText: 2025 Whatstone

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -554,8 +554,8 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
         var origin = ScalePosition(-new Vector2(Offset.X, -Offset.Y));
         handle.DrawLine(origin, origin + angle.ToVec() * ScaledMinimapRadius * 1.42f, Color.Red.WithAlpha(0.1f));
 
-        // Get raw blips with grid information
-        var rawBlips = _blips.GetRawBlips();
+        // Get blips
+        var rawBlips = _blips.GetCurrentBlips();
 
         // Prepare view bounds for culling
         var monoViewBounds = new Box2(-3f, -3f, Size.X + 3f, Size.Y + 3f);
@@ -563,65 +563,21 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
         // Draw blips using the same grid-relative transformation approach as docks
         foreach (var blip in rawBlips)
         {
-            Vector2 blipPosInView;
-
-            // Handle differently based on if there's a grid
-            if (blip.Grid == null)
-            {
-                // For world-space blips without a grid, use standard world transformation
-                blipPosInView = Vector2.Transform(blip.Position, worldToShuttle * shuttleToView);
-            }
-            else if (EntManager.TryGetEntity(blip.Grid, out var gridEntity))
-            {
-                // For grid-relative blips, transform using the grid's transform
-                var gridToWorld = _transform.GetWorldMatrix(gridEntity.Value);
-                var gridToView = gridToWorld * worldToShuttle * shuttleToView;
-
-                // Transform the grid-local position
-                blipPosInView = Vector2.Transform(blip.Position, gridToView);
-            }
-            else
-            {
-                // Skip blips with invalid grid references
-                continue;
-            }
+            var blipPosInView = Vector2.Transform(_transform.ToMapCoordinates(blip.Position).Position, worldToShuttle * shuttleToView);
 
             // Check if this blip is within view bounds before drawing
             if (monoViewBounds.Contains(blipPosInView))
             {
-                    DrawBlipShape(handle, blipPosInView, blip.Scale * 3f, blip.Color.WithAlpha(0.8f), blip.Shape);
+                DrawBlipShape(handle, blipPosInView, blip.Scale * 3f, blip.Color.WithAlpha(0.8f), blip.Shape);
             }
         }
 
         // Draw hitscan lines from the radar blips system
-        var hitscanLines = _blips.GetRawHitscanLines();
+        var hitscanLines = _blips.GetHitscanLines();
         foreach (var line in hitscanLines)
         {
-            Vector2 startPosInView;
-            Vector2 endPosInView;
-
-            // Handle differently based on if there's a grid
-            if (line.Grid == null)
-            {
-                // For world-space lines without a grid, use standard world transformation
-                startPosInView = Vector2.Transform(line.Start, worldToShuttle * shuttleToView);
-                endPosInView = Vector2.Transform(line.End, worldToShuttle * shuttleToView);
-            }
-            else if (EntManager.TryGetEntity(line.Grid, out var gridEntity))
-            {
-                // For grid-relative lines, transform using the grid's transform
-                var gridToWorld = _transform.GetWorldMatrix(gridEntity.Value);
-                var gridToView = gridToWorld * worldToShuttle * shuttleToView;
-
-                // Transform the grid-local positions
-                startPosInView = Vector2.Transform(line.Start, gridToView);
-                endPosInView = Vector2.Transform(line.End, gridToView);
-            }
-            else
-            {
-                // Skip lines with invalid grid references
-                continue;
-            }
+            var startPosInView = Vector2.Transform(line.Start, worldToShuttle * shuttleToView);
+            var endPosInView = Vector2.Transform(line.End, worldToShuttle * shuttleToView);
 
             // Only draw lines if at least one endpoint is within view
             if (monoViewBounds.Contains(startPosInView) || monoViewBounds.Contains(endPosInView))

--- a/Content.Client/_Mono/FireControl/UI/FireControlNavControl.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlNavControl.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 RikuTheKiller
 // SPDX-FileCopyrightText: 2025 ark1368

--- a/Content.Client/_Mono/FireControl/UI/FireControlNavControl.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlNavControl.cs
@@ -218,6 +218,8 @@ public sealed class FireControlNavControl : BaseShuttleControl
         var shuttleToWorld = Matrix3x2.Multiply(posMatrix, ourEntMatrix);
         Matrix3x2.Invert(shuttleToWorld, out var worldToShuttle);
         var shuttleToView = Matrix3x2.CreateScale(new Vector2(MinimapScale, -MinimapScale)) * Matrix3x2.CreateTranslation(MidPointVector);
+        var worldToView = worldToShuttle * shuttleToView;
+        Matrix3x2.Invert(worldToView, out var viewToWorld);
 
         var ourGridId = xform.GridUid;
         if (EntManager.TryGetComponent<MapGridComponent>(ourGridId, out var ourGrid) &&
@@ -262,7 +264,7 @@ public sealed class FireControlNavControl : BaseShuttleControl
                 continue;
 
             var curGridToWorld = _transform.GetWorldMatrix(gUid);
-            var curGridToView = curGridToWorld * worldToShuttle * shuttleToView;
+            var curGridToView = curGridToWorld * worldToView;
 
             var labelColor = _shuttles.GetIFFColor(grid, self: false, iff);
             var coordColor = new Color(labelColor.R * 0.8f, labelColor.G * 0.8f, labelColor.B * 0.8f, 0.5f);
@@ -327,7 +329,8 @@ public sealed class FireControlNavControl : BaseShuttleControl
 
         foreach (var blip in blips)
         {
-            var blipPos = Vector2.Transform(blip.Item1, worldToShuttle * shuttleToView);
+            var blipCoord = _transform.ToMapCoordinates(blip.Item1).Position;
+            var blipPos = Vector2.Transform(blipCoord, worldToView);
 
             if (blip.Item4 == RadarBlipShape.Ring)
             {
@@ -341,7 +344,7 @@ public sealed class FireControlNavControl : BaseShuttleControl
 
             if (_isMouseInside && _controllables != null)
             {
-                var worldPos = blip.Item1;
+                var worldPos = blipCoord;
                 var isFireControllable = _controllables.Any(c =>
                 {
                     var coords = EntManager.GetCoordinates(c.Coordinates);
@@ -355,7 +358,6 @@ public sealed class FireControlNavControl : BaseShuttleControl
                     var cursorViewPos = InverseScalePosition(_lastMousePos);
                     cursorViewPos = ScalePosition(cursorViewPos);
 
-                    Matrix3x2.Invert(worldToShuttle * shuttleToView, out var viewToWorld);
                     var cursorWorldPos = Vector2.Transform(cursorViewPos, viewToWorld);
 
                     var direction = cursorWorldPos - worldPos;
@@ -372,39 +374,11 @@ public sealed class FireControlNavControl : BaseShuttleControl
         }
 
         // Draw hitscan lines from the radar blips system
-        var hitscanLines = _blips.GetRawHitscanLines();
+        var hitscanLines = _blips.GetHitscanLines();
         foreach (var line in hitscanLines)
         {
-            Vector2 startPosInView;
-            Vector2 endPosInView;
-
-            // Handle differently based on if there's a grid
-            if (line.Grid == null)
-            {
-                // For world-space lines without a grid, use standard world transformation
-                startPosInView = Vector2.Transform(line.Start, worldToShuttle * shuttleToView);
-                endPosInView = Vector2.Transform(line.End, worldToShuttle * shuttleToView);
-            }
-            else
-            {
-                // For grid-relative lines, we need to transform from grid space to world space first
-                var gridEntity = EntManager.GetEntity(line.Grid.Value);
-                if (EntManager.TryGetComponent<TransformComponent>(gridEntity, out var gridXform))
-                {
-                    var gridToWorld = _transform.GetWorldMatrix(gridEntity);
-                    var gridStartWorld = Vector2.Transform(line.Start, gridToWorld);
-                    var gridEndWorld = Vector2.Transform(line.End, gridToWorld);
-
-                    startPosInView = Vector2.Transform(gridStartWorld, worldToShuttle * shuttleToView);
-                    endPosInView = Vector2.Transform(gridEndWorld, worldToShuttle * shuttleToView);
-                }
-                else
-                {
-                    // Fallback to treating as world coordinates if grid transform is not available
-                    startPosInView = Vector2.Transform(line.Start, worldToShuttle * shuttleToView);
-                    endPosInView = Vector2.Transform(line.End, worldToShuttle * shuttleToView);
-                }
-            }
+            var startPosInView = Vector2.Transform(line.Start, worldToView);
+            var endPosInView = Vector2.Transform(line.End, worldToView);
 
             // Check if the line is within the view bounds before drawing
             var viewBounds = new Box2(-3f, -3f, Size.X + 3f, Size.Y + 3f);

--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 ark1368
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Numerics;
 using Content.Shared._Mono.Radar;
 using Robust.Shared.Map;

--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared._Mono.Radar;
+using Robust.Shared.Map;
 using Robust.Shared.Timing;
 
 namespace Content.Client._Mono.Radar;
@@ -8,8 +9,8 @@ public sealed partial class RadarBlipsSystem : EntitySystem
 {
     private const double BlipStaleSeconds = 3.0;
     private static readonly List<(Vector2, float, Color, RadarBlipShape)> EmptyBlipList = new();
-    private static readonly List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)> EmptyRawBlipList = new();
-    private static readonly List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)> EmptyHitscanList = new();
+    private static readonly List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> EmptyRawBlipList = new();
+    private static readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> EmptyHitscanList = new();
     private TimeSpan _lastRequestTime = TimeSpan.Zero;
     private static readonly TimeSpan RequestThrottle = TimeSpan.FromMilliseconds(250);
 
@@ -20,8 +21,8 @@ public sealed partial class RadarBlipsSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xform = default!;
 
     private TimeSpan _lastUpdatedTime;
-    private List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)> _blips = new();
-    private List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)> _hitscans = new();
+    private List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> _blips = new();
+    private List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> _hitscans = new();
     private Vector2 _radarWorldPosition;
 
     public override void Initialize()
@@ -78,104 +79,39 @@ public sealed partial class RadarBlipsSystem : EntitySystem
 
     /// <summary>
     /// Gets the current blips as world positions with their scale, color and shape.
-    /// This is needed for the legacy radar display that expects world coordinates.
     /// </summary>
-    public List<(Vector2, float, Color, RadarBlipShape)> GetCurrentBlips()
+    public List<(EntityCoordinates Position, float Scale, Color Color, RadarBlipShape Shape)> GetCurrentBlips()
     {
         // If it's been more than the stale threshold since our last update,
         // the data is considered stale - return an empty list
         if (_timing.CurTime.TotalSeconds - _lastUpdatedTime.TotalSeconds > BlipStaleSeconds)
-            return EmptyBlipList;
+            return new List<(EntityCoordinates, float, Color, RadarBlipShape)>();
 
-        var result = new List<(Vector2, float, Color, RadarBlipShape)>(_blips.Count);
+        var result = new List<(EntityCoordinates, float, Color, RadarBlipShape)>(_blips.Count);
 
         foreach (var blip in _blips)
         {
-            Vector2 worldPosition;
+            var coord = GetCoordinates(blip.Position);
 
-            // If no grid, position is already in world coordinates
-            if (blip.Grid == null)
-            {
-                worldPosition = blip.Position;
-
-                // Distance culling for world position blips
-                if (Vector2.DistanceSquared(worldPosition, _radarWorldPosition) > MaxBlipRenderDistance * MaxBlipRenderDistance)
-                    continue;
-
-                result.Add((worldPosition, blip.Scale, blip.Color, blip.Shape));
+            if (!coord.IsValid(EntityManager))
                 continue;
-            }
 
-            // If grid exists, transform from grid-local to world coordinates
-            if (TryGetEntity(blip.Grid, out var gridEntity))
-            {
-                // Transform the grid-local position to world position
-                var worldPos = _xform.GetWorldPosition(gridEntity.Value);
-                var gridRot = _xform.GetWorldRotation(gridEntity.Value);
+            var predictedPos = new EntityCoordinates(coord.EntityId, coord.Position + blip.Vel * (float)(_timing.CurTime - _lastUpdatedTime).TotalSeconds);
 
-                // Rotate the local position by grid rotation and add grid position
-                var rotatedLocalPos = gridRot.RotateVec(blip.Position);
-                worldPosition = worldPos + rotatedLocalPos;
+            // Distance culling for world position blips
+            if (Vector2.DistanceSquared(predictedPos.Position, _radarWorldPosition) > MaxBlipRenderDistance * MaxBlipRenderDistance)
+                continue;
 
-                // Distance culling for grid position blips
-                if (Vector2.DistanceSquared(worldPosition, _radarWorldPosition) > MaxBlipRenderDistance * MaxBlipRenderDistance)
-                    continue;
-
-                result.Add((worldPosition, blip.Scale, blip.Color, blip.Shape));
-            }
+            result.Add((predictedPos, blip.Scale, blip.Color, blip.Shape));
         }
 
         return result;
     }
 
     /// <summary>
-    /// Gets the raw blips data which includes grid information for more accurate rendering.
-    /// </summary>
-    public List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)> GetRawBlips()
-    {
-        if (_timing.CurTime.TotalSeconds - _lastUpdatedTime.TotalSeconds > BlipStaleSeconds)
-            return EmptyRawBlipList;
-
-        // Implement distance culling for raw blips as well
-        if (_blips.Count == 0)
-            return _blips;
-
-        var filteredBlips = new List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)>(_blips.Count);
-
-        foreach (var blip in _blips)
-        {
-            // For non-grid blips, do direct distance check
-            if (blip.Grid == null)
-            {
-                if (Vector2.DistanceSquared(blip.Position, _radarWorldPosition) <= MaxBlipRenderDistance * MaxBlipRenderDistance)
-                {
-                    filteredBlips.Add(blip);
-                }
-                continue;
-            }
-
-            // For grid blips, transform to world space for distance check
-            if (TryGetEntity(blip.Grid, out var gridEntity))
-            {
-                var worldPos = _xform.GetWorldPosition(gridEntity.Value);
-                var gridRot = _xform.GetWorldRotation(gridEntity.Value);
-                var rotatedLocalPos = gridRot.RotateVec(blip.Position);
-                var worldPosition = worldPos + rotatedLocalPos;
-
-                if (Vector2.DistanceSquared(worldPosition, _radarWorldPosition) <= MaxBlipRenderDistance * MaxBlipRenderDistance)
-                {
-                    filteredBlips.Add(blip);
-                }
-            }
-        }
-
-        return filteredBlips;
-    }
-
-    /// <summary>
     /// Gets the hitscan lines to be rendered on the radar
     /// </summary>
-    public List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> GetWorldHitscanLines()
+    public List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> GetHitscanLines()
     {
         if (_timing.CurTime.TotalSeconds - _lastUpdatedTime.TotalSeconds > BlipStaleSeconds)
             return new List<(Vector2, Vector2, float, Color)>();
@@ -184,109 +120,20 @@ public sealed partial class RadarBlipsSystem : EntitySystem
 
         foreach (var hitscan in _hitscans)
         {
-            Vector2 worldStart, worldEnd;
+            var worldStart = hitscan.Start;
+            var worldEnd = hitscan.End;
 
-            // If no grid, positions are already in world coordinates
-            if (hitscan.Grid == null)
-            {
-                worldStart = hitscan.Start;
-                worldEnd = hitscan.End;
+            // Distance culling - check if either end of the line is in range
+            var startDist = Vector2.DistanceSquared(worldStart, _radarWorldPosition);
+            var endDist = Vector2.DistanceSquared(worldEnd, _radarWorldPosition);
 
-                // Distance culling - check if either end of the line is in range
-                var startDist = Vector2.DistanceSquared(worldStart, _radarWorldPosition);
-                var endDist = Vector2.DistanceSquared(worldEnd, _radarWorldPosition);
-
-                if (startDist > MaxBlipRenderDistance * MaxBlipRenderDistance &&
-                    endDist > MaxBlipRenderDistance * MaxBlipRenderDistance)
-                    continue;
-
-                result.Add((worldStart, worldEnd, hitscan.Thickness, hitscan.Color));
+            if (startDist > MaxBlipRenderDistance * MaxBlipRenderDistance &&
+                endDist > MaxBlipRenderDistance * MaxBlipRenderDistance)
                 continue;
-            }
 
-            // If grid exists, transform from grid-local to world coordinates
-            if (TryGetEntity(hitscan.Grid, out var gridEntity))
-            {
-                // Transform the grid-local positions to world positions
-                var worldPos = _xform.GetWorldPosition(gridEntity.Value);
-                var gridRot = _xform.GetWorldRotation(gridEntity.Value);
-
-                // Rotate the local positions by grid rotation and add grid position
-                var rotatedLocalStart = gridRot.RotateVec(hitscan.Start);
-                var rotatedLocalEnd = gridRot.RotateVec(hitscan.End);
-
-                worldStart = worldPos + rotatedLocalStart;
-                worldEnd = worldPos + rotatedLocalEnd;
-
-                // Distance culling - check if either end of the line is in range
-                var startDist = Vector2.DistanceSquared(worldStart, _radarWorldPosition);
-                var endDist = Vector2.DistanceSquared(worldEnd, _radarWorldPosition);
-
-                if (startDist > MaxBlipRenderDistance * MaxBlipRenderDistance &&
-                    endDist > MaxBlipRenderDistance * MaxBlipRenderDistance)
-                    continue;
-
-                result.Add((worldStart, worldEnd, hitscan.Thickness, hitscan.Color));
-            }
+            result.Add((worldStart, worldEnd, hitscan.Thickness, hitscan.Color));
         }
 
         return result;
-    }
-
-    /// <summary>
-    /// Gets the raw hitscan data which includes grid information for more accurate rendering.
-    /// </summary>
-    public List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)> GetRawHitscanLines()
-    {
-        if (_timing.CurTime.TotalSeconds - _lastUpdatedTime.TotalSeconds > BlipStaleSeconds)
-            return EmptyHitscanList;
-
-        if (_hitscans.Count == 0)
-            return _hitscans;
-
-        var filteredHitscans = new List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)>(_hitscans.Count);
-
-        foreach (var hitscan in _hitscans)
-        {
-            // For non-grid hitscans, do direct distance check
-            if (hitscan.Grid == null)
-            {
-                // Check if either endpoint is in range
-                var startDist = Vector2.DistanceSquared(hitscan.Start, _radarWorldPosition);
-                var endDist = Vector2.DistanceSquared(hitscan.End, _radarWorldPosition);
-
-                if (startDist <= MaxBlipRenderDistance * MaxBlipRenderDistance ||
-                    endDist <= MaxBlipRenderDistance * MaxBlipRenderDistance)
-                {
-                    filteredHitscans.Add(hitscan);
-                }
-                continue;
-            }
-
-            // For grid hitscans, transform to world space for distance check
-            if (TryGetEntity(hitscan.Grid, out var gridEntity))
-            {
-                var worldPos = _xform.GetWorldPosition(gridEntity.Value);
-                var gridRot = _xform.GetWorldRotation(gridEntity.Value);
-
-                var rotatedLocalStart = gridRot.RotateVec(hitscan.Start);
-                var rotatedLocalEnd = gridRot.RotateVec(hitscan.End);
-
-                var worldStart = worldPos + rotatedLocalStart;
-                var worldEnd = worldPos + rotatedLocalEnd;
-
-                // Check if either endpoint is in range
-                var startDist = Vector2.DistanceSquared(worldStart, _radarWorldPosition);
-                var endDist = Vector2.DistanceSquared(worldEnd, _radarWorldPosition);
-
-                if (startDist <= MaxBlipRenderDistance * MaxBlipRenderDistance ||
-                    endDist <= MaxBlipRenderDistance * MaxBlipRenderDistance)
-                {
-                    filteredHitscans.Add(hitscan);
-                }
-            }
-        }
-
-        return filteredHitscans;
     }
 }

--- a/Content.Server/_Mono/Radar/RadarBlipComponent.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipComponent.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 ark1368
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace Content.Server._Mono.Radar;
 
 using Content.Shared._Mono.Radar;

--- a/Content.Server/_Mono/Radar/RadarBlipComponent.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipComponent.cs
@@ -42,7 +42,7 @@ public sealed partial class RadarBlipComponent : Component
     /// Whether this blip should be visible on radar across different grids.
     /// </summary>
     [DataField]
-    public bool VisibleFromOtherGrids = false;
+    public bool VisibleFromOtherGrids = true;
 
     [DataField]
     public bool Enabled = true;

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 ark1368
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -7,16 +7,25 @@ using System.Numerics;
 using Content.Shared._Mono.Radar;
 using Content.Shared.Projectiles;
 using Content.Shared.Shuttles.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Server._Mono.Radar;
 
 public sealed partial class RadarBlipSystem : EntitySystem
 {
     [Dependency] private readonly SharedTransformSystem _xform = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
+    private EntityQuery<PhysicsComponent> _physQuery;
+
     public override void Initialize()
     {
         base.Initialize();
         SubscribeNetworkEvent<RequestBlipsEvent>(OnBlipsRequested);
+
+        _physQuery = GetEntityQuery<PhysicsComponent>();
     }
 
     private void OnBlipsRequested(RequestBlipsEvent ev, EntitySessionEventArgs args)
@@ -35,9 +44,9 @@ public sealed partial class RadarBlipSystem : EntitySystem
         RaiseNetworkEvent(giveEv, args.SenderSession);
     }
 
-    private List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)> AssembleBlipsReport(EntityUid uid, RadarConsoleComponent? component = null)
+    private List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> AssembleBlipsReport(EntityUid uid, RadarConsoleComponent? component = null)
     {
-        var blips = new List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)>();
+        var blips = new List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)>();
 
         if (Resolve(uid, ref component))
         {
@@ -56,25 +65,11 @@ public sealed partial class RadarBlipSystem : EntitySystem
                 if (!blip.Enabled)
                     continue;
 
-                // Don't show radar blips for projectiles on different maps than the one they were fired from
-                if (TryComp<ProjectileComponent>(blipUid, out var projectile))
-                {
-                    // If the projectile is on a different map than the radar, don't show it
-                    if (blipXform.MapID != radarMapId)
-                        continue;
-
-                    // If we can determine the shooter and they're on a different map, don't show the blip
-                    if (projectile.Shooter != null &&
-                        TryComp<TransformComponent>(projectile.Shooter, out var shooterXform) &&
-                        shooterXform.MapID != blipXform.MapID)
-                        continue;
-                }
-
                 // This prevents blips from showing on radars that are on different maps
                 if (blipXform.MapID != radarMapId)
                     continue;
 
-                var blipGrid = _xform.GetGrid(blipUid);
+                var blipGrid = blipXform.GridUid;
 
                 // if (HasComp<CircularShieldRadarComponent>(blipUid))
                 // {
@@ -95,62 +90,25 @@ public sealed partial class RadarBlipSystem : EntitySystem
                 //         continue;
                 // }
 
-                var blipPosition = _xform.GetWorldPosition(blipUid);
-                var distance = (blipPosition - radarPosition).Length();
+                var blipVelocity = _physics.GetMapLinearVelocity(blipUid);
+
+                var distance = (blipXform.WorldPosition - radarPosition).Length();
                 if (distance > component.MaxRange)
                     continue;
 
-                if (blip.RequireNoGrid)
-                {
-                    if (blipGrid != null)
-                        continue;
+                if (blip.RequireNoGrid && blipGrid != null // if we want no grid but we are on a grid
+                    || !blip.VisibleFromOtherGrids && blipGrid != radarGrid) // or if we don't want to be visible from other grids but we're on another grid
+                    continue; // don't show this blip
 
-                    // For free-floating blips without a grid, use world position with null grid
-                    blips.Add((null, blipPosition, blip.Scale, blip.RadarColor, blip.Shape));
-                }
-                else if (blip.VisibleFromOtherGrids)
-                {
-                    // For blips that should be visible from other grids, add them regardless of grid
-                    // If on a grid, use grid-relative coordinates
-                    if (blipGrid != null)
-                    {
-                        // Local position relative to grid
-                        var gridMatrix = _xform.GetWorldMatrix(blipGrid.Value);
-                        Matrix3x2.Invert(gridMatrix, out var invGridMatrix);
-                        var localPos = Vector2.Transform(blipPosition, invGridMatrix);
+                // due to PVS being a thing, things will break if we try to parent to not the map or a grid
+                var coord = blipXform.Coordinates;
+                if (blipXform.ParentUid != blipXform.MapUid && blipXform.ParentUid != blipGrid)
+                    coord = _xform.WithEntityId(coord, blipGrid ?? blipXform.MapUid!.Value);
+                // we're parented to either the map or a grid and this is relative velocity so account for grid movement
+                if (blipGrid != null)
+                    blipVelocity -= _physics.GetLinearVelocity(blipGrid.Value, coord.Position);
 
-                        // Add grid-relative blip with grid entity ID
-                        blips.Add((GetNetEntity(blipGrid.Value), localPos, blip.Scale, blip.RadarColor, blip.Shape));
-                    }
-                    else
-                    {
-                        // Fallback to world position with null grid
-                        blips.Add((null, blipPosition, blip.Scale, blip.RadarColor, blip.Shape));
-                    }
-                }
-                else
-                {
-                    // If we're requiring grid, make sure they're on the same grid
-                    if (blipGrid != radarGrid)
-                        continue;
-
-                    // For grid-aligned blips, store grid NetEntity and grid-local position
-                    if (blipGrid != null)
-                    {
-                        // Local position relative to grid
-                        var gridMatrix = _xform.GetWorldMatrix(blipGrid.Value);
-                        Matrix3x2.Invert(gridMatrix, out var invGridMatrix);
-                        var localPos = Vector2.Transform(blipPosition, invGridMatrix);
-
-                        // Add grid-relative blip with grid entity ID
-                        blips.Add((GetNetEntity(blipGrid.Value), localPos, blip.Scale, blip.RadarColor, blip.Shape));
-                    }
-                    else
-                    {
-                        // Fallback to world position with null grid
-                        blips.Add((null, blipPosition, blip.Scale, blip.RadarColor, blip.Shape));
-                    }
-                }
+                blips.Add((GetNetCoordinates(coord), blipVelocity, blip.Scale, blip.RadarColor, blip.Shape));
             }
         }
 
@@ -160,9 +118,9 @@ public sealed partial class RadarBlipSystem : EntitySystem
     /// <summary>
     /// Assembles trajectory information for hitscan projectiles to be displayed on radar
     /// </summary>
-    private List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)> AssembleHitscanReport(EntityUid uid, RadarConsoleComponent? component = null)
+    private List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> AssembleHitscanReport(EntityUid uid, RadarConsoleComponent? component = null)
     {
-        var hitscans = new List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)>();
+        var hitscans = new List<(Vector2 Start, Vector2 End, float Thickness, Color Color)>();
 
         if (!Resolve(uid, ref component))
             return hitscans;
@@ -186,25 +144,7 @@ public sealed partial class RadarBlipSystem : EntitySystem
             if (startDistance > component.MaxRange && endDistance > component.MaxRange)
                 continue;
 
-            // If there's an origin grid, use that for coordinate system
-            if (hitscan.OriginGrid != null && hitscan.OriginGrid.Value.IsValid())
-            {
-                var gridUid = hitscan.OriginGrid.Value;
-
-                // Convert world positions to grid-local coordinates
-                var gridMatrix = _xform.GetWorldMatrix(gridUid);
-                Matrix3x2.Invert(gridMatrix, out var invGridMatrix);
-
-                var localStart = Vector2.Transform(hitscan.StartPosition, invGridMatrix);
-                var localEnd = Vector2.Transform(hitscan.EndPosition, invGridMatrix);
-
-                hitscans.Add((GetNetEntity(gridUid), localStart, localEnd, hitscan.LineThickness, hitscan.RadarColor));
-            }
-            else
-            {
-                // Use world coordinates with null grid
-                hitscans.Add((null, hitscan.StartPosition, hitscan.EndPosition, hitscan.LineThickness, hitscan.RadarColor));
-            }
+            hitscans.Add((hitscan.StartPosition, hitscan.EndPosition, hitscan.LineThickness, hitscan.RadarColor));
         }
 
         return hitscans;

--- a/Content.Shared/_Mono/Radar/RadarMessages.cs
+++ b/Content.Shared/_Mono/Radar/RadarMessages.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 ark1368
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using System.Numerics;
 using Robust.Shared.Map;

--- a/Content.Shared/_Mono/Radar/RadarMessages.cs
+++ b/Content.Shared/_Mono/Radar/RadarMessages.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Numerics;
+using Robust.Shared.Map;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._Mono.Radar;
@@ -21,35 +22,24 @@ public enum RadarBlipShape
 public sealed class GiveBlipsEvent : EntityEventArgs
 {
     /// <summary>
-    /// Blips are now (grid entity, position, scale, color, shape).
-    /// If grid entity is null, position is in world coordinates.
-    /// If grid entity is not null, position is in grid-local coordinates.
+    /// Blips are now (position, velocity, scale, color, shape).
     /// </summary>
-    public readonly List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)> Blips;
+    public readonly List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> Blips;
 
     /// <summary>
-    /// Hitscan lines to display on the radar as (grid entity, start position, end position, thickness, color).
-    /// If grid entity is null, positions are in world coordinates.
-    /// If grid entity is not null, positions are in grid-local coordinates.
+    /// Hitscan lines to display on the radar as (start position, end position, thickness, color).
     /// </summary>
-    public readonly List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)> HitscanLines;
+    public readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> HitscanLines;
 
-    // Constructor for back-compatibility
-    public GiveBlipsEvent(List<(Vector2, float, Color)> blips)
-    {
-        Blips = blips.Select(b => ((NetEntity?)null, b.Item1, b.Item2, b.Item3, RadarBlipShape.Circle)).ToList();
-        HitscanLines = new List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)>();
-    }
-
-    public GiveBlipsEvent(List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)> blips)
+    public GiveBlipsEvent(List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips)
     {
         Blips = blips;
-        HitscanLines = new List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)>();
+        HitscanLines = new List<(Vector2 Start, Vector2 End, float Thickness, Color Color)>();
     }
 
     public GiveBlipsEvent(
-        List<(NetEntity? Grid, Vector2 Position, float Scale, Color Color, RadarBlipShape Shape)> blips,
-        List<(NetEntity? Grid, Vector2 Start, Vector2 End, float Thickness, Color Color)> hitscans)
+        List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips,
+        List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> hitscans)
     {
         Blips = blips;
         HitscanLines = hitscans;

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -385,6 +385,7 @@
   - type: ShipGunClass
     shipClass: Superlight
   - type: RadarBlip
+    visibleFromOtherGrids: false
     radarColor: "#FF0040"
     scale: 1.25
   - type: ShipGunType

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -1,3 +1,27 @@
+# SPDX-FileCopyrightText: 2021 metalgearsloth
+# SPDX-FileCopyrightText: 2021 shaeone
+# SPDX-FileCopyrightText: 2022 Moony
+# SPDX-FileCopyrightText: 2022 Myctai
+# SPDX-FileCopyrightText: 2022 Radrark
+# SPDX-FileCopyrightText: 2022 Rinkashikachi
+# SPDX-FileCopyrightText: 2023 AJCM-git
+# SPDX-FileCopyrightText: 2023 Checkraze
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 TemporalOroboros
+# SPDX-FileCopyrightText: 2023 Whisper
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Ed
+# SPDX-FileCopyrightText: 2024 Ilya246
+# SPDX-FileCopyrightText: 2024 Kara
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 checkraze
+# SPDX-FileCopyrightText: 2024 lzk
+# SPDX-FileCopyrightText: 2024 spacedwarf14
+# SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 ArtisticRoomba
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: BaseThruster
   parent: BaseStructureDynamic

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -103,6 +103,7 @@
   - type: PirateBountyItem # Frontier
     id: Thruster # Frontier
   - type: RadarBlip # Mono
+    visibleFromOtherGrids: false
     radarColor: "#99FF99"
     scale: 1
     shape: diamond

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
@@ -67,6 +67,7 @@
       ballistic-ammo: !type:Container
   - type: FireControllable
   - type: RadarBlip
+    visibleFromOtherGrids: false
     radarColor: "#9999FF"
     scale: 1
   - type: ShipGunType
@@ -147,6 +148,7 @@
       ballistic-ammo: !type:Container
   - type: FireControllable
   - type: RadarBlip
+    visibleFromOtherGrids: false
     radarColor: "#9999FF"
     scale: 1
   - type: Gun
@@ -240,6 +242,7 @@
       gun_magazine: !type:ContainerSlot
   - type: FireControllable
   - type: RadarBlip
+    visibleFromOtherGrids: false
     radarColor: "#9999FF"
     scale: 1
   - type: Gun

--- a/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Shuttles/capital_thrusters.yml
@@ -61,6 +61,7 @@
   - type: StaticPrice
     price: 1500
   - type: RadarBlip
+    visibleFromOtherGrids: false
     radarColor: "#99FF99"
     scale: 2
     shape: diamond


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- code cleanup
- radar blips now also send velocity so they move smoothly

## Why / Balance
good

## How to test
check if grid movement and rotation works properly with blips
check if blips parented to another entity (jumpsuit on urist) still work outside of PVS range

## Media
https://github.com/user-attachments/assets/48223a68-cee0-4c4d-9e74-c45dcb3445c1

as you see there's some resulting "tunneling" of projectiles into grids but i'm not sure how to fix this besides hardcoding a check if there's a grid under the predicted position and temporarily disabling this blip or just straight up PVS overriding radarblipped entities so client knows they exist

## Breaking changes
quite a bit but we have no downstreams so

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Radar blips should now move more smoothly.
