### PR TITLE
Buff Plasma Lance Direct Damage and HP

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -143,7 +143,7 @@
   - type: ShipGunClass
     shipClass: Heavy
 
-# Plasma lance
+# T241 plasma lance
 
 - type: entity
   id: WeaponTurretType241
@@ -206,7 +206,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 35000
+        damage: 70000
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -98,9 +98,9 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 200
-        Structural: 300
-        Heat: 400
+        Radiation: 700
+        Structural: 4000
+        Heat: 5000
         Ion: 500
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/plasmashot.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes plasma lance direct damage way stronger

## Why / Balance
Gigahot scifi plasma or whatever, I dont care. I need more power.

Asakim Warriors explaining how glassing everything from a wyvern is extremely high honor

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Buffed direct (not explosion) damage of superheavy ship plasma lance (from 700/1400 hull/shield damage to 9000/10200 hull/shield damage per projectile)
- tweak: Doubled HP of ship plasma lance to make it harder to destroy.