### PR TITLE
Manually Reloaded Ship Turret Ammo Display

### DIFF
--- a/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 ark1368
+//
+// SPDX-License-Identifier: MPL-2.0
+
 // Copyright Rane (elijahrane@gmail.com) 2025
 // All rights reserved. Relicensed under AGPL with permission
 

--- a/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright Rane (elijahrane@gmail.com) 2025
 // All rights reserved. Relicensed under AGPL with permission
 
+using System.Linq;
 using Content.Client.UserInterface.Controls;
 using Content.Shared._Mono.FireControl;
 using Content.Shared._Mono.ShipGuns;
@@ -27,6 +28,8 @@ public sealed partial class FireControlWindow : FancyWindow
     // Dictionary to store weapon entity to type mapping
     private readonly Dictionary<NetEntity, ShipGunType> _weaponTypes = new();
 
+    private FireControlConsoleBoundInterfaceState? _currentState;
+
     public FireControlWindow()
     {
         RobustXamlLoader.Load(this);
@@ -47,6 +50,8 @@ public sealed partial class FireControlWindow : FancyWindow
         }
 
         OnWeaponSelectionChanged?.Invoke();
+
+        UpdateAllWeaponButtonTexts();
     }
 
     private void UnselectAllWeapons(BaseButton.ButtonEventArgs args)
@@ -57,6 +62,8 @@ public sealed partial class FireControlWindow : FancyWindow
         }
 
         OnWeaponSelectionChanged?.Invoke();
+
+        UpdateAllWeaponButtonTexts();
     }
 
     private void SelectBallisticWeapons(BaseButton.ButtonEventArgs args)
@@ -80,6 +87,7 @@ public sealed partial class FireControlWindow : FancyWindow
         }
 
         OnWeaponSelectionChanged?.Invoke();
+        UpdateAllWeaponButtonTexts();
     }
 
     private void SelectEnergyWeapons(BaseButton.ButtonEventArgs args)
@@ -103,6 +111,7 @@ public sealed partial class FireControlWindow : FancyWindow
         }
 
         OnWeaponSelectionChanged?.Invoke();
+        UpdateAllWeaponButtonTexts();
     }
 
     private void SelectMissileWeapons(BaseButton.ButtonEventArgs args)
@@ -126,10 +135,53 @@ public sealed partial class FireControlWindow : FancyWindow
         }
 
         OnWeaponSelectionChanged?.Invoke();
+        UpdateAllWeaponButtonTexts();
+    }
+
+    /// <summary>
+    /// Updates the text of a weapon button based on its selection state and manual reload status.
+    /// </summary>
+    private void UpdateWeaponButtonText(Button button, FireControllableEntry controllable)
+    {
+        if (button.Pressed && controllable.HasManualReload && controllable.AmmoCount.HasValue)
+        {
+            button.Text = controllable.AmmoCount.Value.ToString();
+
+            if (controllable.AmmoCount.Value == 0)
+            {
+                button.ModulateSelfOverride = Color.Red;
+            }
+            else
+            {
+                button.ModulateSelfOverride = null;
+            }
+        }
+        else
+        {
+            button.Text = controllable.Name;
+            button.ModulateSelfOverride = null;
+        }
+    }
+
+    /// <summary>
+    /// Updates all weapon button texts based on current selection state.
+    /// </summary>
+    private void UpdateAllWeaponButtonTexts()
+    {
+        foreach (var (netEntity, button) in WeaponsList)
+        {
+            var controllable = _currentState?.FireControllables?.FirstOrDefault(c => c.NetEntity == netEntity);
+
+            if (controllable.HasValue)
+            {
+                UpdateWeaponButtonText(button, controllable.Value);
+            }
+        }
     }
 
     public void UpdateStatus(FireControlConsoleBoundInterfaceState state)
     {
+        _currentState = state;
         NavRadar.UpdateState(state.NavState);
 
         if (state.Connected)
@@ -145,6 +197,8 @@ public sealed partial class FireControlWindow : FancyWindow
         }
 
         UpdateWeaponsList(state);
+
+        UpdateAllWeaponButtonTexts();
 
         // Update the category buttons state based on whether weapons of that type are available
         bool hasBallisticWeapons = false;
@@ -201,6 +255,7 @@ public sealed partial class FireControlWindow : FancyWindow
             if (WeaponsList.TryGetValue(controllable.NetEntity, out var existingButton))
             {
                 toRemove.Remove(controllable.NetEntity);
+                UpdateWeaponButtonText(existingButton, controllable);
             }
             else
             {
@@ -213,10 +268,16 @@ public sealed partial class FireControlWindow : FancyWindow
                     Margin = new Thickness(4, 1)
                 };
 
-                button.OnToggled += _ => OnWeaponSelectionChanged?.Invoke();
+                button.OnToggled += _ =>
+                {
+                    OnWeaponSelectionChanged?.Invoke();
+                    UpdateAllWeaponButtonTexts();
+                };
 
                 ControllablesBox.AddChild(button);
                 WeaponsList.Add(controllable.NetEntity, button);
+
+                UpdateWeaponButtonText(button, controllable);
             }
         }
 

--- a/Content.Shared/_Mono/FireControl/FireControlMessages.cs
+++ b/Content.Shared/_Mono/FireControl/FireControlMessages.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 ark1368
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Robust.Shared.Serialization;
 using Robust.Shared.Map;
 using Content.Shared.Shuttles.BUIStates;

--- a/Content.Shared/_Mono/FireControl/FireControlMessages.cs
+++ b/Content.Shared/_Mono/FireControl/FireControlMessages.cs
@@ -89,10 +89,22 @@ public struct FireControllableEntry
     /// </summary>
     public string Name;
 
-    public FireControllableEntry(NetEntity entity, NetCoordinates coordinates, string name)
+    /// <summary>
+    /// Current ammunition count.
+    /// </summary>
+    public int? AmmoCount;
+
+    /// <summary>
+    /// Whether this weapon has manual reload.
+    /// </summary>
+    public bool HasManualReload;
+
+    public FireControllableEntry(NetEntity entity, NetCoordinates coordinates, string name, int? ammoCount = null, bool hasManualReload = false)
     {
         NetEntity = entity;
         Coordinates = coordinates;
         Name = name;
+        AmmoCount = ammoCount;
+        HasManualReload = hasManualReload;
     }
 }


### PR DESCRIPTION
## About the PR
Manually reloaded ship turrets now display their ammo count. Beautiful shitcode.

## Why / Balance
Ballistic ship turrets may require manual reloading in the future.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Ark
- add: Manually reloaded ship turrets now display their live ammo count in the Gunnery Control.