### PR TITLE
Fixes AP Balance and Reverts "Better Incorporate Recoil Into More Guns"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -129,15 +129,8 @@
     sprite: _Mono/Objects/Weapons/Guns/Rifles/akm_inhands_32x.rsi
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/Rifles/akm_inhands_32x.rsi # Mono
-  - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -31
   - type: Gun
     fireRate: 5
-    minAngle: 21
-    maxAngle: 64
-    angleIncrease: 4
-    angleDecay: 14
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
   - type: ChamberMagazineAmmoProvider
@@ -196,16 +189,9 @@
   - type: ChamberMagazineAmmoProvider # Mono
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
-  - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -31
   - type: Gun
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/light_rifle_1.ogg # Mono
-    minAngle: 21
-    maxAngle: 64
-    angleIncrease: 2
-    angleDecay: 14
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -33,6 +33,7 @@
 # SPDX-FileCopyrightText: 2025 BramvanZijp
 # SPDX-FileCopyrightText: 2025 Eden077
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 UltimateJester
 # SPDX-FileCopyrightText: 2025 Whatstone
 # SPDX-FileCopyrightText: 2025 core-mene

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -140,10 +140,6 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
     fireRate: 8.5
-    minAngle: 6
-    maxAngle: 45
-    angleIncrease: 2
-    angleDecay: 23
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
   - type: MagazineVisuals
@@ -195,9 +191,7 @@
     maxAngle: -16
   - type: Gun
     minAngle: 21
-    maxAngle: 46
-    angleIncrease: 1
-    angleDecay: 17
+    maxAngle: 32
     shotsPerBurst: 5
     availableModes:
     - Burst
@@ -310,9 +304,9 @@
   - type: Gun
     fireRate: 5.5
     minAngle: 1
-    maxAngle: 24
+    maxAngle: 6
     angleIncrease: 1.5
-    angleDecay: 15
+    angleDecay: 6
     selectedMode: FullAuto
     shotsPerBurst: 5
     burstCooldown: 0.2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -39,6 +39,7 @@
 # SPDX-FileCopyrightText: 2025 Eden077
 # SPDX-FileCopyrightText: 2025 K-Dynamic
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 UltimateJester
 # SPDX-FileCopyrightText: 2025 Whatstone
 # SPDX-FileCopyrightText: 2025 core-mene

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -24,13 +24,13 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -25
+    minAngle: -12
+    maxAngle: -18
   - type: Gun
-    minAngle: 21
-    maxAngle: 52
-    angleIncrease: 5 # 6->5 - Mono
-    angleDecay: 15
+    minAngle: 13
+    maxAngle: 20
+    angleIncrease: 5
+    angleDecay: 25
     fireRate: 4
     selectedMode: SemiAuto
     availableModes:
@@ -124,7 +124,7 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
     minAngle: 22
-    maxAngle: 45
+    maxAngle: 36
     angleIncrease: 2
     angleDecay: 8
     fireRate: 8

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -20,13 +20,13 @@
   - type: Clothing
     sprite: _DV/Objects/Weapons/Guns/SMGs/typewriter.rsi
   - type: GunWieldBonus
-    minAngle: -29
-    maxAngle: -44
+    minAngle: -20
+    maxAngle: -30
   - type: Gun
-    minAngle: 30
-    maxAngle: 55
-    angleIncrease: 2
-    angleDecay: 17
+    minAngle: 21
+    maxAngle: 45
+    angleIncrease: 5
+    angleDecay: 20
     fireRate: 8
     soundGunshot:
       path: /Audio/_DV/Weapons/Guns/Gunshots/typewriter.ogg

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Dvir
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -23,10 +23,7 @@
   - type: Item # Mono
     sprite: _Mono/Objects/Weapons/Guns/Rifles/annie_inhands_32x.rsi
   - type: Clothing
-    sprite: _Mono/Objects/Weapons/Guns/Rifles/annie_inhands_32x.rsi # Mono
-  - type: GunWieldBonus
-    minAngle: -14
-    maxAngle: -32
+    sprite: _Mono/Objects/Weapons/Guns/Rifles/annie_inhands_32x.rsi
   - type: Gun
     availableModes:
     - FullAuto
@@ -36,10 +33,6 @@
     shotsPerBurst: 4
     fireRate: 6.5
     projectileSpeed: 42.5 # Mono
-    minAngle: 15
-    maxAngle: 54
-    angleIncrease: 4
-    angleDecay: 33
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/thock.ogg
   - type: ChamberMagazineAmmoProvider
@@ -103,10 +96,6 @@
     burstFireRate: 20 # Mono
     burstCooldown: 0.4 # Mono
     projectileSpeed: 45 # Mono
-    minAngle: 15
-    maxAngle: 54
-    angleIncrease: 2
-    angleDecay: 33
     fireRate: 7.5 # Mono, does nothing because its burst only but it makes it clear it can fire at this rate.
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/bwuh.ogg
@@ -156,17 +145,9 @@
   - type: ChamberMagazineAmmoProvider # Mono
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
-  - type: GunWieldBonus
-    minAngle: -14
-    maxAngle: -38
   - type: Gun
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/light_rifle_2.ogg # Mono
-    projectileSpeed: 60 # Mono
-    minAngle: 15
-    maxAngle: 54
-    angleIncrease: 5
-    angleDecay: 28
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 BlueHNT
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -21,12 +21,12 @@
     sprite: _Harmony/Objects/Weapons/Guns/Rifles/bandit.rsi
   - type: GunWieldBonus # Mono
     minAngle: -32
-    maxAngle: -44 # Mono
+    maxAngle: -51
   - type: Gun
     minAngle: 32 # Mono
-    maxAngle: 67 # Mono
-    angleIncrease: 8
-    angleDecay: 14
+    maxAngle: 54 # Mono
+    angleIncrease: 14
+    angleDecay: 5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 halycon
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/4.6x30mm.yml
@@ -31,7 +31,7 @@
     damage:
       types:
         Piercing: 16
-    armorPenetration: 0.1
+    armorPenetration: 0.075
 
 - type: entity
   id: Bullet46x30mmPractice
@@ -135,7 +135,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16
+        Piercing: 14
     armorPenetration: 0.25
 
 - type: entity
@@ -147,7 +147,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
+        Piercing: 13
     armorPenetration: 0.45
 
 - type: entity
@@ -159,7 +159,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 14
+        Piercing: 11
     armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/4.6x30mm.yml
@@ -160,7 +160,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 11
+        Piercing: 12
     armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/4.6x30mm.yml
@@ -15,6 +15,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_ACP.yml
@@ -31,7 +31,7 @@
     damage:
       types:
         Piercing: 26
-    armorPenetration: -0.1
+    armorPenetration: 0.05
 
 - type: entity
   id: Bullet45_ACPPractice
@@ -132,7 +132,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 24
+        Piercing: 23
     armorPenetration: 0.1
 
 - type: entity
@@ -145,7 +145,7 @@
     damage:
       types:
         Piercing: 21
-    armorPenetration: 0.25
+    armorPenetration: 0.3
 
 - type: entity
   id: Bullet45_ACPSynthAP
@@ -157,7 +157,7 @@
     damage:
       types:
         Piercing: 18
-    armorPenetration: 0.4
+    armorPenetration: 0.5
   - type: Tracer
     color: "#6f7c82ff"
     length: 3

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_ACP.yml
@@ -15,6 +15,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_ACP.yml
@@ -157,7 +157,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 18
+        Piercing: 19
     armorPenetration: 0.5
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_magnum.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_magnum.yml
@@ -139,7 +139,7 @@
     damage:
       types:
         Piercing: 32
-    armorPenetration: 0.3
+    armorPenetration: 0.4
 
 - type: entity
   id: Bullet45_magnumPlasteelAP
@@ -151,7 +151,7 @@
     damage:
       types:
         Piercing: 28
-    armorPenetration: 0.5
+    armorPenetration: 0.6
 
 - type: entity
   id: Bullet45_magnumSynthAP
@@ -162,8 +162,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 26
-    armorPenetration: 0.7
+        Piercing: 25
+    armorPenetration: 0.8
   - type: Tracer
     color: "#6f7c82ff"
     length: 3

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_magnum.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_magnum.yml
@@ -163,7 +163,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 25
+        Piercing: 26
     armorPenetration: 0.8
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_magnum.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/45_magnum.yml
@@ -22,6 +22,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56x45mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56x45mm.yml
@@ -119,7 +119,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 23
+        Piercing: 21
     armorPenetration: 0.25
 
 - type: entity
@@ -131,7 +131,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 20
+        Piercing: 18
     armorPenetration: 0.45
 
 - type: entity
@@ -143,7 +143,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 16
     armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56x45mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56x45mm.yml
@@ -144,7 +144,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16
+        Piercing: 17
     armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56x45mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56x45mm.yml
@@ -16,6 +16,7 @@
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2025 Ghagliiarghii
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.7x28mm.yml
@@ -155,7 +155,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 14
+        Piercing: 15
     armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.7x28mm.yml
@@ -15,6 +15,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.7x28mm.yml
@@ -31,7 +31,7 @@
     damage:
       types:
         Piercing: 20
-    armorPenetration: 0.05
+    armorPenetration: 0.075
 
 - type: entity
   id: Bullet57x28mmPractice
@@ -130,7 +130,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 18
     armorPenetration: 0.25
 
 - type: entity
@@ -142,7 +142,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 16
     armorPenetration: 0.45
 
 - type: entity

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/6.35x40mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/6.35x40mm.yml
@@ -12,6 +12,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/6.35x40mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/6.35x40mm.yml
@@ -27,7 +27,7 @@
     damage:
       types:
         Piercing: 19
-    armorPenetration: 0.05
+    armorPenetration: 0.085
 
 - type: entity
   id: Bullet635x40mmCaselessPractice

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
@@ -162,7 +162,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 18
+        Piercing: 19
     armorPenetration: 0.6
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x39mm.yml
@@ -39,7 +39,7 @@
     damage:
       types:
         Piercing: 25
-    armorPenetration: 0.075
+    armorPenetration: 0.085
 
 - type: entity
   id: Bullet762x39mmPractice
@@ -138,8 +138,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 22
-    armorPenetration: 0.15
+        Piercing: 23
+    armorPenetration: 0.2
 
 - type: entity
   id: Bullet762x39mmPlasteelAP
@@ -151,7 +151,7 @@
     damage:
       types:
         Piercing: 20
-    armorPenetration: 0.35
+    armorPenetration: 0.4
 
 - type: entity
   id: Bullet762x39mmSynthAP
@@ -163,7 +163,7 @@
     damage:
       types:
         Piercing: 18
-    armorPenetration: 0.55
+    armorPenetration: 0.6
   - type: Tracer
     color: "#6f7c82ff"
     length: 3

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x51mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x51mm.yml
@@ -143,7 +143,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 25
+        Piercing: 27
     armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x51mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x51mm.yml
@@ -31,7 +31,7 @@
     damage:
       types:
         Piercing: 36
-    armorPenetration: 0.075
+    armorPenetration: 0.1
 
 - type: entity
   id: Bullet762x51mmPractice
@@ -130,7 +130,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 26
+        Piercing: 29
     armorPenetration: 0.45
 
 - type: entity
@@ -142,7 +142,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 23
+        Piercing: 25
     armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x51mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x51mm.yml
@@ -15,6 +15,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x54mmR.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x54mmR.yml
@@ -141,7 +141,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 31
+        Piercing: 34
     armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x54mmR.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x54mmR.yml
@@ -30,6 +30,7 @@
     damage:
       types:
         Piercing: 45
+    armorPenetration: 0.1
 
 - type: entity
   id: Bullet762x54mmRPractice
@@ -115,8 +116,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 37
-    armorPenetration: 0.2
+        Piercing: 41
+    armorPenetration: 0.25
 
 - type: entity
   id: Bullet762x54mmRPlasteelAP
@@ -127,8 +128,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 32
-    armorPenetration: 0.4
+        Piercing: 36
+    armorPenetration: 0.45
 
 - type: entity
   id: Bullet762x54mmRSynthAP
@@ -139,8 +140,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 27
-    armorPenetration: 0.6
+        Piercing: 31
+    armorPenetration: 0.65
   - type: Tracer
     color: "#6f7c82ff"
     length: 3

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x54mmR.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62x54mmR.yml
@@ -15,6 +15,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/9x19mm.yml
@@ -156,7 +156,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 18
     armorPenetration: 0.5
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/9x19mm.yml
@@ -15,6 +15,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Plykiya
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/9x19mm.yml
@@ -31,7 +31,7 @@
     damage:
       types:
         Piercing: 24
-    armorPenetration: -0.1
+    armorPenetration: 0.05
 
 - type: entity
   id: Bullet9x19mmPractice
@@ -131,7 +131,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 22
     armorPenetration: 0.1
 
 - type: entity
@@ -143,7 +143,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 19
     armorPenetration: 0.3
 
 - type: entity
@@ -155,7 +155,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
+        Piercing: 17
     armorPenetration: 0.5
   - type: Tracer
     color: "#6f7c82ff"

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -238,10 +238,10 @@
     maxAngle: -20
   - type: Gun
     minAngle: 24
-    maxAngle: 75
-    angleIncrease: 2
-    angleDecay: 54
-    fireRate: 9 # 540 rpm
+    maxAngle: 36
+    angleIncrease: 3
+    angleDecay: 34
+    fireRate: 6 # 360 rpm
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -329,13 +329,13 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/LMGs/ratel/Ratel-inhands.rsi
   - type: GunWieldBonus
-    minAngle: -24
+    minAngle: -20
     maxAngle: -30
   - type: Gun
     minAngle: 25
-    maxAngle: 65
+    maxAngle: 40
     angleIncrease: 5
-    angleDecay: 32
+    angleDecay: 34
     fireRate: 5 # 300 rpm
     selectedMode: FullAuto
     availableModes:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -26,12 +26,12 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -21
-    maxAngle: -26
+    maxAngle: -47
   - type: Gun
     minAngle: 21
     maxAngle: 48
-    angleIncrease: 5
-    angleDecay: 14
+    angleIncrease: 27
+    angleDecay: 2
     fireRate: 3 # 180 rpm
     selectedMode: SemiAuto
     availableModes:
@@ -98,11 +98,11 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -21
-    maxAngle: -43
+    maxAngle: -47
   - type: Gun
     minAngle: 21
     maxAngle: 52
-    angleIncrease: 11
+    angleIncrease: 6
     angleDecay: 24
     fireRate: 5 # 300 rpm
     soundGunshot:
@@ -163,8 +163,8 @@
     maxAngle: -17
   - type: Gun
     minAngle: 18
-    maxAngle: 48
-    angleIncrease: 5
+    maxAngle: 35
+    angleIncrease: 4
     angleDecay: 40
     fireRate: 11 # 660 rpm
     shotsPerBurst: 3
@@ -231,12 +231,12 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -20
-    maxAngle: -27
+    maxAngle: -50
   - type: Gun
     minAngle: 21
     maxAngle: 52
-    angleIncrease: 7
-    angleDecay: 12
+    angleIncrease: 1.4
+    angleDecay: 24
     fireRate: 4 #240 RPM, its semi-auto anyway
     selectedMode: SemiAuto
     availableModes:
@@ -288,12 +288,13 @@
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: GunWieldBonus
     minAngle: -27
-    maxAngle: -26
+    maxAngle: -40
   - type: Gun
     minAngle: 30
     maxAngle: 46
-    angleIncrease: 2
-    angleDecay: 25
+    angleIncrease: 76
+    angleDecay: 7
+    cameraRecoilScalar: 0
     fireRate: 3
     selectedMode: Burst
     soundGunshot:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -28,8 +28,8 @@
     maxAngle: -34
   - type: Gun
     minAngle: 21
-    maxAngle: 74
-    angleIncrease: 2
+    maxAngle: 38
+    angleIncrease: 5
     angleDecay: 20
     fireRate: 9.5
     soundGunshot:
@@ -75,7 +75,7 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -19
-    maxAngle: -24
+    maxAngle: -34
   - type: ChamberMagazineAmmoProvider
     soundRack:
       path: /Audio/Weapons/Guns/Cock/ltrifle_cock.ogg
@@ -83,9 +83,9 @@
     sprite: _Mono/Objects/Weapons/Guns/SMGs/ak220.rsi
   - type: Gun
     minAngle: 22
-    maxAngle: 58
-    fireRate: 8
-    angleIncrease: 3
+    maxAngle: 40
+    fireRate: 6
+    angleIncrease: 21
     angleDecay: 14
     selectedMode: FullAuto
     soundGunshot:
@@ -134,15 +134,11 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -5
-    maxAngle: -14
+    maxAngle: -5
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/SMGs/vector.rsi
   - type: Gun
     fireRate: 7.5
-    minAngle: 7
-    maxAngle: 40
-    angleIncrease: 3
-    angleDecay: 16
     selectedMode: Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -195,15 +191,11 @@
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
     minAngle: -5
-    maxAngle: -14
+    maxAngle: -5
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/SMGs/vector.rsi
   - type: Gun
     fireRate: 6
-    minAngle: 7
-    maxAngle: 40
-    angleIncrease: 5
-    angleDecay: 16
     selectedMode: Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -264,9 +256,9 @@
   - type: Gun
     fireRate: 6
     minAngle: 19
-    maxAngle: 32
-    angleIncrease: 9
-    angleDecay: 14
+    maxAngle: 21
+    angleIncrease: 16
+    angleDecay: 10
     selectedMode: Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -316,12 +308,12 @@
   components:
   - type: GunWieldBonus
     minAngle: -27
-    maxAngle: -36
+    maxAngle: -45
   - type: Gun
     minAngle: 30
     maxAngle: 55
-    angleIncrease: 4
-    angleDecay: 12
+    angleIncrease: 18
+    angleDecay: 4
     fireRate: 7
   - type: StaticPrice
     price: 500
@@ -341,16 +333,12 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
-    minAngle: -27
-    maxAngle: -23
+    minAngle: -5
+    maxAngle: -5
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/SMGs/drozd.rsi
   - type: Gun
     fireRate: 6
-    minAngle: 28
-    maxAngle: 42
-    angleIncrease: 4
-    angleDecay: 13
     selectedMode: FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Dvir
 # SPDX-FileCopyrightText: 2025 Eden077
 # SPDX-FileCopyrightText: 2025 Onezero0
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 UltimateJester
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 significant harassment

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -32,9 +32,7 @@
     maxAngle: -36
   - type: Gun
     minAngle: 27
-    maxAngle: 54
-    angleIncrease: 8
-    angleDecay: 14
+    maxAngle: 39
     fireRate: 2.25
     selectedMode: SemiAuto
     availableModes:
@@ -74,10 +72,10 @@
   - type: Appearance
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
-    maxOffset: 6.5
-    pvsIncrease: 0.65
+    maxOffset: 2.5
+    pvsIncrease: 0.4
   - type: SpeedModifiedOnWield # Mono
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: PirateBountyItem # Mono
     id: StandardFactionLongarm

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 grandalff
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -250,15 +250,8 @@
     slots:
     - Back
     - suitStorage
-  - type: GunWieldBonus
-    minAngle: -27
-    maxAngle: -36
   - type: Gun
     fireRate: 1.9
-    angleIncrease: 15
-    angleDecay: 14
-    minAngle: 27
-    maxAngle: 54
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -8,6 +8,7 @@
 # SPDX-FileCopyrightText: 2025 LukeZurg22
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 Whatstone
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 significant harassment


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This PR adjusts AP damage values by aligning AP rates with fire rate and ammo types while preserving the original weapon balance. All AP damage values are now calculated directly from the base ammunition, with the following modifiers: Steel AP at 90% of base damage, Plasteel AP at 80%, and Synthalloy AP at 75%(Degration in damage is lower to make up for the rareness of the matterial and ammunition type). This PR also reverts the Recoil PR.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
AP damage values were unbalanced and unreliable, disrupting the original weapon balance and making the game unfair. The recoil PR is being reverted because, while recoil can be a useful way to balance certain gimmick weapons, applying it to every weapon makes combat unengaging and overly favors close-range weapons. This undermines certain weapon types, adds unnecessary RNG, and overall harms the combat experience on the server. If recoil is implemented in the future, it should avoid RNG and instead rely on player skill, such as managing aim or cursor movement, rather than reducing firearms to melee weapons.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Most no longer have large recoils.
- tweak: AP ammunition damages are rebalanced with proper calculations.