### PR TITLE
AKM T2 Arsenal Research

### DIFF
--- a/Resources/Prototypes/_Mono/Recipes/Lathes/merc_weapons.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/merc_weapons.yml
@@ -1,8 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Goldmask990
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 core-mene
 # SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 # SPDX-FileCopyrightText: 2025 tonotom
+# SPDX-FileCopyrightText: 2025 tonotom1
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/merc_weapons.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/merc_weapons.yml
@@ -159,3 +159,16 @@
     Steel: 1500
     Plasteel: 600
     Plastic: 600
+
+- type: latheRecipe
+  parent: BaseWeaponRecipeLong
+  id: WeaponRifleAk
+  result: WeaponRifleAk
+  categories:
+  - Rifles
+  - Ballistic
+  - Weapons
+  materials:
+    Steel: 2500
+    Plasteel: 1000
+    Plastic: 1000

--- a/Resources/Prototypes/_Mono/Research/arsenal.yml
+++ b/Resources/Prototypes/_Mono/Research/arsenal.yml
@@ -32,6 +32,7 @@
   - WeaponRifleVulcanMerc
   - WeaponSubMachineGunVector9x19mm
   - WeaponSubMachineGunFirestarter
+  - WeaponRifleAk
   technologyPrerequisites:
   - MercArmementBasic
   position: 3, 1

--- a/Resources/Prototypes/_Mono/Research/arsenal.yml
+++ b/Resources/Prototypes/_Mono/Research/arsenal.yml
@@ -1,5 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Goldmask990
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 core-mene
+# SPDX-FileCopyrightText: 2025 significant harassment
 # SPDX-FileCopyrightText: 2025 starch
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
@@ -197,6 +197,7 @@
   - WeaponSubMachineGunWt550
   - WeaponRifleNtsfLtr
   - WeaponSubMachineGunVectorNtsfHclm
+  - WeaponRifleAk
 #Mono end
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Goldmask990
 # SPDX-FileCopyrightText: 2025 KiraZen_
 # SPDX-FileCopyrightText: 2025 Onezero0
 # SPDX-FileCopyrightText: 2025 Redrover1760


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds LWC AKM to Civilian T2 Arsenal Research, printable at Mercenary and Military Lathes.

## Why / Balance
Long requested addition of an iconic gun for the masses.

## How to test
Spawn in and check out the addition to the arsenal part of the research tree, specifically T2. Research it and look at the Merc and Mil lathes. Make one and why not, magdump the nearest thing while you're at it.

## Media
<img width="1920" height="1080" alt="Screenshot 2025-11-24 205423" src="https://github.com/user-attachments/assets/8879a153-40d6-4828-b5a0-4691fb65be76" />
<img width="1920" height="1080" alt="Screenshot 2025-11-24 204701" src="https://github.com/user-attachments/assets/150e5b1b-43c8-42f4-9ced-a99d1a78725b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Added AKM to arsenal T2 research, printable at Merc fabs
