### PR TITLE
Delimit IFF From Exped Flatpackvend

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/expeditionaryflatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/expeditionaryflatpackvend.yml
@@ -18,7 +18,7 @@
     MercenaryTechFabFlatpack: 4294967295 # Infinite
     NFHolopadShipFlatpack: 4294967295 # Infinite
     # LaserDrillFlatpack: 4294967295 # Infinite - Mono
-    ComputerIFFFlatpack: 1
+    ComputerIFFFlatpack: 4294967295 # Infinite - Mono
     ResearchAndDevelopmentServerMercFlatpack: 4294967295 # Mono: infinite
     ComputerResearchAndDevelopmentFlatpack: 4294967295 # Mono: infinite
     FTLDriveFlatpack: 4294967295 # Infinite

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/expeditionaryflatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/expeditionaryflatpackvend.yml
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: 2024 ErhardSteinhauer
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2025 Checkraze
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
+# SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
see title/diff

## Why / Balance
since we're fine with giving mercs IFF might as well do this
can already just "buy" IFF via buying a ship with IFF taking IFF and selling

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Expeditionary FlatpackVend IFF consoles are no longer limited.
