### PR TITLE
Removes Power Off Events

### DIFF
--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -8,6 +8,7 @@
 # SPDX-FileCopyrightText: 2024 Shroomerian
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2025 Coenx-flex
+# SPDX-FileCopyrightText: 2025 Cojoke
 # SPDX-FileCopyrightText: 2025 GreaseMonk
 # SPDX-FileCopyrightText: 2025 Redrover1760
 #

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -141,16 +141,16 @@
 #     duration: 1
 #   - type: BluespaceLockerRule
 
-- type: entity
-  id: BreakerFlip
-  parent: BaseGameRule
-  components:
-  - type: StationEvent
-    weight: 7
-    earliestStart: 15 # Frontier
-    duration: 1
-    minimumPlayers: 15
-  - type: BreakerFlipRule
+#- type: entity
+#  id: BreakerFlip
+#  parent: BaseGameRule
+#  components:
+#  - type: StationEvent
+#    weight: 7
+#    earliestStart: 15 # Frontier
+#    duration: 1
+#    minimumPlayers: 15
+#  - type: BreakerFlipRule
 
 # - type: entity
 #   id: BureaucraticError
@@ -351,22 +351,22 @@
 #     duration: 240
 #   - type: KudzuGrowthRule
 
-- type: entity
-  id: PowerGridCheck
-  parent: BaseStationEventShortDelay
-  components:
-  - type: StationEvent
-    weight: 5
-    earliestStart: 15 # Frontier
-    startAnnouncement: station-event-power-grid-check-nf-start-announcement # Frontier: add nf-
-    endAnnouncement: station-event-power-grid-check-nf-end-announcement # Frontier: add nf-
-    startAudio:
-      path: /Audio/Announcements/power_off.ogg
-      params:
-        volume: -4
-    duration: 60
-    maxDuration: 120
-  - type: PowerGridCheckRule
+#- type: entity
+#  id: PowerGridCheck
+#  parent: BaseStationEventShortDelay
+#  components:
+#  - type: StationEvent
+#    weight: 5
+#    earliestStart: 15 # Frontier
+#    startAnnouncement: station-event-power-grid-check-nf-start-announcement # Frontier: add nf-
+#    endAnnouncement: station-event-power-grid-check-nf-end-announcement # Frontier: add nf-
+#    startAudio:
+#      path: /Audio/Announcements/power_off.ogg
+#      params:
+#        volume: -4
+#    duration: 60
+#    maxDuration: 120
+#  - type: PowerGridCheckRule
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_NF/Events/events.yml
+++ b/Resources/Prototypes/_NF/Events/events.yml
@@ -20,7 +20,7 @@
     # - id: AnomalySpawn
     # - id: BluespaceArtifact
     # - id: BluespaceLocker
-    - id: BreakerFlip
+    # - id: BreakerFlip
     # - id: BureaucraticError
     # - id: ClericalError
     - id: CockroachMigration
@@ -31,7 +31,7 @@
     # - id: MassHallucinations # Frontier
     # - id: MimicVendorRule
     - id: MouseMigration
-    - id: PowerGridCheck
+    # - id: PowerGridCheck
     - id: RandomSentience
     # - id: SlimesSpawn
     - id: SolarFlare


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Removes the Breaker Flip and PowerGridCheck events.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

they don't work very well, needing an engineer to flip apcs or giving antags a timeframe to strike aren't things that we worry about. they're rather unpopular too.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Circuit Breaker and Power Outage events no longer run.

