### PR TITLE
Fix Mech Weapon Lockout

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -22,6 +22,7 @@
 // SPDX-FileCopyrightText: 2025 Ark
 // SPDX-FileCopyrightText: 2025 BeeRobynn
 // SPDX-FileCopyrightText: 2025 Blu
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 ScyronX
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -402,14 +402,15 @@ public sealed partial class MechSystem : SharedMechSystem
         if (!Resolve(uid, ref component))
             return false;
 
-        if (!base.TryChangeEnergy(uid, delta, component))
-            return false;
-
         var battery = component.BatterySlot.ContainedEntity;
         if (battery == null)
             return false;
 
         if (!TryComp<BatteryComponent>(battery, out var batteryComp))
+            return false;
+
+        // Mono
+        if (batteryComp.CurrentCharge + delta.Float() < 0 || )
             return false;
 
         _battery.SetCharge(battery!.Value, batteryComp.CurrentCharge + delta.Float(), batteryComp);
@@ -418,6 +419,7 @@ public sealed partial class MechSystem : SharedMechSystem
             Log.Debug($"Battery charge was not equal to mech charge. Battery {batteryComp.CurrentCharge}. Mech {component.Energy}");
             component.Energy = batteryComp.CurrentCharge;
             Dirty(uid, component);
+            UpdateUserInterface(uid, component);
         }
         _actionBlocker.UpdateCanMove(uid);
         return true;

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -411,7 +411,7 @@ public sealed partial class MechSystem : SharedMechSystem
             return false;
 
         // Mono
-        if (batteryComp.CurrentCharge + delta.Float() < 0 || )
+        if (batteryComp.CurrentCharge + delta.Float() < 0)
             return false;
 
         _battery.SetCharge(battery!.Value, batteryComp.CurrentCharge + delta.Float(), batteryComp);

--- a/Content.Server/_Goobstation/Mech/Equipment/EntitySystems/MechGunSystem.cs
+++ b/Content.Server/_Goobstation/Mech/Equipment/EntitySystems/MechGunSystem.cs
@@ -18,59 +18,25 @@ public sealed class MechGunSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<MechEquipmentComponent, HandleMechEquipmentBatteryEvent>(OnHandleMechEquipmentBattery);
-        SubscribeLocalEvent<HitscanBatteryAmmoProviderComponent, CheckMechWeaponBatteryEvent>(OnCheckBattery);
-        SubscribeLocalEvent<ProjectileBatteryAmmoProviderComponent, CheckMechWeaponBatteryEvent>(OnCheckBattery);
     }
 
+    // Mono: changed
     private void OnHandleMechEquipmentBattery(EntityUid uid, MechEquipmentComponent component, HandleMechEquipmentBatteryEvent args)
     {
-        if (!component.EquipmentOwner.HasValue)
+        if (!component.EquipmentOwner.HasValue
+            || !TryComp<MechComponent>(component.EquipmentOwner.Value, out var mech)
+            || !TryComp<BatteryComponent>(uid, out var battery)
+        )
             return;
 
-        if (!TryComp<MechComponent>(component.EquipmentOwner.Value, out var mech))
-            return;
-
-        if (TryComp<BatteryComponent>(uid, out var battery))
-        {
-            var ev = new CheckMechWeaponBatteryEvent(battery);
-            RaiseLocalEvent(uid, ref ev);
-
-            if (ev.Cancelled)
-                return;
-
-            ChargeGunBattery(uid, battery);
-        }
-    }
-
-    private void OnCheckBattery(EntityUid uid, BatteryAmmoProviderComponent component, CheckMechWeaponBatteryEvent args)
-    {
-        if (args.Battery.CurrentCharge > component.FireCost)
-            args.Cancelled = true;
-    }
-
-    private void ChargeGunBattery(EntityUid uid, BatteryComponent component)
-    {
-        if (!TryComp<MechEquipmentComponent>(uid, out var mechEquipment) || !mechEquipment.EquipmentOwner.HasValue)
-            return;
-
-        if (!TryComp<MechComponent>(mechEquipment.EquipmentOwner.Value, out var mech))
-            return;
-
-        var maxCharge = component.MaxCharge;
-        var currentCharge = component.CurrentCharge;
+        var maxCharge = battery.MaxCharge;
+        var currentCharge = battery.CurrentCharge;
 
         var chargeDelta = maxCharge - currentCharge;
 
-        // TODO: The battery charge of the mech would be spent directly when fired.
-        if (chargeDelta <= 0 || mech.Energy - chargeDelta < 0)
+        if (!_mech.TryChangeEnergy(component.EquipmentOwner.Value, -chargeDelta, mech))
             return;
 
-        if (!_mech.TryChangeEnergy(mechEquipment.EquipmentOwner.Value, -chargeDelta, mech))
-            return;
-
-        _battery.SetCharge(uid, component.MaxCharge, component);
+        _battery.SetCharge(uid, battery.MaxCharge, battery);
     }
 }
-
-[ByRefEvent]
-public record struct CheckMechWeaponBatteryEvent(BatteryComponent Battery, bool Cancelled = false);

--- a/Content.Server/_Goobstation/Mech/Equipment/EntitySystems/MechGunSystem.cs
+++ b/Content.Server/_Goobstation/Mech/Equipment/EntitySystems/MechGunSystem.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Server.Mech.Systems;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixes mechguns being unable to fire until battery reinsert if you have a microreactor in it and it discharges while firing

## How to test
- spawn broadsword
- put microreactor
- fully discharge via weapons fire
- wait a bit
- can fire again (as opposed to can't until you reinsert the battery)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed magdumping a mech weapon bricking the mech weapon if the mech has a reactor.
