### PR TITLE
Wyvern Scuttling Device

### DIFF
--- a/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceComponent.cs
+++ b/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using System;

--- a/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceComponent.cs
+++ b/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceComponent.cs
@@ -50,7 +50,7 @@ public sealed partial class ScuttleDeviceComponent : Component
     public TimeSpan DisarmDoafterLength = TimeSpan.FromSeconds(30);
 
     [DataField]
-    public SoundSpecifier ActivateSound = new SoundPathSpecifier("/Audio/Misc/delta_alt.ogg");
+    public SoundSpecifier ActivateSound = new SoundPathSpecifier("/Audio/Misc/delta.ogg");
 
     [DataField]
     public SoundSpecifier AlertSound = new SoundPathSpecifier("/Audio/Machines/Nuke/nuke_alarm.ogg");
@@ -69,6 +69,9 @@ public sealed partial class ScuttleDeviceComponent : Component
     /// </summary>
     [DataField]
     public float UnlockedPrice = 0f;
+
+    [DataField]
+    public float AnnounceRadius = 1500f;
 
     /// <summary>
     ///     Time until explosion in seconds.

--- a/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceComponent.cs
+++ b/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceComponent.cs
@@ -1,0 +1,99 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+using System;
+
+namespace Content.Server._Mono.ScuttleDevice;
+
+/// <summary>
+///     Altered copy of NukeComponent used to scuttle ships.
+///     Requires a specific entity to unlock, after which, it can be detonated and disarmed like a normal nuke.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ScuttleDeviceComponent : Component
+{
+    /// <summary>
+    ///     Default bomb timer value.
+    /// </summary>
+    [DataField]
+    public TimeSpan Timer = TimeSpan.FromSeconds(300);
+
+    /// <summary>
+    ///     If the nuke is disarmed, this sets the minimum amount of time the timer can have.
+    ///     The remaining time will reset to this value if it is below it.
+    /// </summary>
+    [DataField]
+    public TimeSpan MinimumTime = TimeSpan.FromSeconds(180);
+
+    /// <summary>
+    ///     How long until the bomb can arm again after deactivation.
+    ///     Used to prevent announcements spam.
+    /// </summary>
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    ///     When this time is left, nuke will play last alert sound
+    /// </summary>
+    [DataField]
+    public TimeSpan AlertSoundTime = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    ///     How long a user must wait to arm the bomb.
+    /// </summary>
+    [DataField]
+    public TimeSpan ArmDoafterLength = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    ///     How long a user must wait to disarm the bomb.
+    /// </summary>
+    [DataField]
+    public TimeSpan DisarmDoafterLength = TimeSpan.FromSeconds(30);
+
+    [DataField]
+    public SoundSpecifier ActivateSound = new SoundPathSpecifier("/Audio/Misc/delta_alt.ogg");
+
+    [DataField]
+    public SoundSpecifier AlertSound = new SoundPathSpecifier("/Audio/Machines/Nuke/nuke_alarm.ogg");
+
+    [DataField]
+    public SoundSpecifier ArmSound = new SoundPathSpecifier("/Audio/Misc/notice1.ogg");
+
+    [DataField]
+    public SoundSpecifier DisarmSound = new SoundPathSpecifier("/Audio/Misc/notice2.ogg");
+
+    [DataField]
+    public SoundSpecifier ArmMusic = new SoundCollectionSpecifier("NukeMusic");
+
+    /// <summary>
+    ///     How much price to add if we're unlocked.
+    /// </summary>
+    [DataField]
+    public float UnlockedPrice = 0f;
+
+    /// <summary>
+    ///     Time until explosion in seconds.
+    /// </summary>
+    [ViewVariables]
+    public TimeSpan RemainingTime;
+
+    /// <summary>
+    ///     Time until bomb cooldown will expire in seconds.
+    /// </summary>
+    [ViewVariables]
+    public TimeSpan? CooldownTime = null;
+
+    [ViewVariables]
+    public bool Armed = false;
+
+    /// <summary>
+    ///     Check if nuke has already played the nuke song so we don't do it again
+    /// </summary>
+    public bool PlayedNukeSong = false;
+
+    /// <summary>
+    ///     Check if nuke has already played last alert sound
+    /// </summary>
+    public bool PlayedAlertSound = false;
+
+    public EntityUid? AlertAudioStream = default;
+}

--- a/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceSystem.cs
+++ b/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Server.AlertLevel;
 using Content.Server.Audio;
 using Content.Server.Cargo.Systems;

--- a/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceSystem.cs
+++ b/Content.Server/_Mono/ScuttleDevice/ScuttleDeviceSystem.cs
@@ -1,0 +1,342 @@
+using Content.Server.AlertLevel;
+using Content.Server.Audio;
+using Content.Server.Cargo.Systems;
+using Content.Server.Chat.Systems;
+using Content.Server.Explosion.EntitySystems;
+using Content.Server.Pinpointer;
+using Content.Server.Popups;
+using Content.Shared._Mono.ScuttleDevice;
+using Content.Shared.Audio;
+using Content.Shared.Construction.Components;
+using Content.Shared.Coordinates.Helpers;
+using Content.Shared.DoAfter;
+using Content.Shared.Examine;
+using Content.Shared.Lock;
+using Content.Shared.Maps;
+using Content.Shared.Nuke;
+using Content.Shared.Popups;
+using Content.Shared.Shuttles.Systems;
+using Content.Shared.Verbs;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Mono.ScuttleDevice;
+
+public sealed class ScuttleDeviceSystem : EntitySystem
+{
+    [Dependency] private readonly AppearanceSystem _appearance = default!;
+    [Dependency] private readonly ChatSystem _chatSystem = default!;
+    [Dependency] private readonly ExplosionSystem _explosions = default!;
+    [Dependency] private readonly LockSystem _lock = default!;
+    [Dependency] private readonly NavMapSystem _navMap = default!;
+    [Dependency] private readonly PointLightSystem _pointLight = default!;
+    [Dependency] private readonly PopupSystem _popups = default!;
+    [Dependency] private readonly ServerGlobalSoundSystem _sound = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly SharedShuttleSystem _shuttles = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private TimeSpan _nukeSongLength;
+    private ResolvedSoundSpecifier _selectedNukeSong = String.Empty;
+
+    /// <summary>
+    ///     Time to leave between the nuke song and the nuke alarm playing.
+    /// </summary>
+    private TimeSpan NukeSongBuffer = TimeSpan.FromSeconds(1.5);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ScuttleDeviceComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<ScuttleDeviceComponent, ExaminedEvent>(OnExaminedEvent);
+        SubscribeLocalEvent<ScuttleDeviceComponent, GetVerbsEvent<AlternativeVerb>>(OnAlternateVerb);
+        SubscribeLocalEvent<ScuttleDeviceComponent, ScuttleDisarmDoAfterEvent>(OnDisarmDoAfter);
+        SubscribeLocalEvent<ScuttleDeviceComponent, ScuttleArmDoAfterEvent>(OnArmDoAfter);
+        SubscribeLocalEvent<ScuttleDeviceComponent, AnchorAttemptEvent>(OnAnchorAttempt);
+        SubscribeLocalEvent<ScuttleDeviceComponent, PriceCalculationEvent>(OnGetPrice);
+    }
+
+    private void OnInit(Entity<ScuttleDeviceComponent> ent, ref ComponentInit args)
+    {
+        ent.Comp.RemainingTime = ent.Comp.Timer;
+    }
+
+    private void OnExaminedEvent(Entity<ScuttleDeviceComponent> ent, ref ExaminedEvent args)
+    {
+        if (ent.Comp.PlayedAlertSound)
+            args.PushMarkup(Loc.GetString("nuke-examine-exploding"));
+        else if (ent.Comp.Armed)
+            args.PushMarkup(Loc.GetString("nuke-examine-armed"));
+    }
+
+    private void OnAlternateVerb(Entity<ScuttleDeviceComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!Transform(ent).Anchored || !args.CanComplexInteract)
+            return;
+
+        var user = args.User;
+
+        if (ent.Comp.Armed)
+            args.Verbs.Add(new AlternativeVerb()
+            {
+                Act = () => DisarmBombDoafter(ent, user),
+                Text = Loc.GetString("scuttle-device-verb-disarm"),
+                Priority = 10,
+            });
+        else if (!_lock.IsLocked(ent.Owner))
+            args.Verbs.Add(new AlternativeVerb()
+            {
+                Act = () => ArmBombDoafter(ent, user),
+                Text = Loc.GetString("scuttle-device-verb-arm"),
+                Priority = 10,
+            });
+    }
+
+    private void OnDisarmDoAfter(Entity<ScuttleDeviceComponent> ent, ref ScuttleDisarmDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled)
+            return;
+
+        DisarmBomb((ent, ent.Comp));
+
+        args.Handled = true;
+    }
+
+    private void OnArmDoAfter(Entity<ScuttleDeviceComponent> ent, ref ScuttleArmDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled)
+            return;
+
+        ArmBomb((ent, ent.Comp));
+
+        args.Handled = true;
+    }
+
+    private void OnAnchorAttempt(Entity<ScuttleDeviceComponent> ent, ref AnchorAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (ent.Comp.Armed)
+            args.Cancel();
+    }
+
+    private void OnGetPrice(Entity<ScuttleDeviceComponent> ent, ref PriceCalculationEvent args)
+    {
+        if (!_lock.IsLocked(ent.Owner))
+            args.Price += ent.Comp.UnlockedPrice;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<ScuttleDeviceComponent>();
+        while (query.MoveNext(out var uid, out var nuke))
+        {
+            if (nuke.Armed)
+                TickTimer((uid, nuke), frameTime);
+            else if (nuke.CooldownTime != null)
+                TickCooldown((uid, nuke), frameTime);
+        }
+    }
+
+    private void TickCooldown(Entity<ScuttleDeviceComponent?> ent, float frameTime)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        ent.Comp.CooldownTime -= TimeSpan.FromSeconds(frameTime);
+        if (ent.Comp.CooldownTime <= TimeSpan.FromSeconds(0))
+        {
+            // reset nuke to default state
+            ent.Comp.CooldownTime = TimeSpan.FromSeconds(0);
+        }
+    }
+
+    private void TickTimer(Entity<ScuttleDeviceComponent?> ent, float frameTime)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        ent.Comp.RemainingTime -= TimeSpan.FromSeconds(frameTime);
+
+        // Start playing the ent.Comp event song so that it ends a couple seconds before the alert sound
+        // should play
+        if (ent.Comp.RemainingTime <= _nukeSongLength + ent.Comp.AlertSoundTime + NukeSongBuffer && !ent.Comp.PlayedNukeSong && !ResolvedSoundSpecifier.IsNullOrEmpty(_selectedNukeSong))
+        {
+            _sound.DispatchStationEventMusic(ent, _selectedNukeSong, StationEventMusicType.Nuke);
+            ent.Comp.PlayedNukeSong = true;
+        }
+
+        // play alert sound if time is running out
+        if (ent.Comp.RemainingTime <= ent.Comp.AlertSoundTime && !ent.Comp.PlayedAlertSound)
+        {
+            _sound.PlayGlobalOnStation(ent, _audio.ResolveSound(ent.Comp.AlertSound), new AudioParams{Volume = -5f});
+            _sound.StopStationEventMusic(ent, StationEventMusicType.Nuke);
+            ent.Comp.PlayedAlertSound = true;
+        }
+
+        if (ent.Comp.RemainingTime <= TimeSpan.FromSeconds(0))
+        {
+            ent.Comp.RemainingTime = TimeSpan.FromSeconds(0);
+            ActivateBomb(ent);
+        }
+    }
+
+    /// <summary>
+    ///     Force a nuclear bomb to start a countdown timer
+    /// </summary>
+    public void ArmBomb(Entity<ScuttleDeviceComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        if (ent.Comp.Armed)
+            return;
+
+        var nukeXform = Transform(ent);
+        var grid = nukeXform.GridUid;
+
+        // We are collapsing the randomness here, otherwise we would get separate random song picks for checking duration and when actually playing the song afterwards
+        _selectedNukeSong = _audio.ResolveSound(ent.Comp.ArmMusic);
+
+        // warn a crew
+        var announcement = Loc.GetString("scuttle-device-announcement-armed",
+            ("time", (int) ent.Comp.RemainingTime.TotalSeconds),
+            ("location", grid == null ? "Space" : _shuttles.GetIFFLabel(grid));
+        var sender = Loc.GetString("scuttle-device-announcement-sender");
+        _chatSystem.DispatchStationAnnouncement(ent, announcement, sender, false, null, Color.Red);
+
+        _sound.PlayGlobalOnStation(ent, _audio.ResolveSound(ent.Comp.ActivateSound));
+        _sound.PlayGlobalOnStation(ent, _audio.ResolveSound(ent.Comp.ArmSound));
+        _nukeSongLength = _audio.GetAudioLength(_selectedNukeSong);
+
+        // turn on the spinny light
+        _pointLight.SetEnabled(ent, true);
+        // enable the navmap beacon for people to find it
+        _navMap.SetBeaconEnabled(ent, true);
+
+        if (!nukeXform.Anchored)
+        {
+            // Admin command shenanigans, just make sure.
+            _transform.AnchorEntity(ent, nukeXform);
+        }
+
+        ent.Comp.Armed = true;
+        UpdateAppearance((ent, ent.Comp));
+    }
+
+    /// <summary>
+    ///     Stop nuclear bomb timer
+    /// </summary>
+    public void DisarmBomb(Entity<ScuttleDeviceComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        if (!ent.Comp.Armed)
+            return;
+
+        var nukeXform = Transform(ent);
+        var grid = nukeXform.GridUid;
+
+        var announcement = Loc.GetString("scuttle-device-announcement-unarmed",
+            ("location", grid == null ? "Space" : _shuttles.GetIFFLabel(grid));
+        var sender = Loc.GetString("scuttle-device-announcement-sender");
+        _chatSystem.DispatchStationAnnouncement(ent, announcement, sender, false);
+
+        ent.Comp.PlayedNukeSong = false;
+        _sound.PlayGlobalOnStation(ent, _audio.ResolveSound(ent.Comp.DisarmSound));
+        _sound.StopStationEventMusic(ent, StationEventMusicType.Nuke);
+
+        // reset nuke remaining time to either itself or the minimum time, whichever is higher
+        ent.Comp.RemainingTime = TimeSpan.FromSeconds(Math.Max(ent.Comp.RemainingTime.TotalSeconds, ent.Comp.MinimumTime.TotalSeconds));
+
+        // disable sound and reset it
+        ent.Comp.PlayedAlertSound = false;
+        ent.Comp.AlertAudioStream = _audio.Stop(ent.Comp.AlertAudioStream);
+
+        // turn off the spinny light
+        _pointLight.SetEnabled(ent, false);
+        // disable the navmap beacon now that its disarmed
+        _navMap.SetBeaconEnabled(ent, false);
+
+        // start bomb cooldown
+        ent.Comp.CooldownTime = ent.Comp.Cooldown;
+
+        ent.Comp.Armed = false;
+        UpdateAppearance((ent, ent.Comp));
+    }
+
+    /// <summary>
+    ///     Force bomb to explode immediately
+    /// </summary>
+    public void ActivateBomb(Entity<ScuttleDeviceComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
+        _explosions.TriggerExplosive(ent);
+        _sound.StopStationEventMusic(ent, StationEventMusicType.Nuke);
+    }
+
+    private void ArmBombDoafter(Entity<ScuttleDeviceComponent> ent, EntityUid user)
+    {
+        var doAfter = new DoAfterArgs(EntityManager, user, ent.Comp.ArmDoafterLength, new ScuttleArmDoAfterEvent(), ent, target: ent)
+        {
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = false,
+            MultiplyDelay = false,
+        };
+
+        if (!_doAfter.TryStartDoAfter(doAfter))
+            return;
+
+        _popups.PopupEntity(Loc.GetString("scuttle-device-arm-warning"), user,
+            user, PopupType.LargeCaution);
+    }
+
+    private void DisarmBombDoafter(Entity<ScuttleDeviceComponent> ent, EntityUid user)
+    {
+        var doAfter = new DoAfterArgs(EntityManager, user, ent.Comp.DisarmDoafterLength, new ScuttleDisarmDoAfterEvent(), ent, target: ent)
+        {
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = false,
+            MultiplyDelay = false,
+        };
+
+        if (!_doAfter.TryStartDoAfter(doAfter))
+            return;
+
+        _popups.PopupEntity(Loc.GetString("scuttle-device-disarm-warning"), user,
+            user, PopupType.LargeCaution);
+    }
+
+    private void UpdateAppearance(Entity<ScuttleDeviceComponent> ent)
+    {
+        var xform = Transform(ent);
+
+        _appearance.SetData(ent, NukeVisuals.Deployed, xform.Anchored);
+
+        NukeVisualState state;
+        if (ent.Comp.PlayedAlertSound)
+            state = NukeVisualState.YoureFucked;
+        else if (ent.Comp.Armed)
+            state = NukeVisualState.Armed;
+        else
+            state = NukeVisualState.Idle;
+
+        _appearance.SetData(ent, NukeVisuals.State, state);
+    }
+}

--- a/Content.Shared/_Mono/ScuttleDevice/SharedScuttleDevice.cs
+++ b/Content.Shared/_Mono/ScuttleDevice/SharedScuttleDevice.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Shared.DoAfter;
 using Robust.Shared.Serialization;
 

--- a/Content.Shared/_Mono/ScuttleDevice/SharedScuttleDevice.cs
+++ b/Content.Shared/_Mono/ScuttleDevice/SharedScuttleDevice.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Mono.ScuttleDevice;
+
+[Serializable, NetSerializable]
+public sealed partial class ScuttleArmDoAfterEvent : SimpleDoAfterEvent {}
+
+[Serializable, NetSerializable]
+public sealed partial class ScuttleDisarmDoAfterEvent : SimpleDoAfterEvent {}

--- a/Resources/Locale/en-US/_Mono/scuttle-device/scuttle-device.ftl
+++ b/Resources/Locale/en-US/_Mono/scuttle-device/scuttle-device.ftl
@@ -1,0 +1,9 @@
+scuttle-device-disarm-warning = You start fiddling with wires and knobs in order to disarm the device.. This may take a while.
+scuttle-device-arm-warning = You hold the arming trigger active.
+
+scuttle-device-verb-disarm = Disarm
+scuttle-device-verb-arm = Arm
+
+scuttle-device-announcement-sender = Antimatter Annihilation Assembly
+scuttle-device-announcement-armed = The self-destruct mechanism of {$location} has been engaged. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.
+scuttle-device-announcement-armed = The self-destruct mechanism of {$location} has been disengaged.

--- a/Resources/Locale/en-US/_Mono/scuttle-device/scuttle-device.ftl
+++ b/Resources/Locale/en-US/_Mono/scuttle-device/scuttle-device.ftl
@@ -6,4 +6,4 @@ scuttle-device-verb-arm = Arm
 
 scuttle-device-announcement-sender = Antimatter Annihilation Assembly
 scuttle-device-announcement-armed = The self-destruct mechanism of {$location} has been engaged. {$time} seconds until detonation. If this was made in error, the mechanism may still be disarmed.
-scuttle-device-announcement-armed = The self-destruct mechanism of {$location} has been disengaged.
+scuttle-device-announcement-unarmed = The self-destruct mechanism of {$location} has been disengaged.

--- a/Resources/Maps/_Mono/ShuttleEvent/wyvern.yml
+++ b/Resources/Maps/_Mono/ShuttleEvent/wyvern.yml
@@ -1,3 +1,30 @@
+# SPDX-FileCopyrightText: 2023 Cheackraze
+# SPDX-FileCopyrightText: 2023 Dawid Bla
+# SPDX-FileCopyrightText: 2023 deltanedas
+# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
+# SPDX-FileCopyrightText: 2023 lzk
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2024 Checkraze
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 Salvantrix
+# SPDX-FileCopyrightText: 2024 TsjipTsjip
+# SPDX-FileCopyrightText: 2024 Wiebe Geertsma
+# SPDX-FileCopyrightText: 2025 Arcticular
+# SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 Avalon
+# SPDX-FileCopyrightText: 2025 BoskiYourk
+# SPDX-FileCopyrightText: 2025 Cojoke
+# SPDX-FileCopyrightText: 2025 Honestly101
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 RikuTheKiller
+# SPDX-FileCopyrightText: 2025 Whatstone
+# SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: MPL-2.0
+
 meta:
   format: 7
   category: Grid

--- a/Resources/Maps/_Mono/ShuttleEvent/wyvern.yml
+++ b/Resources/Maps/_Mono/ShuttleEvent/wyvern.yml
@@ -1,37 +1,11 @@
-# SPDX-FileCopyrightText: 2023 Cheackraze
-# SPDX-FileCopyrightText: 2023 Dawid Bla
-# SPDX-FileCopyrightText: 2023 deltanedas
-# SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-# SPDX-FileCopyrightText: 2023 lzk
-# SPDX-FileCopyrightText: 2023 metalgearsloth
-# SPDX-FileCopyrightText: 2024 Checkraze
-# SPDX-FileCopyrightText: 2024 Dvir
-# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
-# SPDX-FileCopyrightText: 2024 Salvantrix
-# SPDX-FileCopyrightText: 2024 TsjipTsjip
-# SPDX-FileCopyrightText: 2024 Wiebe Geertsma
-# SPDX-FileCopyrightText: 2025 Arcticular
-# SPDX-FileCopyrightText: 2025 Ark
-# SPDX-FileCopyrightText: 2025 Avalon
-# SPDX-FileCopyrightText: 2025 BoskiYourk
-# SPDX-FileCopyrightText: 2025 Cojoke
-# SPDX-FileCopyrightText: 2025 Honestly101
-# SPDX-FileCopyrightText: 2025 Redrover1760
-# SPDX-FileCopyrightText: 2025 RikuTheKiller
-# SPDX-FileCopyrightText: 2025 Whatstone
-# SPDX-FileCopyrightText: 2025 core-mene
-# SPDX-FileCopyrightText: 2025 starch
-#
-# SPDX-License-Identifier: MPL-2.0
-
 meta:
   format: 7
   category: Grid
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/30/2025 02:50:25
-  entityCount: 5577
+  time: 11/10/2025 11:03:54
+  entityCount: 5578
 maps: []
 grids:
 - 1
@@ -1071,9 +1045,17 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           immutable: True
           moles:
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -1101,11 +1083,19 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 235
           moles:
           - 27.225372
           - 102.419266
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -20350,6 +20340,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,49.5
+      parent: 1
+- proto: ScuttleDeviceWyvern
+  entities:
+  - uid: 5500
+    components:
+    - type: Transform
+      pos: -0.5,-41.5
       parent: 1
 - proto: SheetPlasteel
   entities:

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -319,6 +319,12 @@
     - RobotTalk
     - Draconic
     - Azaziba
+  - type: Access
+    groups:
+    - AllAccess
+    tags:
+    - NuclearOperative
+    - SyndicateAgent
   - type: GhostTakeoverAvailable
   - type: RandomMetadata
     nameSegments: [MonoRemnantCoreNameset]

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: entity
   parent: [BaseStructure, StructureWheeled, BaseC3ContrabandUnredeemable ]
   id: ScuttleDeviceWyvern

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
@@ -56,7 +56,6 @@
     mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
     speed: 120
-    enabled: false
   - type: NavMapBeacon
     color: "#666666"
     text: antimatter annihilation assembly
@@ -71,8 +70,6 @@
     access: [["SyndicateAgent"], ["NuclearOperative"]]
     breakOnAccessBreaker: false
   - type: ScuttleDevice
-    alertLevelOnActivate: delta
-    alertLevelOnDeactivate: green
     unlockedPrice: 800000 # +800k for unlocked antimatter device
   - type: Explosive
     explosionType: Default

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
@@ -1,0 +1,86 @@
+- type: entity
+  parent: [BaseStructure, StructureWheeled, BaseC3ContrabandUnredeemable ]
+  id: ScuttleDeviceWyvern
+  name: antimatter annihilation assembly
+  description: Uses the power of antimatter to completely scuttle a ship. Will sell for more if unlocked.
+  components:
+  - type: Transform
+    anchored: true
+  - type: Sprite
+    sprite: Objects/Devices/nuke.rsi
+    noRot: true
+    layers:
+    - state: nuclearbomb_base
+      map: ["enum.NukeVisualLayers.Base"]
+    - state: nuclearbomb_deployed_unlit
+      map: ["enum.NukeVisualLayers.Unlit"]
+      shader: unshaded
+      visible: false
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.NukeVisuals.Deployed:
+        enum.NukeVisualLayers.Base:
+          False: { state: nuclearbomb_base }
+          True:  { state: nuclearbomb_deployed }
+        enum.NukeVisualLayers.Unlit:
+          True:  { visible: true }
+          False: { visible: false }
+      enum.NukeVisuals.State:
+        enum.NukeVisualLayers.Unlit:
+          Idle:        { state: nuclearbomb_deployed_unlit }
+          Armed:       { state: nuclearbomb_timing }
+          YoureFucked: { state: nuclearbomb_exploding }
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        density: 255 # Has "bluespace technology" to make it lighter, whatever that means. Don't mind the fact that this is lighter then a high capacity fuel tank.
+        mask:
+        - MachineMask
+        layer:
+        - HalfWallLayer
+  - type: PointLight
+    enabled: false
+    radius: 4
+    energy: 2.0
+    color: "#FF4020"
+    mask: /Textures/Effects/LightMasks/double_cone.png
+  - type: RotatingLight
+    speed: 120
+    enabled: false
+  - type: NavMapBeacon
+    color: "#666666"
+    text: antimatter annihilation assembly
+    enabled: false
+  - type: NukeLabel
+  - type: Lock
+    lockOnClick: false
+    unlockOnClick: false
+    breakOnAccessBreaker: false
+    lockTime: 600 # once the genie is out of the bottle there's no letting him back in
+  - type: AccessReader
+    access: [["SyndicateAgent"], ["NuclearOperative"]]
+    breakOnAccessBreaker: false
+  - type: ScuttleDevice
+    alertLevelOnActivate: delta
+    alertLevelOnDeactivate: green
+    unlockedPrice: 800000 # +800k for unlocked antimatter device
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 5000
+    intensitySlope: 500
+    totalIntensity: 200000000
+    deleteAfterExplosion: true
+  - type: StationAiWhitelist
+  - type: Anchorable
+    flags: Unanchorable # no detonating it elsewhere
+    delay: 10
+  - type: InteractionOutline
+  - type: StaticPrice
+    price: 200000 # antimatter is worth a lot
+  - type: FTLSmashImmune


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
adds the Antimatter Annihilation Assembly onto wyvern, basically a giganuke that can be unlocked by ADS and armed with 300s timer
can be disarmed with 30s timer
is worth 200k, or 1mil if it's unlocked
re-locking it takes a very long time
explosion powerful enough to make wyvern no longer exist
can not be re-anchored once unanchored

## Why / Balance
allows ADS forces to "properly" scuttle the wyvern if necessary
gives salvagers a reason to fight to its core to try steal the nuke to sell it

## How to test
addgamerule the wyvern
take AI
check price
check that you can't unlock as non-ADS
unlock and detonate nuke
check price
try disarm
try re-arm
watch detonation

## Media
<img width="394" height="105" alt="image" src="https://github.com/user-attachments/assets/dad60385-da61-4a4d-b152-9d24d2922a11" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: ADS Wyvern now has a powerful self-destruction device. It also sells for a lot, and for even more if left unlocked.
