### PR TITLE
Refactor Toggleable Blips/Add Blips to Borgs

### DIFF
--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -255,20 +255,7 @@ public sealed class SuitSensorSystem : EntitySystem
             default:
                 return;
         }
-        // Mono Begin
-        string radarMsg;
-        switch (component.IFFSignatureEnabled)
-        {
-            case true:
-                radarMsg = "suit-sensor-signature-examine-on";
-                break;
-            case false:
-                radarMsg = "suit-sensor-signature-examine-off";
-                break;
-        }
-        // Mono End
         args.PushMarkup(Loc.GetString(msg));
-        args.PushMarkup(Loc.GetString(radarMsg)); // Mono
     }
 
     private void OnVerb(EntityUid uid, SuitSensorComponent component, GetVerbsEvent<Verb> args)
@@ -295,18 +282,6 @@ public sealed class SuitSensorSystem : EntitySystem
             CreateVerb(uid, component, args.User, SuitSensorMode.SensorVitals),
             CreateVerb(uid, component, args.User, SuitSensorMode.SensorCords)
         });
-
-        // Monolith IFF signature edit Start
-        var verb = new Verb
-        {
-            Text = Loc.GetString("suit-sensor-signature-toggle", ("status", GetStatusSignatureName(component))),
-            Act = () =>
-            {
-                TryToggleSignature(uid, component);
-            }
-        };
-        args.Verbs.Add(verb);
-        // End
     }
 
     private void OnInsert(EntityUid uid, SuitSensorComponent component, EntGotInsertedIntoContainerMessage args)
@@ -382,24 +357,6 @@ public sealed class SuitSensorSystem : EntitySystem
         return Loc.GetString(name);
     }
 
-    // Mono Begin
-    private string GetStatusSignatureName(SuitSensorComponent component)
-    {
-        string signatureName;
-        switch (component.IFFSignatureEnabled)
-        {
-            case true:
-                signatureName = "suit-sensor-signature-verb-disable";
-                break;
-            case false:
-                signatureName = "suit-sensor-signature-verb-enable";
-                break;
-        }
-
-        return Loc.GetString(signatureName);
-    }
-    // Mono End
-
     public void TrySetSensor(Entity<SuitSensorComponent> sensors, SuitSensorMode mode, EntityUid userUid)
     {
         var comp = sensors.Comp;
@@ -419,26 +376,6 @@ public sealed class SuitSensorSystem : EntitySystem
             };
 
             _doAfterSystem.TryStartDoAfter(doAfterArgs);
-        }
-    }
-
-    // Monolith - Radar signature toggle verb
-    public void TryToggleSignature(EntityUid uid, SuitSensorComponent comp)
-    {
-        if (comp.IFFSignatureEnabled || HasComp<RadarBlipComponent>(uid))
-        {
-            comp.IFFSignatureEnabled = false;
-            RemComp<RadarBlipComponent>(uid);
-            _popupSystem.PopupEntity(Loc.GetString("suit-sensor-signature-toggled-off"), uid);
-        }
-        else
-        {
-            comp.IFFSignatureEnabled = true;
-            var blip = EnsureComp<RadarBlipComponent>(uid);
-            blip.RadarColor = Color.Cyan;
-            blip.Scale = 0.5f;
-            blip.VisibleFromOtherGrids = true;
-            _popupSystem.PopupEntity(Loc.GetString("suit-sensor-signature-toggled-on"), uid);
         }
     }
 

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -26,6 +26,7 @@
 // SPDX-FileCopyrightText: 2024 slarticodefast
 // SPDX-FileCopyrightText: 2024 themias
 // SPDX-FileCopyrightText: 2025 Ignaz "Ian" Kraft
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 ScyronX
 //

--- a/Content.Server/_Mono/Radar/ToggleableSignatureComponent.cs
+++ b/Content.Server/_Mono/Radar/ToggleableSignatureComponent.cs
@@ -1,0 +1,21 @@
+namespace Content.Server._Mono.Radar;
+
+/// <summary>
+///     Makes it possible to toggle this entity having a radar blip.
+///     Don't use together with RadarBlipComponent, instead set Enabled to true and specify what blip you want it to have.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ToggleableSignatureComponent : Component
+{
+    /// <summary>
+    ///     Whether its state can be seen on examine.
+    /// </summary>
+    [DataField]
+    public bool Examinable = true;
+
+    [DataField]
+    public bool Enabled = false;
+
+    [DataField]
+    public RadarBlipComponent Blip = new();
+}

--- a/Content.Server/_Mono/Radar/ToggleableSignatureComponent.cs
+++ b/Content.Server/_Mono/Radar/ToggleableSignatureComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace Content.Server._Mono.Radar;
 
 /// <summary>

--- a/Content.Server/_Mono/Radar/ToggleableSignatureSystem.cs
+++ b/Content.Server/_Mono/Radar/ToggleableSignatureSystem.cs
@@ -1,0 +1,110 @@
+using Content.Server.Popups;
+using Content.Shared.Examine;
+using Content.Shared.Interaction;
+using Content.Shared.Verbs;
+
+namespace Content.Server._Mono.Radar;
+
+public sealed class ToggleableSignatureSystem : EntitySystem
+{
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ToggleableSignatureComponent, GetVerbsEvent<Verb>>(OnVerb);
+        SubscribeLocalEvent<ToggleableSignatureComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<ToggleableSignatureComponent, MapInitEvent>(OnInit);
+    }
+
+    // if this is made an alternative verb it conflicts with (un)locking on borgs
+    private void OnVerb(Entity<ToggleableSignatureComponent> ent, ref GetVerbsEvent<Verb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        var verb = new Verb
+        {
+            Text = Loc.GetString("suit-sensor-signature-toggle", ("status", GetStatusSignatureName(ent.Comp))),
+            Act = () => TryToggleSignature(ent)
+        };
+        args.Verbs.Add(verb);
+    }
+
+    private void OnExamine(Entity<ToggleableSignatureComponent> ent, ref ExaminedEvent args)
+    {
+        if (!ent.Comp.Examinable || !args.IsInDetailsRange)
+            return;
+
+        string radarMsg;
+        switch (ent.Comp.Enabled)
+        {
+            case true:
+                radarMsg = "suit-sensor-signature-examine-on";
+                break;
+            case false:
+                radarMsg = "suit-sensor-signature-examine-off";
+                break;
+        }
+
+        args.PushMarkup(Loc.GetString(radarMsg));
+    }
+
+    private void OnInit(Entity<ToggleableSignatureComponent> ent, ref MapInitEvent args)
+    {
+        // so that it works if we specify enabled: true in yml
+        if (ent.Comp.Enabled)
+            TryEnableSignature(ent);
+        else
+            TryDisableSignature(ent);
+    }
+
+    private string GetStatusSignatureName(ToggleableSignatureComponent component)
+    {
+        string signatureName;
+        switch (component.Enabled)
+        {
+            case true:
+                signatureName = "suit-sensor-signature-verb-disable";
+                break;
+            case false:
+                signatureName = "suit-sensor-signature-verb-enable";
+                break;
+        }
+
+        return Loc.GetString(signatureName);
+    }
+
+    public void TryToggleSignature(Entity<ToggleableSignatureComponent> ent)
+    {
+        if (ent.Comp.Enabled || HasComp<RadarBlipComponent>(ent))
+            TryDisableSignature(ent);
+        else
+            TryEnableSignature(ent);
+    }
+
+    public bool TryDisableSignature(Entity<ToggleableSignatureComponent> ent)
+    {
+        ent.Comp.Enabled = false;
+        if (!HasComp<RadarBlipComponent>(ent))
+            return false;
+
+        RemComp<RadarBlipComponent>(ent);
+        _popup.PopupEntity(Loc.GetString("suit-sensor-signature-toggled-off"), ent);
+        return true;
+    }
+
+    public bool TryEnableSignature(Entity<ToggleableSignatureComponent> ent)
+    {
+        ent.Comp.Enabled = true;
+        // if we already have a blip but it's not our blip, someone did something wrong and we should override it
+        if (TryComp<RadarBlipComponent>(ent, out var blip) && blip == ent.Comp.Blip)
+            return false;
+
+        AddComp(ent, ent.Comp.Blip, true);
+        _popup.PopupEntity(Loc.GetString("suit-sensor-signature-toggled-on"), ent);
+        return true;
+    }
+}

--- a/Content.Server/_Mono/Radar/ToggleableSignatureSystem.cs
+++ b/Content.Server/_Mono/Radar/ToggleableSignatureSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.Popups;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -43,6 +43,10 @@
   id: ClothingUniformBase
   components:
   - type: SuitSensor
+  - type: ToggleableSignature
+    blip:
+      radarColor: Cyan
+      scale: 0.5
   - type: DeviceNetwork
     deviceNetId: Wireless
     transmitFrequencyId: SuitSensor

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -1,3 +1,25 @@
+# SPDX-FileCopyrightText: 2021 Alex Evgrashin
+# SPDX-FileCopyrightText: 2021 Paul Ritter
+# SPDX-FileCopyrightText: 2021 Peptide90
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2022 ElectroJr
+# SPDX-FileCopyrightText: 2022 Justin Trotter
+# SPDX-FileCopyrightText: 2022 Kara
+# SPDX-FileCopyrightText: 2022 Leon Friedrich
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2022 metalgearsloth
+# SPDX-FileCopyrightText: 2022 mirrorcult
+# SPDX-FileCopyrightText: 2023 Julian Giebel
+# SPDX-FileCopyrightText: 2023 LankLTE
+# SPDX-FileCopyrightText: 2023 crazybrain23
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 VMSolidus
+# SPDX-FileCopyrightText: 2024 Zachary Yona
+# SPDX-FileCopyrightText: 2025 Dvir
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   abstract: true
   parent: [Clothing, RecyclableItemClothBasic] # Frontier: added RecyclableItemClothBasic

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -312,6 +312,10 @@
       flatReductions:
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
   - type: PreventDropOnDowned # Frontier: borgs don't drop items when falling (e.g. critical/dead)
+  - type: ToggleableSignature # Monolith
+    blip:
+      radarColor: CornflowerBlue
+      scale: 0.5
   - type: Magboots # Monolith
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- unties toggleable blips from jumpsuit system
- gives borgs toggleable radar blip

## Why / Balance
they kinda need it

## How to test
rightclick jumpsuit, toggle signature, see that it works, toggle it off, see that it works
do same with borg as said borg

## Media
<img width="72" height="53" alt="image" src="https://github.com/user-attachments/assets/c7b50b60-32c8-47f3-bc1e-0b1a3379e46e" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Borgs can now toggle radar signature on themselves via rightclick.
