### PR TITLE
Mech Tweaks

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -95,6 +95,12 @@
     - FootstepSound
     - RipleyMkII
     - CivilianMechBounty # Mono
+  - type: Prying # Mono
+    pryPowered: true
+    force: true
+    speedModifier: 3
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: MechRipley2Battery
@@ -161,6 +167,12 @@
     scale: 1.5
     requireNoGrid: true
     shape: square
+  - type: Prying # Mono
+    pryPowered: true
+    force: true
+    speedModifier: 3
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: MechClarkeBattery
@@ -242,6 +254,12 @@
     scale: 1.5
     requireNoGrid: true
     shape: square
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 5
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: MechGygaxBattery
@@ -315,6 +333,12 @@
     scale: 1.5
     requireNoGrid: true
     shape: square
+  - type: Prying # Mono
+    pryPowered: true
+    force: true
+    speedModifier: 5
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: MechDurandBattery
@@ -390,6 +414,12 @@
     scale: 1.5
     requireNoGrid: true
     shape: square
+  - type: Prying # Mono
+    pryPowered: true
+    force: true
+    speedModifier: 5
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: MechMarauderBattery
@@ -475,6 +505,12 @@
     scale: 1.5
     requireNoGrid: true
     shape: square
+  - type: Prying # Mono
+    pryPowered: true
+    force: true
+    speedModifier: 5
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: MechSeraphBattery
@@ -563,6 +599,12 @@
     scale: 1.5
     requireNoGrid: true
     shape: square
+  - type: Prying # Mono
+    pryPowered: true
+    force: true
+    speedModifier: 5
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: MechGygaxSyndieBattery
@@ -647,6 +689,12 @@
     scale: 1.5
     requireNoGrid: true
     shape: square
+  - type: Prying # Mono
+    pryPowered: true
+    force: true
+    speedModifier: 5
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: MechMaulerSyndieBattery

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Ark
 # SPDX-FileCopyrightText: 2025 Avalon
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -98,7 +98,7 @@
     - CivilianMechBounty # Mono
   - type: Prying # Mono
     pryPowered: true
-    speedModifier: 3
+    speedModifier: 2
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -169,7 +169,7 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    speedModifier: 3
+    speedModifier: 2
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -256,7 +256,7 @@
   - type: Prying
     pryPowered: true
     force: true
-    speedModifier: 5
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -334,7 +334,7 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    speedModifier: 5
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -414,7 +414,7 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    speedModifier: 5
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -504,7 +504,7 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    speedModifier: 5
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -597,7 +597,7 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    speedModifier: 5
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -686,7 +686,7 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    speedModifier: 5
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -97,7 +97,6 @@
     - CivilianMechBounty # Mono
   - type: Prying # Mono
     pryPowered: true
-    force: true
     speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -169,7 +168,6 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    force: true
     speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -335,7 +333,6 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    force: true
     speedModifier: 5
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -416,7 +413,6 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    force: true
     speedModifier: 5
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -507,7 +503,6 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    force: true
     speedModifier: 5
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -601,7 +596,6 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    force: true
     speedModifier: 5
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -691,7 +685,6 @@
     shape: square
   - type: Prying # Mono
     pryPowered: true
-    force: true
     speedModifier: 5
     useSound:
       path: /Audio/Items/jaws_pry.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -114,11 +114,10 @@
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
-    # Shit punching damage, equip a melee weapon if you want to get up close
     damage:
       types:
         Blunt: 25
-        Structural: 0
+        Structural: 260
   - type: Destructible
     thresholds:
     - trigger:
@@ -219,11 +218,10 @@
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
-    # Shit punching damage, equip a melee weapon if you want to get up close
     damage:
       types:
         Blunt: 25
-        Structural: 0
+        Structural: 260
   - type: Destructible
     thresholds:
     - trigger:
@@ -315,11 +313,10 @@
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
-    # Shit punching damage, equip a melee weapon if you want to get up close
     damage:
       types:
         Blunt: 25
-        Structural: 0
+        Structural: 260
   - type: Destructible
     thresholds:
     - trigger:
@@ -411,11 +408,10 @@
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
-    # Shit punching damage, equip a melee weapon if you want to get up close
     damage:
       types:
         Blunt: 50
-        Structural: 0
+        Structural: 550
   - type: Destructible
     thresholds:
     - trigger:
@@ -507,11 +503,10 @@
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
-    # Shit punching damage, equip a melee weapon if you want to get up close
     damage:
       types:
         Blunt: 50
-        Structural: 0
+        Structural: 550
   - type: Destructible
     thresholds:
     - trigger:
@@ -607,7 +602,7 @@
     damage:
       types:
         Blunt: 50
-        Structural: 0
+        Structural: 550
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Avalon
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 ScyronX

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -160,6 +160,12 @@
     - DoorBumpOpener
     - FootstepSound
     - Broadsword
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 7
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: AFInterceptorBattery
@@ -265,6 +271,13 @@
     - FootstepSound
     - Halberd
     - MilitaryMechBounty
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 7
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
+
 
 - type: entity
   id: AFInterceptorG
@@ -359,6 +372,12 @@
     - FootstepSound
     - Sabre
     - MilitaryMechBounty
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 7
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 #4x4 mechas
 - type: entity
@@ -455,6 +474,13 @@
     - FootstepSound
     - Flail
     - MilitaryMechBounty
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 10
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
+
 
 - type: entity
   id: AFFlailE
@@ -550,6 +576,12 @@
     - FootstepSound
     - Spyglass
     - MilitaryMechBounty
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 10
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
 
 - type: entity
   id: AFMace
@@ -646,3 +678,9 @@
     - FootstepSound
     - Mace
     - MilitaryMechBounty
+  - type: Prying
+    pryPowered: true
+    force: true
+    speedModifier: 10
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -163,7 +163,6 @@
     - Broadsword
   - type: Prying
     pryPowered: true
-    force: true
     speedModifier: 7
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -274,7 +273,6 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    force: true
     speedModifier: 7
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -375,7 +373,6 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    force: true
     speedModifier: 7
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -477,7 +474,6 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    force: true
     speedModifier: 10
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -579,7 +575,6 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    force: true
     speedModifier: 10
     useSound:
       path: /Audio/Items/jaws_pry.ogg
@@ -681,7 +676,6 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    force: true
     speedModifier: 10
     useSound:
       path: /Audio/Items/jaws_pry.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -163,7 +163,7 @@
     - Broadsword
   - type: Prying
     pryPowered: true
-    speedModifier: 7
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -273,7 +273,7 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    speedModifier: 7
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -373,7 +373,7 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    speedModifier: 7
+    speedModifier: 3
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -474,7 +474,7 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    speedModifier: 10
+    speedModifier: 5
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -575,7 +575,7 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    speedModifier: 10
+    speedModifier: 5
     useSound:
       path: /Audio/Items/jaws_pry.ogg
 
@@ -676,6 +676,6 @@
     - MilitaryMechBounty
   - type: Prying
     pryPowered: true
-    speedModifier: 10
+    speedModifier: 5
     useSound:
       path: /Audio/Items/jaws_pry.ogg


### PR DESCRIPTION
## About the PR
The larger mechs are now able to bust down airlocks instead of uselessly slapping them.

Mechs in general can now pry open doors, speed depends on mech size and type, via ALT left click

## Why / Balance
You're telling me a big fuckoff mech cant destroy/tear open a glass door?

**Changelog**
:cl:
- tweak: Large mechs can now damage structures with melee
- tweak: Mechs can now pry open doors (Alt Left Click)
