### PR TITLE
Fix Lathes

### DIFF
--- a/Content.Shared/Lathe/SharedLatheSystem.cs
+++ b/Content.Shared/Lathe/SharedLatheSystem.cs
@@ -4,6 +4,7 @@
 // SPDX-FileCopyrightText: 2024 Nemanja
 // SPDX-FileCopyrightText: 2024 Whatstone
 // SPDX-FileCopyrightText: 2025 Coenx-flex
+// SPDX-FileCopyrightText: 2025 Cojoke
 // SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 ScarKy0
 // SPDX-FileCopyrightText: 2025 deltanedas

--- a/Content.Shared/Lathe/SharedLatheSystem.cs
+++ b/Content.Shared/Lathe/SharedLatheSystem.cs
@@ -87,7 +87,7 @@ public abstract class SharedLatheSystem : EntitySystem
 
         foreach (var (material, needed) in recipe.Materials)
         {
-            var adjustedAmount = AdjustMaterial(needed, recipe.ApplyMaterialDiscount, component.MaterialUseMultiplier);
+            var adjustedAmount = AdjustMaterial(needed, recipe.ApplyMaterialDiscount, component.FinalMaterialUseMultiplier);
 
             if (_materialStorage.GetMaterialAmount(uid, material) < adjustedAmount * amount)
                 return false;
@@ -227,6 +227,34 @@ public abstract class SharedLatheSystem : EntitySystem
             var old = ent.Comp.TimeMultiplier;
             ent.Comp.TimeMultiplier = time.Value;
             ent.Comp.FinalTimeMultiplier *= time.Value / old;
+
+            DirtyField(ent, nameof(LatheComponent.TimeMultiplier));
+            DirtyField(ent, nameof(LatheComponent.FinalTimeMultiplier));
+        }
+    }
+
+    // Monolith
+    /// <summary>
+    /// Multiplies multipliers for this lathe before modification by machine parts, for non-null arguments.
+    /// </summary>
+    public void MultiplyLatheMultipliers(Entity<LatheComponent?> ent, float? materialUse = null, float? time = null)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        if (materialUse != null)
+        {
+            ent.Comp.MaterialUseMultiplier *= materialUse.Value;
+            ent.Comp.FinalMaterialUseMultiplier *= materialUse.Value;
+
+            DirtyField(ent, nameof(LatheComponent.MaterialUseMultiplier));
+            DirtyField(ent, nameof(LatheComponent.FinalMaterialUseMultiplier));
+        }
+
+        if (time != null)
+        {
+            ent.Comp.TimeMultiplier *= time.Value;
+            ent.Comp.FinalTimeMultiplier *= time.Value;
 
             DirtyField(ent, nameof(LatheComponent.TimeMultiplier));
             DirtyField(ent, nameof(LatheComponent.FinalTimeMultiplier));

--- a/Content.Shared/_DV/Lathe/LatheUpgradeSystem.cs
+++ b/Content.Shared/_DV/Lathe/LatheUpgradeSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Lathe;
 
 namespace Content.Shared._DV.Lathe;

--- a/Content.Shared/_DV/Lathe/LatheUpgradeSystem.cs
+++ b/Content.Shared/_DV/Lathe/LatheUpgradeSystem.cs
@@ -20,6 +20,6 @@ public sealed class LatheUpgradeSystem : EntitySystem
     {
         RemCompDeferred<LatheUpgradeComponent>(ent);
 
-        _lathe.SetLatheMultipliers(ent.Owner, ent.Comp.MaterialUseMultiplier, ent.Comp.TimeMultiplier);
+        _lathe.MultiplyLatheMultipliers(ent.Owner, ent.Comp.MaterialUseMultiplier, ent.Comp.TimeMultiplier);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- upgrades now multiply multipliers instead of setting
- fixed recipe fabricability check

## Why / Balance
fixes

## How to test
check that upgrades to industrial ore processor maintain its base buffs
check that having just above the required material with both hyperconvection upgrade and better parts lets you make it

## Media
<img width="669" height="268" alt="image" src="https://github.com/user-attachments/assets/fc1733fa-7b33-45ab-b0a8-b524cd6ac992" />
me being able to make the actual max amount and not 2 times the ore count

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed lathes sometimes not letting you make recipes when you have just above the requirement.
- fix: Fixed upgrades not properly applying to upgraded-type machines like industrial ore processor.
