### PR TITLE
Microwave & Range Machine Destruction Behavior Parity

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -38,6 +38,7 @@
 # SPDX-FileCopyrightText: 2024 themias
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 starch
+# SPDX-FileCopyrightText: 2025 tonotom
 #
 # SPDX-License-Identifier: MPL-2.0
 

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -132,8 +132,10 @@
         !type:DamageTrigger
         damage: 300
       behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: machineFrame
       - !type:DoActsBehavior
-        acts: [ "Destruction" ]
+        acts: ["Destruction"]
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/microwave_recipe_assemblers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/microwave_recipe_assemblers.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Alice "Arimah" Heurlin
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2025 starch
+# SPDX-FileCopyrightText: 2025 tonotom
 #
 # SPDX-License-Identifier: MPL-2.0
 

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/microwave_recipe_assemblers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/microwave_recipe_assemblers.yml
@@ -109,8 +109,10 @@
         !type:DamageTrigger
         damage: 300
       behaviors:
+      - !type:ChangeConstructionNodeBehavior
+        node: machineFrame
       - !type:DoActsBehavior
-        acts: [ "Destruction" ]
+        acts: ["Destruction"]
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a behavior to make microwave and electric range revert to a machine frame when smashed instead of disappearing

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is how most machines behave when smashed

## How to test
<!-- Describe the way it can be tested -->

Smash that shit

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Microwave, range, and donkco range.

Donkco microwave tested after and confirmed to spill parts

<img width="240" height="238" alt="image" src="https://github.com/user-attachments/assets/1a8f5d5f-f749-470f-8697-fb1856fe85bb" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
- [ X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

doubt it

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Destroyed microwaves and electric ranges now come apart instead of being vaporized
