### PR TITLE
AI/Borg Understands All Languages

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -311,9 +311,43 @@
     speaks:
     - TauCetiBasic
     - RobotTalk
+    - Bubblish
+    - RootSpeak
+    - Nekomimetic
+    - Draconic
+    - SolCommon
+    - NovuNederic
+    - NovaCygniBasic
+    - Tradeband
+    - Freespeak
+    - Elyran
+    - Canilunzt
+    - Moffic
+    - Calcic
+    - Marish
+    - ValyrianStandard
+    - Chittin
+    - Xeeplian
     understands:
     - TauCetiBasic
     - RobotTalk
+    - Bubblish
+    - RootSpeak
+    - Nekomimetic
+    - Draconic
+    - SolCommon
+    - NovuNederic
+    - NovaCygniBasic
+    - Tradeband
+    - Freespeak
+    - Elyran
+    - Canilunzt
+    - Moffic
+    - Calcic
+    - Marish
+    - ValyrianStandard
+    - Chittin
+    - Xeeplian
   - type: ProtectedFromStepTriggers
   - type: DamageOnInteractProtection
     damageProtection:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -75,11 +75,45 @@
   - type: LanguageSpeaker # Einstein Engines - Language
   - type: LanguageKnowledge # Einstein Engines - Language
     speaks:
-    - TauCetiBasic
-    - RobotTalk
+      - TauCetiBasic
+      - RobotTalk
+      - Bubblish
+      - RootSpeak
+      - Nekomimetic
+      - Draconic
+      - SolCommon
+      - NovuNederic
+      - NovaCygniBasic
+      - Tradeband
+      - Freespeak
+      - Elyran
+      - Canilunzt
+      - Moffic
+      - Calcic
+      - Marish
+      - ValyrianStandard
+      - Chittin
+      - Xeeplian
     understands:
-    - TauCetiBasic
-    - RobotTalk
+      - TauCetiBasic
+      - RobotTalk
+      - Bubblish
+      - RootSpeak
+      - Nekomimetic
+      - Draconic
+      - SolCommon
+      - NovuNederic
+      - NovaCygniBasic
+      - Tradeband
+      - Freespeak
+      - Elyran
+      - Canilunzt
+      - Moffic
+      - Calcic
+      - Marish
+      - ValyrianStandard
+      - Chittin
+      - Xeeplian
 
 - type: entity
   parent: MMI
@@ -173,6 +207,40 @@
       speaks:
       - TauCetiBasic # Added since posi brains should be able to talk to roboticists/scientists.
       - RobotTalk
+      - Bubblish
+      - RootSpeak
+      - Nekomimetic
+      - Draconic
+      - SolCommon
+      - NovuNederic
+      - NovaCygniBasic
+      - Tradeband
+      - Freespeak
+      - Elyran
+      - Canilunzt
+      - Moffic
+      - Calcic
+      - Marish
+      - ValyrianStandard
+      - Chittin
+      - Xeeplian
       understands:
       - TauCetiBasic # Added since posi brains should be able to understand TauCetiBasic (they can in a chassis)
       - RobotTalk
+      - Bubblish
+      - RootSpeak
+      - Nekomimetic
+      - Draconic
+      - SolCommon
+      - NovuNederic
+      - NovaCygniBasic
+      - Tradeband
+      - Freespeak
+      - Elyran
+      - Canilunzt
+      - Moffic
+      - Calcic
+      - Marish
+      - ValyrianStandard
+      - Chittin
+      - Xeeplian


### PR DESCRIPTION
## About the PR
Now they can serve as a translator due to their extensive database of known languages.

**Changelog**
:cl:
- tweak: AI/Cyborgs can now speak/understand all languages
