### PR TITLE
Area Based Sound Echo

### DIFF
--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -22,6 +22,10 @@
                 <CheckBox Name="CoalesceIdenticalMessagesCheckBox" Text="{Loc 'ui-options-coalesce-identical-messages'}" /> <!-- WD EDIT -->
                 <CheckBox Name="DetailedExamineCheckBox" Text="{Loc 'ui-options-detailed-examine'}" /> <!-- Goobstation Change -->
                 <CheckBox Name="RadioNoiseCheckBox" Text="{Loc 'ui-options-radio-noise'}" /> <!-- Mono -->
+                <Label Text="{Loc 'ui-options-general-area-echo'}"
+                       StyleClasses="LabelKeyText"/> <!-- Mono -->
+                <CheckBox Name="AreaEchoCheckBox" Text="{Loc 'ui-options-area-echo-enabled'}" /> <!-- Mono -->
+                <CheckBox Name="AreaEchoHighResolutionCheckBox" Text="{Loc 'ui-options-area-echo-highres'}" /> <!-- Mono -->
                 <Label Text="{Loc 'ui-options-general-cursor'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="ShowHeldItemCheckBox" Text="{Loc 'ui-options-show-held-item'}" />

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -72,6 +72,8 @@ public sealed partial class MiscTab : Control
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
         Control.AddOptionCheckBox(CCVars.DetailedExamine, DetailedExamineCheckBox); // Goobstation Change
         Control.AddOptionCheckBox(MonoCVars.RadioNoiseEnabled, RadioNoiseCheckBox); // Mono
+        Control.AddOptionCheckBox(MonoCVars.AreaEchoEnabled, AreaEchoCheckBox); // Mono
+        Control.AddOptionCheckBox(MonoCVars.AreaEchoHighResolution, AreaEchoHighResolutionCheckBox); // Mono
 
         Control.Initialize();
     }

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -9,6 +9,7 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth
 // SPDX-FileCopyrightText: 2024 to4no_fix
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
 // SPDX-FileCopyrightText: 2025 ark1368
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Client/_Mono/Audio/AreaEchoSystem.cs
+++ b/Content.Client/_Mono/Audio/AreaEchoSystem.cs
@@ -188,6 +188,7 @@ public sealed class AreaEchoSystem : EntitySystem
         - Any spaced tile is invalid
         - If the grid has RoofComponent:
         - - Only now, will rays end on invalid tiles (space) or unrooved tiles
+        - - This is checked every `_calculationalFidelity`-ish tiles. Not precisely. But somewhere around that. Its moreso just proportional to that.
     */
     public bool TryProcessAreaSpaceMagnitude(Entity<TransformComponent> entity, float maximumMagnitude, out float magnitude)
     {

--- a/Content.Client/_Mono/Audio/AreaEchoSystem.cs
+++ b/Content.Client/_Mono/Audio/AreaEchoSystem.cs
@@ -54,7 +54,7 @@ public sealed class AreaEchoSystem : EntitySystem
     /// <remarks>
     ///     Keep in ascending order.
     /// </remarks>
-    private static readonly List<(float, ProtoId<AudioPresetPrototype>)> DistancePresets = new() { (15f, "Hallway"), (25f, "Auditorium"), (25f, "ConcertHall") };
+    private static readonly List<(float, ProtoId<AudioPresetPrototype>)> DistancePresets = new() { (15f, "Hallway"), (25f, "Auditorium"), (40f, "ConcertHall") };
 
     /// <summary>
     ///     When is the next time we should check all audio entities and see if they are eligible to be updated.
@@ -275,7 +275,6 @@ public sealed class AreaEchoSystem : EntitySystem
         }
 
         magnitude /= _calculatedDirections.Length;
-        Log.Info($"Magnitude of {magnitude} for entity {ToPrettyString(entity.Owner)}");
         return true;
     }
 
@@ -299,7 +298,7 @@ public sealed class AreaEchoSystem : EntitySystem
                 _audioEffectSystem.TryAddEffect(entity, DistancePresets[0].Item2);
         }
         else
-            _audioEffectSystem.RemoveEffect(entity);
+            _audioEffectSystem.TryRemoveEffect(entity);
     }
 
     private void OnAudioParentChanged(Entity<AudioComponent> entity, ref EntParentChangedMessage args)

--- a/Content.Client/_Mono/Audio/AreaEchoSystem.cs
+++ b/Content.Client/_Mono/Audio/AreaEchoSystem.cs
@@ -6,12 +6,9 @@ using Content.Shared._Mono.CCVar;
 using Content.Shared.Light.Components;
 using Content.Shared.Physics;
 using Robust.Client.GameObjects;
-using Robust.Client.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Components;
-using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
-using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -60,11 +57,11 @@ public sealed class AreaEchoSystem : EntitySystem
     /// <summary>
     ///     Collision mask for echoes.
     /// </summary>
-    private int _echoLayer = (int)(CollisionGroup.Impassable | CollisionGroup.HighImpassable);
+    private int _echoLayer = (int)(CollisionGroup.Impassable | CollisionGroup.HighImpassable); // this could be better but whatever
 
     private bool _echoEnabled = true;
     private float _calculationalFidelity = 5f;
-    private TimeSpan _calculationInterval = TimeSpan.FromSeconds(15);
+    private TimeSpan _calculationInterval = TimeSpan.FromSeconds(15); // how often we should check existing audio re-apply or remove echo from them when necessary
 
     private EntityQuery<MapGridComponent> _gridQuery;
     private EntityQuery<RoofComponent> _roofQuery;
@@ -316,11 +313,3 @@ public sealed class AreaEchoSystem : EntitySystem
         ProcessAudioEntity(entity, args.Transform, minimumMagnitude, maximumMagnitude);
     }
 }
-
-/// <summary>
-///     Raised on a grid (or map if there's no grid) at an audio's position, to override an echo's effect.
-///     Not raised if 
-/// </summary>
-/// <param name="Preset">The preset the audio should use. If null, uses no preset only if <paramref name="Change"/> is true.</param>
-[ByRefEvent]
-public record struct GetGridAreaEchoEvent(EntityCoordinates Position, ProtoId<AudioPresetPrototype>? Preset = null, bool Change = false);

--- a/Content.Client/_Mono/Audio/AreaEchoSystem.cs
+++ b/Content.Client/_Mono/Audio/AreaEchoSystem.cs
@@ -1,0 +1,326 @@
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Content.Client.Light.EntitySystems;
+using Content.Shared._Mono.CCVar;
+using Content.Shared.Light.Components;
+using Content.Shared.Physics;
+using Robust.Client.GameObjects;
+using Robust.Client.Player;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
+
+namespace Content.Client._Mono.Audio;
+
+// i would make this more generalised but theres not really any point
+/// <summary>
+///     Handles making sounds 'echo' in large, open spaces.
+/// </summary>
+public sealed class AreaEchoSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly AudioEffectSystem _audioEffectSystem = default!;
+    [Dependency] private readonly RoofSystem _roofSystem = default!;
+
+    /// <summary>
+    ///     The directions that are raycasted to determine size for echo.
+    ///         Used relative to the grid.
+    /// </summary>
+    private Angle[] _calculatedDirections = [Direction.North.ToAngle(), Direction.West.ToAngle(), Direction.South.ToAngle(), Direction.East.ToAngle()];
+
+    /// <summary>
+    ///     Values for the minimum arbitrary size at which a certain audio preset
+    ///         is picked for sounds. The higher the highest distance here is,
+    ///         the generally more calculations it has to do.
+    /// </summary>
+    /// <remarks>
+    ///     Keep in ascending order.
+    /// </remarks>
+    private static readonly List<(float, ProtoId<AudioPresetPrototype>)> DistancePresets = new() { (9f, "Hallway"), (13.5f, "Auditorium"), (30f, "ConcertHall") };
+
+    /// <summary>
+    ///     When is the next time we should check all audio entities and see if they are eligible to be updated.
+    /// </summary>
+    private TimeSpan _nextExistingUpdate = TimeSpan.Zero;
+
+    /// <summary>
+    ///     Collision mask for echoes.
+    /// </summary>
+    private int _echoLayer = (int)(CollisionGroup.Impassable | CollisionGroup.HighImpassable);
+
+    private bool _echoEnabled = true;
+    private float _calculationalFidelity = 5f;
+    private TimeSpan _calculationInterval = TimeSpan.FromSeconds(15);
+
+    private EntityQuery<MapGridComponent> _gridQuery;
+    private EntityQuery<RoofComponent> _roofQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoEnabled, x => _echoEnabled = x);
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoHighResolution, x => _calculatedDirections = GetEffectiveDirections(x));
+
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoStepFidelity, x => _calculationalFidelity = x);
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoRecalculationInterval, x => _calculationInterval = x);
+
+        _gridQuery = GetEntityQuery<MapGridComponent>();
+        _roofQuery = GetEntityQuery<RoofComponent>();
+
+        _echoEnabled = _configurationManager.GetCVar(MonoCVars.AreaEchoEnabled);
+        _calculatedDirections = GetEffectiveDirections(_configurationManager.GetCVar(MonoCVars.AreaEchoHighResolution));
+        _calculationalFidelity = _configurationManager.GetCVar(MonoCVars.AreaEchoStepFidelity);
+        _calculationInterval = _configurationManager.GetCVar(MonoCVars.AreaEchoRecalculationInterval);
+
+        SubscribeLocalEvent<AudioComponent, EntParentChangedMessage>(OnAudioParentChanged);
+    }
+
+    /// <summary>
+    ///     Returns all four cardinal directions when <paramref name="highResolution"/> is false.
+    ///         Otherwise, returns all eight intercardinal and cardinal directions as listed in
+    ///         <see cref="DirectionExtensions.AllDirections"/>. 
+    /// </summary>
+    public static Angle[] GetEffectiveDirections(bool highResolution)
+    {
+        if (highResolution)
+        {
+            var allDirections = DirectionExtensions.AllDirections;
+            var directions = new Angle[allDirections.Length];
+
+            for (var i = 0; i < allDirections.Length; i++)
+                directions[i] = allDirections[i].ToAngle();
+
+            return directions;
+        }
+
+        return [Direction.North.ToAngle(), Direction.West.ToAngle(), Direction.South.ToAngle(), Direction.East.ToAngle()];
+    }
+
+    /// <summary>
+    ///     Takes an entity's <see cref="TransformComponent"/>. Goes through every parent it
+    ///         has before reaching one that is a map. Returns the hierarchy
+    ///         discovered, which includes the given <paramref name="originEntity"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private List<Entity<TransformComponent>> TryGetHierarchyBeforeMap(Entity<TransformComponent> originEntity)
+    {
+        var hierarchy = new List<Entity<TransformComponent>>() { originEntity };
+
+        ref var currentEntity = ref originEntity;
+        ref var currentTransformComponent = ref currentEntity.Comp;
+
+        var mapUid = currentEntity.Comp.MapUid;
+
+        while (currentTransformComponent.ParentUid != mapUid /* break when the next entity is a map... */ &&
+            currentTransformComponent.ParentUid.IsValid() /* ...or invalid */ )
+        {
+            // iterate to next entity
+            var nextUid = currentTransformComponent.ParentUid;
+            currentEntity.Owner = nextUid;
+            currentTransformComponent = Transform(nextUid);
+
+            hierarchy.Add(currentEntity);
+        }
+
+        DebugTools.Assert(hierarchy.Count >= 1, "Malformed entity hierarchy! Hierarchy must always contain one element, but it doesn't. How did this happen?");
+        return hierarchy;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        if (!_echoEnabled ||
+            _gameTiming.CurTime < _nextExistingUpdate)
+            return;
+
+        _nextExistingUpdate = _gameTiming.CurTime + _calculationInterval;
+
+        var minimumMagnitude = DistancePresets.TryFirstOrNull(out var first) ? first.Value.Item1 : 0f;
+        DebugTools.Assert(minimumMagnitude > 0f, "First distance preset was less than or equal to 0!");
+        if (minimumMagnitude <= 0f)
+            return;
+
+        var maximumMagnitude = DistancePresets.Last().Item1;
+        var audioEnumerator = EntityQueryEnumerator<AudioComponent>();
+
+        while (audioEnumerator.MoveNext(out var uid, out var audioComponent))
+        {
+            if (!CanAudioEcho(audioComponent))
+                continue;
+
+            ProcessAudioEntity((uid, audioComponent), Transform(uid), minimumMagnitude, maximumMagnitude);
+        }
+    }
+
+    /// <summary>
+    ///     Basic check for whether an audio can echo. Doesn't account for distance.
+    /// </summary>
+    public bool CanAudioEcho(AudioComponent audioComponent)
+        => !audioComponent.Global && _echoEnabled;
+
+    /// <summary>
+    ///     Gets the length of the direction that reaches the furthest unobstructed
+    ///         distance, in an attempt to get the size of the area. Aborts early
+    ///         if either grid is missing or the tile isnt rooved.
+    /// 
+    ///     Returned magnitude is the longest valid length of the ray in each direction,
+    ///         divided by the number of total processed angles.
+    /// </summary>
+    /// <returns>Whether anything was actually processed.</returns>
+    // i am the total overengineering guy... and this, is my code.
+    /*
+        This works under a few assumptions:
+        - An entity in space is invalid
+        - Any spaced tile is invalid
+        - If the grid has RoofComponent:
+        - - Only now, will rays end on invalid tiles (space) or unrooved tiles
+    */
+    public bool TryProcessAreaSpaceMagnitude(Entity<TransformComponent> entity, float minimumMagnitude, float maximumMagnitude, out float magnitude)
+    {
+        magnitude = 0f;
+        var transformComponent = entity.Comp;
+
+        // get either the grid or other parent entity this entity is on, and it's rotation
+        var entityHierarchy = TryGetHierarchyBeforeMap(entity);
+        if (entityHierarchy.Count <= 1) // hierarchy always starts with our entity. if it only has our entity, it means the next parent was the map, which we don't want
+            return false; // means this entity is in space/otherwise not on a grid
+
+        // at this point, we know that we are somewhere on a grid
+
+        // e.g.: if a sound is inside a crate, this will now be the grid the crate is on; if the sound is just on the grid, this will be the grid that the sound is on.
+        var entityGrid = entityHierarchy.Last();
+
+        // this is the last entity, or this entity itself, that this entity has, before the parent is a grid/map. e.g.: if a sound is inside a crate, this will be the crate; if the sound is just on the grid, this will be the sound
+        var lastEntityBeforeGrid = entityHierarchy[^2]; // `l[^x]` is analogous to `l[l.Count - x]`
+        // `lastEntityBeforeGrid` is obviously directly before `entityGrid`
+        // the earlier guard clause makes sure this will always be valid
+
+        Log.Debug($"Our grid: {ToPrettyString(entityGrid.Owner)}, our lower highest parent: {ToPrettyString(lastEntityBeforeGrid.Owner)}");
+        if (!_gridQuery.TryGetComponent(entityGrid, out var gridComponent))
+            return false;
+
+        var checkRoof = _roofQuery.TryGetComponent(entityGrid, out var roofComponent);
+        var tileRef = _mapSystem.GetTileRef(entityGrid, gridComponent, lastEntityBeforeGrid.Comp.Coordinates);
+
+        if (checkRoof &&
+            tileRef.Tile.IsEmpty)
+            return false;
+
+        var gridRoofEntity = new Entity<MapGridComponent, RoofComponent?>(entityGrid, gridComponent, roofComponent);
+        if (checkRoof &&
+            !_roofSystem.IsRooved(gridRoofEntity!, tileRef.GridIndices))
+            return false;
+
+        var gridTileSize = gridComponent.TileSize;
+        var originTileIndices = tileRef.GridIndices;
+        var worldPosition = _transformSystem.GetWorldPosition(transformComponent);
+
+        foreach (var direction in _calculatedDirections)
+        {
+            var directionVector = (direction + entityGrid.Comp.LocalRotation).ToVec();
+            var directionFidelityStep = directionVector * _calculationalFidelity;
+
+            var ray = new CollisionRay(worldPosition, directionVector, _echoLayer);
+            var rayResults = _physicsSystem.IntersectRay(transformComponent.MapID, ray, maximumMagnitude, ignoredEnt: lastEntityBeforeGrid, returnOnFirstHit: true);
+
+            // if we hit something, distance to that is magnitude but it must be lower than maximum. if we didnt hit anything, it's maximum magnitude
+            var rayMagnitude = rayResults.TryFirstOrNull(out var firstResult) ?
+                MathF.Min(firstResult.Value.Distance, maximumMagnitude) :
+                maximumMagnitude;
+
+            // if this ray is too short for any echo, ignore this angle
+            if (rayMagnitude < minimumMagnitude)
+                continue;
+
+            var rayMagnitudeSquared = rayMagnitude * rayMagnitude;
+            var incrementedRayMagnitudeSquared = 0f;
+
+            if (checkRoof)
+            {
+                // find the furthest distance this ray reaches until its on an unrooved/dataless (space) tile
+                var nextCheckedPosition = new Vector2(originTileIndices.X, originTileIndices.Y) + directionFidelityStep;
+
+                for (; incrementedRayMagnitudeSquared < rayMagnitudeSquared;)
+                {
+                    var nextCheckedTilePosition = new Vector2i(
+                        (int)MathF.Floor(nextCheckedPosition.X / gridTileSize),
+                        (int)MathF.Floor(nextCheckedPosition.Y / gridTileSize)
+                    );
+
+                    if (!_roofSystem.IsRooved(gridRoofEntity!, nextCheckedTilePosition))
+                        break;
+
+                    nextCheckedPosition += directionFidelityStep;
+                    incrementedRayMagnitudeSquared += directionFidelityStep.LengthSquared();
+                }
+            }
+            else
+                incrementedRayMagnitudeSquared = rayMagnitudeSquared;
+
+            // dont need to sqrt if we didnt even process roofs
+            var adjustedDistanceToFurthestRoovedTile = checkRoof ? MathF.Sqrt(incrementedRayMagnitudeSquared) : rayMagnitude;
+            magnitude += adjustedDistanceToFurthestRoovedTile / _calculatedDirections.Length;
+        }
+
+        return true;
+    }
+
+    private void ProcessAudioEntity(Entity<AudioComponent> entity, TransformComponent transformComponent, float minimumMagnitude, float maximumMagnitude)
+    {
+        TryProcessAreaSpaceMagnitude((entity, transformComponent), minimumMagnitude, maximumMagnitude, out var echoMagnitude);
+
+        if (echoMagnitude > minimumMagnitude)
+        {
+            ProtoId<AudioPresetPrototype>? bestPreset = null;
+            for (var i = DistancePresets.Count - 1; i >= 0; i--)
+            {
+                var preset = DistancePresets[i];
+                if (preset.Item1 < echoMagnitude)
+                    continue;
+
+                bestPreset = preset.Item2;
+            }
+
+            if (bestPreset != null)
+                _audioEffectSystem.TryAddEffect(entity, DistancePresets[0].Item2);
+        }
+    }
+
+    private void OnAudioParentChanged(Entity<AudioComponent> entity, ref EntParentChangedMessage args)
+    {
+        if (!CanAudioEcho(entity))
+            return;
+
+        var minimumMagnitude = DistancePresets.TryFirstOrNull(out var first) ? first.Value.Item1 : 0f;
+        DebugTools.Assert(minimumMagnitude > 0f, "First distance preset was less than or equal to 0!");
+        if (minimumMagnitude <= 0f)
+            return;
+
+        var maximumMagnitude = DistancePresets.Last().Item1;
+
+        ProcessAudioEntity(entity, args.Transform, minimumMagnitude, maximumMagnitude);
+    }
+}
+
+/// <summary>
+///     Raised on a grid (or map if there's no grid) at an audio's position, to override an echo's effect.
+///     Not raised if 
+/// </summary>
+/// <param name="Preset">The preset the audio should use. If null, uses no preset only if <paramref name="Change"/> is true.</param>
+[ByRefEvent]
+public record struct GetGridAreaEchoEvent(EntityCoordinates Position, ProtoId<AudioPresetPrototype>? Preset = null, bool Change = false);

--- a/Content.Client/_Mono/Audio/AreaEchoSystem.cs
+++ b/Content.Client/_Mono/Audio/AreaEchoSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -12,7 +12,6 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 
 namespace Content.Client._Mono.Audio;

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -105,7 +105,7 @@ public sealed class AudioEffectSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Tries to remove effects from the given audio.
+    ///     Tries to remove effects from the given audio. Returns whether the attempt was successful.
     /// </summary>
     public bool TryRemoveEffect(in Entity<AudioComponent> entity)
     {

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -37,9 +37,6 @@ public sealed class AudioEffectSystem : EntitySystem
     {
         base.Initialize();
 
-        var blankAuxiliaryEntity = _audioSystem.CreateAuxiliary();
-        _cachedBlankAuxiliaryUid = blankAuxiliaryEntity.Entity;
-
         // You can't keep references to this past round-end so it must be cleaned up.
         SubscribeNetworkEvent<RoundRestartCleanupEvent>(_ => Cleanup()); // its not raised on client
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypeReload);
@@ -109,9 +106,9 @@ public sealed class AudioEffectSystem : EntitySystem
     /// </summary>
     public bool TryRemoveEffect(in Entity<AudioComponent> entity)
     {
-        DebugTools.Assert(_cachedBlankAuxiliaryUid.IsValid(), "Cached blank audio-auxiliary entity wasn't initialised!");
+        // resolve the cached auxiliary
         if (!_cachedBlankAuxiliaryUid.IsValid())
-            return false;
+            _cachedBlankAuxiliaryUid = _audioSystem.CreateAuxiliary().Entity;
 
         _audioSystem.SetAuxiliary(entity, entity.Comp, _cachedBlankAuxiliaryUid);
         return true;

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -1,4 +1,4 @@
-// borrowed from https://github.com/TornadoTechnology/finster/blob/1af5daf6270477a512ee9d515371311443e97878/Content.Shared/_Finster/Audio/SharedAudioEffectsSystem.cs#L13 , credit to docnite
+// some parts taken and modified from https://github.com/TornadoTechnology/finster/blob/1af5daf6270477a512ee9d515371311443e97878/Content.Shared/_Finster/Audio/SharedAudioEffectsSystem.cs#L13 , credit to docnite
 // they're under WTFPL so its quite allowed
 
 using System.Diagnostics.CodeAnalysis;

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 
 namespace Content.Client._Mono.Audio;
@@ -82,8 +83,12 @@ public sealed class AudioEffectSystem : EntitySystem
             TryQueueDel(cache.Value.AuxiliaryUid);
             TryQueueDel(cache.Value.EffectUid);
         }
-
         CachedEffects.Clear();
+
+        if (_cachedBlankAuxiliaryUid.IsValid())
+            TryQueueDel(_cachedBlankAuxiliaryUid);
+
+        _cachedBlankAuxiliaryUid = EntityUid.Invalid;
     }
 
     /// <summary>
@@ -100,10 +105,17 @@ public sealed class AudioEffectSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Removes effects from the given audio.
+    ///     Tries to remove effects from the given audio.
     /// </summary>
-    public void RemoveEffect(in Entity<AudioComponent> entity)
-        => _audioSystem.SetAuxiliary(entity, entity.Comp, _cachedBlankAuxiliaryUid);
+    public bool TryRemoveEffect(in Entity<AudioComponent> entity)
+    {
+        DebugTools.Assert(_cachedBlankAuxiliaryUid.IsValid(), "Cached blank audio-auxiliary entity wasn't initialised!");
+        if (!_cachedBlankAuxiliaryUid.IsValid())
+            return false;
+
+        _audioSystem.SetAuxiliary(entity, entity.Comp, _cachedBlankAuxiliaryUid);
+        return true;
+    }
 
     /// <summary>
     ///     Tries to resolve an audio auxiliary and effect entity, creating and caching one if one doesn't already exist,

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -1,0 +1,141 @@
+// borrowed from https://github.com/TornadoTechnology/finster/blob/1af5daf6270477a512ee9d515371311443e97878/Content.Shared/_Finster/Audio/SharedAudioEffectsSystem.cs#L13 , credit to docnite
+// they're under WTFPL so its quite allowed
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Content.Shared.GameTicking;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Prototypes;
+using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
+
+namespace Content.Client._Mono.Audio;
+
+/// <summary>
+///     Handler for client-side audio effects.
+/// </summary>
+public sealed class AudioEffectSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+
+    private static readonly Dictionary<ProtoId<AudioPresetPrototype>, (EntityUid AuxiliaryUid, EntityUid EffectUid)> CachedEffects = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // You can't keep references to this past round-end so it must be cleaned up.
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => Cleanup());
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypeReload);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        Cleanup();
+    }
+
+    private void OnPrototypeReload(PrototypesReloadedEventArgs args)
+    {
+        if (!args.WasModified<AudioPresetPrototype>())
+            return;
+
+        // get rid of all old cached entities, and replace them with new ones
+        var oldPresets = new List<ProtoId<AudioPresetPrototype>>();
+        foreach (var cache in CachedEffects)
+        {
+            oldPresets.Add(cache.Key);
+
+            TryQueueDel(cache.Value.AuxiliaryUid);
+            TryQueueDel(cache.Value.EffectUid);
+        }
+        CachedEffects.Clear();
+
+        foreach (var oldPreset in oldPresets)
+        {
+            if (!ResolveCachedEffect(oldPreset, out var cachedAuxiliaryUid, out var cachedEffectUid))
+                continue;
+
+            CachedEffects[oldPreset] = (cachedAuxiliaryUid.Value, cachedEffectUid.Value);
+        }
+    }
+
+    private void Cleanup()
+    {
+        foreach (var cache in CachedEffects)
+        {
+            TryQueueDel(cache.Value.AuxiliaryUid);
+            TryQueueDel(cache.Value.EffectUid);
+        }
+
+        CachedEffects.Clear();
+    }
+
+    /// <summary>
+    ///     Tries to resolve a cached audio auxiliary entity corresponding to the prototype to apply
+    ///         to the given entity.
+    /// </summary>
+    public bool TryAddEffect(Entity<AudioComponent> entity, in ProtoId<AudioPresetPrototype> preset)
+    {
+        if (!ResolveCachedEffect(preset, out var auxiliaryUid, out _))
+            return false;
+
+        _audioSystem.SetAuxiliary(entity, entity.Comp, auxiliaryUid);
+        return true;
+    }
+
+    /// <summary>
+    ///     Tries to resolve an audio auxiliary and effect entity, creating and caching one if one doesn't already exist,
+    ///         for a prototype. Do not modify it in any way.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool ResolveCachedEffect(in ProtoId<AudioPresetPrototype> preset, [NotNullWhen(true)] out EntityUid? auxiliaryUid, [NotNullWhen(true)] out EntityUid? effectUid)
+    {
+        EntityUid? maybeAuxiliaryUid = null;
+        EntityUid? maybeEffectUid = null;
+
+        if (CachedEffects.TryGetValue(preset, out var cached) ||
+            TryCacheEffect(preset, out maybeAuxiliaryUid, out maybeEffectUid))
+        {
+            auxiliaryUid = maybeAuxiliaryUid ?? cached.AuxiliaryUid;
+            effectUid = maybeEffectUid ?? cached.EffectUid;
+            return true;
+        }
+
+        auxiliaryUid = null;
+        effectUid = null;
+        return false;
+    }
+
+    /// <summary>
+    ///     Tries to initialise and cache effect and auxiliary entities corresponding to a prototype,
+    ///         in the system's internal cache.
+    /// 
+    ///     Does nothing if the entity already exists in the cache.
+    /// </summary>
+    /// <returns>Whether the entity was successfully initialised, and it did not previously exist in the cache.</returns>
+    public bool TryCacheEffect(in ProtoId<AudioPresetPrototype> preset, [NotNullWhen(true)] out EntityUid? auxiliaryUid, [NotNullWhen(true)] out EntityUid? effectUid)
+    {
+        effectUid = null;
+        auxiliaryUid = null;
+
+        if (!_prototypeManager.TryIndex(preset, out var presetPrototype))
+            return false;
+
+        var effectEntity = _audioSystem.CreateEffect();
+        _audioSystem.SetEffectPreset(effectEntity.Entity, effectEntity.Component, presetPrototype);
+
+        var auxiliaryEntity = _audioSystem.CreateAuxiliary();
+        _audioSystem.SetEffect(auxiliaryEntity.Entity, auxiliaryEntity.Component, effectEntity.Entity);
+
+        if (!Exists(auxiliaryEntity.Entity))
+            return false;
+
+        effectUid = effectEntity.Entity;
+        auxiliaryUid = auxiliaryEntity.Entity;
+
+        return CachedEffects.TryAdd(preset, (auxiliaryEntity.Entity, effectEntity.Entity));
+    }
+}

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+//
+// SPDX-License-Identifier: MPL-2.0
+
 // some parts taken and modified from https://github.com/TornadoTechnology/finster/blob/1af5daf6270477a512ee9d515371311443e97878/Content.Shared/_Finster/Audio/SharedAudioEffectsSystem.cs#L13 , credit to docnite
 // they're under WTFPL so its quite allowed
 

--- a/Content.Client/_Mono/Radio/ClientRadioNoiseSystem.cs
+++ b/Content.Client/_Mono/Radio/ClientRadioNoiseSystem.cs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
 // SPDX-FileCopyrightText: 2025 ark1368
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Client/_Mono/Radio/ClientRadioNoiseSystem.cs
+++ b/Content.Client/_Mono/Radio/ClientRadioNoiseSystem.cs
@@ -18,16 +18,20 @@ public sealed class ClientRadioNoiseSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
 
+    private bool _radioNoiseEnabled = true;
+
     public override void Initialize()
     {
         base.Initialize();
         SubscribeNetworkEvent<RadioNoiseEvent>(OnRadioNoiseEvent);
+
+        _cfg.OnValueChanged(MonoCVars.RadioNoiseEnabled, @new => _radioNoiseEnabled = @new);
     }
 
     private void OnRadioNoiseEvent(RadioNoiseEvent ev)
     {
         // Only play radio noise if the player has the option enabled
-        if (!_cfg.GetCVar(MonoCVars.RadioNoiseEnabled))
+        if (!_radioNoiseEnabled)
             return;
 
         // Get the entity from the network event

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
@@ -16,20 +16,12 @@ public sealed partial class MonoCVars
         CVarDef.Create("mono.area_echo.enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
 
     /// <summary>
-    ///     Used to determine magnitude of sounds, with the higher meaning more echo.
-    ///         The formula used is `distance * exp(-distance/this)`.
-    /// </summary>
-    /// <seealso cref="AreaEchoSystem"/>
-    public static readonly CVarDef<float> AreaEchoFalloff =
-        CVarDef.Create("mono.area_echo.falloff", 0.4f, CVar.ARCHIVE | CVar.CLIENTONLY);
-
-    /// <summary>
     ///     If false, area echos calculate with 4 directions (NSEW).
     ///         Otherwise, area echos calculate with all 8 directions.
     /// </summary>
     /// <seealso cref="AreaEchoSystem"/>
     public static readonly CVarDef<bool> AreaEchoHighResolution =
-        CVarDef.Create("mono.area_echo.8dir", false, CVar.ARCHIVE | CVar.CLIENTONLY);
+        CVarDef.Create("mono.area_echo.alldirections", false, CVar.ARCHIVE | CVar.CLIENTONLY);
 
 
     /// <summary>

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
@@ -13,7 +13,15 @@ public sealed partial class MonoCVars
     /// </summary>
     /// <seealso cref="AreaEchoSystem"/>
     public static readonly CVarDef<bool> AreaEchoEnabled =
-        CVarDef.Create("mono.area_echo_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
+        CVarDef.Create("mono.area_echo.enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    /// <summary>
+    ///     Used to determine magnitude of sounds, with the higher meaning more echo.
+    ///         The formula used is `distance * exp(-distance/this)`.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<float> AreaEchoFalloff =
+        CVarDef.Create("mono.area_echo.falloff", 0.4f, CVar.ARCHIVE | CVar.CLIENTONLY);
 
     /// <summary>
     ///     If false, area echos calculate with 4 directions (NSEW).
@@ -21,22 +29,30 @@ public sealed partial class MonoCVars
     /// </summary>
     /// <seealso cref="AreaEchoSystem"/>
     public static readonly CVarDef<bool> AreaEchoHighResolution =
-        CVarDef.Create("mono.area_echo_8dir", false, CVar.ARCHIVE | CVar.CLIENTONLY);
+        CVarDef.Create("mono.area_echo.8dir", false, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+
+    /// <summary>
+    ///     How many times a ray can bounce off a surface for an echo calculation.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<int> AreaEchoReflectionCount =
+        CVarDef.Create("mono.area_echo.max_reflections", 1, CVar.ARCHIVE | CVar.CLIENTONLY);
 
     /// <summary>
     ///     Distantial interval, in tiles, in the rays used to calculate the roofs of an open area for echos,
-    ///         at which the tile at that point of the ray is processed.
+    ///         or the ray's distance to space, at which the tile at that point of the ray is processed.
     /// 
-    ///     This shouldn't be at or less than 1 because that would be a horrendous waste of processing.
+    ///     The lower this is, the more 'predictable' and computationally heavy the echoes are.
     /// </summary>
     /// <seealso cref="AreaEchoSystem"/>
     public static readonly CVarDef<float> AreaEchoStepFidelity =
-        CVarDef.Create("mono.area_echo_step_fidelity", 5f, CVar.CLIENTONLY);
+        CVarDef.Create("mono.area_echo.step_fidelity", 5f, CVar.CLIENTONLY);
 
     /// <summary>
     ///     Interval between updates for every audio entity.
     /// </summary>
     /// <seealso cref="AreaEchoSystem"/>
     public static readonly CVarDef<TimeSpan> AreaEchoRecalculationInterval =
-        CVarDef.Create("mono.area_echo_recalculation_interval", TimeSpan.FromSeconds(15), CVar.ARCHIVE | CVar.CLIENTONLY);
+        CVarDef.Create("mono.area_echo.recalculation_interval", TimeSpan.FromSeconds(15), CVar.ARCHIVE | CVar.CLIENTONLY);
 }

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
@@ -1,0 +1,38 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Mono.CCVar;
+
+public sealed partial class MonoCVars
+{
+    /// <summary>
+    ///     Whether to render sounds with echo when they are in 'large' open, rooved areas.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<bool> AreaEchoEnabled =
+        CVarDef.Create("mono.area_echo_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    /// <summary>
+    ///     Distantial interval, in tiles, in the rays used to calculate the roofs of an open area for echos,
+    ///         at which the tile at that point of the ray is processed.
+    /// 
+    ///     This shouldn't be at or less than 1 because that would be a horrendous waste of processing.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<float> AreaEchoStepFidelity =
+        CVarDef.Create("mono.area_echo_step_fidelity", 5f, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    /// <summary>
+    ///     If false, area echos calculate with 4 directions (NSEW).
+    ///         Otherwise, area echos calculate with all 8 directions.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<bool> AreaEchoHighResolution =
+        CVarDef.Create("mono.area_echo_8dir", false, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    /// <summary>
+    ///     Interval between updates for every audio entity.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<TimeSpan> AreaEchoRecalculationInterval =
+        CVarDef.Create("mono.area_echo_recalculation_interval", TimeSpan.FromSeconds(15), CVar.ARCHIVE | CVar.CLIENTONLY);
+}

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
@@ -16,6 +16,14 @@ public sealed partial class MonoCVars
         CVarDef.Create("mono.area_echo_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
 
     /// <summary>
+    ///     If false, area echos calculate with 4 directions (NSEW).
+    ///         Otherwise, area echos calculate with all 8 directions.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<bool> AreaEchoHighResolution =
+        CVarDef.Create("mono.area_echo_8dir", false, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    /// <summary>
     ///     Distantial interval, in tiles, in the rays used to calculate the roofs of an open area for echos,
     ///         at which the tile at that point of the ray is processed.
     /// 
@@ -23,15 +31,7 @@ public sealed partial class MonoCVars
     /// </summary>
     /// <seealso cref="AreaEchoSystem"/>
     public static readonly CVarDef<float> AreaEchoStepFidelity =
-        CVarDef.Create("mono.area_echo_step_fidelity", 5f, CVar.ARCHIVE | CVar.CLIENTONLY);
-
-    /// <summary>
-    ///     If false, area echos calculate with 4 directions (NSEW).
-    ///         Otherwise, area echos calculate with all 8 directions.
-    /// </summary>
-    /// <seealso cref="AreaEchoSystem"/>
-    public static readonly CVarDef<bool> AreaEchoHighResolution =
-        CVarDef.Create("mono.area_echo_8dir", false, CVar.ARCHIVE | CVar.CLIENTONLY);
+        CVarDef.Create("mono.area_echo_step_fidelity", 5f, CVar.CLIENTONLY);
 
     /// <summary>
     ///     Interval between updates for every audio entity.

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.AreaEcho.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Robust.Shared.Configuration;
 
 namespace Content.Shared._Mono.CCVar;

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
@@ -19,11 +19,10 @@ public sealed partial class MonoCVars
     /// </summary>
     public static readonly CVarDef<float> SpaceGarbageCleanupInterval =
         CVarDef.Create("mono.space_garbage_cleanup_interval", 1800.0f, CVar.SERVERONLY);
-		
-	/// <summary>
+
+    /// <summary>
     ///     Whether to play radio static/noise sounds when receiving radio messages on headsets.
     /// </summary>
     public static readonly CVarDef<bool> RadioNoiseEnabled =
         CVarDef.Create("mono.radio_noise_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
-
 }

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 ark1368
 //

--- a/Resources/Locale/en-US/_Mono/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/_Mono/escape-menu/ui/options-menu.ftl
@@ -1,0 +1,5 @@
+ui-options-radio-noise = Play radio static sounds
+
+ui-options-general-area-echo = Area echo
+ui-options-area-echo-enabled = Apply echo to audio in large open spaces
+ui-options-area-echo-highres = Use improved but slower calculations for echoes, if enabled

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -54,7 +54,6 @@ ui-options-show-combat-mode-indicators = Show combat mode indicators with cursor
 ui-options-opaque-storage-window = Opaque storage window
 ui-options-show-ooc-patron-color = Show OOC Patreon color
 ui-options-show-looc-on-head = Show LOOC chat above characters head
-ui-options-radio-noise = Play radio static sounds
 ui-options-fancy-speech = Show names in speech bubbles
 ui-options-fancy-name-background = Add background to speech bubble names
 ui-options-vsync = VSync


### PR DESCRIPTION
one file has code from https://github.com/TornadoTechnology/finster/blob/1af5daf6270477a512ee9d515371311443e97878/Content.Shared/_Finster/Audio/SharedAudioEffectsSystem.cs , [see their license](https://github.com/TornadoTechnology/finster?tab=License-1-ov-file)

## About the PR
sounds in big, open and rooved areas will now be echo-ey

completely clientside and can be disabled by cvar/setting
works by:
1. raycasting from every valid sound in 4 or 8 directions (depends on settings)
2. ending ray if it hits any walls/windows/doors/etc. or an unrooved(/space) tile (but only if the grid can have roofs)
3. applying effects to the sound depending on how much distance the rays covered

## Why / Balance
its cool

## How to test
play the game
go in big area
make sounds that would probably echo (gun sounds, toolbox sounds, see video)

## Media
hear

https://www.youtube.com/watch?v=jfPLWmPKARY

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Sounds in large areas may now have an echo. This effect can be disabled in settings.
