### PR TITLE
Upgrade FTL Obstruction

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -234,7 +234,7 @@ public sealed partial class ShuttleConsoleSystem
                 dockedGrids.Contains(consGrid.Value) || // Skip grids that are docked to us or to the same parent grid
                 !bodyQuery.TryGetComponent(consGrid, out var body) ||
                 body.Mass < ShuttleFTLMassThreshold
-                    && (_transform.GetWorldPosition(consGrid) - _transform.GetWorldPosition(consoleXform)).Length() > ShuttleFTLRange * body.Mass / ShuttleFTLMassThreshold ||
+                    && (_transform.GetWorldPosition(consGrid.Value) - _transform.GetWorldPosition(consoleXform)).Length() > ShuttleFTLRange * body.Mass / ShuttleFTLMassThreshold ||
                 !this.IsPowered(console, EntityManager))
             {
                 continue;

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2024 SlamBamActionman
 // SPDX-FileCopyrightText: 2024 metalgearsloth
 // SPDX-FileCopyrightText: 2025 Ark
+// SPDX-FileCopyrightText: 2025 Ilya246
 // SPDX-FileCopyrightText: 2025 Redrover1760
 // SPDX-FileCopyrightText: 2025 RikuTheKiller
 // SPDX-FileCopyrightText: 2025 gus

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.FTL.cs
@@ -31,7 +31,7 @@ public sealed partial class ShuttleConsoleSystem
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly SharedShuttleSystem _sharedShuttle = default!;
 
-    private const float ShuttleFTLRange = 256f;
+    private const float ShuttleFTLRange = 512f;
     private const float ShuttleFTLMassThreshold = 100f; // Mono: now a soft limit, ships under the limit just stop you from shorter distance
 
     private const float MassConstant = 50f; // Arbitrary, at this value massMultiplier = 0.65


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
FTL obstruction now checks for powered shuttle consoles and not for grids
and grids below mass requirement can still block FTL if close enough
also raises blocking range 256m->512m

## Why / Balance
ADSes were unable to block FTL because they did not have a station assigned
now any powered shuttle console in radius can block FTL
current 256m blocking range is basically pointblank

## How to test
1. try to FTL near ADS
2. can't
3. depower it
4. can

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can no longer FTL when near any powered shuttle console, instead of near player-bought ships.
- tweak: FTL blocking range 256m->512m.