### PR TITLE
Borg Adjustments

### DIFF
--- a/Content.Shared/Silicons/Borgs/SharedBorgSwitchableTypeSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSwitchableTypeSystem.cs
@@ -52,6 +52,7 @@ public abstract class SharedBorgSwitchableTypeSystem : EntitySystem
     private void OnMapInit(Entity<BorgSwitchableTypeComponent> ent, ref MapInitEvent args)
     {
         _actionsSystem.AddAction(ent, ref ent.Comp.SelectTypeAction, ActionId);
+        EnsureComp<BorgSwitchableSubtypeComponent>(ent.Owner); // Mono - Temp fix for borg sprites
         Dirty(ent);
 
         if (ent.Comp.SelectedBorgType != null &&

--- a/Content.Shared/Silicons/Borgs/SharedBorgSwitchableTypeSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSwitchableTypeSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
 // SPDX-FileCopyrightText: 2025 BeBright
+// SPDX-FileCopyrightText: 2025 EckoAurum
 // SPDX-FileCopyrightText: 2025 Ilya246
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -196,7 +196,7 @@
     onUse: false # no item-borg toggling sorry
   #- type: ItemTogglePointLight # Mono - Light removal PR: Borg Adjustments
   - type: NightVision # Mono
-    color: "#1584e6"
+    color: "#808080"
   - type: AccessToggle
   # TODO: refactor movement to just be based on toggle like speedboots but for the boots themselves
   # TODO: or just have sentient speedboots be fast idk

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -193,6 +193,9 @@
     onActivate: false # You should not be able to turn off a borg temporarily.
     activated: false # gets activated when a mind is added
     onUse: false # no item-borg toggling sorry
+  #- type: ItemTogglePointLight # Mono - Light removal PR: Borg Adjustments
+  - type: NightVision # Mono
+    color: "#1584e6"
   - type: AccessToggle
   # TODO: refactor movement to just be based on toggle like speedboots but for the boots themselves
   # TODO: or just have sentient speedboots be fast idk
@@ -266,8 +269,34 @@
         - cell_slot
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: NightVision # Goobstation - Nigthvision - Mono
-    color: "#1584e6"
+  #- type: HandheldLight # Mono - Light removal PR: Borg Adjustments
+  #  toggleOnInteract: false
+  #  wattage: 0.2
+  #  blinkingBehaviourId: blinking
+  #  radiatingBehaviourId: radiating
+  #- type: LightBehaviour
+  #  behaviours:
+  #  - !type:FadeBehaviour
+  #    id: radiating
+  #    maxDuration: 2.0
+  #    startValue: 3.0
+  #    endValue: 2.0
+  #    isLooped: true
+  #    reverseWhenFinished: true
+  #  - !type:PulseBehaviour
+  #    id: blinking
+  #    interpolate: Nearest
+  #    maxDuration: 1.0
+  #    minValue: 0.1
+  #    maxValue: 2.0
+  #    isLooped: true
+  #- type: ToggleableLightVisuals
+  #- type: PointLight
+  #  enabled: false
+  #  mask: /Textures/Effects/LightMasks/cone.png
+  #  autoRot: true
+  #  radius: 4
+  #  netsync: false 
   - type: Pullable
   - type: Puller
     needsHands: false
@@ -412,8 +441,8 @@
   - type: Vocal
     sounds:
       Unsexed: UnisexSiliconSyndicate
-  - type: PointLight
-    color: "#dd200b"
+  #- type: PointLight Mono - Light removal PR: Borg Adjustments
+  #  color: "#dd200b"
 
 - type: entity
   id: BaseBorgChassisDerelict

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -39,6 +39,7 @@
 # SPDX-FileCopyrightText: 2024 slarticodefast
 # SPDX-FileCopyrightText: 2024 themias
 # SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 EckoAurum
 # SPDX-FileCopyrightText: 2025 Errant
 # SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 Ilya246

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -193,7 +193,6 @@
     onActivate: false # You should not be able to turn off a borg temporarily.
     activated: false # gets activated when a mind is added
     onUse: false # no item-borg toggling sorry
-  - type: ItemTogglePointLight
   - type: AccessToggle
   # TODO: refactor movement to just be based on toggle like speedboots but for the boots themselves
   # TODO: or just have sentient speedboots be fast idk
@@ -267,34 +266,8 @@
         - cell_slot
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: HandheldLight
-    toggleOnInteract: false
-    wattage: 0.2
-    blinkingBehaviourId: blinking
-    radiatingBehaviourId: radiating
-  - type: LightBehaviour
-    behaviours:
-    - !type:FadeBehaviour
-      id: radiating
-      maxDuration: 2.0
-      startValue: 3.0
-      endValue: 2.0
-      isLooped: true
-      reverseWhenFinished: true
-    - !type:PulseBehaviour
-      id: blinking
-      interpolate: Nearest
-      maxDuration: 1.0
-      minValue: 0.1
-      maxValue: 2.0
-      isLooped: true
-  - type: ToggleableLightVisuals
-  - type: PointLight
-    enabled: false
-    mask: /Textures/Effects/LightMasks/cone.png
-    autoRot: true
-    radius: 4
-    netsync: false
+  - type: NightVision # Goobstation - Nigthvision - Mono
+    color: "#1584e6"
   - type: Pullable
   - type: Puller
     needsHands: false

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2025 EckoAurum
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 SRV
 # SPDX-FileCopyrightText: 2025 SarahRaven

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -163,6 +163,7 @@
   - BorgModuleTool # Mono
   - BorgModuleTreatment
   - BorgModuleSurgery # Mono
+  - BorgModuleDefibrillator # Mono
 
   radioChannels:
   - Science


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
In the Sisyphean challenge of fixing the localized borg rubberbanding lag #2224, players have identified that cyborg lights have _something_ to do with it, possibly.

This cleans up some of the issues.
**First:** Removed ALL lights from cyborgs in their entirety. Added blue tinted night vision in it's place.

**Second:** Re-adds borg sprites. This was identified as not the issue in #2336, but they're currently still broken. I'm not entirely sure why it works on other forks, but not ours. Adding the SwitchableSubtype comp on initialization seems to fix it for now.

**Third:** Gave the medical cyborg a starting Defibrillator. I intended to fix Medical cyborg not being able to do surgery through clothes, since they cannot strip, but our shitmed is behind and that component doesn't exist without updating our shitmed.

## Why / Balance
**First:** Lights are the possible issue. If they aren't, we can look elsewhere. Nightvision also just fits as it's become quite commonplace.

**Second:** It's nice being able to tell what borg is what,

**Third:** Medical cyborgs can't do surgery without someone to help them. Though we can't fix that yet, In Mono most people are dead by the time you can actually tend to them. Giving them a defib at the start allows them to do their job effectively.


## How to test
Spawn in Cyborgs and play around.

## Media
<img width="495" height="468" alt="image" src="https://github.com/user-attachments/assets/a540b412-d774-41b4-b108-bb9d359e23fe" />

Blue Tint since removed.

<img width="328" height="256" alt="image" src="https://github.com/user-attachments/assets/7f149a4b-ff01-4d74-80ec-2b688009687d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None found so far.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Medical Cyborgs now start with the defibrillator module.
- remove: Removed all lights from Cyborgs.
- add: Cyborgs now have Nightvision.
- tweak: Returned Cyborg sprites.

