### PR TITLE
Increase Hideout Spawn Distance Randomness

### DIFF
--- a/Resources/Prototypes/_Mono/PointsOfInterest/cove.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/cove.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2024 Salvantrix
 # SPDX-FileCopyrightText: 2024 Shroomerian
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 LukeZurg22
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/_Mono/PointsOfInterest/cove.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/cove.yml
@@ -21,8 +21,8 @@
   id: Cove
   parent: BasePOI
   name: ASR Insurgency Hideout
-  minimumDistance: 22500 # Mono
-  maximumDistance: 24000 # Mono
+  minimumDistance: 21000 # Mono
+  maximumDistance: 27000 # Mono
   spawnGamePreset: [ NFAdventure, NFPirate, MonoStandard, MonoRogueTSF, MonoRogueUSSP, MonoADS, MonoChimera, MonoAllAtOnce ]
   spawnGroup: Required
   gridPath: /Maps/_Mono/POI/cove.yml


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
22500-24000 -> 21000-27000

## Why / Balance
currently you can metagame it easily by just circling CO at 23km
i assume that ASR replacement faction will take a while to merge so can have this anyway for now

**Changelog**
:cl:
- tweak: ASR hideout now has higher spawn distance variation.
