### PR TITLE
Better incorporate recoil into more guns

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -114,8 +114,15 @@
         map: ["enum.GunVisualLayers.Base"]
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
+  - type: GunWieldBonus
+    minAngle: -20
+    maxAngle: -31
   - type: Gun
     fireRate: 5
+    minAngle: 21
+    maxAngle: 64
+    angleIncrease: 4
+    angleDecay: 14
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
   - type: ChamberMagazineAmmoProvider
@@ -174,9 +181,16 @@
   - type: ChamberMagazineAmmoProvider # Mono
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
+  - type: GunWieldBonus
+    minAngle: -20
+    maxAngle: -31
   - type: Gun
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/light_rifle_1.ogg # Mono
+    minAngle: 21
+    maxAngle: 64
+    angleIncrease: 2
+    angleDecay: 14
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -129,6 +129,10 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
     fireRate: 8.5
+    minAngle: 6
+    maxAngle: 45
+    angleIncrease: 2
+    angleDecay: 23
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
   - type: MagazineVisuals
@@ -180,7 +184,9 @@
     maxAngle: -16
   - type: Gun
     minAngle: 21
-    maxAngle: 32
+    maxAngle: 46
+    angleIncrease: 1
+    angleDecay: 17
     shotsPerBurst: 5
     availableModes:
     - Burst
@@ -293,9 +299,9 @@
   - type: Gun
     fireRate: 5.5
     minAngle: 1
-    maxAngle: 6
+    maxAngle: 24
     angleIncrease: 1.5
-    angleDecay: 6
+    angleDecay: 15
     selectedMode: FullAuto
     shotsPerBurst: 5
     burstCooldown: 0.2

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -24,13 +24,13 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
-    minAngle: -12
-    maxAngle: -18
+    minAngle: -20
+    maxAngle: -25
   - type: Gun
-    minAngle: 13
-    maxAngle: 20
-    angleIncrease: 5
-    angleDecay: 25
+    minAngle: 21
+    maxAngle: 52
+    angleIncrease: 6
+    angleDecay: 15
     fireRate: 4
     selectedMode: SemiAuto
     availableModes:
@@ -124,7 +124,7 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
     minAngle: 22
-    maxAngle: 36
+    maxAngle: 45
     angleIncrease: 2
     angleDecay: 8
     fireRate: 8

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -20,13 +20,13 @@
   - type: Clothing
     sprite: _DV/Objects/Weapons/Guns/SMGs/typewriter.rsi
   - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -30
+    minAngle: -29
+    maxAngle: -44
   - type: Gun
-    minAngle: 21
-    maxAngle: 45
-    angleIncrease: 5
-    angleDecay: 20
+    minAngle: 30
+    maxAngle: 55
+    angleIncrease: 2
+    angleDecay: 17
     fireRate: 8
     soundGunshot:
       path: /Audio/_DV/Weapons/Guns/Gunshots/typewriter.ogg

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -24,6 +24,9 @@
     sprite: _Mono/Objects/Weapons/Guns/Rifles/annie_inhands_32x.rsi
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/Rifles/annie_inhands_32x.rsi
+  - type: GunWieldBonus
+    minAngle: -14
+    maxAngle: -32
   - type: Gun
     availableModes:
     - FullAuto
@@ -33,6 +36,10 @@
     shotsPerBurst: 4
     fireRate: 6.5
     projectileSpeed: 42.5 # Mono
+    minAngle: 15
+    maxAngle: 54
+    angleIncrease: 4
+    angleDecay: 33
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/thock.ogg
   - type: ChamberMagazineAmmoProvider
@@ -84,6 +91,9 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: Clothing
     sprite: _Goobstation/Objects/Weapons/Guns/Rifles/wspr.rsi
+  - type: GunWieldBonus
+    minAngle: -14
+    maxAngle: -41
   - type: Gun
     availableModes:
     - Burst
@@ -91,6 +101,10 @@
     burstFireRate: 20 # Mono
     burstCooldown: 0.4 # Mono
     projectileSpeed: 45 # Mono
+    minAngle: 15
+    maxAngle: 54
+    angleIncrease: 2
+    angleDecay: 33
     fireRate: 7.5 # Mono, does nothing because its burst only but it makes it clear it can fire at this rate.
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/bwuh.ogg
@@ -140,9 +154,17 @@
   - type: ChamberMagazineAmmoProvider # Mono
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
+  - type: GunWieldBonus
+    minAngle: -14
+    maxAngle: -38
   - type: Gun
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/light_rifle_2.ogg # Mono
+    projectileSpeed: 60 # Mono
+    minAngle: 15
+    maxAngle: 54
+    angleIncrease: 5
+    angleDecay: 28
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -21,12 +21,12 @@
     sprite: _Harmony/Objects/Weapons/Guns/Rifles/bandit.rsi
   - type: GunWieldBonus # Mono
     minAngle: -32
-    maxAngle: -51
+    maxAngle: -44 # Mono
   - type: Gun
     minAngle: 32 # Mono
-    maxAngle: 54 # Mono
-    angleIncrease: 14
-    angleDecay: 5
+    maxAngle: 67 # Mono
+    angleIncrease: 8
+    angleDecay: 14
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -238,10 +238,10 @@
     maxAngle: -20
   - type: Gun
     minAngle: 24
-    maxAngle: 36
-    angleIncrease: 3
-    angleDecay: 34
-    fireRate: 6 # 360 rpm
+    maxAngle: 75
+    angleIncrease: 2
+    angleDecay: 54
+    fireRate: 9 # 360 rpm
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -329,13 +329,13 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/LMGs/ratel/Ratel-inhands.rsi
   - type: GunWieldBonus
-    minAngle: -20
+    minAngle: -24
     maxAngle: -30
   - type: Gun
     minAngle: 25
-    maxAngle: 40
+    maxAngle: 65
     angleIncrease: 5
-    angleDecay: 34
+    angleDecay: 32
     fireRate: 5 # 300 rpm
     selectedMode: FullAuto
     availableModes:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -241,7 +241,7 @@
     maxAngle: 75
     angleIncrease: 2
     angleDecay: 54
-    fireRate: 9 # 360 rpm
+    fireRate: 9 # 540 rpm
     selectedMode: FullAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -26,12 +26,12 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -21
-    maxAngle: -47
+    maxAngle: -26
   - type: Gun
     minAngle: 21
     maxAngle: 48
     angleIncrease: 27
-    angleDecay: 2
+    angleDecay: 8
     fireRate: 3 # 180 rpm
     selectedMode: SemiAuto
     availableModes:
@@ -98,11 +98,11 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -21
-    maxAngle: -47
+    maxAngle: -43
   - type: Gun
     minAngle: 21
     maxAngle: 52
-    angleIncrease: 6
+    angleIncrease: 11
     angleDecay: 24
     fireRate: 5 # 300 rpm
     soundGunshot:
@@ -163,8 +163,8 @@
     maxAngle: -17
   - type: Gun
     minAngle: 18
-    maxAngle: 35
-    angleIncrease: 4
+    maxAngle: 48
+    angleIncrease: 5
     angleDecay: 40
     fireRate: 11 # 660 rpm
     shotsPerBurst: 3
@@ -231,12 +231,12 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -20
-    maxAngle: -50
+    maxAngle: -27
   - type: Gun
     minAngle: 21
     maxAngle: 52
-    angleIncrease: 1.4
-    angleDecay: 24
+    angleIncrease: 7
+    angleDecay: 12
     fireRate: 4 #240 RPM, its semi-auto anyway
     selectedMode: SemiAuto
     availableModes:
@@ -288,13 +288,12 @@
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: GunWieldBonus
     minAngle: -27
-    maxAngle: -40
+    maxAngle: -26
   - type: Gun
     minAngle: 30
     maxAngle: 46
-    angleIncrease: 76
-    angleDecay: 7
-    cameraRecoilScalar: 0
+    angleIncrease: 2
+    angleDecay: 25
     fireRate: 3
     selectedMode: Burst
     soundGunshot:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -30,8 +30,8 @@
   - type: Gun
     minAngle: 21
     maxAngle: 48
-    angleIncrease: 27
-    angleDecay: 8
+    angleIncrease: 5
+    angleDecay: 14
     fireRate: 3 # 180 rpm
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -28,8 +28,8 @@
     maxAngle: -34
   - type: Gun
     minAngle: 21
-    maxAngle: 38
-    angleIncrease: 5
+    maxAngle: 74
+    angleIncrease: 2
     angleDecay: 20
     fireRate: 9.5
     soundGunshot:
@@ -75,7 +75,7 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -19
-    maxAngle: -34
+    maxAngle: -24
   - type: ChamberMagazineAmmoProvider
     soundRack:
       path: /Audio/Weapons/Guns/Cock/ltrifle_cock.ogg
@@ -83,9 +83,9 @@
     sprite: _Mono/Objects/Weapons/Guns/SMGs/ak220.rsi
   - type: Gun
     minAngle: 22
-    maxAngle: 40
-    fireRate: 6
-    angleIncrease: 21
+    maxAngle: 58
+    fireRate: 8
+    angleIncrease: 3
     angleDecay: 14
     selectedMode: FullAuto
     soundGunshot:
@@ -134,11 +134,15 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -5
-    maxAngle: -5
+    maxAngle: -14
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/SMGs/vector.rsi
   - type: Gun
     fireRate: 7.5
+    minAngle: 7
+    maxAngle: 40
+    angleIncrease: 3
+    angleDecay: 16
     selectedMode: Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -191,11 +195,15 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -5
-    maxAngle: -5
+    maxAngle: -14
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/SMGs/vector.rsi
   - type: Gun
     fireRate: 6
+    minAngle: 7
+    maxAngle: 40
+    angleIncrease: 5
+    angleDecay: 16
     selectedMode: Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -256,9 +264,9 @@
   - type: Gun
     fireRate: 6
     minAngle: 19
-    maxAngle: 21
-    angleIncrease: 16
-    angleDecay: 10
+    maxAngle: 32
+    angleIncrease: 9
+    angleDecay: 14
     selectedMode: Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -308,12 +316,12 @@
   components:
   - type: GunWieldBonus
     minAngle: -27
-    maxAngle: -45
+    maxAngle: -36
   - type: Gun
     minAngle: 30
     maxAngle: 55
-    angleIncrease: 18
-    angleDecay: 4
+    angleIncrease: 4
+    angleDecay: 12
     fireRate: 7
   - type: StaticPrice
     price: 500
@@ -333,12 +341,16 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
-    minAngle: -5
-    maxAngle: -5
+    minAngle: -27
+    maxAngle: -23
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/SMGs/drozd.rsi
   - type: Gun
     fireRate: 6
+    minAngle: 28
+    maxAngle: 42
+    angleIncrease: 4
+    angleDecay: 13
     selectedMode: FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -29,7 +29,9 @@
     maxAngle: -36
   - type: Gun
     minAngle: 27
-    maxAngle: 39
+    maxAngle: 54
+    angleIncrease: 8
+    angleDecay: 14
     fireRate: 2.25
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -250,8 +250,15 @@
     slots:
     - Back
     - suitStorage
+  - type: GunWieldBonus
+    minAngle: -27
+    maxAngle: -36
   - type: Gun
     fireRate: 1.9
+    angleIncrease: 15
+    angleDecay: 14
+    minAngle: 27
+    maxAngle: 54
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Redoes weapon accuracy on like all the semi/full auto guns like rifles, SMGs, DMRs, and LMGs
Basically like all weapons can have usable accuracy now, just maintain your accuracy by firing in bursts

## Why / Balance
I balanced guns around thinking recoil would increase max accuracy but instead recoils increases to the max accuracy or whatever, my mistake.
All guns changed were tested, recoil management is finally real in my 2d space game.

## How to test
do showgunspread in console, spawn in rifle/smg/lmg/dmr, fire and see the yellow lines adjust w/ recoil, watch them go down when not firing, whatever.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Properly implemented recoil gain/recovery on guns. SMGs/rifles/DMRs/LMGs should all be controllable now if you just fire in bursts. Also buffed firerate of Grizzly and AK-220. No more near perfect accuracy M-90, so sad for the 0 people using it.