### PR TITLE
Make Asakim Armor Practically Unusable by Other Species

### DIFF
--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -1,3 +1,19 @@
+// SPDX-FileCopyrightText: 2022 Emisse
+// SPDX-FileCopyrightText: 2022 Leon Friedrich
+// SPDX-FileCopyrightText: 2022 mirrorcult
+// SPDX-FileCopyrightText: 2022 rolfero
+// SPDX-FileCopyrightText: 2023 Nemanja
+// SPDX-FileCopyrightText: 2023 Visne
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Cojoke
+// SPDX-FileCopyrightText: 2024 DrSmugleaf
+// SPDX-FileCopyrightText: 2024 Errant
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2024 slarticodefast
+// SPDX-FileCopyrightText: 2025 kotobdev
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Shared._DV.Clothing.Events; // DeltaV - Introduce ClothingSlowResistance to Species
 using Content.Shared.Examine;
 using Content.Shared.Inventory;

--- a/Content.Shared/_DV/Clothing/Components/ClothingSlowResistanceComponent.cs
+++ b/Content.Shared/_DV/Clothing/Components/ClothingSlowResistanceComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 kotobdev
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._DV.Clothing.Components;

--- a/Content.Shared/_DV/Clothing/Components/ClothingSlowResistanceComponent.cs
+++ b/Content.Shared/_DV/Clothing/Components/ClothingSlowResistanceComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Clothing.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ClothingSlowResistanceComponent : Component
+{
+    /// <summary>
+    /// Modifier for both walk and sprint slowdown.
+    /// </summary>
+    [DataField(required: true)]
+    public float Modifier = 0.25f;
+}

--- a/Content.Shared/_DV/Clothing/Events/ModifyClothingSlowdownEvent.cs
+++ b/Content.Shared/_DV/Clothing/Events/ModifyClothingSlowdownEvent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 kotobdev
+//
+// SPDX-License-Identifier: MPL-2.0
+
 namespace Content.Shared._DV.Clothing.Events;
 
 /// <summary>

--- a/Content.Shared/_DV/Clothing/Events/ModifyClothingSlowdownEvent.cs
+++ b/Content.Shared/_DV/Clothing/Events/ModifyClothingSlowdownEvent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._DV.Clothing.Events;
+
+/// <summary>
+/// Raised on an entity when clothing would slow them down or when they examine clothing.
+/// </summary>
+/// <param name="WalkModifier">The walking speed modifier of the clothing.</param>
+/// <param name="RunModifier">The running speed modifier of the clothing.</param>
+[ByRefEvent]
+public record struct ModifyClothingSlowdownEvent(float WalkModifier, float RunModifier);

--- a/Content.Shared/_DV/Clothing/Systems/ClothingSlowResistanceSystem.cs
+++ b/Content.Shared/_DV/Clothing/Systems/ClothingSlowResistanceSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 kotobdev
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Shared._DV.Clothing.Components;
 using Content.Shared._DV.Clothing.Events;
 using Content.Shared.Movement.Systems;

--- a/Content.Shared/_DV/Clothing/Systems/ClothingSlowResistanceSystem.cs
+++ b/Content.Shared/_DV/Clothing/Systems/ClothingSlowResistanceSystem.cs
@@ -1,0 +1,36 @@
+using Content.Shared._DV.Clothing.Components;
+using Content.Shared._DV.Clothing.Events;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared._DV.Clothing.Systems;
+
+public sealed class ClothingSlowResistanceSystem : EntitySystem
+{
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ClothingSlowResistanceComponent, ModifyClothingSlowdownEvent>(OnModifyClothingSlowdown);
+    }
+
+    public void SetModifier(Entity<ClothingSlowResistanceComponent?> ent, float modifier)
+    {
+        ent.Comp ??= EnsureComp<ClothingSlowResistanceComponent>(ent);
+        ent.Comp.Modifier = modifier;
+        Dirty(ent, ent.Comp);
+
+        _movementSpeed.RefreshMovementSpeedModifiers(ent);
+    }
+
+    private void OnModifyClothingSlowdown(Entity<ClothingSlowResistanceComponent> ent, ref ModifyClothingSlowdownEvent args)
+    {
+        var modifier = ent.Comp.Modifier;
+
+        if (args.WalkModifier < 1)
+            args.WalkModifier += (1 - args.WalkModifier) * modifier;
+        if (args.RunModifier < 1)
+            args.RunModifier += (1 - args.RunModifier) * modifier;
+    }
+}

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
@@ -1,6 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Arcticular
 # SPDX-FileCopyrightText: 2025 Arcticular1
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 kotobdev
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
@@ -47,8 +47,8 @@
         Poison: 0.4
         Caustic: 0.4
   - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1
+    walkModifier: 0.2
+    sprintModifier: 0.2
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
@@ -44,6 +44,7 @@
 # SPDX-FileCopyrightText: 2025 ScyronX
 # SPDX-FileCopyrightText: 2025 SuperJoelDood
 # SPDX-FileCopyrightText: 2025 Suyo
+# SPDX-FileCopyrightText: 2025 kotobdev
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Species/asakim.yml
@@ -68,6 +68,8 @@
     baseWalkSpeed : 2.7
     baseSprintSpeed : 4.65
     weightlessAcceleration: 1.5 # Slightly more manueverable in space.
+  - type: ClothingSlowResistance
+    modifier: 1.0 # Completely unaffected by clothing slow
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The asakim harness now has an 80% movement slowdown, and Asakim now ignore all clothing movement slowdown. (This will surely not have any unintended side effects).

Half-port of https://github.com/DeltaV-Station/Delta-v/pull/4364, excluding the Oni changes

## Why / Balance
makes the hardsuit *basically* unusable by anybody that's not an Asakim, so even if a gamer gets their hands on it, it won't really be that useful

I'm not terribly in-tune with monolith hardsuit balancing, but I'm 99% sure there's no reason an asakim would even want to use anything other then their harness anyways, seeing how busted it is. plus they're already The Overpowered Species by design so this is really just on-brand for them

## How to test
- spawn urist, give harness
- control urist, they're very slow
- spawn asakim warrior
- control asakim warrior, they're very fast

## Media
https://github.com/user-attachments/assets/2df9a4f2-c214-414a-9c95-d4211176fb45



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Asakim combat harness now has an 80% slowdown.
- tweak: Asakim now ignore all clothing movement slowdown.
