### PR TITLE
Armor Fixes

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
@@ -26,7 +26,7 @@
       coefficients:
         Blunt: 0.65
         Slash: 0.65
-        Piercing: 0.55
+        Piercing: 0.6
         Heat: 0.7
         Radiation: 0.65
         Caustic: 0.8
@@ -65,7 +65,7 @@
       coefficients:
         Blunt: 0.7
         Slash: 0.65
-        Piercing: 0.55
+        Piercing: 0.6
         Heat: 0.65
         Radiation: 0.5
         Caustic: 0.6

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m86.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m86.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m86.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m86.yml
@@ -24,9 +24,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4
-        Slash: 0.45
-        Piercing: 0.475
+        Blunt: 0.55
+        Slash: 0.55
+        Piercing: 0.55
         Shock: 0.8
         Heat: 0.6
         Radiation: 0.5
@@ -35,7 +35,7 @@
     coefficient: 0.4
   - type: ClothingSpeedModifier
     walkModifier: 0.85
-    sprintModifier: 0.825
+    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -376,7 +376,7 @@
       coefficients:
         Blunt: 0.45
         Slash: 0.45
-        Piercing: 0.6
+        Piercing: 0.4
         Heat: 0.45
         Radiation: 0.6
         Caustic: 0.55

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2025 BramvanZijp
 # SPDX-FileCopyrightText: 2025 LukeZurg22
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 Whatstone
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -374,16 +374,16 @@
   - type: Armor # Mono - Armor Value Changes
     modifiers:
       coefficients:
-        Blunt: 0.35
-        Slash: 0.35
-        Piercing: 0.4
+        Blunt: 0.45
+        Slash: 0.45
+        Piercing: 0.6
         Heat: 0.45
         Radiation: 0.6
         Caustic: 0.55
         Poison: 0.8 # Mono
   - type: ClothingSpeedModifier # Mono - Armor Value Changes
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.75
+    sprintModifier: 0.7
   - type: FactionClothing
     faction: NanoTrasen
   - type: StaminaDamageResistance # Mono - Stamres


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This PR changes the armor values of the TSFMC faction to make it scale better without being too unbalanced while also making it more accurate to each other.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
TSFMC hardsuits were inconsistent because some, like the M92-X Tacsuit, gave better protection while also being faster than other suits. This made the balance of TSFMC armor uneven. On top of that, the base suits had armor values that were too high in some areas compared to other factions, and the overall armor balance for basic suits, even though they caused the same amount of slowdown and avaibility.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: M92X Tacsuit has more slowdown, and the TSFMC basic suits have less melee and ranged damage protection.