### PR TITLE
Buffs AK-410

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 grandalff
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -76,7 +76,7 @@
     maxOffset: 6.5
     pvsIncrease: 0.65
   - type: SpeedModifiedOnWield # Mono
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.65
+    sprintModifier: 0.65
   - type: PirateBountyItem # Mono
     id: StandardFactionLongarm

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -73,8 +73,8 @@
   - type: Appearance
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
-    maxOffset: 2.5
-    pvsIncrease: 0.4
+    maxOffset: 6.5
+    pvsIncrease: 0.65
   - type: SpeedModifiedOnWield # Mono
     walkModifier: 0.85
     sprintModifier: 0.85


### PR DESCRIPTION
## About the PR
Makes the AK-410's zoom equal to Bandit MR-3C
## Why / Balance
one is a much more later-down the tech tree weapon, while also being fully outcompeted by a much less tech-tree research tree. It is insane how bad AK-410 is, being outcompeted by the AK-502 in the same range (which it basically is forced into), while also outcompeted by the bandit in long range.
## How to test
Using the gun

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

- tweak: Made the AK-410 range equal to the MR-3C bandits.

