### PR TITLE
Recipe Pack Fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -324,7 +324,7 @@
     - MonoRestraintsStatic # Mono
   - type: EmagLatheRecipes
     emagStaticPacks:
-    - CivilianAmmoRecipePack
+    - StaticAmmoRecipePack
   - type: BlueprintReceiver
     whitelist:
       tags:
@@ -420,13 +420,13 @@
     - Translators
   - type: EmagLatheRecipes
     emagDynamicPacks:
-    - AdvancedAmmoRecipePack
+    - DynamicAmmoRecipePack
     - SecurityExplosives
     - SecurityEquipment
     - SecurityWeapons
     - SyringeGuns # Delta-V
     emagStaticPacks:
-    - CivilianAmmoRecipePack
+    - StaticAmmoRecipePack
 
 - type: entity
   id: ProtolatheHyperConvection
@@ -635,18 +635,18 @@
     staticPacks:
     - SecurityEquipmentStatic
     - SecurityPracticeStatic
-    - CivilianAmmoRecipePack
+    - StaticAmmoRecipePack
     - SecurityWeaponsStatic
     dynamicPacks:
     - SecurityEquipment
     - SecurityExplosives
-    - AdvancedAmmoRecipePack
+    - DynamicAmmoRecipePack
     - SecurityWeapons
     - SecurityDisablers
     - SMCybernetics
     # Mono - Mechs
     - WeaponMechCombatArsenal
-    - AdvancedAmmoRecipePack
+    - DynamicAmmoRecipePack
     - SmartGun # Goobstation
     # Mono start
     - MonoTSFWeaponsDynamicMelee
@@ -693,10 +693,9 @@
     idleState: icon
     runningState: icon
     staticPacks:
-    - CivilianAmmoRecipePack
+    - StaticAmmoRecipePack
     dynamicPacks:
-    - AdvancedAmmoRecipePack
-    - AllTheAmmo # Mono
+    - DynamicAmmoRecipePack
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/lathe.yml
@@ -32,7 +32,7 @@
     idleState: icon
     runningState: icon
     staticPacks:
-    - CivilianAmmoRecipePack
+    - StaticAmmoRecipePack
     dynamicPacks:
     # rogue start
     - MonoRogueWeaponsDynamicMelee
@@ -58,7 +58,7 @@
     - UniversalMissileAmmo
     - UniversalShellAmmo
     - UniversalOrdinance
-    - AdvancedAmmoRecipePack
+    - DynamicAmmoRecipePack
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
@@ -5,8 +5,8 @@
 
 #All the ammo recipes
 
-- type: latheRecipePack
-  id: AllTheAmmo
+- type: latheRecipePack 
+  id: AllTheAmmo #DO NOT use this or test breaks. Unless its static for some kind of debugg lathe
   recipes:
   - AmmoBox23x75mmBuckshot
   - AmmoBox23x75mmBeanbag
@@ -674,7 +674,7 @@
 #civilian = FMJ + practice + empty + rubber + HP + Steel AP
 
 - type: latheRecipePack
-  id: CivilianAmmoRecipePack
+  id: StaticAmmoRecipePack
   recipes:
 #FMJ recipes
 
@@ -816,7 +816,7 @@
 #advanced = Uranium + Incendiary + Steel AP + Plasteel AP + Synth AP + HP + RIP
 
 - type: latheRecipePack
-  id: AdvancedAmmoRecipePack
+  id: DynamicAmmoRecipePack
   recipes:
 #Uranium recipes
 

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/lathe.yml
@@ -169,10 +169,10 @@
     runningState: icon
     staticPacks:
     - NFNfsdTechfabDeprecatedStatic
-    - CivilianAmmoRecipePack
+    - StaticAmmoRecipePack
     dynamicPacks:
     - NFNfsdTechfabDeprecated
-    - AdvancedAmmoRecipePack
+    - DynamicAmmoRecipePack
     # Mono start
     - MonoTSFWeaponsDynamicMelee
     - MonoTSFWeaponsDynamicRanged
@@ -214,11 +214,11 @@
     runningState: icon
     staticPacks:
     - NFMercenaryTechfabDeprecatedStatic
-    - CivilianAmmoRecipePack
+    - StaticAmmoRecipePack
     - MonoRestraintsStatic # Mono
     dynamicPacks:
     - NFMercenaryTechfabDeprecated
-    - AdvancedAmmoRecipePack
+    - DynamicAmmoRecipePack
     # Mono start
     - MonoTSFWeaponsDynamicMelee
     - MonoTSFWeaponsDynamicRanged
@@ -275,11 +275,11 @@
     runningState: icon
     staticPacks:
     - NFHackedMercenaryTechfabDeprecatedStatic
-    - CivilianAmmoRecipePack
+    - StaticAmmoRecipePack
     - MonoRestraintsStatic
     dynamicPacks:
     - NFHackedMercenaryTechfabDeprecated
-    - AdvancedAmmoRecipePack
+    - DynamicAmmoRecipePack
     - SmartGun # Goobstation
     # Mono start
     - MonoTSFWeaponsDynamicMelee


### PR DESCRIPTION
change the name of recipe packs so people dont fuck up again:
CivilianAmmoRecipePack->StaticAmmoRecipePack
AdvancedAmmoRecipePack->DynamicAmmoRecipePack
nothing for changelog