### PR TITLE
Chimera Change

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -23,6 +23,8 @@
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 SlamBamActionman
 # SPDX-FileCopyrightText: 2024 checkraze
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 Tiniest Shark
 # SPDX-FileCopyrightText: 2025 Winkarst
 # SPDX-FileCopyrightText: 2025 core-mene

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -56,6 +56,7 @@
     - DoorBumpOpener
     - SpiderCraft
     - AnomalyHost
+    - Humanoid # Mono
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -86,7 +86,9 @@
 # SPDX-FileCopyrightText: 2024 deltanedas
 # SPDX-FileCopyrightText: 2024 slarticodefast
 # SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 Solstice
 # SPDX-FileCopyrightText: 2025 Tiniest Shark
 # SPDX-FileCopyrightText: 2025 Winkarst

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -321,6 +321,7 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
+    - Humanoid # Mono
   - type: Targeting # Shitmed Change
   - type: SurgeryTarget # Shitmed Change
   - type: ExaminableCharacter # WWDP

--- a/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2025 Ark
 # SPDX-FileCopyrightText: 2025 Blu
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 NotActuallyMarty
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
@@ -66,6 +66,7 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
+    - Humanoid # Mono
   - type: Butcherable # Mono - MEAT
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/_Mono/Body/Prototypes/chimera.yml
+++ b/Resources/Prototypes/_Mono/Body/Prototypes/chimera.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Jezithyr
 # SPDX-FileCopyrightText: 2023 Nemanja
 # SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Body/Prototypes/chimera.yml
+++ b/Resources/Prototypes/_Mono/Body/Prototypes/chimera.yml
@@ -8,6 +8,19 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: body
+  id: ChimeraBeast
+  name: "chimera endoskeleton"
+  root: torso
+  slots:
+    torso:
+      part: TorsoSkeleton
+      organs:
+        heart: OrganChimeraHeart
+        lungs: OrganChimeraLungs
+        stomach: OrganChimeraStomach
+        liver: OrganChimeraLiver
+
+- type: body
   id: Chimera
   name: "chimera endoskeleton"
   root: torso

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/chimera.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/chimera.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 EctoplasmIsGood
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 Your Name
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/chimera.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/chimera.yml
@@ -8,7 +8,7 @@
 # TODO - new sprites
 
 - type: entity
-  parent: MonoBaseMobFleshLetoferol
+  parent: MonoBaseMobLetoferolHumanoid
   id: MobLetoferolHorror
   name: chimera fleshbeast
   components:
@@ -27,15 +27,10 @@
         Base: horror
       Dead:
         Base: dead
-  - type: MobState
-    allowedStates:
-    - Alive
-    - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Critical
-      800: Dead
+      500: Dead
     allowRevives: true
   - type: SlowOnDamage
     speedModifierThresholds:
@@ -56,14 +51,6 @@
   #- type: ActionGun
   #  action: ActionLetoferolSpike
   #  gunProto: LetoferolSpikeGun
-  - type: ThermalVision
-    lightRadius: 15
-    color: "#f22e55"
-    activateSound: null
-    deactivateSound: null
-  - type: GuideHelp
-    guides:
-    - Letoferol
 
 - type: entity
   parent: MobLetoferolHorror
@@ -81,3 +68,35 @@
     - !type:OverallPlaytimeRequirement
       time: 180000 # 50 hrs
   - type: GhostTakeoverAvailable
+
+- type: entity
+  parent:
+  - MonoBaseMobLetoferol
+  - BaseMobFlesh
+  id: MobLetoferolBeast
+  name: chimera fleshbeast
+  components:
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: Mobs/Aliens/flesh.rsi
+    layers:
+    - map: [ "enum.DamageStateVisualLayers.Base" ]
+      state: jared
+  - type: RandomSprite
+    available:
+    - enum.DamageStateVisualLayers.Base:
+        jared: ""
+        golem: ""
+        clamp: ""
+        lover: ""
+  - type: MeleeWeapon
+    attackRate: 1.5
+    soundHit:
+      path: /Audio/Weapons/Xeno/alien_claw_flesh3.ogg
+    angle: 30
+    animation: WeaponArcClaw
+    damage:
+      types:
+        Blunt: 5
+        Slash: 5
+        Structural: 50

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/chimera_base.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/chimera_base.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 EctoplasmIsGood
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 Your Name
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/chimera_base.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/chimera_base.yml
@@ -9,48 +9,60 @@
 
 - type: entity
   parent:
-  - StripableInventoryBase
-  - MobHumanoidHostileAIChimera
   - MobNonHumanHostileBase
   - MobStepTriggerImmune
-  id: MonoBaseMobFleshLetoferol
+  id: MonoBaseMobLetoferol
   name: chimera fleshbeast
-  description: A once sentient being covered in putrid flesh and bone. You can see a glimpse of humanity left in its eyes, like whoever it was is still awake.
+  description: A horribly mutated whatever-this-once-was.
   abstract: true
   components:
+  - type: HTN
+    rootTask:
+      task: ChimeraHostileCompound
+    blackboard:
+      NavClimb: !type:Bool
+        true
+      NavInteract: !type:Bool
+        false
+      NavPry: !type:Bool
+        true
+      NavSmash: !type:Bool
+        true
+  - type: MobState
+    allowedStates:
+    - Alive
+    - Dead
   - type: NpcFactionMember
     factions:
-    - AberrantFleshExpeditionNF
+    - HostileUniversally
   - type: Sprite
     drawdepth: Mobs
     sprite: _NF/Mobs/Aliens/flesh.rsi
-  - type: MobState
-  - type: DoAfter
-  - type: Stripping
-  - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: Chimera
   - type: MobThresholds
     thresholds:
       0: Alive
-      200: Critical
-      400: Dead
+      200: Dead
+  - type: DamageStateVisuals
+    states:
+      Dead:
+        Base: dead
+  - type: Damageable
+    damageContainer: Biological
+    damageModifierSet: Chimera
   - type: SlowOnDamage
     speedModifierThresholds:
       50: 0.7
       120: 0.5
-  - type: Stamina
-    critThreshold: 150
   - type: Butcherable
     spawned:
     - id: FoodMeat
       amount: 4
-  - type: Inventory
-    templateId: chimera
-  - type: SurgeryTarget
   - type: Bloodstream
     bloodReagent: NaturalLetoferol
     bloodMaxVolume: 300
+    bleedReductionAmount: 1.5
+    bloodlossThreshold: 0
+    bloodRefreshAmount: 10
   - type: MeleeWeapon
     attackRate: 1.5
     soundHit:
@@ -76,26 +88,12 @@
       reagents:
       - ReagentId: NaturalLetoferol
         Quantity: 90
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
-        ents: []
-  - type: UserInterface
-    interfaces:
-      enum.StorageUiKey.Key:
-        type: StorageBoundUserInterface
-      enum.StrippingUiKey.Key:
-        type: StrippableBoundUserInterface
-      enum.SurgeryUIKey.Key:
-        type: SurgeryBui
   - type: MeleeChemicalInjector
     solution: melee
-    transferAmount: 2.5
+    transferAmount: 1.5
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.5
     baseSprintSpeed : 4.25
-  - type: Hands
-  - type: ComplexInteraction
   - type: StatusEffects
     allowed:
     - Stun
@@ -109,28 +107,14 @@
     - StaminaModifier
     - Flashed
     - RadiationProtection
-  - type: Ensnareable
-    sprite: Objects/Misc/ensnare.rsi
-    state: icon
   - type: Climbing
-  - type: Storage
-    clickInsert: false
-    openOnActivate: false
-    grid:
-    - 0,0,4,4
-    maxItemSize: Huge
-    storageInsertSound:
-      path: /Audio/Voice/Slime/slime_squish.ogg
   - type: Tag
     tags:
-    - CanPilot
-    - FootstepSound
     - DoorBumpOpener
     - Chimera
   - type: PassiveDamage
     allowedStates:
     - Alive
-    - Critical
     damage:
       types:
         Radiation: -0.3
@@ -141,11 +125,14 @@
         Burn: -1.2
         Genetic: -0.1
   - type: Targeting
-  - type: Puller
-    needsHands: false
-  - type: Body
-    prototype: Chimera
-    requiredLegs: 2
+  - type: Flammable
+    fireSpread: true
+    canResistFire: true
+    damage: #per second, scales with number of fire 'stacks'
+      types:
+        Heat: 8
+  - type: Clickable
+  - type: ZombieImmune
   - type: Reactive
     groups:
       Flammable: [Touch]
@@ -172,8 +159,89 @@
           types:
             Caustic: 20
             Cellular: 5
+  - type: SurgeryTarget
+  - type: Body
+    prototype: ChimeraBeast
+    requiredLegs: 0
   - type: PlayerToolModifier
     pryTimeMultiplier: 0.4
+  - type: ThermalVision
+    lightRadius: 15
+    color: "#f22e55"
+    activateSound: null
+    deactivateSound: null
+  - type: GuideHelp
+    guides:
+    - Letoferol
+  - type: MovementAlwaysTouching
+
+- type: entity
+  parent:
+  - MonoBaseMobLetoferol
+  - StripableInventoryBase
+  id: MonoBaseMobLetoferolHumanoid
+  name: chimera fleshbeast
+  description: A once sentient being covered in putrid flesh and bone. You can see a glimpse of humanity left in its eyes, like whoever it was is still awake.
+  abstract: true
+  components:
+  - type: HTN
+    rootTask:
+      task: ChimeraHostileCompound
+    blackboard:
+      NavClimb: !type:Bool
+        true
+      NavInteract: !type:Bool
+        true
+      NavPry: !type:Bool
+        true
+      NavSmash: !type:Bool
+        true
+  - type: MeleeChemicalInjector
+    solution: melee
+    transferAmount: 2.5
+  - type: DoAfter
+  - type: Stripping
+  - type: Stamina
+    critThreshold: 150
+  - type: Inventory
+    templateId: chimera
+  - type: SurgeryTarget
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: []
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+      enum.StrippingUiKey.Key:
+        type: StrippableBoundUserInterface
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
+  - type: Hands
+  - type: ComplexInteraction
+  - type: Ensnareable
+    sprite: Objects/Misc/ensnare.rsi
+    state: icon
+  - type: Storage
+    clickInsert: false
+    openOnActivate: false
+    grid:
+    - 0,0,4,4
+    maxItemSize: Huge
+    storageInsertSound:
+      path: /Audio/Voice/Slime/slime_squish.ogg
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
+    - Chimera
+  - type: Puller
+    needsHands: false
+  - type: Body
+    prototype: Chimera
+    requiredLegs: 2
   - type: PlayerAccuracyModifier
     spreadMultiplier: 12
     maxSpreadAngle: 180
@@ -186,11 +254,3 @@
         Heat: 0.5 # fire is scary (esword is op)
   #- type: CollectiveMind  # Part of the organ instead.
   #  channel: Letoferol
-  - type: Flammable
-    fireSpread: true
-    canResistFire: true
-    damage: #per second, scales with number of fire 'stacks'
-      types:
-        Heat: 8
-  - type: Clickable
-  - type: ZombieImmune

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/htn.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/htn.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/htn.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/htn.yml
@@ -70,9 +70,6 @@
             pathfindKey: TargetPathfind
             rangeKey: MeleeRange
         - !type:HTNPrimitiveTask
-          operator: !type:JukeOperator
-            jukeType: Away
-        - !type:HTNPrimitiveTask
           operator: !type:MeleeOperator
             targetKey: Target
             targetState: Dead

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/htn.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/htn.yml
@@ -4,45 +4,28 @@
 
 # Its really annoying how far i have to go in HTN yaml to make a AI that doesnt get stuck trying to pickup a folding chair like a dumbass.
 
-- type: entity
-  id: MobHumanoidHostileAIChimera
-  abstract: true
-  components:
-  - type: HTN
-    rootTask:
-      task: ChimeraHostileCompound
-    blackboard:
-      NavClimb: !type:Bool
-        true
-      NavInteract: !type:Bool
-        true
-      NavPry: !type:Bool
-        true
-      NavSmash: !type:Bool
-        true
-
 - type: htnCompound
   id: ChimeraHostileCompound
   branches:
   - tasks:
     - !type:HTNCompoundTask
-      task: MeleeCombatCompoundNoGrabWeapon
+      task: ChimeraMeleeCombatCompound
   - tasks:
     - !type:HTNCompoundTask
       task: IdleCompound
 
 - type: htnCompound
-  id: MeleeCombatCompoundNoGrabWeapon
+  id: ChimeraMeleeCombatCompound
   branches:
   - tasks:
     - !type:HTNPrimitiveTask
       operator: !type:UtilityOperator
-        proto: NearbyMeleeTargets
+        proto: NearbyChimeraMeleeTargets
     - !type:HTNCompoundTask
-      task: BeforeMeleeAttackTargetCompoundNoGrabWeapon
+      task: BeforeChimeraMeleeAttackTargetCompound
 
 - type: htnCompound
-  id: BeforeMeleeAttackTargetCompoundNoGrabWeapon
+  id: BeforeChimeraMeleeAttackTargetCompound
   branches:
   - preconditions:
     - !type:BuckledPrecondition
@@ -66,4 +49,54 @@
       task: EscapeCompound
   - tasks:
     - !type:HTNCompoundTask
-      task: MeleeAttackTargetCompound
+      task: ChimeraMeleeAttackTargetCompound
+
+# MeleeAttackTargetCompound but also attacks dead and crit
+- type: htnCompound
+  id: ChimeraMeleeAttackTargetCompound
+  branches:
+    - preconditions:
+      - !type:KeyExistsPrecondition
+        key: Target
+      tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:MoveToOperator
+            shutdownState: PlanFinished
+            pathfindInPlanning: true
+            removeKeyOnFinish: false
+            brakeMaxVelocity: null # Monolith - don't try to brake
+            targetKey: TargetCoordinates
+            pathfindKey: TargetPathfind
+            rangeKey: MeleeRange
+        - !type:HTNPrimitiveTask
+          operator: !type:JukeOperator
+            jukeType: Away
+        - !type:HTNPrimitiveTask
+          operator: !type:MeleeOperator
+            targetKey: Target
+            targetState: Dead
+          preconditions:
+            - !type:KeyExistsPrecondition
+              key: Target
+            - !type:TargetInRangePrecondition
+              targetKey: Target
+              rangeKey: MeleeRange
+          services:
+            - !type:UtilityService
+              id: MeleeService
+              proto: NearbyChimeraMeleeTargets
+              key: Target
+
+# NearbyMeleeTargets but ignores health
+- type: utilityQuery
+  id: NearbyChimeraMeleeTargets
+  query:
+    - !type:NearbyHostilesQuery
+  considerations:
+    - !type:TargetDistanceCon
+      curve: !type:PresetCurve
+        preset: TargetDistance
+    - !type:TargetAccessibleCon
+      curve: !type:BoolCurve
+    - !type:TargetInLOSOrCurrentCon
+      curve: !type:BoolCurve

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/htn.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Chimera/htn.yml
@@ -52,7 +52,7 @@
     - !type:HTNCompoundTask
       task: ChimeraMeleeAttackTargetCompound
 
-# MeleeAttackTargetCompound but also attacks dead and crit
+# MeleeAttackTargetCompound but also attacks crit
 - type: htnCompound
   id: ChimeraMeleeAttackTargetCompound
   branches:
@@ -72,7 +72,7 @@
         - !type:HTNPrimitiveTask
           operator: !type:MeleeOperator
             targetKey: Target
-            targetState: Dead
+            targetState: Critical
           preconditions:
             - !type:KeyExistsPrecondition
               key: Target
@@ -91,6 +91,8 @@
   query:
     - !type:NearbyHostilesQuery
   considerations:
+    - !type:TargetIsDeadCon
+      curve: !type:InverseBoolCurve
     - !type:TargetDistanceCon
       curve: !type:PresetCurve
         preset: TargetDistance

--- a/Resources/Prototypes/_Mono/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/_Mono/Polymorphs/polymorph.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 EctoplasmIsGood
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 Your Name
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/_Mono/Polymorphs/polymorph.yml
@@ -38,3 +38,20 @@
     polymorphSound: /Audio/Effects/Fluids/splat.ogg
     exitPolymorphSound: /Audio/Effects/Fluids/glug.ogg
     allowRepeatedMorphs: true
+
+- type: polymorph
+  id: LetoferolMutationBeastNatural
+  configuration:
+    entity: MobLetoferolBeast
+    forced: true
+    inventory: Drop
+    transferName: true
+    polymorphTheLiving: false
+    polymorphTheDead: true
+    transferDamage: false
+    revertOnCrit: false
+    revertOnDeath: false
+    cooldown: 60
+    polymorphSound: /Audio/Effects/Fluids/splat.ogg
+    exitPolymorphSound: /Audio/Effects/Fluids/glug.ogg
+    allowRepeatedMorphs: true

--- a/Resources/Prototypes/_Mono/Reagents/letoferol.yml
+++ b/Resources/Prototypes/_Mono/Reagents/letoferol.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Reagents/letoferol.yml
+++ b/Resources/Prototypes/_Mono/Reagents/letoferol.yml
@@ -100,6 +100,16 @@
         conditions:
         - !type:ReagentThreshold
           min: 15
+        - !type:HasTag
+          tag: Humanoid
+      - !type:Polymorph
+        prototype: LetoferolMutationBeastNatural
+        conditions:
+        - !type:ReagentThreshold
+          min: 10 # less for non-humanoids
+        - !type:HasTag
+          tag: Humanoid
+          invert: true
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_Mono/tags.yml
+++ b/Resources/Prototypes/_Mono/tags.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 LukeZurg22
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760

--- a/Resources/Prototypes/_Mono/tags.yml
+++ b/Resources/Prototypes/_Mono/tags.yml
@@ -427,3 +427,7 @@
 
 - type: Tag
   id: SurvivalBox
+
+# for letoferol chimeras
+- type: Tag
+  id: Humanoid


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- refactors chimera yml a bit
- chimera faction changed to attack everything
- chimeras will now attack even crit mobs
- infecting a non-species mob now only produces a weaker flesh monster and not full fleshbeast
- changed chimeras to not bleed out for some reason
- removes juking so they just run at you

## Why / Balance
500 chimeras from one monkey box too easy
you still get beasts though and they aren't weak either

## Media
<img width="645" height="263" alt="image" src="https://github.com/user-attachments/assets/3ffe9adb-9a5d-4ede-a57d-96ec18f1ac2d" />

also tested with every species, properly turns into normal chimera

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Chimera AI changed to also attack crit mobs.
- tweak: Infecting non-species mobs with letoferol now only makes a weaker flesh monster and not a full chimera.
