### PR TITLE
Fix Missile Max Speed

### DIFF
--- a/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingSystem.cs
+++ b/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingSystem.cs
@@ -159,13 +159,10 @@ public sealed class TargetSeekingSystem : EntitySystem
             // Apply acceleration in the direction the projectile is facing
             _physics.SetLinearVelocity(uid, body.LinearVelocity + _transform.GetWorldRotation(xform).ToWorldVec() * acceleration, body: body);
 
-            // Damping applied for missiles above max speed.
-            if (body.LinearVelocity.Length() > seekingComp.MaxSpeed)
-                _physics.SetLinearDamping(uid, body, seekingComp.Acceleration * (float)ticktime.TotalSeconds * 1.5f);
-            else
-            {
-                _physics.SetLinearDamping(uid, body, 0f);
-            }
+            var velLen = body.LinearVelocity.Length();
+            // cut off velocity above max
+            if (velLen > seekingComp.MaxSpeed)
+                _physics.SetLinearVelocity(uid, body.LinearVelocity * (seekingComp.MaxSpeed / velLen), body: body);
 
             // Skip seeking behavior if disabled (e.g., after entering an enemy grid)
             if (seekingComp.SeekingDisabled)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
now actually obey max speed
we might want to tweak missile max speeds though since torpedoes have them really low
should maybe be done in a separate PR

## How to test
give the blip comp 5000 maxDistance then compare how missile goes without fix then with fix
goes the expected range here

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Missiles now obey their intended max speed.
