### PR TITLE
Craftable Ore Crabs

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/elemental.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   abstract: true
   id: MobOreCrabDocileBase

--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/elemental.yml
@@ -1,0 +1,85 @@
+- type: entity
+  abstract: true
+  id: MobOreCrabDocileBase
+  suffix: Docile
+  components:
+  - type: FactionException
+  - type: NPCRetaliation
+    attackMemoryLength: 10
+  - type: NpcFactionMember
+    factions:
+      - SimpleNeutral
+
+# uranium is already docile
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobQuartzCrabNF]
+  id: MobQuartzCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: quartz
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobIronCrabNF]
+  id: MobIronCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: iron
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobUraniumCrabNF]
+  id: MobUraniumCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: uranium
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobSilverCrabNF]
+  id: MobSilverCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: silver
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobBananiumCrabNF]
+  id: MobBananiumCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: bananium
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobCoalCrabNF]
+  id: MobCoalCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: coal
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobGoldCrabNF]
+  id: MobGoldCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: gold
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobPlasmaCrabNF]
+  id: MobPlasmaCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: plasma
+
+- type: entity
+  parent: [MobOreCrabDocileBase, MobSaltCrabNF]
+  id: MobSaltCrabDocile
+  components:
+  - type: Construction
+    graph: OreCrab
+    node: salt

--- a/Resources/Prototypes/_Mono/Recipes/Construction/Graphs/Misc/orecrab.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Construction/Graphs/Misc/orecrab.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: constructionGraph
   id: OreCrab
   start: start

--- a/Resources/Prototypes/_Mono/Recipes/Construction/Graphs/Misc/orecrab.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Construction/Graphs/Misc/orecrab.yml
@@ -1,0 +1,96 @@
+- type: constructionGraph
+  id: OreCrab
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: quartz
+      steps:
+      - material: SpaceQuartz
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+    - to: iron
+      steps:
+      - material: SteelOre
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+    - to: uranium
+      steps:
+      - material: UraniumOre
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+    - to: silver
+      steps:
+      - material: SilverOre
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+    - to: bananium
+      steps:
+      - material: BananiumOre
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+    - to: coal
+      steps:
+      - material: Coal
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+    - to: gold
+      steps:
+      - material: GoldOre
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+    - to: plasma
+      steps:
+      - material: PlasmaOre
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+    - to: salt
+      steps:
+      - material: SaltOre
+        amount: 5
+        doAfter: 5
+      - material: Bluespace
+        amount: 1
+
+  - node: quartz
+    entity: MobQuartzCrabDocile
+
+  - node: iron
+    entity: MobIronCrabDocile
+
+  - node: uranium
+    entity: MobUraniumCrabDocile
+
+  - node: silver
+    entity: MobSilverCrabDocile
+
+  - node: bananium
+    entity: MobBananiumCrabDocile
+
+  - node: coal
+    entity: MobCoalCrabDocile
+
+  - node: gold
+    entity: MobGoldCrabDocile
+
+  - node: plasma
+    entity: MobPlasmaCrabDocile
+
+  - node: salt
+    entity: MobSaltCrabDocile

--- a/Resources/Prototypes/_Mono/Recipes/Construction/orecrab.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Construction/orecrab.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: construction
   name: quartz ore crab
   id: OreCrabQuartz

--- a/Resources/Prototypes/_Mono/Recipes/Construction/orecrab.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Construction/orecrab.yml
@@ -1,0 +1,116 @@
+- type: construction
+  name: quartz ore crab
+  id: OreCrabQuartz
+  graph: OreCrab
+  startNode: start
+  targetNode: quartz
+  category: construction-category-misc
+  objectType: Item
+  description: A quartz ore crab, if you're feeling lonely.
+  icon:
+    sprite: Mobs/Elemental/orecrab.rsi
+    state: quartz_crab
+
+- type: construction
+  name: iron ore crab
+  id: OreCrabIron
+  graph: OreCrab
+  startNode: start
+  targetNode: iron
+  category: construction-category-misc
+  objectType: Item
+  description: An iron ore crab, if you're feeling lonely.
+  icon:
+    sprite: Mobs/Elemental/orecrab.rsi
+    state: iron_crab
+
+- type: construction
+  name: uranium ore crab
+  id: OreCrabUranium
+  graph: OreCrab
+  startNode: start
+  targetNode: uranium
+  category: construction-category-misc
+  objectType: Item
+  description: An uranium ore crab, if you're feeling lonely.
+  icon:
+    sprite: Mobs/Elemental/orecrab.rsi
+    state: uranium_crab
+
+- type: construction
+  name: silver ore crab
+  id: OreCrabSilver
+  graph: OreCrab
+  startNode: start
+  targetNode: silver
+  category: construction-category-misc
+  objectType: Item
+  description: A silver ore crab, if you're feeling lonely.
+  icon:
+    sprite: Mobs/Elemental/orecrab.rsi
+    state: silver_crab
+
+- type: construction
+  name: bananium ore crab
+  id: OreCrabBananium
+  graph: OreCrab
+  startNode: start
+  targetNode: bananium
+  category: construction-category-misc
+  objectType: Item
+  description: A bananium ore crab, if you're feeling lonely.
+  icon:
+    sprite: _NF/Mobs/Elemental/orecrab.rsi
+    state: bananium_crab
+
+- type: construction
+  name: coal ore crab
+  id: OreCrabCoal
+  graph: OreCrab
+  startNode: start
+  targetNode: coal
+  category: construction-category-misc
+  objectType: Item
+  description: A coal ore crab, if you're feeling lonely.
+  icon:
+    sprite: _NF/Mobs/Elemental/orecrab.rsi
+    state: coal_crab
+
+- type: construction
+  name: gold ore crab
+  id: OreCrabGold
+  graph: OreCrab
+  startNode: start
+  targetNode: gold
+  category: construction-category-misc
+  objectType: Item
+  description: A gold ore crab, if you're feeling lonely.
+  icon:
+    sprite: _NF/Mobs/Elemental/orecrab.rsi
+    state: gold_crab
+
+- type: construction
+  name: plasma ore crab
+  id: OreCrabPlasma
+  graph: OreCrab
+  startNode: start
+  targetNode: plasma
+  category: construction-category-misc
+  objectType: Item
+  description: A plasma ore crab, if you're feeling lonely.
+  icon:
+    sprite: _NF/Mobs/Elemental/orecrab.rsi
+    state: plasma_crab
+
+- type: construction
+  name: salt ore crab
+  id: OreCrabSalt
+  graph: OreCrab
+  startNode: start
+  targetNode: salt
+  category: construction-category-misc
+  objectType: Item
+  description: A salt ore crab, if you're feeling lonely.
+  icon:
+    sprite: _NF/Mobs/Elemental/orecrab.rsi
+    state: salt_crab

--- a/Resources/Prototypes/_Mono/Recipes/Construction/orecrab.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Construction/orecrab.yml
@@ -36,7 +36,7 @@
   targetNode: uranium
   category: construction-category-misc
   objectType: Item
-  description: An uranium ore crab, if you're feeling lonely.
+  description: A uranium ore crab, if you're feeling lonely.
   icon:
     sprite: Mobs/Elemental/orecrab.rsi
     state: uranium_crab


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
you can now craft (docile) ore crabs from 1 bluespace and 5 of their respective ore
will still hit you back if you hit them

## Why / Balance
pet
can also use uranium crabs as a trap

## How to test
get 5 ore and 1 bluespace
make crab

## Media
<img width="519" height="411" alt="image" src="https://github.com/user-attachments/assets/f619e4e4-a6be-4631-85da-724d71175f58" />
<img width="427" height="98" alt="image" src="https://github.com/user-attachments/assets/774ea59f-a0a5-4a68-a0d1-ad48a3c28e70" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now craft ore crabs.
