### PR TITLE
Make apocalypse more accurate to name

### DIFF
--- a/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_events.yml
+++ b/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_events.yml
@@ -1,0 +1,86 @@
+# Seperate versions of ADS shuttles with different weights and whatnot
+
+- type: entityTable
+  id: DamagedAIShipsTableApocalypse
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+    - id: UnknownShuttleZenithApoc
+    - id: UnknownShuttleZenithEApoc
+    - id: UnknownShuttleRazorApoc
+    - id: UnknownShuttleNebulaApoc
+    - id: UnknownShuttleWyvernApoc
+
+- type: entity
+  parent: BaseRandomShuttleRule
+  id: UnknownShuttleZenithApoc
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ai-shuttle-detected
+    startAudio:
+      path: /Audio/Misc/notice1.ogg
+    weight: 7
+    maxOccurrences: 12
+  - type: GameRule
+    minPlayers: 32
+  - type: LoadMapRule
+    preloadedGrid: AIZenith
+
+- type: entity
+  parent: BaseRandomShuttleRule
+  id: UnknownShuttleZenithEApoc
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ai-shuttle-detected
+    startAudio:
+      path: /Audio/Misc/notice1.ogg
+    weight: 7
+    maxOccurrences: 6
+  - type: GameRule
+    minPlayers: 10
+  - type: LoadMapRule
+    preloadedGrid: AIZenithE
+
+- type: entity
+  parent: BaseRandomShuttleRule
+  id: UnknownShuttleNebulaApoc
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ai-shuttle-detected
+    startAudio:
+      path: /Audio/Misc/notice1.ogg
+    weight: 4
+    maxOccurrences: 8
+  - type: GameRule
+    minPlayers: 10
+  - type: LoadMapRule
+    preloadedGrid: AINebula
+
+- type: entity
+  parent: BaseRandomShuttleRule
+  id: UnknownShuttleRazorApoc
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ai-shuttle-detected
+    startAudio:
+      path: /Audio/Misc/notice1.ogg
+    weight: 2 # Its boring to be honest.
+    maxOccurrences: 8
+  - type: GameRule
+    minPlayers: 10
+  - type: LoadMapRule
+    preloadedGrid: AIRazor
+
+- type: entity
+  parent: BaseRandomShuttleRule
+  id: UnknownShuttleWyvernApoc
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-ai-capital-detected
+    startAudio:
+      path: /Audio/Misc/delta_alt.ogg
+    weight: 1 # Lower since it can spawn at any time in round on apoc, and it can spawn three times max.
+    maxOccurrences: 3
+  - type: GameRule
+    minPlayers: 30
+  - type: LoadMapRule
+    preloadedGrid: AIWyvern

--- a/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_schedulers.yml
+++ b/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_schedulers.yml
@@ -1,0 +1,35 @@
+- type: entity
+  id: MonoChimeraSTCShuttleSpawnerSchedulerApocalypse
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: ChimeraShipsTable
+    minimumTimeUntilFirstEvent: 3600 # 60 minutes
+    minMaxEventTiming:
+      min: 1800 # 30 minutes between events
+      max: 1800 # 30 minutes between events
+
+- type: entity
+  id: MonoAISTCShuttleSpawnerSchedulerApocalypse
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: DamagedAIShipsTableApocalypse
+    minimumTimeUntilFirstEvent: 3600 # 60 minutes
+    minMaxEventTiming:
+      min: 1800 # 30 minutes between events
+      max: 1800 # 30 minutes between events
+
+- type: entity
+  id: MonoAsakimSTCShuttleSpawnerSchedulerApocalypse
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: AsakimShipsTable
+    minimumTimeUntilFirstEvent: 1800 # 30 minutes
+    minMaxEventTiming:
+      min: 3600 # 60 minutes between events
+      max: 3600 # 60 minutes between events

--- a/Resources/Prototypes/_Mono/GameRules/Shuttles/ship_spawns.yml
+++ b/Resources/Prototypes/_Mono/GameRules/Shuttles/ship_spawns.yml
@@ -5,54 +5,54 @@
 - type: preloadedGrid
   id: AIZenith
   path: /Maps/_Mono/ShuttleEvent/zenith.yml
-  copies: 6
+  copies: 12
 
 - type: preloadedGrid
   id: AIZenithE
   path: /Maps/_Mono/ShuttleEvent/zenith_e.yml
-  copies: 2
+  copies: 12
 
 - type: preloadedGrid
   id: AINebula
   path: /Maps/_Mono/ShuttleEvent/nebula.yml
-  copies: 6
+  copies: 12
 
 - type: preloadedGrid
   id: AIRazor
   path: /Maps/_Mono/ShuttleEvent/razor.yml
-  copies: 8
+  copies: 12
 
 - type: preloadedGrid
   id: AIWyvern
   path: /Maps/_Mono/ShuttleEvent/wyvern.yml
-  copies: 1
+  copies: 3
 
 - type: preloadedGrid
   id: AsakimSmall
   path: /Maps/_Mono/ShuttleEvent/asakim_small.yml
-  copies: 4
+  copies: 6
 
 - type: preloadedGrid
   id: AsakimMedium
   path: /Maps/_Mono/ShuttleEvent/asakim_medium.yml
-  copies: 4
+  copies: 6
 
 - type: preloadedGrid
   id: ChimeraSakuratsu
   path: /Maps/_Mono/ShuttleEvent/sakuratsu_chimera.yml
-  copies: 1
+  copies: 6
 
 - type: preloadedGrid
   id: ChimeraOlympus
   path: /Maps/_Mono/ShuttleEvent/olympus_chimera.yml
-  copies: 1
+  copies: 3
 
 - type: preloadedGrid
   id: ChimeraTethys
   path: /Maps/_Mono/ShuttleEvent/tethys_chimera.yml
-  copies: 2
+  copies: 6
 
 - type: preloadedGrid
   id: ChimeraLegionnaire
   path: /Maps/_Mono/ShuttleEvent/legionnaire_chimera.yml
-  copies: 2
+  copies: 6

--- a/Resources/Prototypes/_Mono/GameRules/chimera.yml
+++ b/Resources/Prototypes/_Mono/GameRules/chimera.yml
@@ -21,7 +21,7 @@
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
-    maxOccurrences: 1
+    maxOccurrences: 6 # You may think this is absurd, but it can only spawn 4 events max in normal schedulers anyways.
   - type: GameRule
     minPlayers: 40
   - type: LoadMapRule
@@ -36,7 +36,7 @@
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
-    maxOccurrences: 1
+    maxOccurrences: 3 # You may think this is absurd, but it can only spawn 4 events max in normal schedulers anyways.
   - type: GameRule
     minPlayers: 40
   - type: LoadMapRule
@@ -51,7 +51,7 @@
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
-    maxOccurrences: 2
+    maxOccurrences: 6 # You may think this is absurd, but it can only spawn 4 events max in normal schedulers anyways.
   - type: GameRule
     minPlayers: 40
   - type: LoadMapRule
@@ -66,7 +66,7 @@
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
-    maxOccurrences: 2
+    maxOccurrences: 6 # You may think this is absurd, but it can only spawn 4 events max in normal schedulers anyways.
   - type: GameRule
     minPlayers: 40
   - type: LoadMapRule

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -78,6 +78,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoAISTCShuttleSpawnerScheduler
+  - MonoAISTCShuttleSpawnerSchedulerTier2
   - MonoAsakimSTCShuttleSpawnerScheduler
 
 - type: gamePreset
@@ -108,7 +109,7 @@
   - BluespaceSalvageEventScheduler
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
-  - MonoAISTCShuttleSpawnerScheduler
-  - MonoAsakimSTCShuttleSpawnerScheduler
-  - MonoChimeraSTCShuttleSpawnerScheduler
+  - MonoChimeraSTCShuttleSpawnerSchedulerApocalypse
+  - MonoAISTCShuttleSpawnerSchedulerApocalypse
+  - MonoAsakimSTCShuttleSpawnerSchedulerApocalypse
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives apocalypse gigabuffed event schedulers (only 30 minutes between events, can spawn way more max, only needs 1 hour before its allowed to spawn ADS capital and it can spawn it 3 times)

Also fixes remnants not having tier2 ADS scheduler :trollface:

## Why / Balance
Accurate to name

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Apocalypse game preset should be more accurate to name now. All events only need 60 minutes threshold to spawn now, and only have 30 minutes in between events. Do you want 3 ADS capitals?
- fix: Fixed ADS game preset missing the scheduler for more intense ADS spawns after 5 hours. I cant really explain it in a better way.