### PR TITLE
Detection Rework Fixes

### DIFF
--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -364,7 +364,7 @@ public sealed partial class MapScreen : BoxContainer
                 var hideLabel = iffComp != null && (iffComp.Flags & IFFFlags.HideLabel) != 0x0 && grid.Owner != _shuttleEntity; // never hide our own label
                 var detectionLevel = _console == null ? DetectionLevel.Detected : _detection.IsGridDetected(grid.Owner, _console.Value);
                 var detected = detectionLevel != DetectionLevel.Undetected || !hideLabel;
-                if (!detected)
+                if (!detected || iffComp != null && (iffComp.Flags & IFFFlags.Hide) != 0x0)
                     continue;
                 var name = hideLabel ?
                     detectionLevel == DetectionLevel.PartialDetected ?
@@ -376,7 +376,7 @@ public sealed partial class MapScreen : BoxContainer
                 {
                     Name = name, // Mono
                     Entity = grid.Owner,
-                    HideButton = iffComp != null && (iffComp.Flags & IFFFlags.HideLabel) != 0x0,
+                    HideButton = iffComp != null && (iffComp.Flags & IFFFlags.HideLabelAlways) != 0x0,
                 };
 
                 // Always show our shuttle immediately

--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -164,7 +164,7 @@
                         <controls:SliderIntInput Name="MaximumIFFDistanceValue"
                                                  Access="Public"
                                                  MinValue="0"
-                                                 MaxValue="3000"
+                                                 MaxValue="30000"
                                                  Value="3000"
                                                  HorizontalExpand="True"/>
                     </controls:BoxContainer>

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -394,11 +394,11 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
             var hideLabel = iffComp != null && (iffComp.Flags & IFFFlags.HideLabel) != 0x0;
             var detectionLevel = _console == null ? DetectionLevel.Detected : _detection.IsGridDetected(grid.Owner, _console.Value);
             var detected = detectionLevel != DetectionLevel.Undetected || !hideLabel;
-            var blipOnly = detectionLevel == DetectionLevel.PartialDetected;
+            var blipOnly = detectionLevel != DetectionLevel.Detected;
             if (!detected)
                 continue;
 
-            var gridColor = blipOnly ? Color.Orange : _shuttles.GetIFFColor(grid, self: _shuttleEntity == grid.Owner, component: iffComp);
+            var gridColor = hideLabel ? blipOnly ? Color.Orange : Color.White : _shuttles.GetIFFColor(grid, self: _shuttleEntity == grid.Owner, component: iffComp);
 
             var existingVerts = _verts.GetOrNew(gridColor);
             var existingEdges = _edges.GetOrNew(gridColor);

--- a/Content.Client/_Mono/FireControl/UI/FireControlNavControl.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlNavControl.cs
@@ -31,43 +31,15 @@ using Robust.Shared.Timing;
 
 namespace Content.Client._Mono.FireControl.UI;
 
-// TODO: make this not a copypaste of ShuttleNavControl
-public sealed class FireControlNavControl : BaseShuttleControl
+public sealed class FireControlNavControl : ShuttleNavControl
 {
-    [Dependency] private readonly IMapManager _mapManager = default!;
-    private readonly DetectionSystem _detection; // Mono
-    private readonly SharedShuttleSystem _shuttles;
     private readonly SharedTransformSystem _transform;
-    private readonly IEntitySystemManager _sysManager = default!;
-    private readonly RadarBlipsSystem _blips;
     private readonly SharedPhysicsSystem _physics;
-
-    private EntityCoordinates? _coordinates;
-    private EntityUid? _consoleEntity;
-    private Angle? _rotation;
-    private Dictionary<NetEntity, List<DockingPortState>> _docks = new();
+    private readonly RadarBlipsSystem _blips;
 
     private EntityUid? _activeConsole;
     private FireControllableEntry[]? _controllables;
     private HashSet<NetEntity> _selectedWeapons = new();
-
-    private List<Entity<MapGridComponent>> _grids = new();
-
-    #region Mono
-
-    private const float RadarUpdateInterval = 0f;
-    private float _updateAccumulator = 0f;
-    #endregion
-
-    private bool _isMouseDown;
-    private bool _isMouseInside;
-    private Vector2 _lastMousePos;
-    private float _lastFireTime;
-    private const float FireRateLimit = 0.1f;
-
-    public Action<EntityCoordinates>? OnRadarClick;
-    public bool ShowIFF { get; set; } = true;
-    public bool RotateWithEntity { get; set; } = true;
 
     // Add a limit to how often we update the cursor position to prevent network spam
     private float _lastCursorUpdateTime = 0f;
@@ -76,145 +48,34 @@ public sealed class FireControlNavControl : BaseShuttleControl
     public FireControlNavControl() : base(64f, 512f, 512f)
     {
         IoCManager.InjectDependencies(this);
-        _detection = EntManager.System<DetectionSystem>(); // Mono
-        _shuttles = EntManager.System<SharedShuttleSystem>();
-        _transform = EntManager.System<SharedTransformSystem>();
         _blips = EntManager.System<RadarBlipsSystem>();
         _physics = EntManager.System<SharedPhysicsSystem>();
-
-        OnMouseEntered += HandleMouseEntered;
-        OnMouseExited += HandleMouseExited;
+        _transform = EntManager.System<SharedTransformSystem>();
     }
 
     protected override void MouseMove(GUIMouseMoveEventArgs args)
     {
         base.MouseMove(args);
         if (_isMouseInside)
-        {
-            _lastMousePos = args.RelativePosition;
-
             // Continuously update the cursor position for guided missiles
             TryUpdateCursorPosition(_lastMousePos);
-        }
-    }
-
-    private void HandleMouseEntered(GUIMouseHoverEventArgs args)
-    {
-        _isMouseInside = true;
-        _lastMousePos = UserInterfaceManager.MousePositionScaled.Position - GlobalPosition;
-    }
-
-    private void HandleMouseExited(GUIMouseHoverEventArgs args)
-    {
-        _isMouseInside = false;
-    }
-
-    protected override void KeyBindDown(GUIBoundKeyEventArgs args)
-    {
-        base.KeyBindDown(args);
-
-        if (args.Function != EngineKeyFunctions.UIClick)
-            return;
-
-        _isMouseDown = true;
-        _lastMousePos = args.RelativePosition;
-        TryFireAtPosition(_lastMousePos);
-    }
-
-    protected override void KeyBindUp(GUIBoundKeyEventArgs args)
-    {
-        base.KeyBindUp(args);
-
-        if (args.Function != EngineKeyFunctions.UIClick)
-            return;
-
-        _isMouseDown = false;
-    }
-
-    protected override void FrameUpdate(FrameEventArgs args)
-    {
-        base.FrameUpdate(args);
-
-        _updateAccumulator += args.DeltaSeconds;
-
-        if (_updateAccumulator >= RadarUpdateInterval)
-        {
-            _updateAccumulator = 0;
-
-            if (_consoleEntity != null)
-                _blips.RequestBlips((EntityUid)_consoleEntity);
-        }
-
-        if (_isMouseDown && _isMouseInside)
-        {
-            var currentTime = IoCManager.Resolve<IGameTiming>().CurTime.TotalSeconds;
-            if (currentTime - _lastFireTime >= FireRateLimit)
-            {
-                var mousePos = UserInterfaceManager.MousePositionScaled.Position - GlobalPosition;
-                if (mousePos != _lastMousePos)
-                {
-                    _lastMousePos = mousePos;
-                }
-                TryFireAtPosition(_lastMousePos);
-                _lastFireTime = (float)currentTime;
-            }
-        }
-    }
-
-    private void TryFireAtPosition(Vector2 relativePosition)
-    {
-        if (_coordinates == null || _rotation == null || OnRadarClick == null)
-            return;
-
-        var a = InverseScalePosition(relativePosition);
-        var relativeWorldPos = new Vector2(a.X, -a.Y);
-        relativeWorldPos = _rotation.Value.RotateVec(relativeWorldPos);
-        var coords = _coordinates.Value.Offset(relativeWorldPos);
-        OnRadarClick?.Invoke(coords);
-    }
-
-    public void SetMatrix(EntityCoordinates? coordinates, Angle? angle)
-    {
-        _coordinates = coordinates;
-        _rotation = angle;
-    }
-
-    public void SetConsole(EntityUid? consoleEntity)
-    {
-        _consoleEntity = consoleEntity;
-    }
-
-    public void UpdateState(NavInterfaceState state)
-    {
-        SetMatrix(EntManager.GetCoordinates(state.Coordinates), state.Angle);
-        _docks = state.Docks;
-        RotateWithEntity = state.RotateWithEntity;
     }
 
     protected override void Draw(DrawingHandleScreen handle)
     {
-        UseCircleMaskShader(handle); // Mono
-
-        base.Draw(handle);
-
-        DrawBacking(handle);
-        DrawCircles(handle);
-
         if (_coordinates == null || _rotation == null)
-        {
-            DrawNoSignal(handle);
             return;
-        }
 
         var xformQuery = EntManager.GetEntityQuery<TransformComponent>();
-        var fixturesQuery = EntManager.GetEntityQuery<FixturesComponent>();
-        var bodyQuery = EntManager.GetEntityQuery<PhysicsComponent>();
-
         if (!xformQuery.TryGetComponent(_coordinates.Value.EntityId, out var xform)
             || xform.MapID == MapId.Nullspace)
         {
             return;
         }
+
+        UseCircleMaskShader(handle); // Mono
+
+        base.Draw(handle);
 
         var mapPos = _transform.ToMapCoordinates(_coordinates.Value);
         var posMatrix = Matrix3Helpers.CreateTransform(_coordinates.Value.Position, _rotation.Value);
@@ -226,155 +87,19 @@ public sealed class FireControlNavControl : BaseShuttleControl
         var worldToView = worldToShuttle * shuttleToView;
         Matrix3x2.Invert(worldToView, out var viewToWorld);
 
-        var ourGridId = xform.GridUid;
-        if (EntManager.TryGetComponent<MapGridComponent>(ourGridId, out var ourGrid) &&
-            fixturesQuery.HasComponent(ourGridId.Value))
-        {
-            var ourGridToWorld = _transform.GetWorldMatrix(ourGridId.Value);
-            var ourGridToShuttle = Matrix3x2.Multiply(ourGridToWorld, worldToShuttle);
-            var ourGridToView = ourGridToShuttle * shuttleToView;
-            var color = _shuttles.GetIFFColor(ourGridId.Value, self: true);
-
-            DrawGrid(handle, ourGridToView, (ourGridId.Value, ourGrid), color);
-        }
-
-        const float radarVertRadius = 2f;
-        var radarPosVerts = new Vector2[]
-        {
-            ScalePosition(new Vector2(0f, -radarVertRadius)),
-            ScalePosition(new Vector2(radarVertRadius / 2f, 0f)),
-            ScalePosition(new Vector2(0f, radarVertRadius)),
-            ScalePosition(new Vector2(radarVertRadius / -2f, 0f)),
-        };
-
-        handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, radarPosVerts, Color.Lime);
-
-        // Draw shields
-        DrawShields(handle, xform, worldToShuttle);
-
-        _grids.Clear();
-        var maxRange = new Vector2(WorldRange, WorldRange);
-        _mapManager.FindGridsIntersecting(xform.MapID, new Box2(mapPos.Position - maxRange, mapPos.Position + maxRange), ref _grids, approx: true, includeMap: false);
-
-        foreach (var grid in _grids)
-        {
-            var gUid = grid.Owner;
-            if (gUid == ourGridId || !fixturesQuery.HasComponent(gUid))
-                continue;
-
-            var gridBody = bodyQuery.GetComponent(gUid);
-            EntManager.TryGetComponent<IFFComponent>(gUid, out var iff);
-
-            if (!_shuttles.CanDraw(gUid, gridBody, iff))
-                continue;
-
-            var hideLabel = iff != null && (iff.Flags & IFFFlags.HideLabel) != 0x0;
-            var noLabel = iff != null && (iff.Flags & IFFFlags.HideLabelAlways) != 0x0;
-            var detectionLevel = _consoleEntity == null ? DetectionLevel.Detected : _detection.IsGridDetected(grid.Owner, _consoleEntity.Value);
-            var detected = detectionLevel != DetectionLevel.Undetected || !hideLabel;
-            var blipOnly = detectionLevel == DetectionLevel.PartialDetected;
-            if (!detected)
-                continue;
-
-            var curGridToWorld = _transform.GetWorldMatrix(gUid);
-            var curGridToView = curGridToWorld * worldToView;
-
-            var labelColor = _shuttles.GetIFFColor(grid, self: false, iff);
-            var coordColor = new Color(labelColor.R * 0.8f, labelColor.G * 0.8f, labelColor.B * 0.8f, 0.5f);
-
-            var gridCentre = Vector2.Transform(gridBody.LocalCenter, curGridToView);
-
-            if (!blipOnly)
-                DrawGrid(handle, curGridToView, grid, labelColor);
-            else
-                DrawBlipShape(handle, gridCentre, 4, Color.Orange, RadarBlipShape.Circle);
-
-            if (ShowIFF)
-            {
-                var labelName = noLabel ? null : hideLabel ?
-                    detectionLevel == DetectionLevel.PartialDetected ?
-                        Loc.GetString($"shuttle-console-signature-infrared")
-                        : Loc.GetString($"shuttle-console-signature-unknown")
-                    : _shuttles.GetIFFLabel(grid, self: false, component: iff);
-                if (labelName != null)
-                {
-                    var gridBounds = grid.Comp.LocalAABB;
-
-                    var distance = gridCentre.Length();
-                    var labelText = Loc.GetString("shuttle-console-iff-label", ("name", labelName),
-                        ("distance", $"{distance:0.0}"));
-
-                    var mapCoords = _transform.GetWorldPosition(gUid);
-                    var coordsText = $"({mapCoords.X:0.0}, {mapCoords.Y:0.0})";
-
-                    var labelDimensions = handle.GetDimensions(Font, labelText, 0.9f);
-                    var coordsDimensions = handle.GetDimensions(Font, coordsText, 0.65f);
-
-                    var yOffset = Math.Max(gridBounds.Height, gridBounds.Width) * MinimapScale / 1.8f;
-
-                    var gridScaledPosition = gridCentre - new Vector2(0, -yOffset);
-
-                    var gridOffset = gridScaledPosition / PixelSize - new Vector2(0.5f, 0.5f);
-                    var offsetMax = Math.Max(Math.Abs(gridOffset.X), Math.Abs(gridOffset.Y)) * 2f;
-                    if (offsetMax > 1)
-                    {
-                        gridOffset = new Vector2(gridOffset.X / offsetMax, gridOffset.Y / offsetMax);
-                        gridScaledPosition = (gridOffset + new Vector2(0.5f, 0.5f)) * PixelSize;
-                    }
-
-                    var labelUiPosition = gridScaledPosition - new Vector2(labelDimensions.X / 2f, 0);
-                    var coordUiPosition = gridScaledPosition - new Vector2(coordsDimensions.X / 2f, -labelDimensions.Y);
-
-                    var controlExtents = PixelSize - new Vector2(labelDimensions.X, labelDimensions.Y);
-                    labelUiPosition = Vector2.Clamp(labelUiPosition, Vector2.Zero, controlExtents);
-
-                    handle.DrawString(Font, labelUiPosition, labelText, 0.9f, labelColor);
-
-                    if (offsetMax < 1)
-                    {
-                        handle.DrawString(Font, coordUiPosition, coordsText, 0.65f, coordColor);
-                    }
-                }
-            }
-        }
-
-        #region Mono
-
-        var updateRatio = _updateAccumulator / RadarUpdateInterval;
-
-        Angle angle = updateRatio * Math.Tau;
-        var origin = ScalePosition(-new Vector2(Offset.X, -Offset.Y));
-        handle.DrawLine(origin, origin + angle.ToVec() * ScaledMinimapRadius * 1.42f, Color.Red.WithAlpha(0.1f));
-
         var blips = _blips.GetCurrentBlips();
-
+        var colors = new Dictionary<NetEntity, Color>();
         foreach (var blip in blips)
+            colors[blip.NetUid] = blip.Color;
+
+        if (_controllables != null)
         {
-            var blipCoord = _transform.ToMapCoordinates(blip.Item1).Position;
-            var blipPos = Vector2.Transform(blipCoord, worldToView);
-
-            if (blip.Item4 == RadarBlipShape.Ring)
+            foreach (var controllable in _controllables)
             {
-                DrawShieldRing(handle, blipPos, blip.Item2, blip.Item3.WithAlpha(0.8f));
-            }
-            else
-            {
-                // For other shapes, use the regular drawing method
-                DrawBlipShape(handle, blipPos, blip.Item2 * 3f, blip.Item3.WithAlpha(0.8f), blip.Item4);
-            }
+                var coords = EntManager.GetCoordinates(controllable.Coordinates);
+                var worldPos = _transform.ToMapCoordinates(coords).Position;
 
-            if (_isMouseInside && _controllables != null)
-            {
-                var worldPos = blipCoord;
-                var isFireControllable = _controllables.Any(c =>
-                {
-                    var coords = EntManager.GetCoordinates(c.Coordinates);
-                    var entityMapPos = _transform.ToMapCoordinates(coords);
-                    return Vector2.Distance(entityMapPos.Position, worldPos) < 0.1f &&
-                           _selectedWeapons.Contains(c.NetEntity);
-                });
-
-                if (isFireControllable)
+                if (_selectedWeapons.Contains(controllable.NetEntity))
                 {
                     var cursorViewPos = InverseScalePosition(_lastMousePos);
                     cursorViewPos = ScalePosition(cursorViewPos);
@@ -386,166 +111,19 @@ public sealed class FireControlNavControl : BaseShuttleControl
 
                     var results = _physics.IntersectRay(xform.MapID, ray, direction.Length(), ignoredEnt: _coordinates?.EntityId);
 
-                    if (!results.Any())
-                    {
-                        handle.DrawLine(blipPos, cursorViewPos, blip.Item3.WithAlpha(0.3f));
-                    }
+                    if (!results.Any() && colors.TryGetValue(controllable.NetEntity, out var color))
+                        handle.DrawLine(Vector2.Transform(worldPos, worldToView), cursorViewPos, color.WithAlpha(0.3f));
                 }
             }
         }
 
-        // Draw hitscan lines from the radar blips system
-        var hitscanLines = _blips.GetHitscanLines();
-        foreach (var line in hitscanLines)
-        {
-            var startPosInView = Vector2.Transform(line.Start, worldToView);
-            var endPosInView = Vector2.Transform(line.End, worldToView);
-
-            // Check if the line is within the view bounds before drawing
-            var viewBounds = new Box2(-3f, -3f, Size.X + 3f, Size.Y + 3f);
-            var lineBounds = new Box2(
-                Math.Min(startPosInView.X, endPosInView.X),
-                Math.Min(startPosInView.Y, endPosInView.Y),
-                Math.Max(startPosInView.X, endPosInView.X),
-                Math.Max(startPosInView.Y, endPosInView.Y)
-            );
-
-            if (viewBounds.Intersects(lineBounds))
-            {
-                handle.DrawLine(startPosInView, endPosInView, line.Color.WithAlpha(0.8f));
-            }
-        }
-
         ClearShader(handle);
-        #endregion
     }
 
     public void UpdateControllables(EntityUid console, FireControllableEntry[] controllables)
     {
         _activeConsole = console;
         _controllables = controllables;
-    }
-
-    private Vector2 InverseScalePosition(Vector2 value)
-    {
-        // Account for UI scaling: value is unscaled, so adjust by UIScale
-        var scaledValue = value * UIScale;
-        return (scaledValue - MidPointVector) / MinimapScale;
-    }
-
-    private void DrawBlipShape(DrawingHandleScreen handle, Vector2 position, float size, Color color, RadarBlipShape shape)
-    {
-        switch (shape)
-        {
-            case RadarBlipShape.Circle:
-                handle.DrawCircle(position, size, color);
-                break;
-            case RadarBlipShape.Square:
-                var halfSize = size / 2;
-                var rect = new UIBox2(
-                    position.X - halfSize,
-                    position.Y - halfSize,
-                    position.X + halfSize,
-                    position.Y + halfSize
-                );
-                handle.DrawRect(rect, color);
-                break;
-            case RadarBlipShape.Triangle:
-                var points = new Vector2[]
-                {
-                    position + new Vector2(0, -size),
-                    position + new Vector2(-size * 0.866f, size * 0.5f),
-                    position + new Vector2(size * 0.866f, size * 0.5f)
-                };
-                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, points, color);
-                break;
-            case RadarBlipShape.Star:
-                DrawStar(handle, position, size, color);
-                break;
-            case RadarBlipShape.Diamond:
-                var diamondPoints = new Vector2[]
-                {
-                    position + new Vector2(0, -size),
-                    position + new Vector2(size, 0),
-                    position + new Vector2(0, size),
-                    position + new Vector2(-size, 0)
-                };
-                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, diamondPoints, color);
-                break;
-            case RadarBlipShape.Hexagon:
-                DrawHexagon(handle, position, size, color);
-                break;
-            case RadarBlipShape.Arrow:
-                DrawArrow(handle, position, size, color);
-                break;
-            // Ring shapes are handled by DrawShieldRing for constant thickness
-        }
-    }
-
-    private void DrawStar(DrawingHandleScreen handle, Vector2 position, float size, Color color)
-    {
-        var outerRadius = size;
-        var innerRadius = size * 0.4f;
-        var points = new List<Vector2>();
-
-        for (var i = 0; i < 10; i++)
-        {
-            var angle = i * MathF.PI / 5;
-            var radius = i % 2 == 0 ? outerRadius : innerRadius;
-            points.Add(position + new Vector2(
-                radius * MathF.Sin(angle),
-                -radius * MathF.Cos(angle)
-            ));
-        }
-
-        handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, points.ToArray(), color);
-    }
-
-    private void DrawHexagon(DrawingHandleScreen handle, Vector2 position, float size, Color color)
-    {
-        var points = new List<Vector2>();
-
-        for (var i = 0; i < 6; i++)
-        {
-            var angle = i * MathF.PI / 3;
-            points.Add(position + new Vector2(
-                size * MathF.Cos(angle),
-                size * MathF.Sin(angle)
-            ));
-        }
-
-        handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, points.ToArray(), color);
-    }
-
-    private void DrawArrow(DrawingHandleScreen handle, Vector2 position, float size, Color color)
-    {
-        var points = new Vector2[]
-        {
-            position + new Vector2(0, -size),
-            position + new Vector2(size * 0.5f, 0),
-            position + new Vector2(0, size),
-            position + new Vector2(-size * 0.5f, 0)
-        };
-
-        handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, points, color);
-    }
-
-    /// <summary>
-    /// Draws a shield ring with constant thickness regardless of zoom level.
-    /// </summary>
-    private void DrawShieldRing(DrawingHandleScreen handle, Vector2 position, float worldRadius, Color color)
-    {
-        // Convert world radius to radar display radius using the standard minimap scaling
-        var displayRadius = worldRadius * MinimapScale * 0.85f;
-
-        // Draw the shield outline as a ring with constant thickness
-        const float ringThickness = 2.0f; // Fixed thickness in pixels
-
-        // Draw multiple circles with slightly different radii to create a solid ring effect
-        for (float offset = 0; offset <= ringThickness; offset += 0.5f)
-        {
-            handle.DrawCircle(position, displayRadius + offset, color.WithAlpha(0.5f), false);
-        }
     }
 
     public void UpdateSelectedWeapons(HashSet<NetEntity> selectedWeapons)
@@ -578,52 +156,4 @@ public sealed class FireControlNavControl : BaseShuttleControl
     /// Returns true if the mouse button is currently pressed down
     /// </summary>
     public bool IsMouseDown() => _isMouseDown;
-
-    private void DrawShields(DrawingHandleScreen handle, TransformComponent consoleXform, Matrix3x2 matrix)
-    {
-        var shields = EntManager.AllEntityQueryEnumerator<ShipShieldVisualsComponent, FixturesComponent, TransformComponent>();
-        while (shields.MoveNext(out var uid, out var visuals, out var fixtures, out var xform))
-        {
-            if (!EntManager.TryGetComponent<TransformComponent>(xform.GridUid, out var parentXform))
-                continue;
-
-            if (xform.MapID != consoleXform.MapID)
-                continue;
-
-            // Don't draw shields when in FTL
-            if (EntManager.HasComponent<FTLComponent>(parentXform.Owner))
-                continue;
-
-            var detectionLevel = _consoleEntity == null ? DetectionLevel.Detected : _detection.IsGridDetected(parentXform.Owner, _consoleEntity.Value);
-            if (detectionLevel != DetectionLevel.Detected)
-                continue;
-
-            var shieldFixture = fixtures.Fixtures.TryGetValue("shield", out var fixture) ? fixture : null;
-
-            if (shieldFixture == null || shieldFixture.Shape is not ChainShape)
-                continue;
-
-            ChainShape chain = (ChainShape) shieldFixture.Shape;
-
-            var count = chain.Count;
-            var verticies = chain.Vertices;
-
-            var center = xform.LocalPosition;
-
-            for (int i = 1; i < count; i++)
-            {
-                var v1 = Vector2.Add(center, verticies[i - 1]);
-                v1 = Vector2.Transform(v1, parentXform.WorldMatrix); // transform to world matrix
-                v1 = Vector2.Transform(v1, matrix); // get back to local matrix for drawing
-                v1.Y = -v1.Y;
-                v1 = ScalePosition(v1);
-                var v2 = Vector2.Add(center, verticies[i]);
-                v2 = Vector2.Transform(v2, parentXform.WorldMatrix);
-                v2 = Vector2.Transform(v2, matrix);
-                v2.Y = -v2.Y;
-                v2 = ScalePosition(v2);
-                handle.DrawLine(v1, v2, visuals.ShieldColor);
-            }
-        }
-    }
 }

--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -95,14 +95,14 @@ public sealed partial class RadarBlipsSystem : EntitySystem
     /// <summary>
     /// Gets the current blips as world positions with their scale, color and shape.
     /// </summary>
-    public List<(EntityCoordinates Position, float Scale, Color Color, RadarBlipShape Shape)> GetCurrentBlips()
+    public List<(NetEntity NetUid, EntityCoordinates Position, float Scale, Color Color, RadarBlipShape Shape)> GetCurrentBlips()
     {
         // If it's been more than the stale threshold since our last update,
         // the data is considered stale - return an empty list
         if (_timing.CurTime.TotalSeconds - _lastUpdatedTime.TotalSeconds > BlipStaleSeconds)
-            return new List<(EntityCoordinates, float, Color, RadarBlipShape)>();
+            return new();
 
-        var result = new List<(EntityCoordinates, float, Color, RadarBlipShape)>(_blips.Count);
+        var result = new List<(NetEntity, EntityCoordinates, float, Color, RadarBlipShape)>(_blips.Count);
 
         foreach (var blip in _blips)
         {
@@ -117,7 +117,7 @@ public sealed partial class RadarBlipsSystem : EntitySystem
             if (Vector2.DistanceSquared(_xform.ToMapCoordinates(predictedPos).Position, _radarWorldPosition) > MaxBlipRenderDistance * MaxBlipRenderDistance)
                 continue;
 
-            result.Add((predictedPos, blip.Scale, blip.Color, blip.Shape));
+            result.Add((blip.netUid, predictedPos, blip.Scale, blip.Color, blip.Shape));
         }
 
         return result;

--- a/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2024 neuPanda
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: MPL-2.0
+
 // New Frontiers - This file is licensed under AGPLv3
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.

--- a/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/NavScreen.xaml.cs
@@ -19,7 +19,7 @@ namespace Content.Client.Shuttles.UI
             IffSearchCriteria.OnTextChanged += args => OnIffSearchChanged(args.Text);
 
             // Frontier - Maximum IFF Distance
-            MaximumIFFDistanceValue.GetChild(0).GetChild(1).Margin = new Thickness(8, 0, 0, 0);
+            MaximumIFFDistanceValue.GetChild(0).GetChild(1).Margin = new Thickness(10, 0, 0, 0);
             MaximumIFFDistanceValue.OnValueChanged += args => OnRangeFilterChanged(args);
 
             // Frontier - Maximum Shuttle Speed

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -1,3 +1,11 @@
+// SPDX-FileCopyrightText: 2024 neuPanda
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 LukeZurg22
+// SPDX-FileCopyrightText: 2025 Whatstone
+//
+// SPDX-License-Identifier: MPL-2.0
+
 // New Frontiers - This file is licensed under AGPLv3
 // Copyright (c) 2024 New Frontiers Contributors
 // See AGPLv3.txt for details.

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -13,7 +13,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Client.Shuttles.UI
 {
-    public sealed partial class ShuttleNavControl
+    public partial class ShuttleNavControl // Mono
     {
         public InertiaDampeningMode DampeningMode { get; set; }
 

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -590,7 +590,8 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             docks,
             _shuttle.NfGetInertiaDampeningMode(entity), // Frontier: inertia dampening
             portNames,
-            entity.Comp1.Pannable); // Mono
+            entity.Comp1.Pannable, // Mono
+            entity.Comp1.RelativePanning); // Mono
     }
 
     /// <summary>

--- a/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/NavInterfaceState.cs
@@ -57,6 +57,7 @@ public sealed class NavInterfaceState
     // End Frontier fields
 
     public bool Pannable = false; // Mono
+    public bool RelativePanning = false; // Mono
 
     public NavInterfaceState(
         float maxRange,
@@ -65,7 +66,8 @@ public sealed class NavInterfaceState
         Dictionary<NetEntity, List<DockingPortState>> docks,
         InertiaDampeningMode dampeningMode, // Frontier: add dampeningMode
         Dictionary<string, string>? networkPortNames = null,
-        bool pannable = false) // Mono
+        bool pannable = false, // Mono
+        bool relativePan = false) // Mono
     {
         MaxRange = maxRange;
         Coordinates = coordinates;
@@ -74,6 +76,7 @@ public sealed class NavInterfaceState
         DampeningMode = dampeningMode; // Frontier
         NetworkPortNames = networkPortNames ?? new Dictionary<string, string>();
         Pannable = pannable; // Mono
+        RelativePanning = relativePan; // Mono
     }
 }
 

--- a/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
@@ -49,7 +49,11 @@ public sealed partial class RadarConsoleComponent : Component
     public bool HideCoords = false;
     // End Frontier
 
-    // Mono
+    // <Mono>
     [DataField]
     public bool Pannable = false;
+
+    [DataField]
+    public bool RelativePanning = false;
+    // </Mono>
 }

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -66,7 +66,6 @@
 # SPDX-FileCopyrightText: 2024 Ghagliiarghii
 # SPDX-FileCopyrightText: 2024 GreaseMonk
 # SPDX-FileCopyrightText: 2024 Ian
-# SPDX-FileCopyrightText: 2024 Ilya246
 # SPDX-FileCopyrightText: 2024 Julian Giebel
 # SPDX-FileCopyrightText: 2024 Killerqu00
 # SPDX-FileCopyrightText: 2024 Maxtone
@@ -90,6 +89,7 @@
 # SPDX-FileCopyrightText: 2025 Coenx-flex
 # SPDX-FileCopyrightText: 2025 Cojoke
 # SPDX-FileCopyrightText: 2025 DieselMohawk
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 KiraZen_
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 RikuTheKiller

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -235,6 +235,8 @@
           type: WiresBoundUserInterface
   - type: RadarConsole
     maxRange: 1024 #256->1024 Mono
+    pannable: true # Mono
+    relativePanning: true # Mono
   - type: WorldLoader
     radius: 384 # Mono
   - type: PointLight

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 LukeZurg22
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 RikuTheKiller

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -253,6 +253,8 @@
           type: WiresBoundUserInterface
   - type: RadarConsole
     maxRange: 1024
+    pannable: true
+    relativePanning: true
   - type: WorldLoader
     radius: 384 # Mono
   - type: Computer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- gunnery console no longer a copypaste of shuttle console
- gunnery console and shuttle console are now pannable but don't reparent to map when panned

for the rest, see changelog

## Why / Balance
good

## Media
tested it all
i found like 70% of the bugs fixed here through testing

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the shuttle console IFF distance slider not working.
- fix: Fixed IFF spam on mass scanner interfaces (now limited to 3km like it was before).
- fix: Fixed radar triangles being in company color even for IFF-less ships.
- fix: Hopefully fixed radar/shuttle console IFF color jank.
- fix: The shuttle console map now properly shows detected IFF-less grids.
- tweak: Now distant grids even with IFF don't show their outline.
- tweak: Gunnery and shuttle consoles are now pannable too.
