### PR TITLE
Make BZ Purchasable From Cargo

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -130,17 +130,3 @@
 #  cost: 15500
 #  category: cargoproduct-category-name-atmospherics
 #  group: market
-
-- type: cargoProduct
-  id: AtmosphericsTEGCrate
-  name: "TEG Crate"
-  description: "A full set of flatpacked Thermoelectric Generator components, ready to use"
-  icon:
-    sprite: Structures/Power/Generation/teg.rsi
-    state: teg
-  product: CrateTeg 
-  cost: 30000
-  category: cargoproduct-category-name-atmospherics
-  group: market
-  # Create TegCenter, TegCirculator, TegCirculator
-

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -10,6 +10,7 @@
 # SPDX-FileCopyrightText: 2024 Dvir
 # SPDX-FileCopyrightText: 2024 Ilya246
 # SPDX-FileCopyrightText: 2024 MODERN
+# SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
 # SPDX-FileCopyrightText: 2025 SRV
 # SPDX-FileCopyrightText: 2025 SarahRaven
 # SPDX-FileCopyrightText: 2025 Whatstone

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -809,7 +809,7 @@
     - state: bz
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
       - 0 # oxygen
       - 0 # nitrogen
@@ -820,7 +820,7 @@
       - 0 # Miasma
       - 0 # N2O
       - 0 # Frezon
-      - 1871.71051 # BZ
+      - 2769.36 # BZ
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -858,7 +858,7 @@
     - state: healium
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
       - 0 # oxygen
       - 0 # nitrogen
@@ -870,7 +870,7 @@
       - 0 # N2O
       - 0 # Frezon
       - 0 # BZ
-      - 1871.71051 # Healium
+      - 2769.36 # Healium
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -908,7 +908,7 @@
     - state: nitrium
   - type: GasCanister
     gasMixture:
-      volume: 1000
+      volume: 1500
       moles:
       - 0 # oxygen
       - 0 # nitrogen
@@ -921,7 +921,7 @@
       - 0 # Frezon
       - 0 # BZ
       - 0 # Healium
-      - 1871.71051 # Nitrium
+      - 2769.36 # Nitrium
       temperature: 293.15
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -44,9 +44,11 @@
 # SPDX-FileCopyrightText: 2025 ActiveMammmoth
 # SPDX-FileCopyrightText: 2025 ArtisticRoomba
 # SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 # SPDX-FileCopyrightText: 2025 tonotom
+# SPDX-FileCopyrightText: 2025 tonotom1
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Mono/Catalogs/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Cargo/cargo_atmospherics.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: cargoProduct
   id: AtmosphericsBZ
   icon:

--- a/Resources/Prototypes/_Mono/Catalogs/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Cargo/cargo_atmospherics.yml
@@ -1,0 +1,22 @@
+- type: cargoProduct
+  id: AtmosphericsBZ
+  icon:
+    sprite: _NF/Structures/Storage/canister.rsi # Frontier: _NF
+    state: bz
+  product: BZCanister
+  cost: 33500 # 1 can of bz (2769.36mol) at $12/mol is $33232.32
+  category: cargoproduct-category-name-atmospherics
+  group: market
+
+- type: cargoProduct
+  id: AtmosphericsTEGCrate
+  name: "TEG Crate"
+  description: "A full set of flatpacked Thermoelectric Generator components, ready to use"
+  icon:
+    sprite: Structures/Power/Generation/teg.rsi
+    state: teg
+  product: CrateTeg 
+  cost: 30000
+  category: cargoproduct-category-name-atmospherics
+  group: market
+  # Create TegCenter, TegCirculator, TegCirculator


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
made BZ canister buyable from cargo for 33.5k
changed bz, healium, and nitrium canisters to be 1500L because #845
moved both this and TEG crate purchase to be under _Mono

## Why / Balance
less tedious to produce healium/nitrium (for both of which you can get all their precursors _other than BZ_ from wrecks) while being someone who could actually use it (factions), there is not much other use; dedicated atmos moneymakers will just produce bz themselves
could make bz and its products cost less too so that this isn't as exorbitant

using _bought_ BZ to make and sell nitrium doesn't make any sense because at that point you'd already have the precursors for making frezon, of which you can make more of (in worth) than nitrium with the same amount of BZ

## How to test
buy from cargo
scan with gas analyzer, should be 4500kPa as with all other room-temp canisters
cargo requests seemingly dont work on dev map so test on release

## Media
<img height="300" alt="image" src="https://github.com/user-attachments/assets/3541886d-1be4-4c09-a026-205c9654a4ce" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl:
- add: Cargo request computers now offer canisters of BZ.
