### PR TITLE
Ore Drop Consolidation QOL

### DIFF
--- a/Content.Shared/Mining/OrePrototype.cs
+++ b/Content.Shared/Mining/OrePrototype.cs
@@ -20,7 +20,7 @@ public sealed partial class OrePrototype : IPrototype
     public int MinOreYield = 1;
 
     [DataField]
-    public int MaxOreYield = 1;
+    public int MaxOreYield = 1;bunga
 
     [DataField]
     public SpriteSpecifier? OreSprite;

--- a/Content.Shared/Mining/OrePrototype.cs
+++ b/Content.Shared/Mining/OrePrototype.cs
@@ -20,7 +20,7 @@ public sealed partial class OrePrototype : IPrototype
     public int MinOreYield = 1;
 
     [DataField]
-    public int MaxOreYield = 1;bunga
+    public int MaxOreYield = 1;
 
     [DataField]
     public SpriteSpecifier? OreSprite;

--- a/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
+++ b/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
@@ -187,3 +187,30 @@
   components:
   - type: Stack
     count: 5
+
+#Ore denominations used for mining entity consolidation:
+#Iron, Quartz, and Coal absent because drops average at 15 already. Plasma, Uranium, Bananium absent due to fractional drop averages where rounding would be untidy
+
+- type: entity
+  parent: GoldOre
+  id: GoldOre10
+  suffix: Ten
+  components:
+  - type: Stack
+    count: 10
+    
+- type: entity
+  parent: SilverOre
+  id: SilverOre10
+  suffix: Ten
+  components:
+  - type: Stack
+    count: 10
+    
+- type: entity
+  parent: SaltOre
+  id: SaltOre10
+  suffix: Ten
+  components:
+  - type: Stack
+    count: 10

--- a/Resources/Prototypes/_Mono/Recipes/Construction/Graphs/Misc/orecrab.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Construction/Graphs/Misc/orecrab.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 tonotom
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Mono/Recipes/Construction/Graphs/Misc/orecrab.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Construction/Graphs/Misc/orecrab.yml
@@ -11,63 +11,63 @@
     - to: quartz
       steps:
       - material: SpaceQuartz
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1
     - to: iron
       steps:
       - material: SteelOre
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1
     - to: uranium
       steps:
       - material: UraniumOre
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1
     - to: silver
       steps:
       - material: SilverOre
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1
     - to: bananium
       steps:
       - material: BananiumOre
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1
     - to: coal
       steps:
       - material: Coal
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1
     - to: gold
       steps:
       - material: GoldOre
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1
     - to: plasma
       steps:
       - material: PlasmaOre
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1
     - to: salt
       steps:
       - material: SaltOre
-        amount: 5
+        amount: 15
         doAfter: 5
       - material: Bluespace
         amount: 1

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/elemental.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Checkraze
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Kill_Me_I_Noobs
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 tonotom
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # Upstream
 - type: entity
   parent: MobOreCrab

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/elemental.yml
@@ -168,9 +168,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          BananiumOre1:
-            min: 1
-            max: 3
+          BananiumOre1: #Mono 1-3 >> 10
+            min: 10
+            max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -193,9 +193,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          GoldOre1:
-            min: 2
-            max: 4
+          GoldOre1: #Mono 2-4 >> 10
+            min: 10
+            max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -222,9 +222,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          PlasmaOre1:
-            min: 2
-            max: 4
+          PlasmaOre1:  #Mono 2-4 >> 10
+            min: 10
+            max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: PointLight
@@ -251,9 +251,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          Salt1:
-            min: 1
-            max: 3
+          Salt1: #Mono 1-3 >> 10
+            min: 10
+            max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -275,9 +275,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          SpaceQuartz1:
-            min: 3
-            max: 5
+          SpaceQuartz1: #Mono 3-5 >> 15
+            min: 15
+            max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -302,9 +302,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          SteelOre1:
-            min: 3
-            max: 5
+          SteelOre1: #Mono 3-5 >> 15
+            min: 15
+            max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -327,9 +327,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          UraniumOre1:
-            min: 2
-            max: 4
+          UraniumOre1: #Mono 2-4 >> 10
+            min: 10
+            max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: PointLight
@@ -355,9 +355,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          SilverOre1:
-            min: 2
-            max: 4
+          SilverOre1: #Mono 2-4 >> 10
+            min: 10
+            max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -416,8 +416,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          BananiumOre1:
-            min: 5
+          BananiumOre1: #Mono 5-10 >> 10
+            min: 10
             max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -441,9 +441,9 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          Coal1:
-            min: 2
-            max: 4
+          Coal1: #Mono 2-4 >> 15
+            min: 15
+            max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
 
@@ -465,8 +465,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          Coal1:
-            min: 5
+          Coal1: #Mono 1-15 >> 15
+            min: 15
             max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -489,8 +489,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          GoldOre1:
-            min: 5
+          GoldOre1: #Mono 5-15 >> 15
+            min: 15
             max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -513,8 +513,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          SteelOre1:
-            min: 5
+          SteelOre1: #Mono 5-15 >> 15
+            min: 15
             max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -541,8 +541,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          PlasmaOre1:
-            min: 5
+          PlasmaOre1: #Mono 5-15 >> 15
+            min: 15
             max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -569,8 +569,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          SpaceQuartz1:
-            min: 5
+          SpaceQuartz1: #Mono 5-15 >> 15
+            min: 15
             max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -593,8 +593,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          Salt1:
-            min: 5
+          Salt1: #Mono 5-10 >> 10
+            min: 10
             max: 10
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -617,8 +617,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          SilverOre1:
-            min: 5
+          SilverOre1: #Mono 5-15 >> 15
+            min: 15
             max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -644,8 +644,8 @@
           collection: GlassBreak
       - !type:SpawnEntitiesBehavior
         spawn:
-          UraniumOre1:
-            min: 5
+          UraniumOre1: #Mono 5-15 >> 15
+            min: 15
             max: 15
       - !type:DoActsBehavior
         acts: [ "Destruction" ]

--- a/Resources/Prototypes/_NF/ore.yml
+++ b/Resources/Prototypes/_NF/ore.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Kill_Me_I_Noobs
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 tonotom
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # Ore definitions
 
 # Standard rocks

--- a/Resources/Prototypes/_NF/ore.yml
+++ b/Resources/Prototypes/_NF/ore.yml
@@ -5,40 +5,40 @@
 # High yields
 - type: ore
   id: NFOreSteel
-  oreEntity: SteelOre5
+  oreEntity: SteelOre15 #Mono 5 >> 15
   minOreYield: 1
-  maxOreYield: 5
+  maxOreYield: 1 #Mono 5 >> 1
 
 - type: ore
   id: NFOreSpaceQuartz
-  oreEntity: SpaceQuartz5
+  oreEntity: SpaceQuartz15 #Mono 5 >> 15
   minOreYield: 1
-  maxOreYield: 5
+  maxOreYield: 1 #Mono 5 >> 1
 
 - type: ore
   id: NFOreCoal
-  oreEntity: Coal5
+  oreEntity: Coal15 #Mono 5 >> 15
   minOreYield: 1
-  maxOreYield: 5
+  maxOreYield: 1 #Mono 5 >> 1
 
 # Medium yields
 - type: ore
   id: NFOreGold
-  oreEntity: GoldOre5
+  oreEntity: GoldOre10 #Mono 5 >> 10
   minOreYield: 1
-  maxOreYield: 3
+  maxOreYield: 1 #Mono 3 >> 1
 
 - type: ore
   id: NFOreSilver
-  oreEntity: SilverOre5
+  oreEntity: SilverOre10 #Mono 5 >> 10
   minOreYield: 1
-  maxOreYield: 3
+  maxOreYield: 1 #Mono 3 >> 1
 
 - type: ore
   id: NFOreSalt
-  oreEntity: Salt5
+  oreEntity: SaltOre10 #Mono 5 >> 10
   minOreYield: 1
-  maxOreYield: 3
+  maxOreYield: 1 #Mono 3 >> 1
 
 # Low yields
 - type: ore


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

- Iron, quartz, coal simplified to their average drop rate of 15 instead of random. Drops a single entity instead of a pile.
- Gold, silver, salt simplified to a single entity of 10 (Average drop amount) I had to add three protos to do this.
- Plasma, uranium, bananium kept the same due to having an average of 7.5 and me not wanting to round to a non multiple of 5. It's 50% chance to drop a whole extra one entity. Not too bad.
- Bluespace and diamond are already 1
- Artifact fraggies kept same
- Ore crabs and golems now drop an appropriate amount of ore instead of less than a normal drop. Their numbers should be equal to or slightly more than an average ore mine drop.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Slightly more forgiveness for ore bag forgetters
- Ore bag havers win some too
- Miniscule entity overhead reductions
- Crabs are punishment enough. No need to salt the wound with reduced drops.

## How to test
<!-- Describe the way it can be tested -->
Go mining

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Tiny change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
- [X ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Mining ore drops less cluttery and easier to pick up. Gain rates should be roughly the same.
- tweak: Ore crabs and golem drops more ore to ensure they aren't worth less than a regular ore drop.
- tweak: Since ore crabs now drop more than it costs to make a domestic ore crab, the crafting cost had to be increased. Bluespace cost is kept the same.