### PR TITLE
Borg Buffs

### DIFF
--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
@@ -1,3 +1,12 @@
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 ShadowCommander
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
 using Content.Shared.NameIdentifier;

--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
@@ -136,7 +136,7 @@ public sealed partial class BorgMenu : FancyWindow
         foreach (var module in chassis.ModuleContainer.ContainedEntities)
         {
             var moduleComponent = _entity.GetComponent<BorgModuleComponent>(module);
-            var control = new BorgModuleControl(module, _entity, !moduleComponent.DefaultModule);
+            var control = new BorgModuleControl(module, _entity, true); // Mono - can remove even if default
             control.RemoveButtonPressed += () =>
             {
                 RemoveModuleButtonPressed?.Invoke(module);

--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -1,3 +1,19 @@
+// SPDX-FileCopyrightText: 2023 Checkraze
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 TemporalOroboros
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 LankLTE
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 Plykiya
+// SPDX-FileCopyrightText: 2024 ScarKy0
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Whatstone
+// SPDX-FileCopyrightText: 2025 deltanedas
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.Shared.Hands.Components;
 using Content.Shared.Interaction.Components;

--- a/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.Modules.cs
@@ -322,8 +322,9 @@ public sealed partial class BorgSystem
         Entity<BorgModuleComponent> module,
         EntityUid? user = null)
     {
-        if (module.Comp.DefaultModule)
-            return false;
+        // Mono - can remove even if default
+        //if (module.Comp.DefaultModule)
+        //    return false;
 
         return true;
     }

--- a/Content.Shared/Silicons/Borgs/Components/BorgModuleComponent.cs
+++ b/Content.Shared/Silicons/Borgs/Components/BorgModuleComponent.cs
@@ -1,4 +1,11 @@
-﻿using Robust.Shared.GameStates;
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Nemanja
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Silicons.Borgs.Components;
 

--- a/Content.Shared/Silicons/Borgs/Components/BorgModuleComponent.cs
+++ b/Content.Shared/Silicons/Borgs/Components/BorgModuleComponent.cs
@@ -20,6 +20,7 @@ public sealed partial class BorgModuleComponent : Component
 
     /// <summary>
     /// If true, this is a "default" module that cannot be removed from a borg.
+    /// Mono - changed to currently do nothing
     /// </summary>
     [DataField]
     [AutoNetworkedField]

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -1,3 +1,11 @@
+// SPDX-FileCopyrightText: 2024 Fildrance
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Item.ItemToggle;

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -33,7 +33,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
         SubscribeLocalEvent<BorgChassisComponent, EntInsertedIntoContainerMessage>(OnInserted);
         SubscribeLocalEvent<BorgChassisComponent, EntRemovedFromContainerMessage>(OnRemoved);
         SubscribeLocalEvent<BorgChassisComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
-        SubscribeLocalEvent<BorgChassisComponent, ActivatableUIOpenAttemptEvent>(OnUIOpenAttempt);
+        //SubscribeLocalEvent<BorgChassisComponent, ActivatableUIOpenAttemptEvent>(OnUIOpenAttempt); // Mono
         SubscribeLocalEvent<TryGetIdentityShortInfoEvent>(OnTryGetIdentityShortInfo);
 
         InitializeRelay();
@@ -96,12 +96,13 @@ public abstract partial class SharedBorgSystem : EntitySystem
         component.ModuleContainer = Container.EnsureContainer<Container>(uid, component.ModuleContainerId, containerManager);
     }
 
-    private void OnUIOpenAttempt(EntityUid uid, BorgChassisComponent component, ActivatableUIOpenAttemptEvent args)
-    {
-        // borgs can't view their own ui
-        if (args.User == uid)
-            args.Cancel();
-    }
+    // Mono
+    //private void OnUIOpenAttempt(EntityUid uid, BorgChassisComponent component, ActivatableUIOpenAttemptEvent args)
+    //{
+    //    // borgs can't view their own ui
+    //    if (args.User == uid)
+    //        args.Cancel();
+    //}
 
     protected virtual void OnInserted(EntityUid uid, BorgChassisComponent component, EntInsertedIntoContainerMessage args)
     {

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -130,6 +130,8 @@
       # Only used for NT borgs that can switch type, defined here to avoid copy-pasting the rest of this component.
       enum.BorgSwitchableTypeUiKey.SelectBorgType:
         type: BorgSelectTypeUserInterface
+      enum.RadarConsoleUiKey.Key: # Mono
+        type: RadarConsoleBoundUserInterface
   - type: ActivatableUI
     key: enum.BorgUiKey.Key
   - type: SiliconLawBound
@@ -312,12 +314,22 @@
       flatReductions:
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
   - type: PreventDropOnDowned # Frontier: borgs don't drop items when falling (e.g. critical/dead)
-  - type: ToggleableSignature # Monolith
+  # <Mono>
+  - type: ToggleableSignature
     blip:
       radarColor: CornflowerBlue
       scale: 0.5
-  - type: Magboots # Monolith
-  - type: AccessGrantable # Mono
+  - type: Magboots
+  - type: AccessGrantable
+  - type: MovementAlwaysTouching
+  - type: IntrinsicUI
+    uis:
+      enum.RadarConsoleUiKey.Key:
+        toggleAction: ActionObserverShowRadar
+  - type: RadarConsole
+    maxRange: 256
+    followEntity: true
+  # </Mono>
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -288,7 +288,7 @@
 - type: entity
   id: BorgModuleAppraisal
   parent: [ BaseBorgModuleCargo, BaseProviderBorgModule ]
-  name: appraisal cyborg module
+  name: cargo cyborg module # Mono
   components:
   - type: Sprite
     layers:
@@ -298,6 +298,8 @@
     moduleId: Appraisal # Frontier
     items:
     - AppraisalTool
+    - WeaponTetherGun # Mono - we ball
+    - WeaponForceGun # Mono
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: appraisal-module }
 

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 SRV
 # SPDX-FileCopyrightText: 2025 SarahRaven
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -85,6 +85,7 @@
     - BorgModuleCargo
 
   defaultModules:
+  - BorgModuleTool # Mono
   - BorgModuleGrapplingGun
   - BorgModuleMining
   - BorgModuleAppraisal
@@ -121,6 +122,7 @@
     - BorgModuleJanitor
 
   defaultModules:
+  - BorgModuleTool # Mono
   - BorgModuleLightReplacer
   - BorgModuleCleaning
 
@@ -156,7 +158,9 @@
     - BorgModuleMedical
 
   defaultModules:
+  - BorgModuleTool # Mono
   - BorgModuleTreatment
+  - BorgModuleSurgery # Mono
 
   radioChannels:
   - Science
@@ -203,6 +207,7 @@
     - BorgModuleService
 
   defaultModules:
+  - BorgModuleTool # Mono
   - BorgModuleMusique
   - BorgModuleService
   - BorgModuleClowning


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- borgs now get inbuilt mass scanner
- borgs now get MovementIgnoreTouching
- "appraisal module" -> "cargo module" + tethergun + gravity gun
- all borg types now get tool module (all the borgs just get it installed anyway already)
- medical borg gets surgery module
- borgs can now open their own UI
- you can now eject default modules

## Why / Balance
lets borgs not be helpless in space
makes them useful to have for space operations if you don't have voidboots since they can just fly
appraisal module was useless so now isn't, tethergun isn't even that strong
also currently tethergun/gravgun are missing from research tree because frontier so should maybe be added in another PR
as for the last 3 changes, why was it not the case already

## How to test
obvious

## Media
<img width="250" height="152" alt="image" src="https://github.com/user-attachments/assets/1818fc6c-3b01-4d77-9697-a4bf0432ffc7" />

<img width="1111" height="358" alt="image" src="https://github.com/user-attachments/assets/1b6cf49a-89f2-452c-b430-026966132d1a" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Borgs now have inbuilt mass scanner and can freely float in space.
- tweak: Borg appraisal module renamed to cargo module and given tether gun and gravity gun.
- tweak: Medical borgs now get the surgery module right away.
- tweak: All borgs now get the tools module right away.
- tweak: Borgs can now open their own UI.
- tweak: You can now eject default modules from borgs.
