### PR TITLE
Fixes Blip Error Spams, Also Fixes Blips Clipping Into Grids.

### DIFF
--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -65,7 +65,7 @@ public sealed partial class RadarBlipsSystem : EntitySystem
 
     private void RemoveBlip(BlipRemovalEvent args)
     {
-        var blipid = _blips.SingleOrDefault(x => x.netUid == args.NetBlipUid);
+        var blipid = _blips.FirstOrDefault(x => x.netUid == args.NetBlipUid);
         _blips.Remove(blipid);
     }
 

--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -68,11 +68,6 @@ public sealed partial class RadarBlipsSystem : EntitySystem
         _blips.Remove(blipid);
     }
 
-    private static bool EndsWithSaurus(String s)
-    {
-        return s.ToLower().EndsWith("saurus");
-    }
-
     public void RequestBlips(EntityUid console)
     {
         // Only request if we have a valid console

--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Ark
 // SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 ark1368
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -16,7 +16,7 @@ public sealed partial class RadarBlipsSystem : EntitySystem
 {
     private const double BlipStaleSeconds = 3.0;
     private static readonly List<(Vector2, float, Color, RadarBlipShape)> EmptyBlipList = new();
-    private static readonly List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> EmptyRawBlipList = new();
+    private static readonly List<(NetEntity netUid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> EmptyRawBlipList = new();
     private static readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> EmptyHitscanList = new();
     private TimeSpan _lastRequestTime = TimeSpan.Zero;
     private static readonly TimeSpan RequestThrottle = TimeSpan.FromMilliseconds(250);
@@ -28,7 +28,7 @@ public sealed partial class RadarBlipsSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xform = default!;
 
     private TimeSpan _lastUpdatedTime;
-    private List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> _blips = new();
+    private List<(NetEntity netUid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> _blips = new();
     private List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> _hitscans = new();
     private Vector2 _radarWorldPosition;
 
@@ -64,7 +64,7 @@ public sealed partial class RadarBlipsSystem : EntitySystem
 
     private void RemoveBlip(BlipRemovalEvent args)
     {
-        var blipid = _blips.SingleOrDefault(x => x.uid == args.BlipUid);
+        var blipid = _blips.SingleOrDefault(x => x.netUid == args.NetBlipUid);
         _blips.Remove(blipid);
     }
 

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -37,8 +37,6 @@ public sealed partial class RadarBlipSystem : EntitySystem
         if (!TryComp<RadarConsoleComponent>(radarUid, out var radar))
             return;
 
-        if (!TryComp<PhysicsComponent>(radarUid, out _))
-            return;
 
         var blips = AssembleBlipsReport((EntityUid)radarUid, radar);
         var hitscans = AssembleHitscanReport((EntityUid)radarUid, radar);
@@ -62,9 +60,9 @@ public sealed partial class RadarBlipSystem : EntitySystem
             // Check if the radar is on an FTL map
             var isFtlMap = HasComp<FTLComponent>(radarXform.GridUid);
 
-            var blipQuery = EntityQueryEnumerator<RadarBlipComponent, TransformComponent>();
+            var blipQuery = EntityQueryEnumerator<RadarBlipComponent, TransformComponent, PhysicsComponent>();
 
-            while (blipQuery.MoveNext(out var blipUid, out var blip, out var blipXform))
+            while (blipQuery.MoveNext(out var blipUid, out var blip, out var blipXform, out _))
             {
                 if (!blip.Enabled)
                     continue;
@@ -96,7 +94,7 @@ public sealed partial class RadarBlipSystem : EntitySystem
 
                 var blipVelocity = _physics.GetMapLinearVelocity(blipUid);
 
-                var distance = (blipXform.WorldPosition - radarPosition).Length();
+                var distance = (_xform.GetWorldPosition(blipXform) - radarPosition).Length();
                 if (distance > component.MaxRange)
                     continue;
 

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -63,7 +63,7 @@ public sealed partial class RadarBlipSystem : EntitySystem
 
             var blipQuery = EntityQueryEnumerator<RadarBlipComponent, TransformComponent, PhysicsComponent>();
 
-            while (blipQuery.MoveNext(out var blipUid, out var blip, out var blipXform, out _))
+            while (blipQuery.MoveNext(out var blipUid, out var blip, out var blipXform, out var blipPhysics))
             {
                 if (!blip.Enabled)
                     continue;
@@ -93,7 +93,7 @@ public sealed partial class RadarBlipSystem : EntitySystem
                 //         continue;
                 // }
 
-                var blipVelocity = _physics.GetMapLinearVelocity(blipUid);
+                var blipVelocity = _physics.GetMapLinearVelocity(blipUid, blipPhysics, blipXform);
 
                 var distance = (_xform.GetWorldPosition(blipXform) - radarPosition).Length();
                 if (distance > component.MaxRange)

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -49,13 +49,14 @@ public sealed partial class RadarBlipSystem : EntitySystem
 
     private void OnBlipShutdown(EntityUid blipUid, RadarBlipComponent component, ComponentShutdown args)
     {
-        var removalEv = new BlipRemovalEvent(blipUid);
+        var netBlipUid = GetNetEntity(blipUid);
+        var removalEv = new BlipRemovalEvent(netBlipUid);
         RaiseNetworkEvent(removalEv);
     }
 
-    private List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> AssembleBlipsReport(EntityUid uid, RadarConsoleComponent? component = null)
+    private List<(NetEntity netUid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> AssembleBlipsReport(EntityUid uid, RadarConsoleComponent? component = null)
     {
-        var blips = new List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)>();
+        var blips = new List<(NetEntity netUid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)>();
 
         if (Resolve(uid, ref component))
         {
@@ -77,6 +78,8 @@ public sealed partial class RadarBlipSystem : EntitySystem
                 // This prevents blips from showing on radars that are on different maps
                 if (blipXform.MapID != radarMapId)
                     continue;
+
+                var netBlipUid = GetNetEntity(blipUid);
 
                 var blipGrid = blipXform.GridUid;
 
@@ -117,7 +120,7 @@ public sealed partial class RadarBlipSystem : EntitySystem
                 if (blipGrid != null)
                     blipVelocity -= _physics.GetLinearVelocity(blipGrid.Value, coord.Position);
 
-                blips.Add((uid, GetNetCoordinates(coord), blipVelocity, blip.Scale, blip.RadarColor, blip.Shape));
+                blips.Add((netBlipUid, GetNetCoordinates(coord), blipVelocity, blip.Scale, blip.RadarColor, blip.Shape));
             }
         }
 

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Ark
 // SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 ark1368
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -20,14 +20,10 @@ public sealed partial class RadarBlipSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xform = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
-    private EntityQuery<PhysicsComponent> _physQuery;
-
     public override void Initialize()
     {
         base.Initialize();
         SubscribeNetworkEvent<RequestBlipsEvent>(OnBlipsRequested);
-
-        _physQuery = GetEntityQuery<PhysicsComponent>();
     }
 
     private void OnBlipsRequested(RequestBlipsEvent ev, EntitySessionEventArgs args)

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -37,6 +37,9 @@ public sealed partial class RadarBlipSystem : EntitySystem
         if (!TryComp<RadarConsoleComponent>(radarUid, out var radar))
             return;
 
+        if (!TryComp<PhysicsComponent>(radarUid, out _))
+            return;
+
         var blips = AssembleBlipsReport((EntityUid)radarUid, radar);
         var hitscans = AssembleHitscanReport((EntityUid)radarUid, radar);
 

--- a/Content.Shared/_Mono/Radar/RadarMessages.cs
+++ b/Content.Shared/_Mono/Radar/RadarMessages.cs
@@ -30,21 +30,21 @@ public sealed class GiveBlipsEvent : EntityEventArgs
     /// <summary>
     /// Blips are now (position, velocity, scale, color, shape).
     /// </summary>
-    public readonly List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> Blips;
+    public readonly List<(NetEntity uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> Blips;
 
     /// <summary>
     /// Hitscan lines to display on the radar as (start position, end position, thickness, color).
     /// </summary>
     public readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> HitscanLines;
 
-    public GiveBlipsEvent(List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips)
+    public GiveBlipsEvent(List<(NetEntity uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips)
     {
         Blips = blips;
         HitscanLines = new List<(Vector2 Start, Vector2 End, float Thickness, Color Color)>();
     }
 
     public GiveBlipsEvent(
-        List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips,
+        List<(NetEntity uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips,
         List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> hitscans)
     {
         Blips = blips;
@@ -65,10 +65,10 @@ public sealed class RequestBlipsEvent : EntityEventArgs
 [Serializable, NetSerializable]
 public sealed class BlipRemovalEvent : EntityEventArgs
 {
-    public EntityUid BlipUid { get; set; }
+    public NetEntity NetBlipUid { get; set; }
 
-    public BlipRemovalEvent(EntityUid blipUid)
+    public BlipRemovalEvent(NetEntity netBlipUid)
     {
-        BlipUid = blipUid;
+        NetBlipUid = netBlipUid;
     }
 }

--- a/Content.Shared/_Mono/Radar/RadarMessages.cs
+++ b/Content.Shared/_Mono/Radar/RadarMessages.cs
@@ -30,21 +30,21 @@ public sealed class GiveBlipsEvent : EntityEventArgs
     /// <summary>
     /// Blips are now (position, velocity, scale, color, shape).
     /// </summary>
-    public readonly List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> Blips;
+    public readonly List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> Blips;
 
     /// <summary>
     /// Hitscan lines to display on the radar as (start position, end position, thickness, color).
     /// </summary>
     public readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> HitscanLines;
 
-    public GiveBlipsEvent(List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips)
+    public GiveBlipsEvent(List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips)
     {
         Blips = blips;
         HitscanLines = new List<(Vector2 Start, Vector2 End, float Thickness, Color Color)>();
     }
 
     public GiveBlipsEvent(
-        List<(NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips,
+        List<(EntityUid uid, NetCoordinates Position, Vector2 Vel, float Scale, Color Color, RadarBlipShape Shape)> blips,
         List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> hitscans)
     {
         Blips = blips;
@@ -59,5 +59,16 @@ public sealed class RequestBlipsEvent : EntityEventArgs
     public RequestBlipsEvent(NetEntity radar)
     {
         Radar = radar;
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class BlipRemovalEvent : EntityEventArgs
+{
+    public EntityUid BlipUid { get; set; }
+
+    public BlipRemovalEvent(EntityUid blipUid)
+    {
+        BlipUid = blipUid;
     }
 }

--- a/Content.Shared/_Mono/Radar/RadarMessages.cs
+++ b/Content.Shared/_Mono/Radar/RadarMessages.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Ark
 // SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 ark1368
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

fixes 
```
[ERRO] resolve: Can't resolve "Robust.Shared.Physics.Components.PhysicsComponent" on entity 3491259!
   at System.Environment.get_StackTrace()
   at Content.Server._Mono.Radar.RadarBlipSystem.AssembleBlipsReport(EntityUid uid, RadarConsoleComponent component) in /home/runner/work/Monolith/Monolith/Content.Server/_Mono/Radar/RadarBlipSystem.cs:line 50
   at Content.Server._Mono.Radar.RadarBlipSystem.OnBlipsRequested(RequestBlipsEvent ev, EntitySessionEventArgs args) in /home/runner/work/Monolith/Monolith/Content.Server/_Mono/Radar/RadarBlipSystem.cs:line 40
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass4_0`1.<SubscribeEvent>b__0(Unit& ev) in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Broadcast.cs:line 173
   at Robust.Server.GameObjects.ServerEntityManager.DispatchEntityNetworkMessage(MsgEntity message) in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 230
   at Robust.Server.GameObjects.ServerEntityManager.TickUpdate(Single frameTime, Boolean noPredictions, Histogram histogram) in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Server/GameObjects/ServerEntityManager.cs:line 166
   at Robust.Server.BaseServer.Update(FrameEventArgs frameEventArgs) in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Server/BaseServer.cs:line 705
   at Robust.Shared.Timing.GameLoop.Run() in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Shared/Timing/GameLoop.cs:line 235
   at Robust.Server.BaseServer.MainLoop() in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Server/BaseServer.cs:line 572
   at Robust.Server.Program.ParsedMain(CommandLineArgs args, Boolean contentStart, ServerOptions options) in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Server/Program.cs:line 74
   at Robust.Server.Program.Start(String[] args, ServerOptions options, Boolean contentStart) in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Server/Program.cs:line 42
   at Robust.Server.Program.Main(String[] args) in /home/runner/work/Monolith/Monolith/RobustToolbox/Robust.Server/Program.cs:line 25
```
From shooting ship weaponry

also I did a little extra coding and fixed the tunneling issue for non-hitscan blips.

Uses componentshutdown for a radar blip component to make an event that transfers to clientside to tell clientside to remove the appropiate netEntity from the list, removing it instantly and bypassing the rate limiting applied to blips.

I also clear the serverside lists after they are sent to client too, that seemed kinda sus.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## Changelog
:cl:
fix: Some blip error spams.
fix: Normal projectile blips tunneling through walls.