### PR TITLE
Hardsuit Armor/Utility Changes

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
@@ -221,9 +221,13 @@
         Radiation: 0.95
   - type: ThermalVision
     flashDurationMultiplier: 2
-    pulseTime: 4
+    pulseTime: 2
     isEquipment: true
     toggleAction: PulseThermalVision
+  - type: NightVision
+    flashDurationMultiplier: 3.5
+    isEquipment: true
+    color: "#a63c6b"
   - type: ComponentToggler
     components:
     - type: BreathMask

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
@@ -26,15 +26,15 @@
       coefficients:
         Blunt: 0.65
         Slash: 0.65
-        Piercing: 0.6
+        Piercing: 0.55
         Heat: 0.7
-        Radiation: 0.75
+        Radiation: 0.65
         Caustic: 0.8
   - type: StaminaDamageResistance
     coefficient: 0.25
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.875
+    sprintModifier: 0.875
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing
@@ -65,11 +65,11 @@
       coefficients:
         Blunt: 0.7
         Slash: 0.65
-        Piercing: 0.6
-        Heat: 0.7
+        Piercing: 0.55
+        Heat: 0.65
         Radiation: 0.5
         Caustic: 0.6
         Poison: 0.9
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.875
+    sprintModifier: 0.875

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/mercs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/mercs.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/mercs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/mercs.yml
@@ -23,7 +23,7 @@
       coefficients:
         Blunt: 0.65
         Slash: 0.6
-        Piercing: 0.5
+        Piercing: 0.6
         Heat: 0.65
         Radiation: 0.6
         Caustic: 0.8
@@ -42,5 +42,5 @@
   - type: PirateBountyItem
     id: ClothingOuterHardsuitTacsuit
   - type: StaminaDamageResistance
-    coefficient: 0.5
+    coefficient: 0.6
 

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
@@ -20,21 +20,21 @@
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.45
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.6
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.55
         Heat: 0.6
-        Radiation: 0.6
-        Caustic: 0.8
+        Radiation: 0.5
+        Caustic: 0.65
   - type: StaminaDamageResistance # Mono - Stamres
     coefficient: 0.3
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.875
+    sprintModifier: 0.875
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
@@ -163,6 +163,7 @@
         Heat: 0.5
         Radiation: 0.2
         Caustic: 0.3
+        Poison: 0.8
   - type: ComponentToggler
     components:
     - type: PressureProtection

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
@@ -152,8 +152,8 @@
   - type: FireProtection
     reduction: 0.6
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -189,9 +189,16 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
-  - type: FlashImmunity
   - type: EyeProtection
-    protectionTime: 5
+    protectionTime: 15
+  - type: ThermalVision
+    pulseTime: 1.5
+    isEquipment: true
+    toggleAction: PulseThermalVision
+  - type: NightVision
+    flashDurationMultiplier: 2.75
+    isEquipment: true
+    color: "#5e8bac"
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -301,7 +301,7 @@
       coefficients:
         Blunt: 0.4
         Slash: 0.3
-        Piercing: 0.4
+        Piercing: 0.35
         Heat: 0.5
         Radiation: 0.4
         Caustic: 0.5
@@ -366,6 +366,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000
+  - type: FireProtection # Mono
+    reduction: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.4
   - type: Armor # Mono - Armor Value Changes
@@ -378,8 +380,8 @@
         Radiation: 0.6
         Caustic: 0.55
   - type: ClothingSpeedModifier # Mono - Armor Value Changes
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.925
+    sprintModifier: 0.925
   - type: FactionClothing
     faction: NanoTrasen
   - type: StaminaDamageResistance # Mono - Stamres
@@ -476,21 +478,21 @@
     sprite: _NF/Clothing/OuterClothing/Hardsuits/scaf.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.55
-        Slash: 0.55
-        Piercing: 0.55 # Mono
-        Heat: 0.65
-        Radiation: 0.6 # Added Radiation Resist
-        Caustic: 0.7
+      coefficients: # Mono - all of these values are changed
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.45 # Mono
+        Heat: 0.55
+        Radiation: 0.5 # Added Radiation Resist
+        Caustic: 0.65
   - type: ExplosionResistance
-    damageCoefficient: 0.55
+    damageCoefficient: 0.35
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier # Mono - Armor Value Changes
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.825
+    sprintModifier: 0.825
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -305,6 +305,7 @@
         Heat: 0.5
         Radiation: 0.4
         Caustic: 0.5
+        Poison: 0.8 # Mono
   - type: ClothingSpeedModifier # Mono - Armor Value Changes
     walkModifier: 0.85
     sprintModifier: 0.85
@@ -379,6 +380,7 @@
         Heat: 0.45
         Radiation: 0.6
         Caustic: 0.55
+        Poison: 0.8 # Mono
   - type: ClothingSpeedModifier # Mono - Armor Value Changes
     walkModifier: 0.925
     sprintModifier: 0.925


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
tweaking some bad stats left by rebalance op

## Why / Balance
T3 hardsuits were kinda garbage
M82 and pirate scaf were both beaten by WL-01 (since it had basically equal pierce for little to no slowdown, its pierce has been reduced to put it as more of a speed-focused hardsuit, while the SCAF was adjusted to be heavier with more slowdown)

M92-X and RX-01 were given more utility via NVGs/thermals/sufficient poison to block injectors (chimera immunity), M92-X was given more speed (RX-01 had more advantages in some parts still such as better radiation protection)

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Adjusted values of some hardsuits (RX-01 thermal pulse time halved, RX-01 and M92-X both get NVGs/thermals, M92-X loses flash prot, buffed M92-X speed, buffed M82 hardsuits slightly in pierce and heat resist, buffed rogue SCAF resists but slightly nerfed speed, reduced WL-01 pierce by 10%, added fire resist on M92-X equal to RX-01, buffed SCAF hardsuit, buffed base M92 hardsuit, gave M92 hardsuits and RX-01 modsuit 20% poison resist) Slop balance wall of text