### PR TITLE
USSP -> Mil - Remarking USSP Shuttles

### DIFF
--- a/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/kopye.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/kopye.yml
@@ -26,7 +26,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Kopye USSP Ram{1}'
+          mapNameTemplate: 'Kopye MIL Ram{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/kopye.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/kopye.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 Ilya246
 #

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/kupol.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/kupol.yml
@@ -27,7 +27,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Kupol USSP Ram{1}'
+          mapNameTemplate: 'Kupol MIL Ram{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/kupol.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/kupol.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/molotok.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/molotok.yml
@@ -26,7 +26,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Molotok USSP Ram{1}'
+          mapNameTemplate: 'Molotok MIL Ram{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/molotok.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/Rams/molotok.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 Ilya246
 #

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/akula.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/akula.yml
@@ -38,7 +38,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Akula USSP{1}'
+          mapNameTemplate: 'Akula MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/akula.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/akula.yml
@@ -1,9 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/drakon.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/drakon.yml
@@ -34,7 +34,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Drakon USSP{1}'
+          mapNameTemplate: 'Drakon MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/drakon.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/drakon.yml
@@ -1,8 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
@@ -34,7 +34,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Gadyuka USSP{1}'
+          mapNameTemplate: 'Gadyuka MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/gadyuka.yml
@@ -1,8 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 kasature90
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/gruznyk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/gruznyk.yml
@@ -39,7 +39,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Gruznyk USSP{1}'
+          mapNameTemplate: 'Gruznyk MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/gruznyk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/gruznyk.yml
@@ -1,9 +1,12 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 kasature90
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/ledokol.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/ledokol.yml
@@ -38,7 +38,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Ledokol USSP{1}'
+          mapNameTemplate: 'Ledokol MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/ledokol.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/ledokol.yml
@@ -1,8 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/natisk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/natisk.yml
@@ -33,7 +33,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Natisk USSP{1}'
+          mapNameTemplate: 'Natisk MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/natisk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/natisk.yml
@@ -1,8 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/remontnik.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/remontnik.yml
@@ -33,7 +33,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Remontnik USSP{1}'
+          mapNameTemplate: 'Remontnik MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/remontnik.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/remontnik.yml
@@ -1,7 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
@@ -35,7 +35,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Sekunda USSP{1}'
+          mapNameTemplate: 'Sekunda MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sekunda.yml
@@ -1,9 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 significant harassment
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/strayk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/strayk.yml
@@ -34,7 +34,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Strayk USSP{1}'
+          mapNameTemplate: 'Strayk MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/strayk.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/strayk.yml
@@ -1,8 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 grandalff
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sulak.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sulak.yml
@@ -35,7 +35,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Sulak USSP{1}'
+          mapNameTemplate: 'Sulak MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/sulak.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/sulak.yml
@@ -1,9 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 Honestly101
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/tayfun.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/tayfun.yml
@@ -35,7 +35,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Tayfun USSP{1}'
+          mapNameTemplate: 'Tayfun MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/tayfun.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/tayfun.yml
@@ -1,8 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/tunguska.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/tunguska.yml
@@ -37,7 +37,7 @@
       stationProto: StandardFrontierVessel
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Tunguska USSP{1}'
+          mapNameTemplate: 'Tunguska MIL{1}'
           nameGenerator:
             !type:NanotrasenNameGenerator
             prefixCreator: '14'

--- a/Resources/Prototypes/_Mono/Shipyard/USSP/tunguska.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/USSP/tunguska.yml
@@ -1,8 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Avalon
 # SPDX-FileCopyrightText: 2025 BoskiYourk
 # SPDX-FileCopyrightText: 2025 HungryCuban
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 starch
 #


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Sets the IFF of all USSP shuttles to MIL, to reflect the fact USSP are no longer a faction., That was its less confusing for ADS and Faction p layers
## Why / Balance
See above

## How to test
Load up, look at shuttle
## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: All USSP shuttles now marked as MIL