### PR TITLE
No More Plasmaslop (Crystallizer Recipes Rebalance)

### DIFF
--- a/Resources/Prototypes/_Mono/Atmospherics/crystallizer.yml
+++ b/Resources/Prototypes/_Mono/Atmospherics/crystallizer.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 NazrinNya
 # SPDX-FileCopyrightText: 2025 marc-pelletier
 # SPDX-FileCopyrightText: 2025 starch
 #

--- a/Resources/Prototypes/_Mono/Atmospherics/crystallizer.yml
+++ b/Resources/Prototypes/_Mono/Atmospherics/crystallizer.yml
@@ -100,9 +100,9 @@
 - type: crystallizerRecipe
   id: Plasteel
   name: Plasteel (10)
-  minimumTemperature: 1500
-  maximumTemperature: 3500
-  energyRelease: -650
+  minimumTemperature: 1750
+  maximumTemperature: 2500
+  energyRelease: -2040
   products:
     SheetPlasteel10: 1
   dangerous: false

--- a/Resources/Prototypes/_Mono/Atmospherics/crystallizer.yml
+++ b/Resources/Prototypes/_Mono/Atmospherics/crystallizer.yml
@@ -22,6 +22,9 @@
   - 0     # ammonia
   - 0     # n2o
   - 0     # frezon
+  - 0     # bz
+  - 0     # healium
+  - 0     # nitrium
 
 - type: crystallizerRecipe
   id: Iridite
@@ -42,26 +45,34 @@
   - 0     # ammonia
   - 1     # n2o
   - 2     # frezon
+  - 0     # bz
+  - 0     # healium
+  - 0     # nitrium
+
 
 - type: crystallizerRecipe
   id: Plastitanium
-  name: Plastitanium (1)
+  name: Plastitanium (10)
   minimumTemperature: 7920
   maximumTemperature: 8150
   energyRelease: 1840
   products:
-    SheetPlastitanium1: 1
+    SheetPlastitanium10: 1
   dangerous: true
   minimumRequirements:
-  - 27     # oxygen
-  - 2     # nitrogen
-  - 3     # carbon dioxide
+  - 35     # oxygen
+  - 3     # nitrogen
+  - 8     # carbon dioxide
   - 9     # plasma
-  - 2     # tritium
+  - 3     # tritium
   - 0     # vapor
-  - 5     # ammonia
-  - 1     # n2o
+  - 7     # ammonia
+  - 2     # n2o
   - 0     # frezon
+  - 0     # bz
+  - 0     # healium
+  - 0     # nitrium
+
 
 - type: crystallizerRecipe
   id: Synthalloy
@@ -82,35 +93,41 @@
   - 0     # ammonia
   - 1     # n2o
   - 0     # frezon
+  - 0     # bz
+  - 0     # healium
+  - 0     # nitrium
 
 - type: crystallizerRecipe
   id: Plasteel
-  name: Plasteel (1)
+  name: Plasteel (10)
   minimumTemperature: 1500
   maximumTemperature: 3500
   energyRelease: -650
   products:
-    SheetPlasteel1: 1
+    SheetPlasteel10: 1
   dangerous: false
   minimumRequirements:
-  - 4     # oxygen
+  - 6     # oxygen
   - 0     # nitrogen
-  - 6     # carbon dioxide
-  - 2     # plasma
+  - 8     # carbon dioxide
+  - 5     # plasma
   - 0     # tritium
   - 0     # vapor
   - 0     # ammonia
   - 0     # n2o
   - 0     # frezon
+  - 0     # bz
+  - 0     # healium
+  - 0     # nitrium
 
 - type: crystallizerRecipe
   id: Plasma
-  name: Plasma (10)
+  name: Plasma (1)
   minimumTemperature: 40
   maximumTemperature: 60
   energyRelease: 60
   products:
-    SheetPlasma10: 1
+    SheetPlasma1: 1
   dangerous: false
   minimumRequirements:
   - 0     # oxygen
@@ -122,43 +139,52 @@
   - 0     # ammonia
   - 0     # n2o
   - 0     # frezon
+  - 0     # bz
+  - 0     # healium
+  - 0     # nitrium
 
 - type: crystallizerRecipe
   id: Telecrystal
   name: Telecrystal (1)
   minimumTemperature: 0
   maximumTemperature: 10
-  energyRelease: 950
+  energyRelease: 1040
   products:
     Telecrystal1: 1
   dangerous: false
   minimumRequirements:
   - 0     # oxygen
-  - 4     # nitrogen
+  - 5     # nitrogen
   - 0     # carbon dioxide
   - 2     # plasma
-  - 3     # tritium
+  - 4     # tritium
   - 0     # vapor
   - 4     # ammonia
   - 8     # n2o
-  - 2     # frezon
+  - 3     # frezon
+  - 0     # bz
+  - 2     # healium
+  - 0     # nitrium
 
 - type: crystallizerRecipe
-  id: Coal
-  name: Coal (1)
-  minimumTemperature: 720
-  maximumTemperature: 3000
-  energyRelease: 950
+  id: Diamond
+  name: Diamond (1)
+  minimumTemperature: 34800
+  maximumTemperature: 37200
+  energyRelease: -4250
   products:
-    Coal1: 1
-  dangerous: false
+    MaterialDiamond1: 1
+  dangerous: true
   minimumRequirements:
   - 0     # oxygen
   - 0     # nitrogen
-  - 2     # carbon dioxide
+  - 25     # carbon dioxide
   - 0     # plasma
   - 0     # tritium
   - 0     # vapor
   - 0     # ammonia
   - 0     # n2o
   - 0     # frezon
+  - 0     # bz
+  - 0     # healium
+  - 0     # nitrium

--- a/Resources/Prototypes/_Mono/Atmospherics/crystallizer.yml
+++ b/Resources/Prototypes/_Mono/Atmospherics/crystallizer.yml
@@ -178,7 +178,7 @@
   minimumRequirements:
   - 0     # oxygen
   - 0     # nitrogen
-  - 25     # carbon dioxide
+  - 500    # carbon dioxide
   - 0     # plasma
   - 0     # tritium
   - 0     # vapor


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR changes crystallizer recipes to make it somewhat usable besides money farm:
- Plasma
Material stack changed from 10 to 1.
- Telecrystals
Slightly increased amount of required gases and energy release, added healium gas in recipe
- Plastitanium
Stack changed from 1 to 10 with slight gas requirement increase
- Plasteel
same as plastitanium
- Coal
Has been replaced with diamond, requiring absurd temperatures and 25 moles of carbon dioxide.

Also added BZ, healium and nitrium fields
## Why / Balance
In current state, crystallizer is used only for money farms, such as iridite or plasma. Plastitanium and Plasteel was not worth making it due to how much time it consumes for basically nothing.

I decided to not touch iridite because its probably fine for now (You can't really abuse it, like plasma).

Buffing plasteel and plastitanium production also opens more interactions between factions and civilians.

Whats more engaging?
- Atmoslopper that's making 100 million per hour by lagging whole server because of his super 100 crystallizer plasma setup.
- ASR chad slapping 50 layers of plastitanium on his europa (Or the atmos himself, why not)
## How to test
- spawn crystallizer
- check new recipes 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Half of crystallizer recipes got rebalanced. Plasteel and Plastitanium now gives 10 sheets instead of 1 at cost of slightly increased gas amount required.



