### PR TITLE
Jupiter Network Device Fixes

### DIFF
--- a/Resources/Maps/_Mono/POI/jupiter.yml
+++ b/Resources/Maps/_Mono/POI/jupiter.yml
@@ -20022,8 +20022,6 @@ entities:
       pos: -14.5,27.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 29
   - uid: 61
@@ -20033,8 +20031,6 @@ entities:
       pos: -15.5,34.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 29
   - uid: 62
@@ -20044,8 +20040,6 @@ entities:
       pos: -12.5,33.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 29
   - uid: 63
@@ -20055,8 +20049,6 @@ entities:
       pos: -12.5,27.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 29
   - uid: 77
@@ -20066,8 +20058,6 @@ entities:
       pos: -13.5,36.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 29
   - uid: 3089
@@ -27240,8 +27230,6 @@ entities:
       pos: -14.5,33.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 29
     - type: AtmosPipeLayers
@@ -27763,8 +27751,6 @@ entities:
       pos: -14.5,31.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 29
     - type: AtmosPipeLayers
@@ -31857,8 +31843,6 @@ entities:
       pos: -1.5,45.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: SurveillanceCamera
       setupAvailableNetworks:
       - SurveillanceCameraRogue


### PR DESCRIPTION
## About the PR
just removes the invalid part of of these network devices cuz they work perfectly as intended.

## How to test
run the server no more Jupiter crapping out errors saying these networks are invalid when spawning it in when they are in fact valid and properly configured.

**Changelog**
:cl:
- fix: Fixed the network device errors on the Jupiter.
