### PR TITLE
Undisable Sevas Space Artillery

### DIFF
--- a/Resources/Maps/_Mono/POI/sevastopol.yml
+++ b/Resources/Maps/_Mono/POI/sevastopol.yml
@@ -1839,7 +1839,6 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ForceAnchor
-    - type: SpaceArtilleryDisabledGrid
 - proto: AirAlarm
   entities:
   - uid: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
you can now put guns on sevas

## Why / Balance
why weren't you able to
if you went through the trouble it's fine, you can only install small guns anyway

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Shipguns now work if installed on Sevastopol.
