### PR TITLE
Port Wizden #31015: Put Items Inside Cakes!

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -315,8 +315,8 @@ public sealed class FoodSystem : EntitySystem
 
         args.Repeat = !forceFeed;
 
-// Mono: Shut off. We love emergent mechanics!
-//        _solutionContainer.SetCapacity(soln.Value, soln.Value.Comp.Solution.MaxVolume - transferAmount); // Frontier: remove food capacity after taking a bite.
+        // Mono: Shut off. We love emergent mechanics!
+        //        _solutionContainer.SetCapacity(soln.Value, soln.Value.Comp.Solution.MaxVolume - transferAmount); // Frontier: remove food capacity after taking a bite.
 
         if (TryComp<StackComponent>(entity, out var stack))
         {
@@ -347,6 +347,9 @@ public sealed class FoodSystem : EntitySystem
         RaiseLocalEvent(food, ev);
         if (ev.Cancelled)
             return;
+
+        var afterEvent = new AfterFullyEatenEvent(user);
+        RaiseLocalEvent(food, ref afterEvent);
 
         var dev = new DestructionEventArgs();
         RaiseLocalEvent(food, dev);

--- a/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
+using Content.Shared.Destructible;
 
 namespace Content.Server.Nutrition.EntitySystems;
 
@@ -144,6 +145,9 @@ public sealed class SliceableFoodSystem : EntitySystem
         RaiseLocalEvent(uid, ev);
         if (ev.Cancelled)
             return;
+
+        var dev = new DestructionEventArgs();
+        RaiseLocalEvent(uid, dev);
 
         // Locate the sliced food and spawn its trash
         foreach (var trash in foodComp.Trash)

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Actions;
 using Content.Server.Humanoid;
 using Content.Server.Inventory;
 using Content.Server.Mind.Commands;
+using Content.Shared.Nutrition;
 using Content.Server.Polymorph.Components;
 using Content.Shared.Actions;
 using Content.Shared.Buckle;

--- a/Content.Shared/Nutrition/IngestionEvents.cs
+++ b/Content.Shared/Nutrition/IngestionEvents.cs
@@ -24,6 +24,18 @@ public sealed class BeforeFullyEatenEvent : CancellableEntityEventArgs
 }
 
 /// <summary>
+/// Raised directed at the food after finishing eating it and before it's deleted.
+/// </summary>
+[ByRefEvent]
+public readonly record struct AfterFullyEatenEvent(EntityUid User)
+{
+    /// <summary>
+    /// The entity that ate the food.
+    /// </summary>
+    public readonly EntityUid User = User;
+}
+
+/// <summary>
 /// Raised directed at the food being sliced before it's deleted.
 /// Cancel this if you want to do something special before a food is deleted.
 /// </summary>

--- a/Content.Shared/Storage/Components/SecretStashComponent.cs
+++ b/Content.Shared/Storage/Components/SecretStashComponent.cs
@@ -9,6 +9,7 @@ using Content.Shared.DoAfter;
 using Robust.Shared.Serialization;
 using Robust.Shared.Audio;
 using Content.Shared.Whitelist;
+using Content.Shared.Damage;
 
 namespace Content.Shared.Storage.Components
 {
@@ -59,6 +60,12 @@ namespace Content.Shared.Storage.Components
         /// </summary>
         [DataField]
         public string? SecretStashName;
+
+        /// <summary>
+        /// How much damage is delt to something after eating a secret stash that contains an item.
+        /// </summary>
+        [DataField]
+        public DamageSpecifier? DamageEatenItemInside;
 
         /// <summary>
         ///     Container used to keep secret stash item.

--- a/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Construction.EntitySystems;
+using Content.Shared.Damage;
 using Content.Shared.Destructible;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -6,6 +7,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Materials;
+using Content.Shared.Nutrition;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tools.EntitySystems;
@@ -30,6 +32,7 @@ public sealed class SecretStashSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly ToolOpenableSystem _toolOpenableSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
 
     public override void Initialize()
     {
@@ -38,6 +41,7 @@ public sealed class SecretStashSystem : EntitySystem
         SubscribeLocalEvent<SecretStashComponent, DestructionEventArgs>(OnDestroyed);
         SubscribeLocalEvent<SecretStashComponent, GotReclaimedEvent>(OnReclaimed);
         SubscribeLocalEvent<SecretStashComponent, InteractUsingEvent>(OnInteractUsing, after: new[] { typeof(ToolOpenableSystem), typeof(AnchorableSystem) });
+        SubscribeLocalEvent<SecretStashComponent, AfterFullyEatenEvent>(OnEaten);
         SubscribeLocalEvent<SecretStashComponent, InteractHandEvent>(OnInteractHand);
         SubscribeLocalEvent<SecretStashComponent, GetVerbsEvent<InteractionVerb>>(OnGetVerb);
     }
@@ -55,6 +59,14 @@ public sealed class SecretStashSystem : EntitySystem
     private void OnReclaimed(Entity<SecretStashComponent> entity, ref GotReclaimedEvent args)
     {
         DropContentsAndAlert(entity, args.ReclaimerCoordinates);
+    }
+
+    private void OnEaten(Entity<SecretStashComponent> entity, ref AfterFullyEatenEvent args)
+    {
+        // TODO: When newmed is finished should do damage to teeth (Or something like that!)
+        var damage = entity.Comp.DamageEatenItemInside;
+        if (HasItemInside(entity) && damage != null)
+            _damageableSystem.TryChangeDamage(args.User, damage, true);
     }
 
     private void OnInteractUsing(Entity<SecretStashComponent> entity, ref InteractUsingEvent args)

--- a/Content.Shared/Tools/Components/ToolOpenableComponent.cs
+++ b/Content.Shared/Tools/Components/ToolOpenableComponent.cs
@@ -50,6 +50,12 @@ namespace Content.Shared.Tools.Components
         public bool HasVerbs = true;
 
         /// <summary>
+        /// If true, the only way to interact is with verbs. Clicking on the entity will not do anything.
+        /// </summary>
+        [DataField, AutoNetworkedField]
+        public bool VerbOnly;
+
+        /// <summary>
         ///     The name of what is being open and closed.
         ///     E.g toilet lid, pannel, compartment.
         /// </summary>

--- a/Content.Shared/Tools/Systems/ToolOpenableSystem.cs
+++ b/Content.Shared/Tools/Systems/ToolOpenableSystem.cs
@@ -30,7 +30,7 @@ public sealed class ToolOpenableSystem : EntitySystem
 
     private void OnInteractUsing(Entity<ToolOpenableComponent> entity, ref InteractUsingEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || entity.Comp.VerbOnly)
             return;
 
         if (TryOpenClose(entity, args.Used, args.User))

--- a/Resources/Locale/en-US/storage/components/secret-stash-component.ftl
+++ b/Resources/Locale/en-US/storage/components/secret-stash-component.ftl
@@ -23,3 +23,4 @@ comp-secret-stash-verb-open = Open
 secret-stash-plant = plant
 secret-stash-toilet = toilet cistern
 secret-stash-plushie = plushie
+secret-stash-cake = cake

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -28,6 +28,19 @@
   - type: Tag
     tags:
     - Cake
+  - type: SecretStash
+    maxItemSize: "Normal"
+    secretStashName: secret-stash-cake
+    damageEatenItemInside:
+      types:
+        Slash: 7.5
+  - type: ToolOpenable
+    openToolQualityNeeded: Slicing
+    closeToolQualityNeeded: Slicing
+    verbOnly: true
+  - type: ContainerContainer
+    containers:
+      stash: !type:ContainerSlot {}
 
 - type: entity
   parent: FoodCakeBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Ports https://github.com/space-wizards/space-station-14/pull/31015 by [beck-thompson](https://github.com/beck-thompson)

Adds stash to cakes.

You can break your tooth on the item eating the cake.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

An esoteric foodservice buff. Cakes suddenly have a weirdass utility beyond just being chow.

## How to test
<!-- Describe the way it can be tested -->

Check out the new verb
<img width="479" height="71" alt="image" src="https://github.com/user-attachments/assets/d3f62d69-4072-4e2e-8b4b-c29fac576bbe" />
Ensure the default interaction with clicking a cake directly with a knife still cuts it (while it is closed)
Eat a cake with an item inserted into it

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->



https://github.com/user-attachments/assets/f0870ac9-7ebb-4a6a-ab67-b9b5cc429845


https://github.com/user-attachments/assets/993fa3c6-42af-48ac-8a79-f696ecbf0a29


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

C# was touched but I believe I ported everything relevant without fucking up any Mono-specific differences

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: You can now stash items in cakes like a plushie. All credit to beck-thompson
