### PR TITLE
Mob Cleanup and Prevent Random Mob Despawn Again

### DIFF
--- a/Content.Server/_Mono/Cleanup/CheapEntitiesCleanupSystem.cs
+++ b/Content.Server/_Mono/Cleanup/CheapEntitiesCleanupSystem.cs
@@ -14,7 +14,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
-namespace Content.Server._Mono;
+namespace Content.Server._Mono.Cleanup;
 
 /// <summary>
 ///     Deletes all entities with SpaceGarbageComponent.
@@ -29,12 +29,16 @@ public sealed class CheapEntitiesCleanupSystem : EntitySystem
     private ISawmill _log = default!;
     private TimeSpan _nextCleanup = TimeSpan.Zero;
 
+    private EntityQuery<CleanupImmuneComponent> _immuneQuery;
+
     readonly private double _minValueToDelete = 100d;
 
     public override void Initialize()
     {
         base.Initialize();
         _log = Logger.GetSawmill("cheapentitycleanup");
+
+        _immuneQuery = GetEntityQuery<CleanupImmuneComponent>();
     }
 
     public override void Update(float frameTime)
@@ -92,6 +96,9 @@ public sealed class CheapEntitiesCleanupSystem : EntitySystem
             if (HasComp<BrainComponent>(uid))
                 continue;
 
+            if (_immuneQuery.HasComp(uid))
+                continue;
+
             // Adds entity to logging
             entCount += 1;
             // Delete the entity
@@ -126,6 +133,9 @@ public sealed class CheapEntitiesCleanupSystem : EntitySystem
 
             // Final safety check.
             if (HasComp<BrainComponent>(uid2))
+                continue;
+
+            if (_immuneQuery.HasComp(uid2))
                 continue;
 
             // Adds entity to logging

--- a/Content.Server/_Mono/Cleanup/CleanupImmuneComponent.cs
+++ b/Content.Server/_Mono/Cleanup/CleanupImmuneComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: MPL-2.0
+
 namespace Content.Server._Mono.Cleanup;
 
 /// <summary>

--- a/Content.Server/_Mono/Cleanup/CleanupImmuneComponent.cs
+++ b/Content.Server/_Mono/Cleanup/CleanupImmuneComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._Mono.Cleanup;
+
+/// <summary>
+/// Prevents this entity from being cleaned up by automatic cleanup systems.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CleanupImmuneComponent : Component {}

--- a/Content.Server/_Mono/Cleanup/MobCleanupSystem.cs
+++ b/Content.Server/_Mono/Cleanup/MobCleanupSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 ScyronX
 //

--- a/Content.Server/_Mono/Cleanup/MobCleanupSystem.cs
+++ b/Content.Server/_Mono/Cleanup/MobCleanupSystem.cs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Redrover1760
+// SPDX-FileCopyrightText: 2025 ScyronX
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Ghost.Roles.Components;
+using Content.Server.NPC.HTN;
+using Content.Shared._Mono.CCVar;
+using Content.Shared.Ghost;
+using Content.Shared.Mobs.Systems;
+using Robust.Server.Player;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Mono.Cleanup;
+
+/// <summary>
+///     Deletes all entities with SpaceGarbageComponent.
+/// </summary>
+public sealed class MobCleanupSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private ISawmill _log = default!;
+    private TimeSpan _cleanupInterval = TimeSpan.FromSeconds(60);
+    private float _maxDistance;
+
+    private Queue<EntityUid> _checkQueue = new();
+    private TimeSpan _nextCleanup = TimeSpan.Zero;
+    private int _delCount = 0;
+
+    private EntityQuery<GhostRoleComponent> _ghostQuery;
+    private EntityQuery<CleanupImmuneComponent> _immuneQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _log = Logger.GetSawmill("mobcleanup");
+
+        _ghostQuery = GetEntityQuery<GhostRoleComponent>();
+        _immuneQuery = GetEntityQuery<CleanupImmuneComponent>();
+
+        Subs.CVar(_cfg, MonoCVars.MobCleanupDistance, val => _maxDistance = val, true);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // delete one queued entity per update
+        if (_checkQueue.Count != 0)
+        {
+            var uid = _checkQueue.Dequeue();
+
+            if (TerminatingOrDeleted(uid))
+                return;
+
+            var xform = Transform(uid);
+
+            if (xform.GridUid != null
+                || _immuneQuery.HasComp(uid)
+                || _ghostQuery.HasComp(uid)
+                || HasNearbyPlayers(xform.Coordinates, _maxDistance)
+            )
+                return;
+
+            // Adds entity to logging
+            _delCount += 1;
+            QueueDel(uid);
+            return;
+        }
+
+        if (_delCount != 0)
+        {
+            _log.Info($"Deleted {_delCount} mobs");
+            _delCount = 0;
+        }
+
+        // we appear to be done with previous queue so try get another
+        var curTime = _timing.CurTime;
+        if (curTime < _nextCleanup)
+            return;
+        _nextCleanup = curTime + _cleanupInterval;
+
+        // queue the next batch
+        var query = EntityQueryEnumerator<HTNComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            _checkQueue.Enqueue(uid);
+        }
+    }
+
+    public bool HasNearbyPlayers(EntityCoordinates coord, float radius) {
+        var allPlayerData = _player.GetAllPlayerData();
+        foreach (var playerData in allPlayerData)
+        {
+            var exists = _player.TryGetSessionById(playerData.UserId, out var session);
+
+            if (!exists
+                || session == null
+                || session.AttachedEntity is not { Valid: true } playerEnt
+                || HasComp<GhostComponent>(playerEnt)
+                || _mobState.IsDead(playerEnt))
+                continue;
+
+            var playerCoords = Transform(playerEnt).Coordinates;
+
+            if (coord.TryDistance(EntityManager, playerCoords, out var distance)
+                && distance <= radius
+            )
+                return true;
+        }
+        return false;
+    }
+}

--- a/Content.Server/_Mono/Cleanup/SpaceGarbageCleanupSystem.cs
+++ b/Content.Server/_Mono/Cleanup/SpaceGarbageCleanupSystem.cs
@@ -10,7 +10,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 
-namespace Content.Server._Mono;
+namespace Content.Server._Mono.Cleanup;
 
 /// <summary>
 ///     Deletes all entities with SpaceGarbageComponent.
@@ -25,10 +25,14 @@ public sealed class SpaceGarbageCleanupSystem : EntitySystem
     private ISawmill _log = default!;
     private TimeSpan _nextCleanup = TimeSpan.Zero;
 
+    private EntityQuery<CleanupImmuneComponent> _immuneQuery;
+
     public override void Initialize()
     {
         base.Initialize();
         _log = Logger.GetSawmill("spacegarbagecleanup");
+
+        _immuneQuery = GetEntityQuery<CleanupImmuneComponent>();
     }
 
     public override void Update(float frameTime)
@@ -64,6 +68,9 @@ public sealed class SpaceGarbageCleanupSystem : EntitySystem
 
             // Skip deletion if the entity is inside a container.
             if (_container.IsEntityInContainer(uid))
+                continue;
+
+            if (_immuneQuery.HasComp(uid))
                 continue;
 
             // Adds entity to logging

--- a/Content.Server/_NF/Salvage/NFSalvageMobRestrictionsComponent.cs
+++ b/Content.Server/_NF/Salvage/NFSalvageMobRestrictionsComponent.cs
@@ -26,7 +26,7 @@ public sealed partial class NFSalvageMobRestrictionsComponent : Component
     /// Useful for event ghost roles, for instance.
     /// </summary>
     [DataField]
-    public bool DespawnIfOffLinkedGrid = true;
+    public bool DespawnIfOffLinkedGrid = false;
 
     // On walking off grid
     [DataField]

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
@@ -26,6 +26,12 @@ public sealed partial class MonoCVars
     public static readonly CVarDef<bool> RadioNoiseEnabled =
         CVarDef.Create("mono.radio_noise_enabled", true, CVar.ARCHIVE | CVar.CLIENTONLY);
 
+    /// <summary>
+    ///     How far away from any players can a mob be until it gets cleaned up.
+    /// </summary>
+    public static readonly CVarDef<float> MobCleanupDistance =
+        CVarDef.Create("mono.mob_cleanup_distance", 1280.0f, CVar.SERVERONLY);
+
     #region Audio
 
     /// <summary>

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 ark1368
 //


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- adds mob cleanup system which despawns entities with HTN which are too far away from players and not on a grid
- makes wreck/exped mobs no longer despawn on source deletion again

## Why / Balance
good

## How to test
spawn carp 10km away from self
wait
no more carp

take carp from wreck
go far from wreck
carp doesn't disintegrate

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Mobs taken from wrecks or expeditions will no longer randomly despawn.
