### PR TITLE
Fix Fluorosulfuric Acid

### DIFF
--- a/Content.Server/Chemistry/TileReactions/PryTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/PryTileReaction.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2023 DrSmugleaf
 // SPDX-FileCopyrightText: 2024 Kara
 // SPDX-FileCopyrightText: 2024 SlamBamActionman
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 starch
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Chemistry/TileReactions/PryTileReaction.cs
+++ b/Content.Server/Chemistry/TileReactions/PryTileReaction.cs
@@ -10,10 +10,12 @@
 using Content.Server.Maps;
 using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Construction.Components; // Mono
 using Content.Shared.FixedPoint;
 using Content.Shared.Maps;
 using JetBrains.Annotations;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components; // Mono
 
 namespace Content.Server.Chemistry.TileReactions;
 
@@ -28,6 +30,20 @@ public sealed partial class PryTileReaction : ITileReaction
         List<ReagentData>? data)
     {
         var sys = entityManager.System<TileSystem>();
+        var mapSys = entityManager.System<SharedMapSystem>(); // Mono
+
+        // Mono
+        var grid = tile.GridUid;
+        foreach (var ent in mapSys.GetAnchoredEntities((grid, entityManager.GetComponent<MapGridComponent>(grid)), tile.GridIndices))
+        {
+            // if we're not unanchorable, refuse to pry tile
+            if (!entityManager.TryGetComponent<AnchorableComponent>(ent, out var anch))
+                return FixedPoint2.Zero;
+
+            if ((anch.Flags & AnchorableFlags.Unanchorable) == 0)
+                return FixedPoint2.Zero;
+        }
+
         sys.DeconstructTile(tile); // Mono - change from PryTile
         return reactVolume;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
now only works under anchored entities if they're unanchorable

## Why / Balance
can't use it to delete shipguns anymore

## How to test
fire fluorosulfuric spray nozzle at cyrexa
see cyrexa not get deleted

## Media
<img width="247" height="121" alt="image" src="https://github.com/user-attachments/assets/9bdfa5d7-86eb-47db-be80-5d2edc081799" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can no longer use fluorosulfuric acid to unanchor non-unanchorable entities.
