### PR TITLE
Fix TestContainerDestruction

### DIFF
--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -95,12 +95,8 @@ namespace Content.Server.Destructible
                         return b.GetType().Name;
                     }));
 
-                    bool spaceOrigin = false;
                     // Check if the damage is from space (barotrauma)
-                    if (args.Origin != null && EntityManager.TryGetComponent<BarotraumaComponent>(args.Origin.Value, out _))
-                    {
-                        spaceOrigin = true;
-                    }
+                    var spaceOrigin = args.Origin != null && EntityManager.HasComponent<BarotraumaComponent>(args.Origin.Value);
 
                     if (args.Origin != null)
                     {
@@ -120,16 +116,6 @@ namespace Content.Server.Destructible
                 if (EntityManager.IsQueuedForDeletion(uid) || EntityManager.Deleted(uid))
                     return;
             }
-        }
-
-        public void BreakEntity(EntityUid uid)
-        {
-            RaiseLocalEvent(uid, new BreakageEventArgs(), true);
-        }
-
-        public void DestroyEntity(EntityUid uid)
-        {
-            EntityManager.QueueDeleteEntity(uid);
         }
 
         // FFS this shouldn't be this hard. Maybe this should just be a field of the destructible component. Its not

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -18,6 +18,8 @@
 // SPDX-FileCopyrightText: 2024 Nemanja
 // SPDX-FileCopyrightText: 2024 TemporalOroboros
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Coenx-flex
+// SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 metalgearsloth
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -42,7 +42,6 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
         SubscribeLocalEvent<EntityStorageComponent, GetVerbsEvent<InteractionVerb>>(AddToggleOpenVerb);
         SubscribeLocalEvent<EntityStorageComponent, ContainerRelayMovementEntityEvent>(OnRelayMovement);
         SubscribeLocalEvent<EntityStorageComponent, FoldAttemptEvent>(OnFoldAttempt);
-        SubscribeLocalEvent<EntityStorageComponent, EntityTerminatingEvent>(OnEntityTerminating);
 
         SubscribeLocalEvent<EntityStorageComponent, ComponentGetState>(OnGetState);
         SubscribeLocalEvent<EntityStorageComponent, ComponentHandleState>(OnHandleState);
@@ -57,21 +56,6 @@ public sealed class EntityStorageSystem : SharedEntityStorageSystem
         SubscribeLocalEvent<InsideEntityStorageComponent, AtmosExposedGetAirEvent>(OnInsideExposed);
 
         SubscribeLocalEvent<InsideEntityStorageComponent, EntGotRemovedFromContainerMessage>(OnRemoved);
-    }
-
-    /// <summary>
-    /// Handles emptying the storage container when the entity is being terminated.
-    /// This prevents the contents from being deleted along with the container.
-    /// </summary>
-    private void OnEntityTerminating(EntityUid uid, EntityStorageComponent component, ref EntityTerminatingEvent args)
-    {
-        // Skip if this component is being deleted via DestructionEventArgs,
-        // since that event handler may have specific deletion behavior
-        if (component.DeleteContentsOnDestruction)
-            return;
-
-        // Empty the container to prevent the contained entities from being deleted
-        OpenStorage(uid, component);
     }
 
     private void OnMapInit(EntityUid uid, EntityStorageComponent component, MapInitEvent args)

--- a/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/EntityStorageSystem.cs
@@ -1,3 +1,23 @@
+// SPDX-FileCopyrightText: 2022 Alex Evgrashin
+// SPDX-FileCopyrightText: 2022 Bright0
+// SPDX-FileCopyrightText: 2022 Chief-Engineer
+// SPDX-FileCopyrightText: 2022 Jezithyr
+// SPDX-FileCopyrightText: 2022 Leon Friedrich
+// SPDX-FileCopyrightText: 2022 Lucas
+// SPDX-FileCopyrightText: 2022 Moony
+// SPDX-FileCopyrightText: 2022 wrexbe
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Kara
+// SPDX-FileCopyrightText: 2023 Nemanja
+// SPDX-FileCopyrightText: 2023 TemporalOroboros
+// SPDX-FileCopyrightText: 2023 deltanedas
+// SPDX-FileCopyrightText: 2024 Errant
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Coenx-flex
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Diagnostics.CodeAnalysis;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fix Tests, partial fix of SpawnAndDeleteAllEntitiesInTheSameSpot
## How to test
<!-- Describe the way it can be tested -->
Run tests, the issue was some way that Ark tried to fix gibbing in space, which involved breaking the destruction event for some reason. You can't even get gibbed in space anymore because of how barotrama was changed to no damage you past a margin (tested it anyway, it's fine)
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->