### PR TITLE
Ship Telecommunications Start with Shortband

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/telecomms.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2024 Alice "Arimah" Heurlin
+# SPDX-FileCopyrightText: 2024 AndresE55
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Salvantrix
+# SPDX-FileCopyrightText: 2025 Daniel Lenrd
+# SPDX-FileCopyrightText: 2025 LukeZurg22
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: TelecomServer
   id: NFTelecomServerFilled
@@ -44,6 +54,7 @@
     containers:
       key_slots:
       - EncryptionKeyCommon
+      - EncryptionKeyTraffic
       - EncryptionKeyMedical
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
~~Shortband no longer works between different maps.~~
Ship TeleCommunications servers start with shortband encryption key
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why
~~Hearing a person from Colonial while on a different planet doesn't seem right, this is an oversight as MaxRadioDistance only checks for X, Y distance and not a plane of existance you are on.~~

Shortband is probably the 2nd most important encryption you need on Expeditions, and is probably so important for crew communication it can just be part of common encryption key.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
~~Join as 2~4 different characters~~

Buy an expeditionary ship
Check the telecommunications server on it

~~Make some of the characters go on expedition
Test the Planet/Planet Planet/Station Station/Station communication
check your PDA coordinates~~
<!-- Describe the way it can be tested -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] This PR does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Ship telecommunications servers now start with shortband encryption key.