### PR TITLE
Fix Borg Id Copy-Onto

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -317,6 +317,7 @@
       radarColor: CornflowerBlue
       scale: 0.5
   - type: Magboots # Monolith
+  - type: AccessGrantable # Mono
 
 - type: entity
   abstract: true
@@ -346,7 +347,6 @@
     intensitySlope: 20
     maxIntensity: 20
     canCreateVacuum: false # its for killing the borg not the station
-  - type: AccessGrantable # Mono
 
 - type: entity
   id: BaseBorgChassisNT


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
i somehow put it on the wrong proto so you're currently unable to copy id onto derelict borgs 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can now scan your ID on derelict borgs too.
