### PR TITLE
Ammo Display Fix

### DIFF
--- a/Content.Server/_Mono/FireControl/FireControlSystem.Console.cs
+++ b/Content.Server/_Mono/FireControl/FireControlSystem.Console.cs
@@ -17,8 +17,10 @@ using Content.Shared.Popups;
 using Content.Shared.Power;
 using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.UserInterface;
+using Content.Shared.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Server.GameObjects;
+using Robust.Shared.Containers;
 
 namespace Content.Server._Mono.FireControl;
 
@@ -29,6 +31,7 @@ public sealed partial class FireControlSystem : EntitySystem
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly CrewedShuttleSystem _crewedShuttle = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
 
     private bool _completedCheck = false;
 
@@ -271,6 +274,38 @@ public sealed partial class FireControlSystem : EntitySystem
             return (ballisticAmmo.Count, ballisticAmmo.Cycleable);
         }
 
+        if (TryComp<MagazineAmmoProviderComponent>(weaponEntity, out var magazineAmmo))
+        {
+            var magazineEntity = GetMagazineEntity(weaponEntity);
+            if (magazineEntity != null)
+            {
+                if (TryComp<BallisticAmmoProviderComponent>(magazineEntity, out var magazineBallisticAmmo))
+                {
+                    return (magazineBallisticAmmo.Count, magazineBallisticAmmo.Cycleable);
+                }
+
+                if (TryComp<BasicEntityAmmoProviderComponent>(magazineEntity, out var magazineBasicAmmo))
+                {
+                    var hasRecharge = HasComp<RechargeBasicEntityAmmoComponent>(magazineEntity);
+                    return (magazineBasicAmmo.Count, !hasRecharge);
+                }
+            }
+        }
+
         return (null, false);
+    }
+
+    /// <summary>
+    /// Gets the magazine entity from a weapon's magazine slot.
+    /// </summary>
+    private EntityUid? GetMagazineEntity(EntityUid weaponEntity)
+    {
+        if (!_containers.TryGetContainer(weaponEntity, "gun_magazine", out var container) ||
+            container is not ContainerSlot slot)
+        {
+            return null;
+        }
+
+        return slot.ContainedEntity;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
ALL manually reloaded ship turrets SHOULD now display their ammo count. Curse you magazine!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix

## How to test
<!-- Describe the way it can be tested -->
Gunnery Control

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Ark
- fix: Manually reloaded ship turrets should actually now display their live ammo count in the Gunnery Control.