### PR TITLE
Gcqueue Additions

### DIFF
--- a/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
@@ -29,9 +29,9 @@ public sealed class GCQueuePrototype : IPrototype
     public int Depth { get; }
 
     /// <summary>
-    ///     The amount of time in milliseconds spent deleting things for this queue, later multiplied by the total count of objects. Mono Dynamic Queueing
+    ///     How many miliseconds to spend deleting objects per object in the queue above the MinDepth? Mono Dynamic Queueing
     /// </summary>
-    [DataField("maximumTickTime")]
+    [DataField]
     public double TimeDeletePerObject { get; } = 0.1; // Mono - at 100 objects past the MinDepth will spend up to 10 milliseconds trying to do deletions
 
     /// <summary>

--- a/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
@@ -1,4 +1,13 @@
-﻿using Robust.Shared.Prototypes;
+// SPDX-FileCopyrightText: 2023 Cheackraze
+// SPDX-FileCopyrightText: 2023 Moony
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Checkraze
+// SPDX-FileCopyrightText: 2024 Dvir
+// SPDX-FileCopyrightText: 2025 Redrover1760
+//
+// SPDX-License-Identifier: MIT
+
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Worldgen.Prototypes;
 

--- a/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Cheackraze
+﻿// SPDX-FileCopyrightText: 2023 Cheackraze
 // SPDX-FileCopyrightText: 2023 Moony
 // SPDX-FileCopyrightText: 2023 metalgearsloth
 // SPDX-FileCopyrightText: 2024 Checkraze

--- a/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
+++ b/Content.Server/Worldgen/Prototypes/GCQueuePrototype.cs
@@ -20,10 +20,10 @@ public sealed class GCQueuePrototype : IPrototype
     public int Depth { get; }
 
     /// <summary>
-    ///     The maximum amount of time that can be spent processing this queue.
+    ///     The amount of time in milliseconds spent deleting things for this queue, later multiplied by the total count of objects. Mono Dynamic Queueing
     /// </summary>
     [DataField("maximumTickTime")]
-    public TimeSpan MaximumTickTime { get; } = TimeSpan.FromMilliseconds(3); // 1->3 Mono
+    public double TimeDeletePerObject { get; } = 0.1; // Mono - at 100 objects past the MinDepth will spend up to 10 milliseconds trying to do deletions
 
     /// <summary>
     ///     The minimum depth before entities in the queue actually get processed for deletion.

--- a/Content.Server/Worldgen/Systems/GC/GCQueueSystem.cs
+++ b/Content.Server/Worldgen/Systems/GC/GCQueueSystem.cs
@@ -48,7 +48,15 @@ public sealed class GCQueueSystem : EntitySystem
                 continue;
 
             queueWatch.Restart();
-            while (queueWatch.Elapsed < proto.MaximumTickTime && queue.Count >= proto.MinDepthToProcess &&
+
+            // Mono Begin - Dynamic Queue Times (Like League of Legends)
+            var entsOverDepth = Math.Abs(queue.Count - proto.MinDepthToProcess);
+            // We get a constant associated with the prototype, and multiply it by the count of objects in that prototype. Dynamic scaling, instead of static constants.
+            TimeSpan maxQueueTickTime = TimeSpan.FromMilliseconds(entsOverDepth * proto.TimeDeletePerObject);
+
+            // Mono End
+
+            while (queueWatch.Elapsed < maxQueueTickTime && queue.Count >= proto.MinDepthToProcess &&
                    overallWatch.Elapsed < _maximumProcessTime)
             {
                 var e = queue.Dequeue();

--- a/Content.Server/Worldgen/Systems/GC/GCQueueSystem.cs
+++ b/Content.Server/Worldgen/Systems/GC/GCQueueSystem.cs
@@ -1,4 +1,12 @@
-﻿using System.Linq;
+// SPDX-FileCopyrightText: 2023 Cheackraze
+// SPDX-FileCopyrightText: 2023 Moony
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Dvir
+// SPDX-FileCopyrightText: 2025 Redrover1760
+//
+// SPDX-License-Identifier: MIT
+
+using System.Linq;
 using Content.Server.Worldgen.Components.GC;
 using Content.Server.Worldgen.Prototypes;
 using Content.Shared.CCVar;

--- a/Resources/Prototypes/GC/world.yml
+++ b/Resources/Prototypes/GC/world.yml
@@ -1,5 +1,5 @@
 ﻿- type: gcQueue
   id: SpaceDebris
-  depth: 400 # Mono
-  minDepthToProcess: 50 # Mono
+  depth: 150 # Mono
+  minDepthToProcess: 25 # Mono
 #  trySkipQueue: true  # Frontier - Attempt immediate removal if possible # Mono Revert

--- a/Resources/Prototypes/GC/world.yml
+++ b/Resources/Prototypes/GC/world.yml
@@ -1,4 +1,14 @@
-﻿- type: gcQueue
+# SPDX-FileCopyrightText: 2023 Cheackraze
+# SPDX-FileCopyrightText: 2023 Moony
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2024 Checkraze
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 sleepyyapril
+#
+# SPDX-License-Identifier: MIT
+
+- type: gcQueue
   id: SpaceDebris
   depth: 150 # Mono
   minDepthToProcess: 25 # Mono


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
LICENSE: MIT
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

adds dynamic queued deletion. GCqueue will spend more time each tick trying to delete entities the fuller it is, and less time the less full it is.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

May help fix memory hell issues and stop spikes of lag.

Dynamic Queuing added for GCqueue for League of Legends. tm

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->


