### PR TITLE
(Fix) Move Modsuits From outerClothing: To Back: Where They Belong

### DIFF
--- a/Resources/Prototypes/_Mono/Loadouts/outer.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/outer.yml
@@ -34,16 +34,16 @@
   id: ContractorClothingModsuitCaptainPowerCell
   price: 5000
   equipment:
-    outerClothing: ClothingModsuitCaptainPowerCell
+    back: ClothingModsuitCaptainPowerCell
 
 - type: loadout
   id: ContractorClothingModsuitAtmostechPowerCell
   price: 5000
   equipment:
-    outerClothing: ClothingModsuitAtmostechPowerCell
+    back: ClothingModsuitAtmostechPowerCell
     
 - type: loadout
   id: ContractorClothingModsuitEngineerPowerCell
   price: 5000
   equipment:
-    outerClothing: ClothingModsuitEngineerPowerCell
+    back: ClothingModsuitEngineerPowerCell


### PR DESCRIPTION
## About the PR
moves loadout civilian modsuits from outerClothing slot to back slot

## Why / Balance
modsuit is a backpack
armor with loadout drops on ground

## How to test
localhost
select loadout modsuit
spawn to confirm its on the back not the vest

## Media
none

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [y ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
- [x ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
shouldnt be any

**Changelog**
changed 3 lines of code in _Mono/Loadouts/outer.yml

