### PR TITLE
Rebalance PTK/M25

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -14,6 +14,7 @@
 # SPDX-FileCopyrightText: 2025 Winkarst
 # SPDX-FileCopyrightText: 2025 ark1368
 # SPDX-FileCopyrightText: 2025 beck-thompson
+# SPDX-FileCopyrightText: 2025 bitcrushing
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -336,7 +336,7 @@
   id: ShuttleGunKinetic
   parent: [ ShuttleGunBase, ConstructibleMachine]
   name: PTK-1500e "Matter Dematerializer" # Frontier: "800"<"1500e" (consistent with naming scheme)
-  description: Mining turret, effective for blasting hardened targets. Gradually accumulates charges on its own. # Mono: description changed
+  description: Mining turret, effective for blasting hardened targets. Has considerable range but lower firerate. # Mono: description changed
   # categories: [ DoNotMap ] Mono
   components:
   - type: Sprite
@@ -359,7 +359,7 @@
         - !type:DoActsBehavior
           acts: ["Destruction"]
   - type: Gun
-    projectileSpeed: 20
+    projectileSpeed: 80
     fireRate: 2
     selectedMode: SemiAuto
     angleDecay: 45

--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Ghagliiarghii
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Whatstone
 # SPDX-FileCopyrightText: 2025 deltanedas
 # SPDX-FileCopyrightText: 2025 starch

--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -35,5 +35,5 @@
   recipes:
   - OreProcessorIndustrialMachineCircuitboard
   # - CargoTelepadMachineCircuitboard # Frontier
-  # - ShuttleGunKineticCircuitboard
+  - ShuttleGunKineticCircuitboard
   - WeaponTurretM25Circuitboard # Mono

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -27,6 +27,7 @@
 # SPDX-FileCopyrightText: 2025 Ark
 # SPDX-FileCopyrightText: 2025 Ghagliiarghii
 # SPDX-FileCopyrightText: 2025 Honestly101
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 blackknight954

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -47,7 +47,7 @@
   cost: 5000
   recipeUnlocks:
   - WeaponProtoKineticAccelerator
-  #- ShuttleGunKineticCircuitboard
+  - ShuttleGunKineticCircuitboard
   - WeaponTurretM25Circuitboard # Mono
   # These are roundstart but not replenishable for salvage
   - WeaponCrusher

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -239,7 +239,7 @@
   id: WeaponTurretM25
   name: M25 mining pulser
   parent: [BallisticArtillery, ConstructibleMachine] #Could possibly create a ConstructibleTurret proto if more are added; comps currently do nothing upgrade wise
-  description: Uses mechanisms to launch... something. Destroys rock easily.
+  description: Uses mechanisms to launch... something. Destroys rock easily. Limited range.
   components:
   - type: StaticPrice
     price: 1500
@@ -257,8 +257,8 @@
     range: 500
   - type: FireControlRotate
   - type: Gun
-    fireRate: 4.0
-    projectileSpeed: 40
+    fireRate: 5
+    projectileSpeed: 20
     minAngle: 0
     maxAngle: 5
     shootThermalSignature: 10000 # 400m - intentionally relatively low


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- makes PTK "researchable" (though it's in a static pack so it was never removed)
- quadruples PTK projectile speed to bring its range to 120
- halves M25 projectile speed but firerate 4->5

i was also considering decreasing M25 range even more so it's best to use a mix of both

## Why / Balance
makes more PTK viable as a makeshift shipgun
let people build scrapmaxxing hand-built salvage abominations
makes PTK more viable for mining large objects like vgroids
tested it ingame and DPS seems okay for a makeshift weapon, especially considering the range, might even need further improvement
also allows us to somewhat use it as a weapon on scrapyard ships

## Media
<img width="103" height="200" alt="image" src="https://github.com/user-attachments/assets/9ab40f1e-4a70-439e-8921-5cd11c051587" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: PTK projectile velocity, and range, quadrupled.
- tweak: M25 mining pulsar range halved but firerate 4->5.
