### PR TITLE
Ushankas for USSP Roles

### DIFF
--- a/Resources/Prototypes/_Mono/Loadouts/USSP/universal_groups.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/USSP/universal_groups.yml
@@ -104,6 +104,7 @@
   loadouts:
   - USSPHelmet
   - USSPBeret
+  - ContractorClothingHeadHatUshanka
 
 - type: loadoutGroup
   id: USSPEars
@@ -130,9 +131,11 @@
   name: loadout-group-contractor-head
   loadouts:
   - USSPCommissarCap
+  - ContractorClothingHeadHatUshanka
 
 - type: loadoutGroup
   id: USSPHeadOfficer
   name: loadout-group-contractor-head
   loadouts:
   - USSPOfficerCap
+  - ContractorClothingHeadHatUshanka


### PR DESCRIPTION

## About the PR
makes available Ushankas in USSP loadouts. 

## Why / Balance
Tabarich we need Ushankas for the revolution.

## How to test
Check USSP loadouts

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
- [ x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**

:cl:
- add: Added ushankas for USSP in loadouts


