### PR TITLE
Colossus Touchups 3

### DIFF
--- a/Resources/Maps/_Mono/Outpost/colossus_central.yml
+++ b/Resources/Maps/_Mono/Outpost/colossus_central.yml
@@ -1,3 +1,47 @@
+# SPDX-FileCopyrightText: 2022 0x6273
+# SPDX-FileCopyrightText: 2022 20kdc
+# SPDX-FileCopyrightText: 2022 Francesco
+# SPDX-FileCopyrightText: 2022 Kara
+# SPDX-FileCopyrightText: 2022 LittleBuilderJane
+# SPDX-FileCopyrightText: 2022 Nairod
+# SPDX-FileCopyrightText: 2022 metalgearsloth
+# SPDX-FileCopyrightText: 2023 Debug
+# SPDX-FileCopyrightText: 2023 Leon Friedrich
+# SPDX-FileCopyrightText: 2023 Nemanja
+# SPDX-FileCopyrightText: 2023 TsjipTsjip
+# SPDX-FileCopyrightText: 2023 avery
+# SPDX-FileCopyrightText: 2023 lzk
+# SPDX-FileCopyrightText: 2024 Alice "Arimah" Heurlin
+# SPDX-FileCopyrightText: 2024 AndresE55
+# SPDX-FileCopyrightText: 2024 Dvir
+# SPDX-FileCopyrightText: 2024 Emisse
+# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
+# SPDX-FileCopyrightText: 2024 GreaseMonk
+# SPDX-FileCopyrightText: 2024 Maxtone
+# SPDX-FileCopyrightText: 2024 PECK
+# SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2024 ThatOneGoblin25
+# SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Ark
+# SPDX-FileCopyrightText: 2025 Avalon
+# SPDX-FileCopyrightText: 2025 Blu
+# SPDX-FileCopyrightText: 2025 BoskiYourk
+# SPDX-FileCopyrightText: 2025 Checkraze
+# SPDX-FileCopyrightText: 2025 Cojoke
+# SPDX-FileCopyrightText: 2025 Ghagliiarghii
+# SPDX-FileCopyrightText: 2025 Redrover1760
+# SPDX-FileCopyrightText: 2025 RikuTheKiller
+# SPDX-FileCopyrightText: 2025 WreakHavocOnTheMiddleClass
+# SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 dustylens
+# SPDX-FileCopyrightText: 2025 significant harassment
+# SPDX-FileCopyrightText: 2025 sleepyyapril
+# SPDX-FileCopyrightText: 2025 starch
+# SPDX-FileCopyrightText: 2025 thoughtlessuser
+# SPDX-FileCopyrightText: 2025 tonotom1
+#
+# SPDX-License-Identifier: MPL-2.0
+
 meta:
   format: 7
   category: Map

--- a/Resources/Maps/_Mono/Outpost/colossus_central.yml
+++ b/Resources/Maps/_Mono/Outpost/colossus_central.yml
@@ -1,54 +1,10 @@
-# SPDX-FileCopyrightText: 2022 0x6273
-# SPDX-FileCopyrightText: 2022 20kdc
-# SPDX-FileCopyrightText: 2022 Francesco
-# SPDX-FileCopyrightText: 2022 Kara
-# SPDX-FileCopyrightText: 2022 LittleBuilderJane
-# SPDX-FileCopyrightText: 2022 Nairod
-# SPDX-FileCopyrightText: 2022 metalgearsloth
-# SPDX-FileCopyrightText: 2023 Debug
-# SPDX-FileCopyrightText: 2023 Leon Friedrich
-# SPDX-FileCopyrightText: 2023 Nemanja
-# SPDX-FileCopyrightText: 2023 TsjipTsjip
-# SPDX-FileCopyrightText: 2023 avery
-# SPDX-FileCopyrightText: 2023 lzk
-# SPDX-FileCopyrightText: 2024 Alice "Arimah" Heurlin
-# SPDX-FileCopyrightText: 2024 AndresE55
-# SPDX-FileCopyrightText: 2024 Dvir
-# SPDX-FileCopyrightText: 2024 Emisse
-# SPDX-FileCopyrightText: 2024 ErhardSteinhauer
-# SPDX-FileCopyrightText: 2024 GreaseMonk
-# SPDX-FileCopyrightText: 2024 Maxtone
-# SPDX-FileCopyrightText: 2024 PECK
-# SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
-# SPDX-FileCopyrightText: 2024 ThatOneGoblin25
-# SPDX-FileCopyrightText: 2024 Whatstone
-# SPDX-FileCopyrightText: 2025 Ark
-# SPDX-FileCopyrightText: 2025 Avalon
-# SPDX-FileCopyrightText: 2025 Blu
-# SPDX-FileCopyrightText: 2025 BoskiYourk
-# SPDX-FileCopyrightText: 2025 Checkraze
-# SPDX-FileCopyrightText: 2025 Cojoke
-# SPDX-FileCopyrightText: 2025 Ghagliiarghii
-# SPDX-FileCopyrightText: 2025 Redrover1760
-# SPDX-FileCopyrightText: 2025 RikuTheKiller
-# SPDX-FileCopyrightText: 2025 WreakHavocOnTheMiddleClass
-# SPDX-FileCopyrightText: 2025 core-mene
-# SPDX-FileCopyrightText: 2025 dustylens
-# SPDX-FileCopyrightText: 2025 significant harassment
-# SPDX-FileCopyrightText: 2025 sleepyyapril
-# SPDX-FileCopyrightText: 2025 starch
-# SPDX-FileCopyrightText: 2025 thoughtlessuser
-# SPDX-FileCopyrightText: 2025 tonotom1
-#
-# SPDX-License-Identifier: MPL-2.0
-
 meta:
   format: 7
   category: Map
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 11/10/2025 05:43:27
+  time: 11/10/2025 15:44:44
   entityCount: 10690
 maps:
 - 10548
@@ -10086,8 +10042,18 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -57.5,42.5
       parent: 1
-    - type: Docking
-      name: BUS
+  - uid: 1600
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -57.5,43.5
+      parent: 1
+  - uid: 1604
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -57.5,41.5
+      parent: 1
 - proto: AirlockFreezer
   entities:
   - uid: 595
@@ -10238,12 +10204,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -42.5,83.5
       parent: 1
-  - uid: 1600
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -57.5,41.5
-      parent: 1
   - uid: 1601
     components:
     - type: Transform
@@ -10263,12 +10223,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -69.5,29.5
-      parent: 1
-  - uid: 1604
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -57.5,43.5
       parent: 1
   - uid: 1605
     components:
@@ -30575,7 +30529,7 @@ entities:
       pos: 25.5,46.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -70517.7
+      secondsUntilStateChange: -71708.805
       state: Closing
   - uid: 8154
     components:
@@ -39457,7 +39411,7 @@ entities:
       pos: 14.5,27.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -96079.33
+      secondsUntilStateChange: -97270.43
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -59720,11 +59674,11 @@ entities:
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 1143
+  - uid: 796
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 26.5,28.5
+      pos: 26.5,29.5
       parent: 1
   - uid: 7775
     components:
@@ -59802,11 +59756,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 34.5,47.5
       parent: 1
-  - uid: 7804
+  - uid: 8135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 26.5,29.5
+      pos: 26.5,28.5
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
@@ -59840,35 +59794,36 @@ entities:
   - uid: 794
     components:
     - type: Transform
-      pos: 13.5,38.5
-      parent: 1
-  - uid: 796
-    components:
-    - type: Transform
-      pos: 14.5,38.5
+      rot: 3.141592653589793 rad
+      pos: 27.5,30.5
       parent: 1
   - uid: 798
-    components:
-    - type: Transform
-      pos: 12.5,38.5
-      parent: 1
-  - uid: 799
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,41.5
       parent: 1
-  - uid: 802
+  - uid: 799
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,40.5
       parent: 1
-  - uid: 804
+  - uid: 802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,42.5
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      pos: 13.5,38.5
+      parent: 1
+  - uid: 1143
+    components:
+    - type: Transform
+      pos: 14.5,38.5
       parent: 1
   - uid: 1149
     components:
@@ -59887,6 +59842,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,28.5
+      parent: 1
+  - uid: 3950
+    components:
+    - type: Transform
+      pos: 12.5,38.5
       parent: 1
   - uid: 4739
     components:
@@ -59917,6 +59877,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 11.5,26.5
       parent: 1
+  - uid: 7002
+    components:
+    - type: Transform
+      pos: 28.5,25.5
+      parent: 1
   - uid: 7777
     components:
     - type: Transform
@@ -59931,23 +59896,12 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 27.5,30.5
+      pos: 28.5,30.5
       parent: 1
   - uid: 7780
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,30.5
-      parent: 1
-  - uid: 7781
-    components:
-    - type: Transform
       pos: 27.5,25.5
-      parent: 1
-  - uid: 7782
-    components:
-    - type: Transform
-      pos: 28.5,25.5
       parent: 1
   - uid: 7784
     components:
@@ -60007,12 +59961,6 @@ entities:
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 3950
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,24.5
-      parent: 1
   - uid: 4043
     components:
     - type: MetaData
@@ -60138,54 +60086,6 @@ entities:
         4739:
         - - Pressed
           - Toggle
-  - uid: 7001
-    components:
-    - type: MetaData
-      name: shutters
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,25.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        6990:
-        - - Pressed
-          - Toggle
-        6984:
-        - - Pressed
-          - Toggle
-        6991:
-        - - Pressed
-          - Toggle
-        6992:
-        - - Pressed
-          - Toggle
-  - uid: 7002
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,39.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        796:
-        - - Pressed
-          - Toggle
-        794:
-        - - Pressed
-          - Toggle
-        798:
-        - - Pressed
-          - Toggle
-        804:
-        - - Pressed
-          - Toggle
-        802:
-        - - Pressed
-          - Toggle
-        799:
-        - - Pressed
-          - Toggle
   - uid: 7272
     components:
     - type: MetaData
@@ -60225,154 +60125,6 @@ entities:
         - - Pressed
           - Toggle
         10605:
-        - - Pressed
-          - Toggle
-  - uid: 8135
-    components:
-    - type: Transform
-      pos: 25.18163,30.437252
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        7806:
-        - - Pressed
-          - DoorBolt
-        7804:
-        - - Pressed
-          - Toggle
-        1143:
-        - - Pressed
-          - Toggle
-        7781:
-        - - Pressed
-          - Toggle
-        7782:
-        - - Pressed
-          - Toggle
-        7779:
-        - - Pressed
-          - Toggle
-        7780:
-        - - Pressed
-          - Toggle
-  - uid: 8136
-    components:
-    - type: Transform
-      pos: 36.78593,34.460255
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        7808:
-        - - Pressed
-          - DoorBolt
-        7791:
-        - - Pressed
-          - Toggle
-        7783:
-        - - Pressed
-          - Toggle
-        1450:
-        - - Pressed
-          - Toggle
-        7785:
-        - - Pressed
-          - Toggle
-        7784:
-        - - Pressed
-          - Toggle
-        7793:
-        - - Pressed
-          - Toggle
-        7794:
-        - - Pressed
-          - Toggle
-        7792:
-        - - Pressed
-          - Toggle
-  - uid: 8137
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 35.051918,49.84318
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        1109:
-        - - Pressed
-          - DoorBolt
-        7798:
-        - - Pressed
-          - Toggle
-        7799:
-        - - Pressed
-          - Toggle
-        7796:
-        - - Pressed
-          - Toggle
-        7797:
-        - - Pressed
-          - Toggle
-        7795:
-        - - Pressed
-          - Toggle
-        7800:
-        - - Pressed
-          - Toggle
-        7802:
-        - - Pressed
-          - Toggle
-        7801:
-        - - Pressed
-          - Toggle
-        7803:
-        - - Pressed
-          - Toggle
-  - uid: 8138
-    components:
-    - type: Transform
-      pos: 25.167313,35.07677
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        6622:
-        - - Pressed
-          - DoorBolt
-        7775:
-        - - Pressed
-          - Toggle
-        7776:
-        - - Pressed
-          - Toggle
-        7778:
-        - - Pressed
-          - Toggle
-        7777:
-        - - Pressed
-          - Toggle
-  - uid: 8139
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 35.042015,24.153187
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        7805:
-        - - Pressed
-          - DoorBolt
-        7790:
-        - - Pressed
-          - Toggle
-        7789:
-        - - Pressed
-          - Toggle
-        1149:
-        - - Pressed
-          - Toggle
-        1151:
-        - - Pressed
-          - Toggle
-        7788:
         - - Pressed
           - Toggle
   - uid: 8331
@@ -60440,6 +60192,310 @@ entities:
         4882:
         - - Pressed
           - Toggle
+- proto: SignalSwitchDirectional
+  entities:
+  - uid: 7001
+    components:
+    - type: Transform
+      pos: 25.5,30.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        794:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7779:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7780:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7002:
+        - - On
+          - Open
+        - - Off
+          - Close
+        796:
+        - - On
+          - Open
+        - - Off
+          - Close
+        8135:
+        - - On
+          - Open
+        - - Off
+          - Close
+  - uid: 7781
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,24.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        3973:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        3977:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        3958:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        3946:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        3976:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        3955:
+        - - On
+          - Forward
+        - - Off
+          - Off
+  - uid: 7782
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,25.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        6990:
+        - - On
+          - Open
+        - - Off
+          - Close
+        6984:
+        - - On
+          - Open
+        - - Off
+          - Close
+        6991:
+        - - On
+          - Open
+        - - Off
+          - Close
+        6992:
+        - - On
+          - Open
+        - - Off
+          - Close
+  - uid: 7804
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,39.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        3950:
+        - - On
+          - Open
+        - - Off
+          - Close
+        799:
+        - - On
+          - Open
+        - - Off
+          - Close
+        798:
+        - - On
+          - Open
+        - - Off
+          - Close
+        802:
+        - - On
+          - Open
+        - - Off
+          - Close
+        1143:
+        - - On
+          - Open
+        - - Off
+          - Close
+        804:
+        - - On
+          - Open
+        - - Off
+          - Close
+  - uid: 8136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 34.5,49.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        7798:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7799:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7796:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7797:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7795:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7803:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7801:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7802:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7800:
+        - - On
+          - Open
+        - - Off
+          - Close
+  - uid: 8137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,34.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        7775:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7776:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7777:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7778:
+        - - On
+          - Open
+        - - Off
+          - Close
+  - uid: 8138
+    components:
+    - type: Transform
+      pos: 36.5,34.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        7792:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7793:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7794:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7783:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7791:
+        - - On
+          - Open
+        - - Off
+          - Close
+        1450:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7785:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7784:
+        - - On
+          - Open
+        - - Off
+          - Close
+  - uid: 8139
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 34.5,24.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        7790:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7789:
+        - - Off
+          - Close
+        - - On
+          - Open
+        1149:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7788:
+        - - On
+          - Open
+        - - Off
+          - Close
+        1151:
+        - - On
+          - Open
+        - - Off
+          - Close
 - proto: SignAnomaly
   entities:
   - uid: 4236

--- a/Resources/Maps/_Mono/Outpost/colossus_central.yml
+++ b/Resources/Maps/_Mono/Outpost/colossus_central.yml
@@ -30528,9 +30528,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 25.5,46.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -71708.805
-      state: Closing
   - uid: 8154
     components:
     - type: Transform
@@ -39410,9 +39407,6 @@ entities:
     - type: Transform
       pos: 14.5,27.5
       parent: 1
-    - type: Door
-      secondsUntilStateChange: -97270.43
-      state: Closing
     - type: DeviceNetwork
       deviceLists:
       - 7070


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Progressively pettier touchups

This one just changes out buttons in the shops for switches so they auto-fix themselves if one of them gets blocked and desyncs
Also the conveyor belts for the shooting range work now, have fun using it
Swaps out the docking airlocks in the bus dock for transit priority ones, not sure that does anything given how fucked the bus code we inherited is

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Touchup ad nauseum

## How to test
<!-- Describe the way it can be tested -->

You spawn at colossus you know what to do

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Changes mostly invisible

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Colossus shooting range is now functional. The abandoned shop shutter doors can now correct themselves if desynced.
