### PR TITLE
Gigabuff Bluespace Machine Parts

### DIFF
--- a/Content.IntegrationTests/Tests/Construction/Interaction/MachineConstruction.cs
+++ b/Content.IntegrationTests/Tests/Construction/Interaction/MachineConstruction.cs
@@ -82,7 +82,7 @@ public sealed class MachineConstruction : InteractionTest
         // Query now returns higher quality parts.
         foreach (var part in SConstruction.GetAllParts(SEntMan.GetEntity(Target!.Value)))
         {
-            Assert.That(part.Part.Rating, Is.EqualTo(4)); // Frontier: using MachinePartState instead of MachinePart
+            Assert.That(part.Part.Rating, Is.EqualTo(6)); // Frontier: using MachinePartState instead of MachinePart // Mono: 4->6
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Construction/Interaction/MachineConstruction.cs
+++ b/Content.IntegrationTests/Tests/Construction/Interaction/MachineConstruction.cs
@@ -1,3 +1,13 @@
+// SPDX-FileCopyrightText: 2023 TemporalOroboros
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Emisse
+// SPDX-FileCopyrightText: 2024 Leon Friedrich
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2024 checkraze
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.IntegrationTests.Tests.Interaction;
 
 namespace Content.IntegrationTests.Tests.Construction.Interaction;

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -327,7 +327,7 @@
       autoRechargeRate: 40
     - type: MachinePart # Frontier
       part: PowerCell # Frontier
-      rating: 4 # Frontier: tier of this is arguable
+      rating: 6 # Frontier: tier of this is arguable # Mono: 4->6 - if you use this for a SMES it better work good
 
 # Power cage (big heavy power cell for big devices)
 

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -46,6 +46,7 @@
 # SPDX-FileCopyrightText: 2024 Nemanja
 # SPDX-FileCopyrightText: 2024 Whatstone
 # SPDX-FileCopyrightText: 2024 lzk
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 wewman222
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_silicons.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_silicons.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 ErhardSteinhauer
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 blackknight954
 # SPDX-FileCopyrightText: 2025 core-mene
 #

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_silicons.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_silicons.yml
@@ -114,10 +114,10 @@
       prob: 0.5
     # Parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.01
+      prob: 0.05
       amount: 1
     - id: FemtoManipulatorStockPart
-      prob: 0.01
+      prob: 0.02
       amount: 1
     - id: BluespaceMatterBinStockPart
       prob: 0.01
@@ -187,13 +187,13 @@
       prob: 1.0
     # Parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.03
+      prob: 0.12
       amount: 1
     - id: FemtoManipulatorStockPart
-      prob: 0.03
+      prob: 0.06
       amount: 1
     - id: BluespaceMatterBinStockPart
-      prob: 0.03
+      prob: 0.02
       amount: 1
     - id: SuperCapacitorStockPart
       prob: 0.4
@@ -255,13 +255,14 @@
       prob: 0.5
     # Parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.1
+      prob: 0.4
       amount: 1
+      maxAmount: 2
     - id: FemtoManipulatorStockPart
-      prob: 0.1
+      prob: 0.2
       amount: 1
     - id: BluespaceMatterBinStockPart
-      prob: 0.1
+      prob: 0.08
       amount: 1
     - id: SuperCapacitorStockPart
       prob: 0.5
@@ -325,26 +326,15 @@
       prob: 0.1
     # Parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.5
-      amount: 1
-      maxAmount: 2
+      prob: 0.8
+      amount: 2
     - id: FemtoManipulatorStockPart
-      prob: 0.5
+      prob: 0.8
       amount: 1
       maxAmount: 2
     - id: BluespaceMatterBinStockPart
       prob: 0.5
       amount: 1
-      maxAmount: 2
-    - id: QuadraticCapacitorStockPart
-      prob: 0.5
-      amount: 3
-    - id: FemtoManipulatorStockPart
-      prob: 0.5
-      amount: 3
-    - id: BluespaceMatterBinStockPart
-      prob: 0.5
-      amount: 3
     - id: SpawnDungeonLootPowerCell
       prob: 0.5
     # - id: SpawnDungeonLootPartsEngi #Mono: mostly trash and bloat

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_silicons.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_silicons.yml
@@ -113,13 +113,13 @@
       prob: 0.5
     # Parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.05
+      prob: 0.01
       amount: 1
     - id: FemtoManipulatorStockPart
-      prob: 0.05
+      prob: 0.01
       amount: 1
     - id: BluespaceMatterBinStockPart
-      prob: 0.05
+      prob: 0.01
       amount: 1
     - id: SuperCapacitorStockPart
       prob: 0.2
@@ -186,14 +186,14 @@
       prob: 1.0
     # Parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.2
-      amount: 2
+      prob: 0.03
+      amount: 1
     - id: FemtoManipulatorStockPart
-      prob: 0.2
-      amount: 2
+      prob: 0.03
+      amount: 1
     - id: BluespaceMatterBinStockPart
-      prob: 0.2
-      amount: 2
+      prob: 0.03
+      amount: 1
     - id: SuperCapacitorStockPart
       prob: 0.4
       amount: 3
@@ -254,14 +254,14 @@
       prob: 0.5
     # Parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.33
-      amount: 2
+      prob: 0.1
+      amount: 1
     - id: FemtoManipulatorStockPart
-      prob: 0.33
-      amount: 2
+      prob: 0.1
+      amount: 1
     - id: BluespaceMatterBinStockPart
-      prob: 0.33
-      amount: 2
+      prob: 0.1
+      amount: 1
     - id: SuperCapacitorStockPart
       prob: 0.5
       amount: 3
@@ -325,13 +325,16 @@
     # Parts
     - id: QuadraticCapacitorStockPart
       prob: 0.5
-      amount: 3
+      amount: 1
+      maxAmount: 2
     - id: FemtoManipulatorStockPart
       prob: 0.5
-      amount: 3
+      amount: 1
+      maxAmount: 2
     - id: BluespaceMatterBinStockPart
       prob: 0.5
-      amount: 3
+      amount: 1
+      maxAmount: 2
     - id: QuadraticCapacitorStockPart
       prob: 0.5
       amount: 3

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/machine_parts.yml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: 2020 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 kxv
+# SPDX-FileCopyrightText: 2023 lzk
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2024 AJCM-git
+# SPDX-FileCopyrightText: 2024 Emisse
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2024 checkraze
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # Frontier: old versions of upgraded components, made stackable.
 
 # Rating 2

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/machine_parts.yml
@@ -107,7 +107,7 @@
       state: quadratic_capacitor
     - type: MachinePart
       part: Capacitor
-      rating: 4
+      rating: 6 # Mono: 4->6
     - type: Stack
       stackType: BluespaceCapacitor
 
@@ -122,7 +122,7 @@
       state: femto_mani
     - type: MachinePart
       part: Manipulator
-      rating: 4
+      rating: 6 # Mono: 4->6
     - type: Stack
       stackType: BluespaceManipulator
 
@@ -137,7 +137,7 @@
       state: bluespace_matter_bin
     - type: MachinePart
       part: MatterBin
-      rating: 4
+      rating: 6 # Mono: 4->6
     - type: Stack
       stackType: BluespaceMatterBin
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
rating 4->6
essentially additionally improves them by as much as super parts improve over normal parts
also nerfs rogue silicon droprates
varies droprates to be bin<manip<capacitor so you get 500 capacitors and little bins:
```
   |  cap   |  man   |  bin
t0 |0       |0       |0
t1 |0.05    |0.02    |0.01
t2 |0.12    |0.06    |0.02
t3 |0.4x1-2 |0.2     |0.08
t4 |0.8x2   |0.8x1-2 |0.5
```

## Why / Balance
they're very rare

## How to test
try part in machine
machine go brrr

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Bluespace machine parts massively buffed.
- tweak: Rogue silicon bluespace machine part drop rate nerfed.