### PR TITLE
Laser Drill Fix

### DIFF
--- a/Content.Server/_Goobstation/ItemMiner/Systems/PlanetMinerSystem.cs
+++ b/Content.Server/_Goobstation/ItemMiner/Systems/PlanetMinerSystem.cs
@@ -40,7 +40,7 @@ public sealed class PlanetMinerSystem : EntitySystem
         var gridUid = xform.GridUid;
 
         // check if we're on a planet
-        if (!_gridQuery.TryComp(mapUid, out var mapGrid) || gridUid == null)
+        if (mapUid == null || !_mapQuery.HasComp(mapUid.Value) || gridUid == null || !_gridQuery.HasComp(gridUid.Value))
         {
             args.Cancelled = true;
             return;

--- a/Content.Server/_Goobstation/ItemMiner/Systems/PlanetMinerSystem.cs
+++ b/Content.Server/_Goobstation/ItemMiner/Systems/PlanetMinerSystem.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 EckoAurum
 // SPDX-FileCopyrightText: 2025 Ilya246
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/laser_drill.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/laser_drill.yml
@@ -67,6 +67,20 @@
   - type: Construction
     graph: LaserDrill
     node: laserDrill
+    
+- type: entity
+  id: LaserDrillStation
+  name: advanced automated laser drill
+  parent: [ BaseStructureDisableAnchoring, LaserDrill]
+  description: A large automated drill that digs up random materials when powered with 50 kW of HV.
+  components:
+  - type: PlanetMiner
+    requireExpedition: false
+    requireGround: false
+  - type: ItemMiner
+    proto: SpawnLootOres15
+    interval: 20
+    needApcPower: false
 
 - type: entity
   name: random ores

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/laser_drill.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/laser_drill.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 EckoAurum
 # SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 significant harassment


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The laser drill technically worked fine, I assume, but noticed when changing "requireExpedition" to false, the setting didn't work.

My best guess is that the gridQuery looked for a map to see if it has a grid component. I believe only expedition maps have one of those baked in, so it would fail the check no matter the condition set if it wasn't on an expedition planet. No issue in normal circumstances, but won't let you toggle the requirement correctly in the yaml.

I shoved a bunch of or statements to replace the sanity check. cancel if there's no map, if the map doesnt have a mapcomponent, if the grid doesnt exist, or if the grid doesnt have a grid component.

Can probably cut that down, i don't know if it's physically possible to even have maps or grids without their components, but i'm not usually the redundancy type of coder, so i threw it in just in case, feel free to cut it.

## Why / Balance
I discovered this when trying to show someone how easy and simple it was to make a new laser drill that works off expeditions for their map. I was wrong, because it was broken.

I've added a prototype for a station laser drill that can be used for mapping. It's unanchorable, works on stations, and is twice as slow.

## How to test
Load up, hook up laser drill and advanced laser drill to the dev station. Watch as only the advanced one will mine.

Go to an expedition, spawn both, watch as the regular laser drill now mines.

## Media
No visual changes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
This has no noticeable impact to players.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
