### PR TITLE
Fix Language Implanter

### DIFF
--- a/Content.Server/_EinsteinEngines/Language/TranslatorImplantSystem.cs
+++ b/Content.Server/_EinsteinEngines/Language/TranslatorImplantSystem.cs
@@ -28,8 +28,9 @@ public sealed class TranslatorImplantSystem : EntitySystem
             return;
 
         var implantee = Transform(uid).ParentUid;
-        if (implantee is not { Valid: true } || !TryComp<LanguageKnowledgeComponent>(implantee, out var knowledge))
+        if (implantee is not { Valid: true })
             return;
+        var knowledge = EnsureComp<LanguageKnowledgeComponent>(implantee);
 
         component.Enabled = true;
         // To operate an implant, you need to know its required language intrinsically, because like... it connects to your brain or something,

--- a/Content.Server/_EinsteinEngines/Language/TranslatorImplantSystem.cs
+++ b/Content.Server/_EinsteinEngines/Language/TranslatorImplantSystem.cs
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: 2025 CerberusWolfie <wb.johnb.willis@gmail.com>
-// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 CerberusWolfie
+// SPDX-FileCopyrightText: 2025 GoobBot
+// SPDX-FileCopyrightText: 2025 Ilya246
+// SPDX-FileCopyrightText: 2025 ScyronX
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
@@ -187,6 +187,11 @@
   - type: NightVision # Goobstation - Nigthvision - Mono
     activateSound: null
     deactivateSound: null
+  - type: LanguageKnowledge
+    speaks:
+    - TauCetiBasic
+    understands:
+    - TauCetiBasic
 
 #- type: entity
 #  categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 AndresE55
 # SPDX-FileCopyrightText: 2024 Whatstone
+# SPDX-FileCopyrightText: 2025 Ilya246
 # SPDX-FileCopyrightText: 2025 Redrover1760
 # SPDX-FileCopyrightText: 2025 starch
 #


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
didn't work on baby space dragon
it should just ensurecomp so i did that
also gives baby dragon tauceti

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed language implanters not working on all mobs, like baby space dragon.
- fix: Baby space dragon now understands Tau Ceti by default.
