### PR TITLE
Rogue Silicon Balance

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -79,8 +79,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      160: Critical #Mono, health buff
-      280: Dead
+      160: Dead #Mono, health buff
     stateAlertDict:
       Alive: BorgHealth
       Critical: BorgCrit
@@ -190,8 +189,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      120: Critical #Mono, health buff
-      240: Dead
+      120: Dead #Mono, health buff
   - type: SlowOnDamage
     speedModifierThresholds:
       36: 0.7
@@ -249,8 +247,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      60: Critical #Mono, health buff
-      180: Dead
+      60: Dead #Mono, health buff
   - type: SlowOnDamage
     speedModifierThresholds:
       18: 0.7
@@ -642,8 +639,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      24: Critical #Mono, health buff
-      40: Dead
+      24: Dead #Mono, health buff
   - type: DamageStateVisuals
     states:
       Alive:
@@ -925,8 +921,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      220: Critical #Mono, health buff
-      320: Dead
+      220: Dead #Mono, health buff
   - type: SlowOnDamage
     speedModifierThresholds:
       66: 0.7
@@ -938,7 +933,7 @@
     fireCost: 100
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 30
+    autoRechargeRate: 50 # Mono 30 -> 50
   - type: Battery
     maxCharge: 300
     startingCharge: 300
@@ -956,6 +951,39 @@
     radius: 1
     energy: 1.5
     color: "#47f8ff"
+
+#Mono Start: version of the tesla projectile for tesla-unit, less cancerous, more dangerous
+- type: entity
+  name: tesla gun lightning
+  id: TeslaGunBulletRogueSilicon
+  parent: BaseBullet
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 5
+  - type: Sprite
+    sprite: Structures/Power/Generation/Tesla/energy_miniball.rsi
+    layers:
+    - state: tesla_projectile
+      shader: unshaded
+  - type: StaminaDamageOnCollide
+    damage: 35
+  - type: EmbeddableProjectile
+  - type: Projectile
+    deleteOnCollide: false
+    soundHit:
+      path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
+    damage:
+      types:
+        Piercing: 0
+        Heat: 20
+        Schock: 15
+  - type: Electrified
+    requirePower: false
+  - type: Tag
+    tags:
+      - HideContextMenu
+#Mono end
 
 ## Tier 4 Boss
 - type: entity
@@ -1001,8 +1029,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      200: Critical
-      400: Dead
+      200: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       120: 0.7
@@ -1057,8 +1084,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      300: Critical
-      400: Dead
+      300: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       200: 0.7

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -976,8 +976,8 @@
     damage:
       types:
         Piercing: 0
-        Heat: 20
-        Schock: 15
+        Heat: 17
+        Shock: 10
   - type: Electrified
     requirePower: false
   - type: Tag

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -79,7 +79,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      200: Dead #Mono, health buff, twice
+      200: Dead #Mono, health buff
     stateAlertDict:
       Alive: BorgHealth
       Critical: BorgCrit
@@ -189,7 +189,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      150: Dead #Mono, health buff, twice
+      240: Dead #Mono, health buff
   - type: SlowOnDamage
     speedModifierThresholds:
       36: 0.7
@@ -247,7 +247,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      90: Dead #Mono, health buff, twice
+      180: Dead #Mono, health buff
   - type: SlowOnDamage
     speedModifierThresholds:
       18: 0.7
@@ -639,7 +639,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      40: Dead #Mono, health buff, twice
+      40: Dead #Mono, health buff
   - type: DamageStateVisuals
     states:
       Alive:
@@ -921,7 +921,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      260: Dead #Mono, health buff, twice
+      320: Dead #Mono, health buff
   - type: SlowOnDamage
     speedModifierThresholds:
       66: 0.7
@@ -1029,7 +1029,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      400: Dead
+      400: Dead #Mono, health buff
   - type: SlowOnDamage
     speedModifierThresholds:
       120: 0.7
@@ -1084,7 +1084,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      450: Dead
+      450: Dead #Mono, health buff
   - type: SlowOnDamage
     speedModifierThresholds:
       200: 0.7

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -79,7 +79,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      160: Dead #Mono, health buff
+      200: Dead #Mono, health buff, twice
     stateAlertDict:
       Alive: BorgHealth
       Critical: BorgCrit
@@ -189,7 +189,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      120: Dead #Mono, health buff
+      150: Dead #Mono, health buff, twice
   - type: SlowOnDamage
     speedModifierThresholds:
       36: 0.7
@@ -247,7 +247,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      60: Dead #Mono, health buff
+      90: Dead #Mono, health buff, twice
   - type: SlowOnDamage
     speedModifierThresholds:
       18: 0.7
@@ -639,7 +639,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      24: Dead #Mono, health buff
+      40: Dead #Mono, health buff, twice
   - type: DamageStateVisuals
     states:
       Alive:
@@ -921,7 +921,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      220: Dead #Mono, health buff
+      260: Dead #Mono, health buff, twice
   - type: SlowOnDamage
     speedModifierThresholds:
       66: 0.7
@@ -1029,7 +1029,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      200: Dead
+      400: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       120: 0.7
@@ -1084,7 +1084,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      300: Dead
+      450: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       200: 0.7


### PR DESCRIPTION
Removed the critical state from rogue silicon, they straight up die instead
Made the tesla unit use an armor piercing heat + shock projectile instead of the cancerous lighting ball (noob trap) + more firerate for it so its still very strong
Make it so having insuls doesnt make you invulnerable by them and an actual threat

:cl:
- tweak: Rogue silicon no longer new player trap