### PR TITLE
No Gas Purity Penalty At Edison

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -28,11 +28,26 @@ public partial class AtmosphereSystem
 
         // Pay more for gas canisters that are more pure
         float purity = 1;
-        if (totalMoles > 0) {
+        if (totalMoles > 0)
+        {
             purity = maxComponent / totalMoles;
         }
 
         return basePrice * purity;
+    }
+
+    /// <summary>
+    /// Mono - Gets the price of an air mixture without purity penalty.
+    /// </summary>
+    public double GetPriceNoPurity(GasMixture mixture)
+    {
+        float basePrice = 0; // moles of gas * price/mole
+        for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+        {
+            basePrice += mixture.Moles[i] * GetGas(i).PricePerMole;
+        }
+
+        return basePrice;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Utils.cs
@@ -1,3 +1,11 @@
+// SPDX-FileCopyrightText: 2022 Vera Aguilera Puerto
+// SPDX-FileCopyrightText: 2022 metalgearsloth
+// SPDX-FileCopyrightText: 2023 Kara
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2025 bitcrushing
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using System.Runtime.CompilerServices;
 using Content.Server.Atmos.Components;
 using Content.Server.Maps;

--- a/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
@@ -284,7 +284,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
             salePoint.Comp.GasStorage.Clear();
         }
 
-        var amount = _atmosphere.GetPrice(mixture);
+        var amount = _atmosphere.GetPriceNoPurity(mixture); // Mono - No purity penalty
         if (TryComp<MarketModifierComponent>(ent, out var priceMod))
             amount *= priceMod.Mod;
 
@@ -324,7 +324,7 @@ public sealed class GasDepositSystem : SharedGasDepositSystem
             _atmosphere.Merge(mixture, salePoint.Comp.GasStorage);
         }
 
-        value = _atmosphere.GetPrice(mixture);
+        value = _atmosphere.GetPriceNoPurity(mixture); // Mono - No purity penalty
     }
 
     private List<Entity<GasSalePointComponent>> GetNearbySalePoints(EntityUid consoleUid, EntityUid gridUid)

--- a/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
+++ b/Content.Server/_NF/Atmos/Systems/GasDepositSystem.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Milon
 // SPDX-FileCopyrightText: 2025 Whatstone
+// SPDX-FileCopyrightText: 2025 bitcrushing
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a GasPriceNoPurity method to AtmosphereSystem.Utils.cs to be used by Edison gas sale consoles, suggested by people on the Discord server.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Having to wait 10mins for a gas to clear out of the Edison pipenet so you can sell it without a penalty is not fun
Makes gas mining purely for sales more viable

## How to test
<!-- Describe the way it can be tested -->
Pipe mixed and unmixed gases into a gas sale port
Use gas sale console to look at price, compare mixed and unmixed to see they add up

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None, alternative method to GasPrice

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: No more gas purity malus on mixed gas sales at Edison