### PR TITLE
New Missile Tracking

### DIFF
--- a/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingComponent.cs
+++ b/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingComponent.cs
@@ -43,7 +43,7 @@ public sealed partial class TargetSeekingComponent : Component
     /// Tracking algorithm used for intercepting the target.
     /// </summary>
     [DataField]
-    public TrackingMethod TrackingAlgorithm = TrackingMethod.Predictive;
+    public TrackingMethod TrackingAlgorithm = TrackingMethod.AdvancedPredictive;
 
     /// <summary>
     /// How fast the projectile accelerates in m/s².

--- a/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingComponent.cs
+++ b/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingComponent.cs
@@ -69,12 +69,6 @@ public sealed partial class TargetSeekingComponent : Component
     public bool Launched = false;
 
     /// <summary>
-    /// Current speed of the projectile in m/s.
-    /// </summary>
-    [DataField]
-    public float CurrentSpeed;
-
-    /// <summary>
     /// The amount of time in seconds left the missile starts searching for targets. // Mono
     /// </summary>
     [DataField]
@@ -87,16 +81,6 @@ public sealed partial class TargetSeekingComponent : Component
     public float ScanArc = 90f;
 
     /// <summary>
-    /// Used for tracking metrics between updates.
-    /// </summary>
-    public float PreviousDistance;
-
-    /// <summary>
-    /// Previous position of the target, used for velocity calculation.
-    /// </summary>
-    public Vector2 PreviousTargetPosition;
-
-    /// <summary>
     /// Whether seeking has been disabled (e.g., after entering an enemy grid).
     /// </summary>
     public bool SeekingDisabled;
@@ -105,15 +89,21 @@ public sealed partial class TargetSeekingComponent : Component
 /// <summary>
 /// Defines different tracking algorithms that can be used.
 /// </summary>
+[Serializable]
 public enum TrackingMethod
 {
     /// <summary>
-    /// Advanced tracking that predicts target movement.
-    /// </summary>
-    Predictive = 1,
-
-    /// <summary>
     /// Basic tracking that simply points directly at the target.
     /// </summary>
-    Direct = 2
+    Direct = 1,
+
+    /// <summary>
+    /// Advanced tracking that predicts target movement.
+    /// </summary>
+    Predictive = 2,
+
+    /// <summary>
+    /// Even more accurate tracking.
+    /// </summary>
+    AdvancedPredictive = 3
 }

--- a/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingComponent.cs
+++ b/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingComponent.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 RikuTheKiller
 //

--- a/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingSystem.cs
+++ b/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingSystem.cs
@@ -80,7 +80,6 @@ public sealed class TargetSeekingSystem : EntitySystem
         var query = EntityQueryEnumerator<TargetSeekingComponent, PhysicsComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var seekingComp, out var body, out var xform))
         {
-            // Mono Begin
             var acceleration = seekingComp.Acceleration * frameTime;
             // Initialize launch speed.
             if (seekingComp.Launched == false)
@@ -111,16 +110,33 @@ public sealed class TargetSeekingSystem : EntitySystem
             }
 
             // If we have a target, track it using the selected algorithm
-            if (seekingComp.CurrentTarget.HasValue)
+            if (seekingComp.CurrentTarget.HasValue && !TerminatingOrDeleted(seekingComp.CurrentTarget))
             {
-                if (seekingComp.TrackingAlgorithm == TrackingMethod.Predictive)
+                var target = seekingComp.CurrentTarget.Value;
+                var targetXform = Transform(target);
+                Angle wantAngle = new Angle(0);
+
+                var ourEnt = (uid, seekingComp, xform);
+                var targEnt = (target, targetXform);
+
+                switch (seekingComp.TrackingAlgorithm)
                 {
-                    ApplyPredictiveTracking(uid, seekingComp, xform, frameTime);
+                    case TrackingMethod.Direct:
+                        wantAngle = ApplyDirectTracking(ourEnt, targEnt, frameTime); break;
+                    case TrackingMethod.Predictive:
+                        wantAngle = ApplyPredictiveTracking(ourEnt, targEnt, frameTime); break;
+                    case TrackingMethod.AdvancedPredictive:
+                        wantAngle = ApplyAdvancedTracking(ourEnt, targEnt, frameTime); break;
                 }
-                else
-                {
-                    ApplyDirectTracking(uid, seekingComp, xform, frameTime);
-                }
+
+                _rotateToFace.TryRotateTo(
+                    uid,
+                    wantAngle,
+                    frameTime,
+                    seekingComp.Tolerance,
+                    seekingComp.TurnRate?.Theta ?? MathF.PI * 2,
+                    xform
+                );
             }
             else
             {
@@ -194,43 +210,32 @@ public sealed class TargetSeekingSystem : EntitySystem
 
         // Set our new target
         if (bestTarget.HasValue)
-        {
             component.CurrentTarget = bestTarget;
-
-            // Initialize tracking data
-            if (TryComp<TransformComponent>(bestTarget, out var targetXform))
-            {
-                component.PreviousTargetPosition = _transform.ToMapCoordinates(targetXform.Coordinates).Position;
-                component.PreviousDistance = closestDistance;
-            }
-        }
     }
 
     /// <summary>
     /// Advanced tracking that predicts where the target will be based on its velocity.
     /// </summary>
-    public void ApplyPredictiveTracking(EntityUid uid, TargetSeekingComponent comp, TransformComponent xform, float frameTime)
+    public Angle ApplyPredictiveTracking(Entity<TargetSeekingComponent, TransformComponent> ent, Entity<TransformComponent> target, float frameTime)
     {
-        if (!comp.CurrentTarget.HasValue || !TryComp<TransformComponent>(comp.CurrentTarget.Value, out var targetXform))
-        {
-            return;
-        }
+        if (!TryComp<PhysicsComponent>(target, out var targetBody) || !TryComp<PhysicsComponent>(ent, out var body))
+            return new Angle(0);
 
         // Get current positions
-        var currentTargetPosition = _transform.ToMapCoordinates(targetXform.Coordinates).Position;
-        var sourcePosition = _transform.ToMapCoordinates(xform.Coordinates).Position;
+        var currentTargetPosition = _transform.GetWorldPosition(target.Comp);
+        var sourcePosition = _transform.GetWorldPosition(ent.Comp2);
 
         // Calculate current distance
-        var currentDistance = Vector2.Distance(sourcePosition, currentTargetPosition);
+        var toTargetVec = currentTargetPosition - sourcePosition;
+        var currentDistance = toTargetVec.Length();
 
-        // Calculate target velocity
-        var targetVelocity = currentTargetPosition - comp.PreviousTargetPosition;
+        var targetVelocity = _physics.GetMapLinearVelocity(target, targetBody, target.Comp);
+        var ourVelocity = _physics.GetMapLinearVelocity(ent, body, ent.Comp2);
+        var relVel = ourVelocity - targetVelocity;
 
         // Calculate time to intercept (using closing rate)
-        var closingRate = (comp.PreviousDistance - currentDistance);
-        var timeToIntercept = closingRate > 0.01f ?
-            currentDistance / closingRate :
-            currentDistance / comp.CurrentSpeed;
+        var closingRate = Vector2.Dot(relVel, toTargetVec) / toTargetVec.Length();
+        var timeToIntercept = currentDistance / closingRate;
 
         // Prevent negative or very small intercept times that could cause erratic behavior
         timeToIntercept = MathF.Max(timeToIntercept, 0.1f);
@@ -241,45 +246,63 @@ public sealed class TargetSeekingSystem : EntitySystem
         // Calculate angle to the predicted position
         var targetAngle = (predictedPosition - sourcePosition).ToWorldAngle();
 
-        // Rotate toward that angle at our turn rate
-        _rotateToFace.TryRotateTo(
-            uid,
-            targetAngle,
-            frameTime,
-            comp.Tolerance,
-            comp.TurnRate?.Theta ?? MathF.PI * 2,
-            xform
-        );
+        return targetAngle;
+    }
 
-        // Update tracking data for next frame
-        comp.PreviousTargetPosition = currentTargetPosition;
-        comp.PreviousDistance = currentDistance;
+    /// <summary>
+    /// More advanced and accurate tracking.
+    /// Works best for missiles with low friction and high max speed, where they spend all or most of their lifetime accelerating and being under max speed.
+    /// </summary>
+    // see: https://github.com/Ilya246/orbitfight/blob/master/src/entities.cpp for original
+    public Angle ApplyAdvancedTracking(Entity<TargetSeekingComponent, TransformComponent> ent, Entity<TransformComponent> target, float frameTime)
+    {
+        if (!TryComp<PhysicsComponent>(target, out var targetBody) || !TryComp<PhysicsComponent>(ent, out var body))
+            return new Angle(0);
+
+        const int guidanceIterations = 3;
+
+        var accel = ent.Comp1.Acceleration;
+
+        var ownVel    = _physics.GetMapLinearVelocity(ent);
+        var ownPos    = _transform.GetWorldPosition(ent.Comp2);
+        var targetVel = _physics.GetMapLinearVelocity(target);
+        var targetPos = _transform.GetWorldPosition(target.Comp);
+        var relVel = targetVel - ownVel;
+        var relPos = targetPos - ownPos;
+
+        var dVx    = relVel.X;
+        var dVy    = relVel.Y;
+        var dX     = relPos.X;
+        var dY     = relPos.Y;
+        var refRot = MathF.Atan2(dVy, dVx);
+        var vel    = dVx / MathF.Cos(refRot);
+        var projX  = dX * MathF.Cos(refRot) + dY * MathF.Sin(refRot);
+        var projY  = dY * MathF.Cos(refRot) - dX * MathF.Sin(refRot);
+        var itime  = GuessInterceptTime(0f, -projX, -vel, projY, accel);
+        for (var i = 0; i < guidanceIterations; i++)
+            itime = GuessInterceptTime(itime, -projX, -vel, projY, accel);
+
+        var targetRot = (relPos + relVel * itime).ToWorldAngle();
+
+        return targetRot;
+
+        // the explanation for how this works would take more space than the enclosing method so it's not included here
+        float GuessInterceptTime(float prev, float x0, float vel, float y0, float accel) {
+            var x  = x0 + vel * prev;
+            var d  = MathF.Sqrt(x * x + y0 * y0);
+            var dd = vel * x / d;
+            return (dd + MathF.Sqrt(dd * dd + 2f * accel * (d - dd * prev))) / (accel);
+        }
     }
 
     /// <summary>
     /// Basic tracking that points directly at the current target position.
     /// </summary>
-    public void ApplyDirectTracking(EntityUid uid, TargetSeekingComponent comp, TransformComponent xform, float frameTime)
+    public Angle ApplyDirectTracking(Entity<TargetSeekingComponent, TransformComponent> ent, Entity<TransformComponent> target, float frameTime)
     {
-        if (!comp.CurrentTarget.HasValue || !TryComp<TransformComponent>(comp.CurrentTarget.Value, out var targetXform))
-        {
-            return;
-        }
-
         // Get the angle directly toward the target
-        var angleToTarget = (
-            _transform.ToMapCoordinates(targetXform.Coordinates).Position -
-            _transform.ToMapCoordinates(xform.Coordinates).Position
-        ).ToWorldAngle();
+        var angleToTarget = (_transform.GetWorldPosition(target.Comp) - _transform.GetWorldPosition(ent.Comp2)).ToWorldAngle();
 
-        // Rotate toward that angle at our turn rate
-        _rotateToFace.TryRotateTo(
-            uid,
-            angleToTarget,
-            frameTime,
-            comp.Tolerance,
-            comp.TurnRate?.Theta ?? MathF.PI * 2,
-            xform
-        );
+        return angleToTarget;
     }
 }

--- a/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingSystem.cs
+++ b/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 RikuTheKiller
 //

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Blu
 # SPDX-FileCopyrightText: 2025 Disguised Bear
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 RikuTheKiller
 # SPDX-FileCopyrightText: 2025 core-mene

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -208,4 +208,3 @@
     launchSpeed: 50
     maxSpeed: 125
     trackDelay: 0.6
-    trackingAlgorithm: AdvancedPredictive

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -207,3 +207,4 @@
     launchSpeed: 50
     maxSpeed: 125
     trackDelay: 0.6
+    trackingAlgorithm: AdvancedPredictive


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- minor refactor of the system/comp
- adds new tier of missile tracking
- gives it to tovek

## Why / Balance
emp missiles being more likely to hit you seems good
though i'm pretty sure it's physically undodgeable with our ships, considering the place this was originally intended for and worked well in

## How to test
spawn calypso near station
make it move via vv
shoot missiles at it
watch them not miss even if you change its velocity
OR
spawn baeg
spawn tovek on station
bind station tovek to baeg shuttle console signal port 1
get to a distance in baeg
fail to dodge missile

## Media
baeg is too slow to dodge

<img width="325" height="304" alt="image" src="https://github.com/user-attachments/assets/a3b366c1-73e7-44ac-b453-26b164347c05" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: All missiles now have a further improved tracking algorithm.
