### PR TITLE
ADS Weapons Re-Buff

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -666,7 +666,7 @@
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
-    fireRate: 0.025 # 40s
+    fireRate: 0.04 # 25s same as reaper the nebula gets a treat
     minAngle: 0
     maxAngle: 0
     projectileSpeed: 750
@@ -740,7 +740,7 @@
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
-    fireRate: 1.2
+    fireRate: 1
     minAngle: 0
     maxAngle: 4
     shootThermalSignature: 4000000 # ~2.8km with continuous fire
@@ -810,7 +810,7 @@
     range: 500
   - type: Gun
     fireRate: 1
-    projectileSpeed: 200
+    projectileSpeed: 290
     minAngle: 0
     maxAngle: 6
     shootThermalSignature: 500000 # ~5.6km with continuous fire

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -667,7 +667,7 @@
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
-    fireRate: 0.04 # 25s same as reaper the nebula gets a treat
+    fireRate: 0.025 # ~40s they fear the EMP spam from any high ROF
     minAngle: 0
     maxAngle: 0
     projectileSpeed: 750

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2025 Disguised Bear
 # SPDX-FileCopyrightText: 2025 Ghagliiarghii
 # SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 Nope1356
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 RikuTheKiller

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 RikuTheKiller
 # SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 kasature90
 # SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -264,15 +264,15 @@
     requireNoGrid: true
     shape: triangle
   - type: TimedDespawn
-    lifetime: 3
+    lifetime: 3.5
   - type: PointLight
     radarColor: "#ffffff"
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: DefaultShipGun
-    totalIntensity: 500
+    totalIntensity: 525
     intensitySlope: 35
-    maxIntensity: 50
+    maxIntensity: 55
 
 # Harbringer
 
@@ -425,7 +425,7 @@
     damage:
      types:
       Heat: 350
-      Structural: 2500
+      Structural: 3500
   - type: HitscanSpawnEntity
     spawnedEntity: SunderExplosion
   - type: HitscanBasicRaycast
@@ -484,7 +484,7 @@
   - type: Explosive
     explosionType: HardBombShipGun
     totalIntensity: 7000
-    intensitySlope: 100
+    intensitySlope: 150
     maxIntensity: 2400
 
 - type: entity
@@ -495,6 +495,6 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: HardBombShipGun
-    totalIntensity: 22
+    totalIntensity: 28
     intensitySlope: 2
-    maxIntensity: 5
+    maxIntensity: 10


### PR DESCRIPTION
Yea.
People complained too much, then powercreep kept chugging while ADS weapons got nerfed.
This rebuffs ADS weapons into being something scary and valuable, not fucking analogs of 90mm and kargil.

To whoever reviews this: Do not crucify me for touching the explosions. I based my knowledge off of the other explosions in the code.

edit: unbuffed harbinger since I had people complain about that specifically. Did not touch the others since the EMP seemed to be main point of contention.

**Changelog**

:cl:
- tweak: Buffs 3/5 ADS weapons with one or more of the following: increased range, damage, and fire rate.
