### PR TITLE
Hackable CC Vends

### DIFF
--- a/Content.Server/_Mono/GridRaiderSystem.cs
+++ b/Content.Server/_Mono/GridRaiderSystem.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
+//
+// SPDX-License-Identifier: MPL-2.0
+
 using System.Linq;
 using Content.Shared._Mono;
 using Content.Shared._Mono.NoHack;

--- a/Content.Server/_Mono/GridRaiderSystem.cs
+++ b/Content.Server/_Mono/GridRaiderSystem.cs
@@ -75,30 +75,37 @@ public sealed class GridRaiderSystem : EntitySystem
 
             // Check if this entity should be protected based on current settings
             var shouldProtect = false;
+            var hackProtect = true;
 
             if (component.ProtectDoors && HasComp<DoorComponent>(entity))
                 shouldProtect = true;
 
             if (component.ProtectVendingMachines && HasComp<VendingMachineComponent>(entity))
+            {
                 shouldProtect = true;
+                hackProtect = false; // vendors can be hackable
+            }
 
             if (shouldProtect)
-                ApplyProtection(entity, component);
+                ApplyProtection(entity, component, hackProtect);
         }
     }
 
     /// <summary>
     /// Applies NoHack and NoDeconstruct to an entity and adds it to the protected entities list
     /// </summary>
-    private void ApplyProtection(EntityUid entityUid, GridRaiderComponent component)
+    private void ApplyProtection(EntityUid entityUid, GridRaiderComponent component, bool hackProtect = true, bool deconProtect = true)
     {
         // Skip if the entity is already protected
         if (component.ProtectedEntities.Contains(entityUid))
             return;
 
         // Apply NoHack and NoDeconstruct components
-        EnsureComp<NoHackComponent>(entityUid);
-        EnsureComp<NoDeconstructComponent>(entityUid);
+        if (hackProtect)
+            EnsureComp<NoHackComponent>(entityUid);
+        if (deconProtect)
+            EnsureComp<NoDeconstructComponent>(entityUid);
+
         component.ProtectedEntities.Add(entityUid);
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
you can now hack vendors in safezones

## Why / Balance
why is it not allowed
contraband inventory is all just fun items or items with no real gameplay effect or which you can obtain easily

## Media
<img width="272" height="227" alt="image" src="https://github.com/user-attachments/assets/d8dedf83-d1cd-41b8-9f40-9d3f143c08c9" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Safezone vendomats are now hackable.
