### PR TITLE
Reenable Grand Lottery

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -230,12 +230,11 @@
 
 - type: cargoProduct
   id: FunCrateGambling
-  abstract: true # Frontier
   icon:
     sprite: Objects/Economy/cash.rsi
     state: cash_1000000
   product: CrateCargoGambling
-  cost: 1000000 # Frontier 10000<1000000 in the case this is added again by mistake.
+  cost: 10000 # Frontier 10000<1000000 in the case this is added again by mistake. # Mono - let's go gambling!
   category: cargoproduct-category-name-fun
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -1,3 +1,35 @@
+# SPDX-FileCopyrightText: 2021 Fishfish458
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2021 SweptWasTaken
+# SPDX-FileCopyrightText: 2022 Checkraze
+# SPDX-FileCopyrightText: 2022 EmoGarbage404
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2022 Rinkashikachi
+# SPDX-FileCopyrightText: 2022 Visne
+# SPDX-FileCopyrightText: 2022 keronshb
+# SPDX-FileCopyrightText: 2023 Arendian
+# SPDX-FileCopyrightText: 2023 Ed
+# SPDX-FileCopyrightText: 2023 Emisse
+# SPDX-FileCopyrightText: 2023 EnDecc
+# SPDX-FileCopyrightText: 2023 Gotimanga
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 Link
+# SPDX-FileCopyrightText: 2023 Nemanja
+# SPDX-FileCopyrightText: 2023 lapatison
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Houtblokje
+# SPDX-FileCopyrightText: 2024 Kukutis96513
+# SPDX-FileCopyrightText: 2024 MODERN
+# SPDX-FileCopyrightText: 2024 brainfood1183
+# SPDX-FileCopyrightText: 2024 checkraze
+# SPDX-FileCopyrightText: 2024 metalgearsloth
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 SpaceLizard
+# SPDX-FileCopyrightText: 2025 TeenSarlacc
+# SPDX-FileCopyrightText: 2025 Whatstone
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: cargoProduct
   id: FunInstrumentsVariety
   abstract: true # Frontier - Moved to AutoTune

--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -391,9 +391,10 @@
     - id: FoodPlateTin
       prob: 0.01
       orGroup: NotUseful
-    - id: WeakKudzu
-      prob: 0.01
-      orGroup: NotUseful
+    # Mono - 100% free lag
+    #- id: WeakKudzu
+    #  prob: 0.01
+    #  orGroup: NotUseful
     - id: MagazineFoamBox
       prob: 0.001
       orGroup: NotUseful

--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -1,3 +1,16 @@
+# SPDX-FileCopyrightText: 2023 EnDecc
+# SPDX-FileCopyrightText: 2024 Ed
+# SPDX-FileCopyrightText: 2024 EdenTheLiznerd
+# SPDX-FileCopyrightText: 2024 Emisse
+# SPDX-FileCopyrightText: 2024 IProduceWidgets
+# SPDX-FileCopyrightText: 2024 Moomoobeef
+# SPDX-FileCopyrightText: 2024 Mr. 27
+# SPDX-FileCopyrightText: 2024 checkraze
+# SPDX-FileCopyrightText: 2024 lzk
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: CrateCargoLuxuryHardsuit
   parent: CratePirate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- makes grand lottery orderable
- removes kudzu from loot pool so no 100% free lag

## Why / Balance
Let's go gambling!
we should also add more (50k, 400k?) tiers of gambling crates later to deflate the economy more

## How to test
go to cargo request console
gamble

## Media
<img width="566" height="68" alt="image" src="https://github.com/user-attachments/assets/c9f5261c-6751-42b0-9017-4f0ba518f8e6" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added gambling (reenabled grand lottery).
