### PR TITLE
Make Bananium Generators Not Contra Anymore

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Power/Generation/portable_generator.yml
@@ -62,7 +62,7 @@
     Highly radioactive without protection.
   parent:
   - PortableGeneratorSuperPacman
-  - BaseC2ContrabandUnredeemable # Need a doctor's note to run this.
+  # Mono - Not contraband
   id: PortableGeneratorDK
   suffix: Bananium, Rad+, 60 kW
   components:
@@ -136,7 +136,7 @@
     Runs off bananium and is rated for up to 100 kW.
     Quite radioactive without protection.
   parent:
-  - BaseC1Contraband # Mildly illegal. Just enough to add some spice to your life.
+  # Mono - Not contraband
   - PortableGeneratorDK
   id: PortableGeneratorDKJr
   suffix: Bananium, Rad-, 60 kW


### PR DESCRIPTION
## About the PR
literally just makes bananium generators not contra, i dont know why they were contra in the first place
i was going to make another PR that would do something else, but i saw this and got extremely confused
im surprised they haven't made the AME contra at this rate

## Why / Balance
why is a ship available generator contraband

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Bananium generators are no longer class 2 contraband.