### PR TITLE
Area Based Sound Echo [Goob/Monolith Port]

### DIFF
--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -21,6 +21,10 @@
                 <CheckBox Name="LogInChatCheckBox" Text="{Loc 'ui-options-log-in-chat'}" /> <!-- WD EDIT -->
                 <CheckBox Name="CoalesceIdenticalMessagesCheckBox" Text="{Loc 'ui-options-coalesce-identical-messages'}" /> <!-- WD EDIT -->
                 <CheckBox Name="DetailedExamineCheckBox" Text="{Loc 'ui-options-detailed-examine'}" /> <!-- Goobstation Change -->
+		<Label Text="{Loc 'ui-options-general-area-echo'}"
+                	StyleClasses="LabelKeyText"/> <!-- Mono -->
+                <CheckBox Name="AreaEchoCheckBox" Text="{Loc 'ui-options-area-echo-enabled'}" /> <!-- Mono -->
+                <CheckBox Name="AreaEchoHighResolutionCheckBox" Text="{Loc 'ui-options-area-echo-highres'}" /> <!-- Mono -->
                 <CheckBox Name="RadioNoiseCheckBox" Text="{Loc 'ui-options-radio-noise'}" /> <!-- Mono -->
                 <Label Text="{Loc 'ui-options-general-cursor'}"
                        StyleClasses="LabelKeyText"/>

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -72,6 +72,8 @@ public sealed partial class MiscTab : Control
         Control.AddOptionCheckBox(CCVars.StaticStorageUI, StaticStorageUI);
         Control.AddOptionCheckBox(CCVars.DetailedExamine, DetailedExamineCheckBox); // Goobstation Change
         Control.AddOptionCheckBox(MonoCVars.RadioNoiseEnabled, RadioNoiseCheckBox); // Mono
+        Control.AddOptionCheckBox(MonoCVars.AreaEchoEnabled, AreaEchoCheckBox); // Mono
+        Control.AddOptionCheckBox(MonoCVars.AreaEchoHighResolution, AreaEchoHighResolutionCheckBox); // Mono
 
         Control.Initialize();
     }

--- a/Content.Client/_Mono/Audio/AudioEchoSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEchoSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+// SPDX-FileCopyrightText: 2025 ark1368
 //
 // SPDX-License-Identifier: MPL-2.0
 

--- a/Content.Client/_Mono/Audio/AudioEchoSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEchoSystem.cs
@@ -287,7 +287,6 @@ public sealed class AreaEchoSystem : EntitySystem
                 var delta = currentOriginLocalPosition - previousRayOriginLocalPosition;
                 if (delta.LengthSquared() <= float.Epsilon + float.Epsilon)
                 {
-                    Log.Warning($"Echo-ray has the same origin position as its hit position! At: {_mapSystem.WorldToLocal(gridRoofEntity, gridRoofEntity, currentOriginLocalPosition)}, on entity: {ToPrettyString(gridRoofEntity.Owner)}");
                     break;
                 }
 

--- a/Content.Client/_Mono/Audio/AudioEchoSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEchoSystem.cs
@@ -1,0 +1,469 @@
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+//
+// SPDX-License-Identifier: MPL-2.0
+
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Content.Client.Light.EntitySystems;
+using Content.Shared._Mono.CCVar;
+using Content.Shared.Light.Components;
+using Content.Shared.Maps;
+using Content.Shared.Physics;
+using Robust.Client.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
+
+namespace Content.Goobstation.Client.Audio;
+
+/// <summary>
+///     Handles making sounds 'echo' in large, open spaces. Uses simplified raytracing.
+/// </summary>
+// could use RaycastSystem but the api it has isn't very amazing
+public sealed class AreaEchoSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [Dependency] private readonly ITileDefinitionManager _tileDefinitionManager = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly AudioEffectSystem _audioEffectSystem = default!;
+    [Dependency] private readonly RoofSystem _roofSystem = default!;
+    [Dependency] private readonly TurfSystem _turfSystem = default!;
+
+    /// <summary>
+    ///     The directions that are raycasted to determine size for echo.
+    ///         Used relative to the grid.
+    /// </summary>
+    private Angle[] _calculatedDirections = [Direction.North.ToAngle(), Direction.West.ToAngle(), Direction.South.ToAngle(), Direction.East.ToAngle()];
+
+    /// <summary>
+    ///     Values for the minimum arbitrary size at which a certain audio preset
+    ///         is picked for sounds. The higher the highest distance here is,
+    ///         the generally more calculations it has to do.
+    /// </summary>
+    /// <remarks>
+    ///     Keep in ascending order.
+    /// </remarks>
+    private static readonly List<(float, ProtoId<AudioPresetPrototype>)> DistancePresets = new() { (12f, "Hallway"), (20f, "Auditorium"), (30f, "ConcertHall"), (40f, "Hangar") };
+
+    /// <summary>
+    ///     When is the next time we should check all audio entities and see if they are eligible to be updated.
+    /// </summary>
+    private TimeSpan _nextExistingUpdate = TimeSpan.Zero;
+
+    /// <summary>
+    ///     Collision mask for echoes.
+    /// </summary>
+    private int _echoLayer = (int) (CollisionGroup.Opaque | CollisionGroup.Impassable); // this could be better but whatever
+
+    private int _echoMaxReflections;
+    private bool _echoEnabled = true;
+    private TimeSpan _calculationInterval = TimeSpan.FromSeconds(15); // how often we should check existing audio re-apply or remove echo from them when necessary
+    private float _calculationalFidelity;
+
+    private EntityQuery<MapGridComponent> _gridQuery;
+    private EntityQuery<RoofComponent> _roofQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoReflectionCount, x => _echoMaxReflections = x, invokeImmediately: true);
+
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoEnabled, x => _echoEnabled = x, invokeImmediately: true);
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoHighResolution, x => _calculatedDirections = GetEffectiveDirections(x), invokeImmediately: true);
+
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoRecalculationInterval, x => _calculationInterval = x, invokeImmediately: true);
+        _configurationManager.OnValueChanged(MonoCVars.AreaEchoStepFidelity, x => _calculationalFidelity = x, invokeImmediately: true);
+
+        _gridQuery = GetEntityQuery<MapGridComponent>();
+        _roofQuery = GetEntityQuery<RoofComponent>();
+
+        SubscribeLocalEvent<AudioComponent, EntParentChangedMessage>(OnAudioParentChanged);
+    }
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        if (!_echoEnabled ||
+            _gameTiming.CurTime < _nextExistingUpdate)
+            return;
+
+        _nextExistingUpdate = _gameTiming.CurTime + _calculationInterval;
+
+        var minimumMagnitude = DistancePresets.TryFirstOrNull(out var first) ? first.Value.Item1 : 0f;
+        DebugTools.Assert(minimumMagnitude > 0f, "First distance preset was less than or equal to 0!");
+        if (minimumMagnitude <= 0f)
+            return;
+
+        var maximumMagnitude = DistancePresets.Last().Item1;
+        var audioEnumerator = EntityQueryEnumerator<AudioComponent>();
+
+        while (audioEnumerator.MoveNext(out var uid, out var audioComponent))
+        {
+            if (!CanAudioEcho(audioComponent) ||
+                !audioComponent.Playing)
+                continue;
+
+            ProcessAudioEntity((uid, audioComponent), Transform(uid), minimumMagnitude, maximumMagnitude);
+        }
+    }
+
+    /// <summary>
+    ///     Returns all four cardinal directions when <paramref name="highResolution"/> is false.
+    ///         Otherwise, returns all eight intercardinal and cardinal directions as listed in
+    ///         <see cref="DirectionExtensions.AllDirections"/>.
+    /// </summary>
+    [Pure]
+    public static Angle[] GetEffectiveDirections(bool highResolution)
+    {
+        if (highResolution)
+        {
+            var allDirections = DirectionExtensions.AllDirections;
+            var directions = new Angle[allDirections.Length];
+
+            for (var i = 0; i < allDirections.Length; i++)
+                directions[i] = allDirections[i].ToAngle();
+
+            return directions;
+        }
+
+        return [Direction.North.ToAngle(), Direction.West.ToAngle(), Direction.South.ToAngle(), Direction.East.ToAngle()];
+    }
+
+    /// <summary>
+    ///     Takes an entity's <see cref="TransformComponent"/>. Goes through every parent it
+    ///         has before reaching one that is a map. Returns the hierarchy
+    ///         discovered, which includes the given <paramref name="originEntity"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private List<Entity<TransformComponent>> TryGetHierarchyBeforeMap(Entity<TransformComponent> originEntity)
+    {
+        var hierarchy = new List<Entity<TransformComponent>>() { originEntity };
+
+        ref var currentEntity = ref originEntity;
+        ref var currentTransformComponent = ref currentEntity.Comp;
+
+        var mapUid = currentEntity.Comp.MapUid;
+
+        while (currentTransformComponent.ParentUid != mapUid /* break when the next entity is a map... */ &&
+            currentTransformComponent.ParentUid.IsValid() /* ...or invalid */ )
+        {
+            // iterate to next entity
+            var nextUid = currentTransformComponent.ParentUid;
+            currentEntity.Owner = nextUid;
+            currentTransformComponent = Transform(nextUid);
+
+            hierarchy.Add(currentEntity);
+        }
+
+        DebugTools.Assert(hierarchy.Count >= 1, "Malformed entity hierarchy! Hierarchy must always contain one element, but it doesn't. How did this happen?");
+        return hierarchy;
+    }
+
+    /// <summary>
+    ///     Basic check for whether an audio can echo. Doesn't account for distance.
+    /// </summary>
+    public bool CanAudioEcho(AudioComponent audioComponent)
+        => !audioComponent.Global && _echoEnabled;
+
+    /// <summary>
+    ///     Gets the length of the direction that reaches the furthest unobstructed
+    ///         distance, in an attempt to get the size of the area. Aborts early
+    ///         if either grid is missing or the tile isnt rooved.
+    ///
+    ///     Returned magnitude is the longest valid length of the ray in each direction,
+    ///         divided by the number of total processed angles.
+    /// </summary>
+    /// <returns>Whether anything was actually processed.</returns>
+    // i am the total overengineering guy... and this, is my code.
+    /*
+        This works under a few assumptions:
+        - An entity in space is invalid
+        - Any spaced tile is invalid
+        - Rays end on invalid tiles (space) or unrooved tiles, and dont process on separate grids.
+        - - This checked every `_calculationalFidelity`-ish tiles. Not precisely. But somewhere around that. Its moreso just proportional to that.
+        - Rays bounce.
+    */
+    public bool TryProcessAreaSpaceMagnitude(Entity<TransformComponent> entity, float maximumMagnitude, out float magnitude)
+    {
+        magnitude = 0f;
+        var transformComponent = entity.Comp;
+
+        // get either the grid or other parent entity this entity is on, and it's rotation
+        var entityHierarchy = TryGetHierarchyBeforeMap(entity);
+        if (entityHierarchy.Count <= 1) // hierarchy always starts with our entity. if it only has our entity, it means the next parent was the map, which we don't want
+            return false; // means this entity is in space/otherwise not on a grid
+
+        // at this point, we know that we are somewhere on a grid
+
+        // e.g.: if a sound is inside a crate, this will now be the grid the crate is on; if the sound is just on the grid, this will be the grid that the sound is on.
+        var entityGrid = entityHierarchy.Last();
+
+        // this is the last entity, or this entity itself, that this entity has, before the parent is a grid/map. e.g.: if a sound is inside a crate, this will be the crate; if the sound is just on the grid, this will be the sound
+        var lastEntityBeforeGrid = entityHierarchy[^2]; // `l[^x]` is analogous to `l[l.Count - x]`
+        // `lastEntityBeforeGrid` is obviously directly before `entityGrid`
+        // the earlier guard clause makes sure this will always be valid
+
+        if (!_gridQuery.TryGetComponent(entityGrid, out var gridComponent))
+            return false;
+
+        var checkRoof = _roofQuery.TryGetComponent(entityGrid, out var roofComponent);
+        var tileRef = _mapSystem.GetTileRef(entityGrid, gridComponent, lastEntityBeforeGrid.Comp.Coordinates);
+
+        if (tileRef.Tile.IsEmpty)
+            return false;
+
+        var gridRoofEntity = new Entity<MapGridComponent, RoofComponent?>(entityGrid, gridComponent, roofComponent);
+        if (checkRoof &&
+            !_roofSystem.IsRooved(gridRoofEntity!, tileRef.GridIndices))
+            return false;
+
+        var originTileIndices = tileRef.GridIndices;
+        var worldPosition = _transformSystem.GetWorldPosition(transformComponent);
+
+        // At this point, we are ready for war against the client's pc.
+        foreach (var direction in _calculatedDirections)
+        {
+            var currentDirectionVector = direction.ToVec();
+            var currentTargetEntityUid = lastEntityBeforeGrid.Owner;
+
+            var totalDistance = 0f;
+            var remainingDistance = maximumMagnitude;
+
+            var currentOriginWorldPosition = worldPosition;
+            var currentOriginTileIndices = originTileIndices;
+
+            for (var reflectIteration = 0; reflectIteration <= _echoMaxReflections /* if maxreflections is 0 we still cast atleast once */; reflectIteration++)
+            {
+                var (distanceCovered, raycastResults) = CastEchoRay(
+                    currentOriginWorldPosition,
+                    currentOriginTileIndices,
+                    currentDirectionVector,
+                    transformComponent.MapID,
+                    currentTargetEntityUid,
+                    gridRoofEntity,
+                    checkRoof,
+                    remainingDistance
+                );
+
+                totalDistance += distanceCovered;
+                remainingDistance -= distanceCovered;
+
+                // we don't need further logic anyway if we just finished the last iteration
+                if (reflectIteration == _echoMaxReflections)
+                    break;
+
+                if (raycastResults is not { }) // means we didnt hit anything
+                    break;
+
+                // i think cross-grid would actually be pretty easy here? but the tile-marching doesnt often account for that at fidelities above 1 so whatever.
+
+                var previousRayWorldOriginPosition = currentOriginWorldPosition;
+                currentOriginWorldPosition = raycastResults.Value.HitPos; // it's now where we hit
+                currentTargetEntityUid = raycastResults.Value.HitEntity;
+
+                if (!_mapSystem.TryGetTileRef(entityGrid, gridComponent, currentOriginWorldPosition, out var hitTileRef)) // means tile that ray hit is invalid, just assume the ray ends here
+                    break;
+
+                currentOriginTileIndices = hitTileRef.GridIndices;
+
+                var worldMatrix = _transformSystem.GetInvWorldMatrix(gridRoofEntity);
+                var previousRayOriginLocalPosition = Vector2.Transform(previousRayWorldOriginPosition, worldMatrix);
+                var currentOriginLocalPosition = Vector2.Transform(currentOriginWorldPosition, worldMatrix);
+
+                var delta = currentOriginLocalPosition - previousRayOriginLocalPosition;
+                if (delta.LengthSquared() <= float.Epsilon + float.Epsilon)
+                {
+                    Log.Warning($"Echo-ray has the same origin position as its hit position! At: {_mapSystem.WorldToLocal(gridRoofEntity, gridRoofEntity, currentOriginLocalPosition)}, on entity: {ToPrettyString(gridRoofEntity.Owner)}");
+                    break;
+                }
+
+                var normalVector = GetNormalVector(delta);
+                normalVector = GetTileHitNormal(currentOriginLocalPosition, _mapSystem.TileToVector(gridRoofEntity, currentOriginTileIndices), gridRoofEntity.Comp1.TileSize);
+                currentDirectionVector = Reflect(currentDirectionVector, normalVector);
+            }
+
+            magnitude += totalDistance;
+        }
+
+        magnitude /= _calculatedDirections.Length * _echoMaxReflections;
+        return true;
+    }
+
+    /// <summary>
+    ///     Gets the normal angle of a Vector2, relative to
+    ///         0, 0.
+    /// </summary>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector2 GetNormalVector(in Vector2 deltaVector)
+    {
+        return Vector2.Normalize(
+            MathF.Abs(deltaVector.X) > MathF.Abs(deltaVector.Y) ?
+            new Vector2(MathF.Sign(deltaVector.X), 0f) :
+            new Vector2(0f, MathF.Sign(deltaVector.Y))
+        );
+    }
+
+    Vector2 GetTileHitNormal(Vector2 rayHitPos, Vector2 tileOrigin, float tileSize)
+    {
+        // Position inside the tile (0..tileSize)
+        Vector2 local = rayHitPos - tileOrigin;
+
+        // Distances to each side
+        float left = local.X;
+        float right = tileSize - local.X;
+        float bottom = local.Y;
+        float top = tileSize - local.Y;
+
+        // Find smallest distance
+        float minDist = MathF.Min(MathF.Min(left, right), MathF.Min(bottom, top));
+
+        if (minDist == left) return new Vector2(-1, 0);
+        if (minDist == right) return new Vector2(1, 0);
+        if (minDist == bottom) return new Vector2(0, -1);
+        return new Vector2(0, 1); // must be top
+    }
+
+    /// <remarks>
+    ///     <paramref name="normal"/> should be normalised upon calling.
+    /// </remarks>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector2 Reflect(in Vector2 direction, in Vector2 normal)
+        => direction - 2 * Vector2.Dot(direction, normal) * normal;
+
+    // this caused vsc to spike to 28gb memory usage
+    /// <summary>
+    ///     Casts a ray and marches it. See <see cref="MarchRayByTiles"/>.
+    /// </summary>
+    private (float, RayCastResults?) CastEchoRay(
+        in Vector2 originWorldPosition,
+        in Vector2i originTileIndices,
+        in Vector2 directionVector,
+        in MapId mapId,
+        in EntityUid ignoredEntity,
+        in Entity<MapGridComponent, RoofComponent?> gridRoofEntity,
+        bool checkRoof,
+        float maximumDistance
+    )
+    {
+        var directionFidelityStep = directionVector * _calculationalFidelity;
+
+        var ray = new CollisionRay(originWorldPosition, directionVector, _echoLayer);
+        var rayResults = _physicsSystem.IntersectRay(mapId, ray, maxLength: maximumDistance, ignoredEnt: ignoredEntity, returnOnFirstHit: true);
+
+        // if we hit something, distance to that is magnitude but it must be lower than maximum. if we didnt hit anything, it's maximum magnitude
+        var rayMagnitude = rayResults.TryFirstOrNull(out var firstResult) ?
+            MathF.Min(firstResult.Value.Distance, maximumDistance) :
+            maximumDistance;
+
+        var nextCheckedPosition = new Vector2(originTileIndices.X, originTileIndices.Y) * gridRoofEntity.Comp1.TileSize + directionFidelityStep;
+        var incrementedRayMagnitude = MarchRayByTiles(
+            rayMagnitude,
+            gridRoofEntity,
+            directionFidelityStep,
+            ref nextCheckedPosition,
+            gridRoofEntity.Comp1.TileSize,
+            checkRoof
+        );
+
+        return (incrementedRayMagnitude, firstResult);
+    }
+
+    /// <summary>
+    ///     Advances a ray, in intervals of `_calculationalFidelity`, by tiles until
+    ///         reaching an unrooved tile (if checking roofs) or space.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private float MarchRayByTiles(
+        in float rayMagnitude,
+        in Entity<MapGridComponent, RoofComponent?> gridRoofEntity,
+        in Vector2 directionFidelityStep,
+        ref Vector2 nextCheckedPosition,
+        ushort gridTileSize,
+        bool checkRoof
+    )
+    {
+        // find the furthest distance this ray reaches until its on an unrooved/dataless (space) tile
+
+        var fidelityStepLength = directionFidelityStep.Length();
+        var incrementedRayMagnitude = 0f;
+
+        for (; incrementedRayMagnitude < rayMagnitude;)
+        {
+            var nextCheckedTilePosition = new Vector2i(
+                (int) MathF.Floor(nextCheckedPosition.X / gridTileSize),
+                (int) MathF.Floor(nextCheckedPosition.Y / gridTileSize)
+            );
+
+            if (checkRoof)
+            { // if we're checking roofs, end this ray if this tile is unrooved or dataless (latter is inherent of this method)
+                if (!_roofSystem.IsRooved(gridRoofEntity!, nextCheckedTilePosition))
+                    break;
+            } // if we're not checking roofs, end this ray if this tile is empty/space
+            else if (!_mapSystem.TryGetTileRef(gridRoofEntity, gridRoofEntity, nextCheckedTilePosition, out var tile) ||
+                tile.IsSpace())
+                break;
+
+            nextCheckedPosition += directionFidelityStep;
+            incrementedRayMagnitude += fidelityStepLength;
+        }
+
+        return MathF.Min(incrementedRayMagnitude, rayMagnitude);
+    }
+
+    private void ProcessAudioEntity(Entity<AudioComponent> entity, TransformComponent transformComponent, float minimumMagnitude, float maximumMagnitude)
+    {
+        TryProcessAreaSpaceMagnitude((entity, transformComponent), maximumMagnitude, out var echoMagnitude);
+
+        if (echoMagnitude > minimumMagnitude)
+        {
+            ProtoId<AudioPresetPrototype>? bestPreset = null;
+            for (var i = DistancePresets.Count - 1; i >= 0; i--)
+            {
+                var preset = DistancePresets[i];
+                if (preset.Item1 < echoMagnitude)
+                    continue;
+
+                bestPreset = preset.Item2;
+            }
+
+            if (bestPreset != null)
+                _audioEffectSystem.TryAddEffect(entity, DistancePresets[0].Item2);
+        }
+        else
+            _audioEffectSystem.TryRemoveEffect(entity);
+    }
+
+    // Maybe TODO: defer this onto ticks? but whatever its just clientside
+    private void OnAudioParentChanged(Entity<AudioComponent> entity, ref EntParentChangedMessage args)
+    {
+        if (args.Transform.MapID == MapId.Nullspace)
+            return;
+
+        if (!CanAudioEcho(entity))
+            return;
+
+        var minimumMagnitude = DistancePresets.TryFirstOrNull(out var first) ? first.Value.Item1 : 0f;
+        DebugTools.Assert(minimumMagnitude > 0f, "First distance preset was less than or equal to 0!");
+        if (minimumMagnitude <= 0f)
+            return;
+
+        var maximumMagnitude = DistancePresets.Last().Item1;
+
+        ProcessAudioEntity(entity, args.Transform, minimumMagnitude, maximumMagnitude);
+    }
+}

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+// SPDX-FileCopyrightText: 2025 ark1368
 //
 // SPDX-License-Identifier: MPL-2.0
 

--- a/Content.Client/_Mono/Audio/AudioEffectSystem.cs
+++ b/Content.Client/_Mono/Audio/AudioEffectSystem.cs
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus
+//
+// SPDX-License-Identifier: MPL-2.0
+
+// some parts taken and modified from https://github.com/TornadoTechnology/finster/blob/1af5daf6270477a512ee9d515371311443e97878/Content.Shared/_Finster/Audio/SharedAudioEffectsSystem.cs#L13 , credit to docnite
+// they're under WTFPL so its quite allowed
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Content.Shared.GameTicking;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
+
+namespace Content.Goobstation.Client.Audio;
+
+/// <summary>
+///     Handler for client-side audio effects.
+/// </summary>
+public sealed class AudioEffectSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
+
+    /// <summary>
+    ///     Whether creating new auxiliaries is safe.
+    ///         This is done because integration tests
+    ///         apparently can't handle them.
+    ///
+    ///     Null means this value wasn't determined yet.
+    ///
+    ///     Any not-null value here is the final result,
+    ///         and no more attempts to determine this
+    ///         will be made afterwards.
+    /// </summary>
+    // actually this problem applies for effects too
+    private bool? _auxiliariesSafe = null;
+
+    private static readonly Dictionary<ProtoId<AudioPresetPrototype>, (EntityUid AuxiliaryUid, EntityUid EffectUid)> CachedEffects = new();
+
+    /// <summary>
+    ///     An auxiliary with no effect; for removing effects.
+    /// </summary>
+    // TODO: remove this when an rt method to actually remove effects gets added
+    private EntityUid _cachedBlankAuxiliaryUid;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // You can't keep references to this past round-end so it must be cleaned up.
+        SubscribeNetworkEvent<RoundRestartCleanupEvent>(_ => Cleanup()); // its not raised on client
+        SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypeReload);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        Cleanup();
+    }
+
+    private void OnPrototypeReload(PrototypesReloadedEventArgs args)
+    {
+        if (!args.WasModified<AudioPresetPrototype>())
+            return;
+
+        // get rid of all old cached entities, and replace them with new ones
+        var oldPresets = new List<ProtoId<AudioPresetPrototype>>();
+        foreach (var cache in CachedEffects)
+        {
+            oldPresets.Add(cache.Key);
+
+            TryQueueDel(cache.Value.AuxiliaryUid);
+            TryQueueDel(cache.Value.EffectUid);
+        }
+        CachedEffects.Clear();
+
+        foreach (var oldPreset in oldPresets)
+        {
+            if (!ResolveCachedEffect(oldPreset, out var cachedAuxiliaryUid, out var cachedEffectUid))
+                continue;
+
+            CachedEffects[oldPreset] = (cachedAuxiliaryUid.Value, cachedEffectUid.Value);
+        }
+    }
+
+    private void Cleanup()
+    {
+        foreach (var cache in CachedEffects)
+        {
+            TryQueueDel(cache.Value.AuxiliaryUid);
+            TryQueueDel(cache.Value.EffectUid);
+        }
+        CachedEffects.Clear();
+
+        if (_cachedBlankAuxiliaryUid.IsValid())
+            TryQueueDel(_cachedBlankAuxiliaryUid);
+
+        _cachedBlankAuxiliaryUid = EntityUid.Invalid;
+    }
+
+
+    /// <summary>
+    ///     Figures out whether auxiliaries are safe to use. Returns
+    ///         whether a safe auxiliary pair has been outputted
+    ///         for use.
+    /// </summary>
+    private bool DetermineAuxiliarySafety([NotNullWhen(true)] out (EntityUid Entity, AudioAuxiliaryComponent Component)? auxiliaryPair, bool destroyPairAfterUse = true)
+    {
+        (EntityUid Entity, AudioAuxiliaryComponent Component)? maybeAuxiliaryPair = null;
+        try
+        {
+            maybeAuxiliaryPair = _audioSystem.CreateAuxiliary();
+            _auxiliariesSafe = true;
+        }
+        catch (Exception ex)
+        {
+            Log.Info($"Determined audio auxiliaries are unsafe in this run! If this is not an integration test, report this immediately. Exception: {ex}");
+            _auxiliariesSafe = false;
+
+            TryQueueDel(maybeAuxiliaryPair?.Entity);
+
+            auxiliaryPair = null;
+            return false;
+        }
+
+        if (destroyPairAfterUse)
+        {
+            QueueDel(maybeAuxiliaryPair.Value.Entity);
+
+            auxiliaryPair = null;
+            return false;
+        }
+
+        auxiliaryPair = maybeAuxiliaryPair.Value;
+        return true;
+    }
+
+    /// <summary>
+    ///     Returns whether auxiliaries are definitely safe to use.
+    ///         Determines auxiliary safety if not already.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool AuxiliariesAreDefinitelySafe()
+    {
+        if (_auxiliariesSafe == null)
+            DetermineAuxiliarySafety(out _, destroyPairAfterUse: true);
+
+        return _auxiliariesSafe == true;
+    }
+
+    /// <summary>
+    ///     Tries to resolve a cached audio auxiliary entity corresponding to the prototype to apply
+    ///         to the given entity.
+    /// </summary>
+    public bool TryAddEffect(in Entity<AudioComponent> entity, in ProtoId<AudioPresetPrototype> preset)
+    {
+        if (!AuxiliariesAreDefinitelySafe() ||
+            !ResolveCachedEffect(preset, out var auxiliaryUid, out _))
+            return false;
+
+        _audioSystem.SetAuxiliary(entity, entity.Comp, auxiliaryUid);
+        return true;
+    }
+
+    /// <summary>
+    ///     Tries to remove effects from the given audio. Returns whether the attempt was successful,
+    ///         or no auxiliary is applied to the audio.
+    /// </summary>
+    public bool TryRemoveEffect(in Entity<AudioComponent> entity)
+    {
+        if (!AuxiliariesAreDefinitelySafe())
+            return false;
+
+        if (entity.Comp.Auxiliary is not { } existingAuxiliaryUid ||
+            !existingAuxiliaryUid.IsValid())
+            return true;
+
+        // resolve the cached auxiliary
+        if (!_cachedBlankAuxiliaryUid.IsValid())
+            _cachedBlankAuxiliaryUid = _audioSystem.CreateAuxiliary().Entity;
+
+        _audioSystem.SetAuxiliary(entity, entity.Comp, _cachedBlankAuxiliaryUid);
+        return true;
+    }
+
+    /// <summary>
+    ///     Tries to resolve an audio auxiliary and effect entity, creating and caching one if one doesn't already exist,
+    ///         for a prototype. Do not modify it in any way.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool ResolveCachedEffect(in ProtoId<AudioPresetPrototype> preset, [NotNullWhen(true)] out EntityUid? auxiliaryUid, [NotNullWhen(true)] out EntityUid? effectUid)
+    {
+        if (_auxiliariesSafe == false)
+        {
+            auxiliaryUid = null;
+            effectUid = null;
+            return false;
+        }
+
+        if (CachedEffects.TryGetValue(preset, out var cached))
+        {
+            auxiliaryUid = cached.AuxiliaryUid;
+            effectUid = cached.EffectUid;
+            return true;
+        }
+
+        return TryCacheEffect(preset, out auxiliaryUid, out effectUid);
+    }
+
+    /// <summary>
+    ///     Tries to initialise and cache effect and auxiliary entities corresponding to a prototype,
+    ///         in the system's internal cache.
+    ///
+    ///     Does nothing if the entity already exists in the cache.
+    /// </summary>
+    /// <returns>Whether the entity was successfully initialised, and it did not previously exist in the cache.</returns>
+    public bool TryCacheEffect(in ProtoId<AudioPresetPrototype> preset, [NotNullWhen(true)] out EntityUid? auxiliaryUid, [NotNullWhen(true)] out EntityUid? effectUid)
+    {
+
+        effectUid = null;
+        auxiliaryUid = null;
+
+        if (_auxiliariesSafe == false ||
+            !_prototypeManager.TryIndex(preset, out var presetPrototype))
+            return false;
+
+        // i cant `??=` it
+        (EntityUid Entity, AudioAuxiliaryComponent Component)? maybeAuxiliaryPair = null;
+
+        // if undetermined, determine and keep the pair if confirmed safe
+        if (_auxiliariesSafe == null)
+        {
+            // if determined unsafe, cleanup the pair
+            if (!DetermineAuxiliarySafety(out maybeAuxiliaryPair, destroyPairAfterUse: false))
+                return false;
+        }
+
+        // now, auxiliaries are known to be safe.
+        // only when initially determining if auxiliaries are safe will we have a pair to use. in future attempts, we won't so just make one if necessary
+        var auxiliaryPair = maybeAuxiliaryPair ?? _audioSystem.CreateAuxiliary();
+
+        DebugTools.Assert(Exists(auxiliaryPair.Entity), "Audio auxiliary pair's entity does not exist!");
+        if (!Exists(auxiliaryPair.Entity))
+            return false;
+
+        var effectPair = _audioSystem.CreateEffect();
+        _audioSystem.SetEffectPreset(effectPair.Entity, effectPair.Component, presetPrototype);
+        _audioSystem.SetEffect(auxiliaryPair.Entity, auxiliaryPair.Component, effectPair.Entity);
+
+        effectUid = effectPair.Entity;
+        auxiliaryUid = auxiliaryPair.Entity;
+
+        return CachedEffects.TryAdd(preset, (auxiliaryPair.Entity, effectPair.Entity));
+    }
+}

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
@@ -19,11 +19,55 @@ public sealed partial class MonoCVars
     /// </summary>
     public static readonly CVarDef<float> SpaceGarbageCleanupInterval =
         CVarDef.Create("mono.space_garbage_cleanup_interval", 1800.0f, CVar.SERVERONLY);
-		
+
 	/// <summary>
     ///     Whether to play radio static/noise sounds when receiving radio messages on headsets.
     /// </summary>
     public static readonly CVarDef<bool> RadioNoiseEnabled =
         CVarDef.Create("mono.radio_noise_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    #region Audio
+
+    /// <summary>
+    ///     Whether to render sounds with echo when they are in 'large' open, rooved areas.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<bool> AreaEchoEnabled =
+        CVarDef.Create("mono.area_echo.enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    /// <summary>
+    ///     If false, area echos calculate with 4 directions (NSEW).
+    ///         Otherwise, area echos calculate with all 8 directions.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<bool> AreaEchoHighResolution =
+        CVarDef.Create("mono.area_echo.alldirections", false, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+
+    /// <summary>
+    ///     How many times a ray can bounce off a surface for an echo calculation.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<int> AreaEchoReflectionCount =
+        CVarDef.Create("mono.area_echo.max_reflections", 1, CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    /// <summary>
+    ///     Distantial interval, in tiles, in the rays used to calculate the roofs of an open area for echos,
+    ///         or the ray's distance to space, at which the tile at that point of the ray is processed.
+    ///
+    ///     The lower this is, the more 'predictable' and computationally heavy the echoes are.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<float> AreaEchoStepFidelity =
+        CVarDef.Create("mono.area_echo.step_fidelity", 5f, CVar.CLIENTONLY);
+
+    /// <summary>
+    ///     Interval between updates for every audio entity.
+    /// </summary>
+    /// <seealso cref="AreaEchoSystem"/>
+    public static readonly CVarDef<TimeSpan> AreaEchoRecalculationInterval =
+        CVarDef.Create("mono.area_echo.recalculation_interval", TimeSpan.FromSeconds(15), CVar.ARCHIVE | CVar.CLIENTONLY);
+
+    #endregion
 
 }

--- a/Resources/Locale/en-US/_Mono/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/_Mono/escape-menu/ui/options-menu.ftl
@@ -26,3 +26,7 @@ ui-options-function-open-pocket1 = Open 1st pocket
 ui-options-function-open-pocket2 = Open 2nd pocket
 ui-options-function-open-suit-storage = Open shoulder storage
 ui-options-function-open-outer-clothing = Open armor storage
+
+ui-options-general-area-echo = Area echo
+ui-options-area-echo-enabled = Apply echo to audio in large open spaces
+ui-options-area-echo-highres = Use improved but slower calculations for echoes, if enabled


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds new echo audio based on the players position on the client-side.
Ported from https://github.com/Monolith-Station/Monolith/pull/2377 and https://github.com/Goob-Station/Goob-Station/pull/4817.
This is not any of my work, except fixing a line of code when it was ported from Goob.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I'm doing this because the original one has still been a draft for a few weeks now and it seems like development has stopped on it(?) (https://github.com/Monolith-Station/Monolith/pull/2377).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Ark, LaCumbiaDelCoronavirus, JohnJJohn
- add: Sounds in large areas now have an echo. This effect can be disabled in settings. This is all client-side.
