### PR TITLE
PTS+TM Update

### DIFF
--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -73,7 +73,7 @@ public sealed class NFCCVars
     /// The amount of time the bus waits at a station.
     /// </summary>
     public static readonly CVarDef<float> PublicTransitWaitTime =
-        CVarDef.Create("nf14.publictransit.wait_time", 120f, CVar.SERVERONLY);
+        CVarDef.Create("nf14.publictransit.wait_time", 40f, CVar.SERVERONLY);
 
     /// <summary>
     /// The amount of time the flies through FTL space.

--- a/Content.Shared/_NF/CCVar/NFCCVars.cs
+++ b/Content.Shared/_NF/CCVar/NFCCVars.cs
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: 2024 GreaseMonk
 // SPDX-FileCopyrightText: 2024 Shroomerian
 // SPDX-FileCopyrightText: 2025 EctoplasmIsGood
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 Whatstone
 // SPDX-FileCopyrightText: 2025 Your Name

--- a/Resources/Maps/_NF/POI/trademall.yml
+++ b/Resources/Maps/_NF/POI/trademall.yml
@@ -1,43 +1,11 @@
-# SPDX-FileCopyrightText: 2022 0x6273
-# SPDX-FileCopyrightText: 2022 20kdc
-# SPDX-FileCopyrightText: 2022 Francesco
-# SPDX-FileCopyrightText: 2022 Kara
-# SPDX-FileCopyrightText: 2022 LittleBuilderJane
-# SPDX-FileCopyrightText: 2022 Nairod
-# SPDX-FileCopyrightText: 2022 metalgearsloth
-# SPDX-FileCopyrightText: 2023 Debug
-# SPDX-FileCopyrightText: 2023 Leon Friedrich
-# SPDX-FileCopyrightText: 2023 Nemanja
-# SPDX-FileCopyrightText: 2023 TsjipTsjip
-# SPDX-FileCopyrightText: 2023 avery
-# SPDX-FileCopyrightText: 2023 lzk
-# SPDX-FileCopyrightText: 2024 Alice "Arimah" Heurlin
-# SPDX-FileCopyrightText: 2024 AndresE55
-# SPDX-FileCopyrightText: 2024 Dvir
-# SPDX-FileCopyrightText: 2024 Emisse
-# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
-# SPDX-FileCopyrightText: 2024 GreaseMonk
-# SPDX-FileCopyrightText: 2024 Maxtone
-# SPDX-FileCopyrightText: 2024 PECK
-# SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
-# SPDX-FileCopyrightText: 2024 ThatOneGoblin25
-# SPDX-FileCopyrightText: 2025 Alkheemist
-# SPDX-FileCopyrightText: 2025 Blu
-# SPDX-FileCopyrightText: 2025 Checkraze
-# SPDX-FileCopyrightText: 2025 Jakumba
-# SPDX-FileCopyrightText: 2025 Whatstone
-# SPDX-FileCopyrightText: 2025 starch
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 meta:
   format: 7
   category: Grid
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/27/2025 22:37:50
-  entityCount: 6295
+  time: 11/01/2025 13:37:45
+  entityCount: 6298
 maps: []
 grids:
 - 1
@@ -83,7 +51,6 @@ entities:
     - type: MetaData
       name: Trade Mall
     - type: Transform
-      pos: 10000,0
       parent: invalid
     - type: MapGrid
       chunks:
@@ -10304,12 +10271,6 @@ entities:
       parent: 1
 - proto: BenchSteelMiddle
   entities:
-  - uid: 867
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,19.5
-      parent: 1
   - uid: 868
     components:
     - type: Transform
@@ -10334,14 +10295,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: 12.5,-17.5
       parent: 1
-  - uid: 872
+- proto: BenchSteelRight
+  entities:
+  - uid: 867
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,18.5
+      pos: 2.5,19.5
       parent: 1
-- proto: BenchSteelRight
-  entities:
   - uid: 873
     components:
     - type: Transform
@@ -10353,12 +10314,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-18.5
-      parent: 1
-  - uid: 875
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,17.5
       parent: 1
 - proto: BoozeDispenserEmpty
   entities:
@@ -10477,6 +10432,11 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
+  - uid: 875
+    components:
+    - type: Transform
+      pos: 6.5,21.5
+      parent: 1
   - uid: 894
     components:
     - type: Transform
@@ -13656,6 +13616,21 @@ entities:
     components:
     - type: Transform
       pos: -2.5,-40.5
+      parent: 1
+  - uid: 6003
+    components:
+    - type: Transform
+      pos: 8.5,21.5
+      parent: 1
+  - uid: 6296
+    components:
+    - type: Transform
+      pos: 9.5,21.5
+      parent: 1
+  - uid: 6297
+    components:
+    - type: Transform
+      pos: 7.5,21.5
       parent: 1
 - proto: CableApcStack
   entities:
@@ -29255,8 +29230,7 @@ entities:
   - uid: 3903
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,21.5
+      pos: 5.5,17.5
       parent: 1
 - proto: GravityGenerator
   entities:
@@ -31449,7 +31423,7 @@ entities:
     - type: Transform
       pos: -13.5,7.5
       parent: 1
-- proto: KitchenDeepFryerPOI
+- proto: KitchenDeepFryerCauldronPOI
   entities:
   - uid: 4299
     components:
@@ -32330,6 +32304,13 @@ entities:
     components:
     - type: Transform
       pos: 45.5,3.5
+      parent: 1
+- proto: PoweredDimSmallLight
+  entities:
+  - uid: 6298
+    components:
+    - type: Transform
+      pos: 4.5,20.5
       parent: 1
 - proto: Poweredlight
   entities:
@@ -34570,6 +34551,18 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.6519165,12.624256
+      parent: 1
+- proto: ScrapSteel
+  entities:
+  - uid: 872
+    components:
+    - type: Transform
+      pos: 2.9516072,18.584389
+      parent: 1
+  - uid: 6009
+    components:
+    - type: Transform
+      pos: 5.3332624,18.549835
       parent: 1
 - proto: SheetPlasma10
   entities:
@@ -41698,12 +41691,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,17.5
       parent: 1
-  - uid: 6003
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,18.5
-      parent: 1
   - uid: 6004
     components:
     - type: Transform
@@ -41733,12 +41720,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,23.5
-      parent: 1
-  - uid: 6009
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,20.5
       parent: 1
   - uid: 6010
     components:

--- a/Resources/Maps/_NF/POI/trademall.yml
+++ b/Resources/Maps/_NF/POI/trademall.yml
@@ -1,3 +1,36 @@
+# SPDX-FileCopyrightText: 2022 0x6273
+# SPDX-FileCopyrightText: 2022 20kdc
+# SPDX-FileCopyrightText: 2022 Francesco
+# SPDX-FileCopyrightText: 2022 Kara
+# SPDX-FileCopyrightText: 2022 LittleBuilderJane
+# SPDX-FileCopyrightText: 2022 Nairod
+# SPDX-FileCopyrightText: 2022 metalgearsloth
+# SPDX-FileCopyrightText: 2023 Debug
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 Nemanja
+# SPDX-FileCopyrightText: 2023 TsjipTsjip
+# SPDX-FileCopyrightText: 2023 avery
+# SPDX-FileCopyrightText: 2023 lzk
+# SPDX-FileCopyrightText: 2024 Alice "Arimah" Heurlin
+# SPDX-FileCopyrightText: 2024 AndresE55
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Emisse
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 GreaseMonk
+# SPDX-FileCopyrightText: 2024 Maxtone
+# SPDX-FileCopyrightText: 2024 PECK
+# SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2024 ThatOneGoblin25
+# SPDX-FileCopyrightText: 2025 Alkheemist
+# SPDX-FileCopyrightText: 2025 Blu
+# SPDX-FileCopyrightText: 2025 Checkraze
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 Jakumba
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: MPL-2.0
+
 meta:
   format: 7
   category: Grid

--- a/Resources/Prototypes/_NF/PointsOfInterest/grifty.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/grifty.yml
@@ -20,6 +20,7 @@
   - type: SolarPoweredGrid
     trackOnInit: true
     doNotCull: true
+  - type: StationTransit # Mono
 
 - type: gameMap
   id: Grifty

--- a/Resources/Prototypes/_NF/PointsOfInterest/grifty.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/grifty.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Shroomerian
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # Author Info
 # GitHub:
 # Discord: ???


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
see changelog

## Why / Balance
scrapyard console is a bit hard to access right now
we can put funny things in it
also PTS waits 5 years for no reason

## Media
<img width="572" height="396" alt="image" src="https://github.com/user-attachments/assets/2b0a1510-5da3-4789-b765-2fb61231354e" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Public Transport Shuttle now waits 3 times less.
- tweak: Trade Mall's scrapyard console is now much easier to find.
- tweak: Grifty's is now a PTS destination.
