### PR TITLE
Dewhitelist Vessel AI Core

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -401,6 +401,9 @@
     raffle:
       settings: default
     prototype: VesselAICore
+    requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 180000 # 50 hrs
   - type: GhostTakeoverAvailable
   - type: RandomMetadata
     nameSegments: [ VesselCoreNameset ]

--- a/Resources/Prototypes/_Mono/Roles/Ghostroles/ai.yml
+++ b/Resources/Prototypes/_Mono/Roles/Ghostroles/ai.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: ghostRole
   id: VesselAICore
   name: ghost-role-information-vessel-core

--- a/Resources/Prototypes/_Mono/Roles/Ghostroles/ai.yml
+++ b/Resources/Prototypes/_Mono/Roles/Ghostroles/ai.yml
@@ -1,0 +1,6 @@
+- type: ghostRole
+  id: VesselAICore
+  name: ghost-role-information-vessel-core
+  description: ghost-role-information-vessel-core-description
+  rules: ghost-role-information-silicon-rules
+  entityPrototype: StationAiBrainVessel

--- a/Resources/Prototypes/_Mono/Roles/Ghostroles/whitelisted.yml
+++ b/Resources/Prototypes/_Mono/Roles/Ghostroles/whitelisted.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Ilya246
+# SPDX-FileCopyrightText: 2025 KiraZen_
+# SPDX-FileCopyrightText: 2025 starch
+#
+# SPDX-License-Identifier: MPL-2.0
+
 - type: ghostRole
   id: RedactedBorg
   name: ghost-role-information-redacted-borg

--- a/Resources/Prototypes/_Mono/Roles/Ghostroles/whitelisted.yml
+++ b/Resources/Prototypes/_Mono/Roles/Ghostroles/whitelisted.yml
@@ -15,14 +15,6 @@
   whitelisted: true
 
 - type: ghostRole
-  id: VesselAICore
-  name: ghost-role-information-vessel-core
-  description: ghost-role-information-vessel-core-description
-  rules: ghost-role-information-silicon-rules
-  entityPrototype: StationAiBrainVessel
-  whitelisted: true
-
-- type: ghostRole
   id: TSFMCAICore
   name: ghost-role-information-tsfmc-core
   description: ghost-role-information-tsfmc-core-description


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
vessel AI core no longer whitelist-only
now just has 50hr playtime requirement instead

## Why / Balance
i think arkansaw or player-built AIs being non-whitelist is okay
not as dangerous as ADS/halc/flyssa AIs plus we made wyvern basically non-whitelist and it's usually okay

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Vessel AI cores are no longer whitelist-only.
