### PR TITLE
Fix PTS and Central Station

### DIFF
--- a/Content.Server/_NF/PublicTransit/PublicTransitSystem.cs
+++ b/Content.Server/_NF/PublicTransit/PublicTransitSystem.cs
@@ -1,3 +1,13 @@
+// SPDX-FileCopyrightText: 2024 Checkraze
+// SPDX-FileCopyrightText: 2024 GreaseMonk
+// SPDX-FileCopyrightText: 2024 Whatstone
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Dvir
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 ScyronX
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using Content.Server._NF.PublicTransit.Components;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking;

--- a/Content.Server/_NF/PublicTransit/PublicTransitSystem.cs
+++ b/Content.Server/_NF/PublicTransit/PublicTransitSystem.cs
@@ -48,7 +48,7 @@ public sealed class PublicTransitSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<StationTransitComponent, ComponentStartup>(OnStationStartup);
+        SubscribeLocalEvent<StationTransitComponent, MapInitEvent>(OnStationStartup);
         SubscribeLocalEvent<StationTransitComponent, ComponentShutdown>(OnStationShutdown);
         SubscribeLocalEvent<TransitShuttleComponent, ComponentStartup>(OnShuttleStartup);
         SubscribeLocalEvent<TransitShuttleComponent, EntityUnpausedEvent>(OnShuttleUnpaused);
@@ -96,7 +96,7 @@ public sealed class PublicTransitSystem : EntitySystem
     /// Checks to make sure the grid is on the appropriate playfield, i.e., not in mapping space being worked on.
     /// If so, adds the grid to the list of bus stops, but only if its not already there
     /// </summary>
-    private void OnStationStartup(EntityUid uid, StationTransitComponent component, ComponentStartup args)
+    private void OnStationStartup(EntityUid uid, StationTransitComponent component, MapInitEvent args)
     {
         if (Transform(uid).MapID == _ticker.DefaultMap) //best solution i could find because of componentinit/mapinit race conditions
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
frontier goidacode made it never arrive to central station
fixed here

## How to test
load game in a normal gamemode
wait for it to PTS
PTS actually comes

## Media
<img width="327" height="206" alt="image" src="https://github.com/user-attachments/assets/b8686d6f-629f-4a01-88d1-3860590b09a2" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The PTS now properly docks to Central.