### PR TITLE
The Great EMP Nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -223,7 +223,7 @@
     - type: TriggerImplantAction
     - type: EmpOnTrigger
       range: 2.75
-      energyConsumption: 2700000 # Frontier: 50000<2700000
+      energyConsumption: 2250 # 2700000-> 2250 - Mono
       disableDuration: 10
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -26,6 +26,7 @@
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2024 metalgearsloth
 # SPDX-FileCopyrightText: 2024 plykiya
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 LukeZurg22
 # SPDX-FileCopyrightText: 2025 Preston Smith
 # SPDX-FileCopyrightText: 2025 Redrover1760

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -883,8 +883,8 @@
     layers:
       - state: frag
   - type: EmpOnTrigger
-    range: 5
-    energyConsumption: 2700000
+    range: 3 # 5->3 - Mono
+    energyConsumption: 1550 #270000->1550 roughly 3-4 shots to fully drain a S2-S4 mech - Mono
     disableDuration: 10
   - type: Ammo
     muzzleFlash: null
@@ -1286,9 +1286,9 @@
     - state: emp_projectile
       shader: unshaded
   - type: EmpOnTrigger
-    range: 0.3
-    energyConsumption: 2700000
-    disableDuration: 10
+    range: 0.1 # 0.3-0.1 - Mono
+    energyConsumption: 50 # 270000-50 should not completely disable a S2-S4 mech with a single shot - Mono
+    disableDuration: 2 # 10->2 - Mono
 
 - type: entity
   id: BulletRocketEmp
@@ -1308,8 +1308,8 @@
     - state: frag-emp
   - type: EmpOnTrigger
     range: 4
-    energyConsumption: 2700000
-    disableDuration: 60
+    energyConsumption: 2700 # 2700000-2700 2 shots roughly are all you need to disable a S2-S4 mech - Mono
+    disableDuration: 10 # 60-10 - Mono
 
 - type: entity
   parent: BaseBulletTrigger
@@ -1343,8 +1343,8 @@
     lifetime: 15
   - type: EmpOnTrigger
     range: 2
-    energyConsumption: 2700000
-    disableDuration: 30
+    energyConsumption: 2250 # 270000->2250 only used for the EMP emitter - Mono
+    disableDuration: 10 # 30->10 - Mono
 
 - type: entity
   id: BulletCannonBallEmp
@@ -1368,8 +1368,8 @@
         Shock: 0
   - type: EmpOnTrigger
     range: 4
-    energyConsumption: 50000
-    disableDuration: 60
+    energyConsumption: 2250 # 50000->2250 yarr - Mono
+    disableDuration: 10 # 60->10 - Mono
 
 # DeltaV projectiles
 # For whatever magical reasons, I cannot put those in the DeltaV folders without having errors.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -54,6 +54,7 @@
 # SPDX-FileCopyrightText: 2024 Winkarst
 # SPDX-FileCopyrightText: 2024 checkraze
 # SPDX-FileCopyrightText: 2025 DVDPlayerOfDiscordFame
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 cheetah1984

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -355,8 +355,9 @@
   - type: Sprite
     sprite: Objects/Weapons/Grenades/empgrenade.rsi
   - type: EmpOnTrigger
-    range: 5.5
-    energyConsumption: 2700000 # Frontier: Upstream - #28984, 50000<2700000
+    range: 4 # 5.5->4 - Mono
+    energyConsumption: 1550 #270000->1550 roughly 3-4 shots to fully drain a S2-S4 mech - Mono
+    disableDuration: 10 # Mono
   - type: DeleteOnTrigger
   - type: Appearance
   - type: TimerTriggerVisuals

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -1,3 +1,56 @@
+# SPDX-FileCopyrightText: 2019 Injazz
+# SPDX-FileCopyrightText: 2019 Swept
+# SPDX-FileCopyrightText: 2020 AJCM-git
+# SPDX-FileCopyrightText: 2020 Hugo Laloge
+# SPDX-FileCopyrightText: 2020 Paul Ritter
+# SPDX-FileCopyrightText: 2020 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto
+# SPDX-FileCopyrightText: 2020 py01
+# SPDX-FileCopyrightText: 2021 BulletGrade
+# SPDX-FileCopyrightText: 2021 DrSmugleaf
+# SPDX-FileCopyrightText: 2021 Galactic Chimp
+# SPDX-FileCopyrightText: 2021 Visne
+# SPDX-FileCopyrightText: 2022 Alex Evgrashin
+# SPDX-FileCopyrightText: 2022 Moony
+# SPDX-FileCopyrightText: 2022 Peptide90
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2023 AlexMorgan3817
+# SPDX-FileCopyrightText: 2023 Arendian
+# SPDX-FileCopyrightText: 2023 Cody ~ Aexxie
+# SPDX-FileCopyrightText: 2023 Dawid Bla
+# SPDX-FileCopyrightText: 2023 Flareguy
+# SPDX-FileCopyrightText: 2023 Hmeister-fake
+# SPDX-FileCopyrightText: 2023 I.K
+# SPDX-FileCopyrightText: 2023 Slava0135
+# SPDX-FileCopyrightText: 2023 TemporalOroboros
+# SPDX-FileCopyrightText: 2023 crazybrain23
+# SPDX-FileCopyrightText: 2023 deltanedas
+# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2023 potato1234_x
+# SPDX-FileCopyrightText: 2024 DenisShvalov
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Firewatch
+# SPDX-FileCopyrightText: 2024 Ian
+# SPDX-FileCopyrightText: 2024 Kara
+# SPDX-FileCopyrightText: 2024 Leon Friedrich
+# SPDX-FileCopyrightText: 2024 Mangohydra
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 Plykiya
+# SPDX-FileCopyrightText: 2024 Saphire Lattice
+# SPDX-FileCopyrightText: 2024 Tayrtahn
+# SPDX-FileCopyrightText: 2024 Winkarst
+# SPDX-FileCopyrightText: 2024 deathride58
+# SPDX-FileCopyrightText: 2024 lzk
+# SPDX-FileCopyrightText: 2024 plykiya
+# SPDX-FileCopyrightText: 2025 BramvanZijp
+# SPDX-FileCopyrightText: 2025 Honestly101
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 keronshb
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: entity
   abstract: true
   parent: [BaseItem, RecyclableItemSteelSmall] # Frontier: added RecyclableItemSteelSmall

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/4.6x30mm.yml
@@ -104,10 +104,9 @@
   - type: CartridgeAmmo
     proto: Bullet46x30mmEmp
   - type: EmpDescription
-    range: 0.3
-    energyConsumption: 2700000
-    disableDuration: 10
-
+    range: 0.1 # 0.3-0.1 - Mono
+    energyConsumption: 50 # 270000-50 - Mono
+    disableDuration: 2 # 10->2 - Mono
 # Mono AP syst
 #anti-flesh:
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/4.6x30mm.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/45_ACP.yml
@@ -129,9 +129,9 @@
   - type: CartridgeAmmo
     proto: Bullet45_ACPEmp
   - type: EmpDescription
-    range: 0.3
-    energyConsumption: 2700000
-    disableDuration: 10
+    range: 0.1 # 0.3-0.1 - Mono
+    energyConsumption: 50 # 270000-50 - Mono
+    disableDuration: 2 # 10->2 - Mono
 
 # Mono AP syst
 #anti-flesh:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/45_ACP.yml
@@ -23,6 +23,7 @@
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2024 Winkarst
 # SPDX-FileCopyrightText: 2025 BramvanZijp
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/5.7x28mm.yml
@@ -104,9 +104,9 @@
   - type: CartridgeAmmo
     proto: Bullet57x28mmEmp
   - type: EmpDescription
-    range: 0.3
-    energyConsumption: 2700000
-    disableDuration: 10
+    range: 0.1 # 0.3-0.1 - Mono
+    energyConsumption: 50 # 270000-50 - Mono
+    disableDuration: 2 # 10->2 - Mono
 
 # Mono AP syst
 #anti-flesh:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/5.7x28mm.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/9x19mm.yml
@@ -129,9 +129,9 @@
   - type: CartridgeAmmo
     proto: Bullet9x19mmEmp
   - type: EmpDescription
-    range: 0.3
-    energyConsumption: 2700000
-    disableDuration: 10
+    range: 0.1 # 0.3-0.1 - Mono
+    energyConsumption: 50 # 270000-50 - Mono
+    disableDuration: 2 # 10->2 - Mono
 
 # Mono AP syst
 #anti-flesh:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/9x19mm.yml
@@ -23,6 +23,7 @@
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2024 Winkarst
 # SPDX-FileCopyrightText: 2025 BramvanZijp
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -169,9 +169,9 @@
     state: frag
     suffix: false
   - type: EmpDescription # Frontier
-    range: 5 # Frontier
-    energyConsumption: 2700000 # Frontier
-    disableDuration: 10 # Frontier
+    range: 3 # 5->3 - Mono
+    energyConsumption: 1550 #270000->1550 - Mono
+    disableDuration: 10
 
 # Cannon Balls
 
@@ -248,9 +248,9 @@
     sprite: _Mono/Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
     state: rpg-emp
   - type: EmpDescription
-    range: 6
-    energyConsumption: 4500000
-    disableDuration: 25
+    range: 4
+    energyConsumption: 2700 # 2700000-2700 - Mono
+    disableDuration: 10 # 60-10 - Mono
 
 # Cannon Balls
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -21,9 +21,11 @@
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2024 Winkarst
 # SPDX-FileCopyrightText: 2024 metalgearsloth
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 LukeZurg22
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 sleepyyapril
+# SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -49,8 +49,8 @@
   - type: Appearance
   - type: EmpDescription
     range: 2
-    energyConsumption: 2700000
-    disableDuration: 30
+    energyConsumption: 2250 # 270000->2250 - Mono
+    disableDuration: 10 # 30->10 - Mono
   - type: PirateBountyItem # Mono
     id: StandardFactionLongarm
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2025 Blu
 # SPDX-FileCopyrightText: 2025 BlueHNT
 # SPDX-FileCopyrightText: 2025 Daniel Lenrd
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 Redrover1760
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/crossbow_bolts.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/crossbow_bolts.yml
@@ -468,8 +468,8 @@
   - type: StaminaDamageOnCollide
     damage: 20
   - type: EmpOnTrigger
-    range: 0.5
-    energyConsumption: 2700000
+    range: 1 # 0.5->1 - Mono
+    energyConsumption: 1550 # 270000->1550 - Mono
     disableDuration: 10
   - type: PointLight
     radius: 1.3

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/crossbow_bolts.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/crossbow_bolts.yml
@@ -3,8 +3,10 @@
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2024 checkraze
 # SPDX-FileCopyrightText: 2025 GreaseMonk
+# SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 KiraZen_
 # SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/floor_trap.yml
+++ b/Resources/Prototypes/floor_trap.yml
@@ -57,7 +57,8 @@
       fixtureID: floortrap
     - type: EmpOnTrigger
       range: 2
-      energyConsumption: 270000 # Frontier: 5kJ<270kJ
+      energyConsumption: 4550 # 270000-4550 watch your step bozo - Mono
+      disableDuration: 10 # Mono
     - type: DeleteOnTrigger
 
 - type: entity

--- a/Resources/Prototypes/floor_trap.yml
+++ b/Resources/Prototypes/floor_trap.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Nim
+# SPDX-FileCopyrightText: 2025 Honestly101
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: entity
   id: CollideFloorTrap
   abstract: true


### PR DESCRIPTION
## About the PR
Nerfs alota of the weapon EMP values to not be completely busted, 45. ACP and such no longer one shots mechs into no energy but are still decent against such..

Ship emp weapons untouched, cuz well they are ship mounted, they are meant to be strong.

## Why / Balance
AUGH my emp.

**Changelog**
:cl:
- tweak:  Nerfed emp across the board, ship weapons unaffected.
