### PR TITLE
Give Grizzly & Lecter Multiple Calibers Like TSF Sentry

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -179,7 +179,7 @@
   name: TCA M-6 Lecter (6.8x52mm Caseless)
   parent: [BaseWeaponRifle, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
   id: WeaponRifleLecter
-  description: The result of a project to make a new standard rifle for the branches of the TSF military. Accurate, easy to use, and firing the 6.8x52mm STANAG round.
+  description: The result of a project to make a new standard rifle for the branches of the TSF military. Accurate, easy to use, and firing the 6.8x52mm STANAG round. Also accepts 5.56x45mm magazines to assist with standardization.
   components:
   - type: Item # Mono
     size: Huge
@@ -217,6 +217,7 @@
         whitelist:
           tags:
             - Magazine68x52mmCaseless # Mono
+            - Magazine556x45mmFMJ # Mono
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
@@ -225,6 +226,7 @@
         whitelist:
           tags:
             - Cartridge68x52mmCaseless # Mono
+            - Cartridge556x45mmFMJ # Mono
   - type: ContainerContainer
     containers:
       gun_magazine: !type:ContainerSlot

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -224,7 +224,7 @@
   name: TCA MMG-68 "Grizzly" (6.8x52mm Caseless)
   parent: [BaseWeaponLightMachineGun, BaseGunWieldable, BaseC2ContrabandUnredeemable]
   id: WeaponLMGGrizzly
-  description: A medium machine gun chambered in 6.8x52mm Caseless, accepts both box and standard magazines. A label on the side reads "FOR MILITARY USE ONLY". The weight of the machine gun make it hard to wield easily.
+  description: A medium machine gun chambered in 6.8x52mm Caseless, accepts both box and standard magazines. A label on the side reads "FOR MILITARY USE ONLY". The weight of the machine gun make it hard to wield easily. To assist with standardization, it also accepts 5.56x45mm and 7.62x39mm.
   components:
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/LMGs/grizzly/Grizzly-icon.rsi
@@ -272,6 +272,11 @@
           - Magazine68x52mmCaselessBoxSmall
           - Magazine68x52mmCaselessBoxBig
           - Magazine68x52mmCaseless
+          - Magazine556x45mmFMJ
+          - Magazine556x45mmBox
+          - Magazine762x39mmFMJ
+          - Magazine762x39mmLowCapacityFMJ
+          - Magazine762x39mmBox
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
@@ -280,6 +285,8 @@
         whitelist:
           tags:
           - Cartridge68x52mmCaseless
+          - Cartridge556x45mmFMJ
+          - Cartridge762x39mmFMJ
   - type: ContainerContainer
     containers:
       gun_magazine: !type:ContainerSlot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives Grizzly 7.62x39mm and 5.56x45mm, gives Lecter just 5.56x45mm

## Why / Balance
I like multi-caliber guns. Also, locking them to caseless which has no special ammo types is pretty boring. Also also, the Grizzly is kinda garbage compared to the Ratel.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Lecter can accept 5.56x45mm mags now.
- tweak: Grizzly can also accept 5.56x45mm and 7.62x39mm now. Both boxes and mags. Don't question how. Its sci-fi tech.