### PR TITLE
Nukallizer [Crystallizer Nerf. Again]

### DIFF
--- a/Content.Server/_Funkystation/Atmos/EntitySystems/CrystallizerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/EntitySystems/CrystallizerSystem.cs
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2025 NazrinNya
 // SPDX-FileCopyrightText: 2025 marc-pelletier
+// SPDX-FileCopyrightText: 2025 starch
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/_Funkystation/Atmos/EntitySystems/CrystallizerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/EntitySystems/CrystallizerSystem.cs
@@ -251,7 +251,7 @@ namespace Content.Server._Funkystation.Atmos.Systems
 
             if (crystalMix.Temperature >= medianTemperature * MinDeviationRate && crystalMix.Temperature <= medianTemperature * MaxDeviationRate)
             {
-                crystallizer.QualityLoss = Math.Max(crystallizer.QualityLoss - progressAmountToQuality, -85f);
+                crystallizer.QualityLoss = Math.Max(crystallizer.QualityLoss - progressAmountToQuality, -25f); // Mono edit -85>-25. Crystallizer nerf
             }
 
             float heatCapacity = _atmos.GetHeatCapacity(crystalMix, true);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Crystallizer in this PR saves up to 25% of gas if you get temperatures close to midpoint instead of 85%.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Current crystallizer will use only 75 moles from 500 if you hit midpoint temperature, which kinda blows up economy.
This crystallizer will use 375 moles from 500 instead, which should be fine.
## How to test
<!-- Describe the way it can be tested -->
load localhost
setup crystallizer that can cook at midpoint temperature
watch more gas to be used
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Crystallizer now saves up to 25% of gas on reaching midpoint temperatures instead of 85%.
