### PR TITLE
Borg Id Copy-Onto

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -1,3 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Checkraze
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 ShadowCommander
+// SPDX-FileCopyrightText: 2023 TemporalOroboros
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Cojoke
+// SPDX-FileCopyrightText: 2024 Dvir
+// SPDX-FileCopyrightText: 2024 Ed
+// SPDX-FileCopyrightText: 2024 Krunklehorn
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 Plykiya
+// SPDX-FileCopyrightText: 2024 Tayrtahn
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2025 Errant
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 ScarKy0
+// SPDX-FileCopyrightText: 2025 eoineoineoin
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Actions;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -305,24 +305,6 @@ public sealed partial class BorgSystem : SharedBorgSystem
 
         Toggle.TryActivate(uid);
 
-        // Frontier: add cyborg access
-        if (TryComp<AccessComponent>(uid, out var oldAccess))
-        {
-            var access = oldAccess.Tags.ToList();
-
-            access.Clear();
-            access.Add($"Captain");
-            access.Add($"Maintenance");
-            access.Add($"External");
-            access.Add($"Medical");
-            access.Add($"Pilot");
-            access.Add($"Mercenary");
-
-            _access.TrySetTags(uid, access);
-        }
-        _access.SetAccessEnabled(uid, true);
-        // End Frontier
-
         if (_powerCell.HasDrawCharge(uid))
         {
             Toggle.TryActivate(uid);

--- a/Content.Server/_Mono/Access/AccessGrantableComponent.cs
+++ b/Content.Server/_Mono/Access/AccessGrantableComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._Mono.Access;
+
+/// <summary>
+///     Allows you to grant this entity an ID card's accesses by interacting with it.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AccessGrantableComponent : Component { }

--- a/Content.Server/_Mono/Access/AccessGrantableComponent.cs
+++ b/Content.Server/_Mono/Access/AccessGrantableComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace Content.Server._Mono.Access;
 
 /// <summary>

--- a/Content.Server/_Mono/Access/AccessGrantableSystem.cs
+++ b/Content.Server/_Mono/Access/AccessGrantableSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Popups;
 using Content.Shared.Access.Components;
 using Content.Shared.Interaction;

--- a/Content.Server/_Mono/Access/AccessGrantableSystem.cs
+++ b/Content.Server/_Mono/Access/AccessGrantableSystem.cs
@@ -1,0 +1,46 @@
+using Content.Server.Popups;
+using Content.Shared.Access.Components;
+using Content.Shared.Interaction;
+
+namespace Content.Server._Mono.Access;
+
+public sealed class AccessGrantableSystem : EntitySystem
+{
+    [Dependency] private readonly PopupSystem _popupSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AccessGrantableComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
+    }
+
+    private void OnAfterInteractUsing(Entity<AccessGrantableComponent> ent, ref AfterInteractUsingEvent args)
+    {
+        if (args.Target != ent || !args.CanReach || !HasComp<IdCardComponent>(args.Used))
+            return;
+
+        if (!TryComp<AccessComponent>(ent, out var ourAccess) || !TryComp<AccessComponent>(args.Used, out var cardAccess))
+            return;
+
+        var beforeLength = ourAccess.Tags.Count;
+        ourAccess.Tags.UnionWith(cardAccess.Tags);
+        var addedLength = ourAccess.Tags.Count - beforeLength;
+
+        if (addedLength == 0)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("agent-id-no-new", ("card", args.Used)), ent);
+            return;
+        }
+
+        Dirty(ent, ourAccess);
+
+        if (addedLength == 1)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("agent-id-new-1", ("card", args.Used)), ent);
+            return;
+        }
+
+        _popupSystem.PopupEntity(Loc.GetString("agent-id-new", ("number", addedLength), ("card", args.Used)), ent);
+    }
+}

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -10,6 +10,7 @@
 # SPDX-FileCopyrightText: 2024 deltanedas
 # SPDX-FileCopyrightText: 2024 neuPanda
 # SPDX-FileCopyrightText: 2025 HungryCuban
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 KiraZen_
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -54,4 +54,5 @@
   - Chapel
   - Hydroponics
   - Atmospherics
+  - Pilot # Mono
 #  - Pirate # Mono

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -342,6 +342,7 @@
     intensitySlope: 20
     maxIntensity: 20
     canCreateVacuum: false # its for killing the borg not the station
+  - type: AccessGrantable # Mono
 
 - type: entity
   id: BaseBorgChassisNT


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
you can now swipe id on borg to copy accesses onto it

## Why / Balance
currently faction ship doors are just forever locked for borgs even with guest access

## How to test
get ussp/tsf/rogue id, swipe on borg, try open faction ship doors

## Media
<img width="365" height="133" alt="image" src="https://github.com/user-attachments/assets/91a02b20-944e-485d-b7d9-1bd46e6033cd" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now swipe ID cards on borgs to grant them the card's accesses.
