### PR TITLE
Make Liquid and Plasma Gas Canisters Buyable Again.

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -43,7 +43,7 @@
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: oxygen_liquid # Frontier blue<oxygen_liquid
   product: LiquidOxygenCanister
-  cost: 5000 # Mono - re-enable liquid gasses
+  cost: 15000 # Mono - re-enable liquid gasses
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -63,18 +63,17 @@
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: nitrogen_liquid # Frontier red<nitrogen_liquid
   product: LiquidNitrogenCanister
-  cost: 5000 # Mono - re-enable liquid gasses
+  cost: 12500 # Mono - re-enable liquid gasses
   category: cargoproduct-category-name-atmospherics
   group: market
 
 - type: cargoProduct
   id: AtmosphericsCarbonDioxide
-  abstract: true # Frontier
   icon:
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: carbon # Frontier black<carbon
   product: CarbonDioxideCanister
-  cost: 2200 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
+  cost: 8000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -84,7 +83,7 @@
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: carbon_liquid # Frontier black<carbon_liquid
   product: LiquidCarbonDioxideCanister
-  cost: 6000 # Mono - re-enable liquid gasses
+  cost: 16000 # Mono - re-enable liquid gasses
   category: cargoproduct-category-name-atmospherics
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -10,8 +10,10 @@
 # SPDX-FileCopyrightText: 2024 Dvir
 # SPDX-FileCopyrightText: 2024 Ilya246
 # SPDX-FileCopyrightText: 2024 MODERN
+# SPDX-FileCopyrightText: 2025 SRV
 # SPDX-FileCopyrightText: 2025 SarahRaven
 # SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 mikus
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -116,7 +116,7 @@
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: plasma # Frontier orange<plasma
   product: PlasmaCanister
-  cost: 5000 # Frontier: 4000<5000
+  cost: 7000 # Mono - Gas sell prices
   category: cargoproduct-category-name-atmospherics
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -37,12 +37,11 @@
 
 - type: cargoProduct
   id: AtmosphericsLiquidOxygen
-  abstract: true # Frontier
   icon:
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: oxygen_liquid # Frontier blue<oxygen_liquid
   product: LiquidOxygenCanister
-  cost: 2500
+  cost: 5000 # Mono - re-enable liquid gasses
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -58,12 +57,11 @@
 
 - type: cargoProduct
   id: AtmosphericsLiquidNitrogen
-  abstract: true # Frontier
   icon:
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: nitrogen_liquid # Frontier red<nitrogen_liquid
   product: LiquidNitrogenCanister
-  cost: 2500
+  cost: 5000 # Mono - re-enable liquid gasses
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -80,12 +78,11 @@
 
 - type: cargoProduct
   id: AtmosphericsLiquidCarbonDioxide
-  abstract: true # Frontier
   icon:
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: carbon_liquid # Frontier black<carbon_liquid
   product: LiquidCarbonDioxideCanister
-  cost: 4000
+  cost: 6000 # Mono - re-enable liquid gasses
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -112,8 +109,7 @@
 #  group: market
 
 - type: cargoProduct
-  id: AtmosphericsPlasma
-  abstract: true # Frontier
+  id: AtmosphericsPlasma # Mono - Make plasma canisters buyable again
   icon:
     sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
     state: plasma # Frontier orange<plasma


### PR DESCRIPTION
## About the PR
removes the abstract value from: liquid oxygen/nitrogen and basic plasma canisters
also makes liquid gasses a bit more pricy than their normal counterparts

## Why / Balance
why was plasma turned off? i don't even know
liquid oxygen and nitrogen are literally never used, ever.
everyone uses space lungs anyways so it doesn't hurt to turn these back on to spend a little bit of money to make your canisters last longer

## How to test
open console
see you can buy liquid oxygen/nitrogen and basic plasma canisters
buy
check sprites
check gas

:do:

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes

**Changelog**
:cl:
- add: Liquid oxygen/nitrogen canisters along with plasma canisters are buyable again.
