### PR TITLE
Revert Dewreckening

### DIFF
--- a/Resources/Prototypes/World/noise_channels.yml
+++ b/Resources/Prototypes/World/noise_channels.yml
@@ -41,7 +41,7 @@
     clippedValue: 0
     remapTo0Through1: true
     inputMultiplier: 24 # Makes wreck concentration very low noise at scale.
-    outputMultiplier: 0.05 # Mono: fewer wrecks
+    outputMultiplier: 0.14 # Mono: fewer wrecks
 
   - type: noiseChannel
     id: Temperature

--- a/Resources/Prototypes/World/noise_channels.yml
+++ b/Resources/Prototypes/World/noise_channels.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023 Moony
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/World/noise_channels.yml
+++ b/Resources/Prototypes/World/noise_channels.yml
@@ -40,8 +40,8 @@
     - 0.0, 0.4
     clippedValue: 0
     remapTo0Through1: true
-    inputMultiplier: 24 # Makes wreck concentration very low noise at scale.
-    outputMultiplier: 0.14 # Mono: fewer wrecks
+    inputMultiplier: 16 # Makes wreck concentration very low noise at scale.
+    outputMultiplier: 0.35 # Frontier: fewer wrecks
 
   - type: noiseChannel
     id: Temperature


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
reverts #2010

## Why / Balance
this made wrecks very very uncommon
i don't think they even lag anyway, they don't actually even generate anything on themselves until you get 16m within them
even then they despawn once you fly away

## How to test
fly around
see that wrecks actually exist

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wrecks should be common again.
