### PR TITLE
Ruby Price Fix

### DIFF
--- a/Resources/Prototypes/_Mono/Shipyard/ruby.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/ruby.yml
@@ -22,7 +22,7 @@
   parent: BaseVessel
   name: AES Ruby
   description: A large vessel for all things science related, anomaly generator included.
-  price: 120000
+  price: 125000
   category: Large
   group: Shipyard
   shuttlePath: /Maps/_Mono/Shuttles/ruby.yml

--- a/Resources/Prototypes/_Mono/Shipyard/ruby.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/ruby.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2024 Long YM
 # SPDX-FileCopyrightText: 2024 Maxtone
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 bluebrouny
 # SPDX-FileCopyrightText: 2025 starch


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
120k->125k

## Why / Balance
if i appraisegrid an init'd ruby ingame it appraises to 123k, and price being low also for some reason fails test on #2536 specifically and nowhere else
i have no idea how this happens and why other PR tests are succeeding

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Ruby price 120k->125k to raise price above worth.
