### PR TITLE
Modifications - Turbolaser + Scythe

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -787,7 +787,7 @@
     range: 500
   - type: Gun
     fireRate: 1
-    projectileSpeed: 200
+    projectileSpeed: 150
     shootThermalSignature: 500000 # ~5.6km with continuous fire
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/autopulse_laser_fire_01.ogg

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -389,7 +389,7 @@
           bounds: "-0.75,-0.75,0.75,0.75"
         density: 1500
   - type: Gun
-    projectileSpeed: 150
+    projectileSpeed: 200
     fireRate: 0.75
     shootThermalSignature: 12000000 # ~6km after firing
     soundGunshot:
@@ -786,8 +786,8 @@
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
-    fireRate: 5
-    projectileSpeed: 400
+    fireRate: 1
+    projectileSpeed: 200
     shootThermalSignature: 500000 # ~5.6km with continuous fire
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/autopulse_laser_fire_01.ogg

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -268,7 +268,7 @@
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
-    lifetime: 3
+    lifetime: 4
   - type: PointLight
     radarColor: "#ffffff"
   - type: ExplodeOnTrigger

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -226,7 +226,7 @@
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
-    lifetime: 6
+    lifetime: 10
   - type: PointLight
     color: "#6BC1FF"
   - type: ExplodeOnTrigger
@@ -251,9 +251,9 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 1000
-        Structural: 1500
-        Heat: 400
+        Radiation: 1500
+        Structural: 3000
+        Heat: 1000
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/Projectiles/ship_projectiles.rsi
     layers:
@@ -264,19 +264,19 @@
   - type: ShipWeaponProjectile
   - type: RadarBlip
     radarColor: "#ffffff"
-    scale: 1.5
+    scale: 2.5
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
-    lifetime: 2.5
+    lifetime: 3
   - type: PointLight
     radarColor: "#ffffff"
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: DefaultShipGun
-    totalIntensity: 50
-    intensitySlope: 4
-    maxIntensity: 40
+    totalIntensity: 500
+    intensitySlope: 35
+    maxIntensity: 50
 
 # Harbringer
 

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -252,7 +252,7 @@
     damage:
       types:
         Radiation: 1500
-        Structural: 3000
+        Structural: 5000
         Heat: 1000
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/Projectiles/ship_projectiles.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adjusts both the Turbolaser and the ADS weapon Scythe

## Why / Balance
Turbolaser range was shit, people complained about the scythe

- Scythe now fires slower, fatter projectiles, but much more punchy - 2-3 hits to kill plastic walls, much bigger boom
- Turbolaser range increased by slightly upping speed and increasing projectile lifetime

## How to test
Load up, spawn guns, pew

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Scythes now fire slower but hit harder
- tweak: Turbolasers have been tuned to have a much longer range