### PR TITLE
Added Button/Switch/Port Support that the LMB Was Lacking

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/light_munitions_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/light_munitions_launcher.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
+# SPDX-FileCopyrightText: 2025 Greenwall
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -19,6 +20,7 @@
   - type: Appearance
   - type: AmmoCounter
   - type: WirelessNetworkConnection
+  - type: GunSignalControl
     range: 500
   - type: Gun
     projectileSpeed: 10

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/light_munitions_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/light_munitions_launcher.yml
@@ -1,7 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Greenwall
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
+# SPDX-FileCopyrightText: 2025 Your Name
 # SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
-# SPDX-FileCopyrightText: 2025 Greenwall
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -20,6 +22,7 @@
   - type: Appearance
   - type: AmmoCounter
   - type: WirelessNetworkConnection
+    range: 700
   - type: GunSignalControl
     range: 500
   - type: Gun

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/light_munitions_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/light_munitions_launcher.yml
@@ -1,7 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Greenwall
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
+# SPDX-FileCopyrightText: 2025 Your Name
 # SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
-# SPDX-FileCopyrightText: 2025 Greenwall
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Light Munitions Bay wasn't working with shuttle console

## Why / Balance
every other ship weapon i've used has the option to be linked with shuttle console, this one didnt so i fixed it
## How to test
slap one on a shuttle, load it, link it to trigger and not fire armament and hit the port button

## Media
<img width="1565" height="622" alt="image" src="https://github.com/user-attachments/assets/e21eb26b-975b-498d-a1d8-428f5c036543" />
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: port/button/switch support for the Light Munitions Bay
-->
