### PR TITLE
Ship Movement Rework

### DIFF
--- a/Content.Server/Physics/Components/PilotedShuttleComponent.cs
+++ b/Content.Server/Physics/Components/PilotedShuttleComponent.cs
@@ -1,0 +1,18 @@
+using System.Numerics;
+
+// Mono - whole file
+
+namespace Content.Server.Physics.Controllers;
+
+/// <summary>
+///     Component used to store input data for shuttles that are currently being piloted.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PilotedShuttleComponent : Component
+{
+    /// <summary>
+    ///     List of inputs currently given to this shuttle by any pilots.
+    /// </summary>
+    [DataField]
+    public List<ShuttleInput> InputList = new();
+}

--- a/Content.Server/Physics/Components/PilotedShuttleComponent.cs
+++ b/Content.Server/Physics/Components/PilotedShuttleComponent.cs
@@ -5,14 +5,15 @@ using System.Numerics;
 namespace Content.Server.Physics.Controllers;
 
 /// <summary>
-///     Component used to store input data for shuttles that are currently being piloted.
+///     Component used to store entities that want to give input to this shuttle.
 /// </summary>
 [RegisterComponent]
 public sealed partial class PilotedShuttleComponent : Component
 {
     /// <summary>
-    ///     List of inputs currently given to this shuttle by any pilots.
+    ///     List of sources to query for input for this shuttle.
+    ///     Cleaned up automatically if the entity did not respond to GetShuttleInputsEvent.
     /// </summary>
     [DataField]
-    public List<ShuttleInput> InputList = new();
+    public HashSet<EntityUid> InputSources = new();
 }

--- a/Content.Server/Physics/Controllers/MoverEvents.cs
+++ b/Content.Server/Physics/Controllers/MoverEvents.cs
@@ -1,0 +1,13 @@
+using System.Numerics;
+
+// Mono - whole file
+
+namespace Content.Server.Physics.Controllers;
+
+public record struct ShuttleInput(Vector2 Strafe, float Rotation, float Brakes);
+
+/// <summary>
+///     Raised to get inputs given to a shuttle.
+/// </summary>
+[ByRefEvent]
+public record struct GetShuttleInputsEvent(List<ShuttleInput> Inputs);

--- a/Content.Server/Physics/Controllers/MoverEvents.cs
+++ b/Content.Server/Physics/Controllers/MoverEvents.cs
@@ -7,7 +7,8 @@ namespace Content.Server.Physics.Controllers;
 public record struct ShuttleInput(Vector2 Strafe, float Rotation, float Brakes);
 
 /// <summary>
-///     Raised to get inputs given to a shuttle.
+///     Raised on pilots to get inputs given to a shuttle.
+///     If GotInput is false, this piloted is removed from input sources.
 /// </summary>
 [ByRefEvent]
-public record struct GetShuttleInputsEvent(List<ShuttleInput> Inputs);
+public record struct GetShuttleInputsEvent(ShuttleInput? Input = null, bool GotInput = false);

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -86,7 +86,7 @@ namespace Content.Server.Shuttles.Components
         /// At what Thrust-Weight-Ratio should this ship have the base max velocity as its maximum velocity.
         /// </summary>
         [DataField]
-        public float BaseMaxVelocityTWR = 2f;
+        public float BaseMaxVelocityTWR = 8f;
 
         /// <summary>
         /// How much should TWR affect max velocity.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
refactors ship movement
changes the way max velocity limiting works
max velocity is now limited on an ellipse
if you're going at or above max velocity, going to the side now properly just rotates your velocity instead of not letting you move, so if you go forward at max speed and thrust to the side it will let you

## Why / Balance
necessary for ship HTN

## How to test
1. get pluto
2. go forward at max speed
3. go right
4. observe it actually go right

## Media
[x] tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Ships going at max speed can now properly thrust to the side without having to brake first.
- tweak: Decreased thruster upgrade effect on max speed. There's now only effect via thrust increase.