### PR TITLE
Spasaka Sabotage Kit Upgrades

### DIFF
--- a/Resources/Locale/en-US/_Mono/research/rogue-research.ftl
+++ b/Resources/Locale/en-US/_Mono/research/rogue-research.ftl
@@ -30,4 +30,4 @@ research-technology-rogue-access-breaker = Advanced Hacking Procedures
 research-technology-rogue-hf-sword = Weaponised Resonance Technology
 research-technology-rogue-syndicate-tacsuits = Blood-Red Imitation
 research-technology-rogue-syndicate-tacsuits-t3 = Synthalloy Utilization
-research-technology-rogue-rx01 = RX-01 Modsuit
+

--- a/Resources/Prototypes/_Mono/Catalogs/selectable_sets.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/selectable_sets.yml
@@ -86,6 +86,7 @@
   - NaniteApplicatorSyndicate
   - RadioJammer
   - MedkitCombatFilled
+  - AccessBreaker
   - ClothingModsuitRoguePowerCell
   - ClothingBackpackDuffelSyndicateC4tBundle
   - ScramImplanter

--- a/Resources/Prototypes/_Mono/Catalogs/selectable_sets.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/selectable_sets.yml
@@ -85,13 +85,12 @@
   - WelderExperimental
   - NaniteApplicatorSyndicate
   - RadioJammer
-  - ClothingEyesNightVisionGoggles
-  - ClothingOuterHardsuitCarp
-  - ClothingShoesBootsMagVoid
+  - MedkitCombatFilled
+  - ClothingModsuitRoguePowerCell
   - ClothingBackpackDuffelSyndicateC4tBundle
   - ScramImplanter
   - AccessConfiguratorAntag
   - SyndiHypo
   - NocturineChemistryBottle
-  - WeaponPistolCobra
-  - BoxMagazine635x40mmCaselessPistol
+  - WeaponSubMachineGunMla73
+  - Magazine635x40mmCaselessBig

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Back/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Back/modsuit.yml
@@ -189,7 +189,7 @@
   parent: [Clothing, ContentsExplosionResistanceBase, BaseC3PirateContrabandHighValue]
   id: ClothingModsuitRogue
   name: RX-01 hardsuit control unit
-  description: Core control unit for the RX-01. Survives power spikes, hull breaches, and rogue ingenuity. Somehow.
+  description: Core control unit for the RX-01. Survives power spikes, hull breaches, and black market ingenuity. Somehow. Also has built in experimental voidboots.
   components:
   - type: Appearance
   - type: Sprite

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/modsuit.yml
@@ -214,4 +214,4 @@
     spriteLayer: sealed
     clothingVisuals:
       shoes:
-      - state: equipped-FEET-sealed
+      - state: equipped-FEET-sealed      - state: equipped-FEET-sealed

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/modsuit.yml
@@ -125,6 +125,7 @@
       walkModifier: 0.95
       sprintModifier: 0.95
   - type: Magboots
+    requiresGrid: false
   - type: SealableClothingVisuals
     spriteLayer: sealed
     clothingVisuals:

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/modsuit.yml
@@ -214,4 +214,4 @@
     spriteLayer: sealed
     clothingVisuals:
       shoes:
-      - state: equipped-FEET-sealed      - state: equipped-FEET-sealed
+      - state: equipped-FEET-sealed

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/modsuit.yml
@@ -92,7 +92,7 @@
   parent: ClothingShoesBase
   id: ClothingModsuitBootsRogue
   name: RX-01 modsuit boots
-  description: Magnetized to help you avoid slips, trips, and Feds.
+  description: Magnetized voidboots to help you avoid slips, trips, and Feds.
   categories: [ HideSpawnMenu ]
   components:
   - type: Appearance

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/equipment_rogue.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/equipment_rogue.yml
@@ -36,13 +36,6 @@
   parent: MonoHardsuitT3Recipe
   result: ClothingOuterHardsuitCybersunStealth
 
-# T3 modsuit
-
-- type: latheRecipe
-  id: ClothingModsuitRoguePowerCellRogue
-  parent: MonoHardsuitT3Recipe
-  result: ClothingModsuitRoguePowerCell
-
 # T3 synthalloy
 
 - type: latheRecipe

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/equipment.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Rogues/equipment.yml
@@ -8,7 +8,6 @@
   - ClothingShoesBootsMagSyndieRogue
   - ClothingMaskGasSyndicateRogue
   - ClothingEyesThermalVisionGoggles
-  - ClothingModsuitRoguePowerCellRogue
 
 - type: latheRecipePack
   id: MonoRogueGearProDynamic # for syndie hardsuits and shit

--- a/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/faction_tacsuits.yml
@@ -71,15 +71,3 @@
   - RogueSyndicateTacsuits
   position: 21, 12
 
-- type: technology
-  id: RogueRx01
-  name: research-technology-rogue-rx01
-  entityIcon: ClothingModsuitRoguePowerCell
-  discipline: RogueEquipment
-  tier: 3
-  cost: 35000
-  recipeUnlocks:
-  - ClothingModsuitRoguePowerCellRogue
-  technologyPrerequisites:
-  - RogueAdvancedEquipment
-  position: 21, 6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Spasaka saboteurs become better boarders with the addition of an RX-01 modsuit equipped with voidboots, fully automatic silenced smg (MLA-73) , and an access breaker. 

Removes RX-01 from research.
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The sabotage kit is better suited for situations outside just attacking the Halcyon. The RX-01 gets void boots and removed from research to help the spasaka board vessels, as well as them getting a fully automatic weapon and access breaker to help with this objective.

## How to test
<!-- Describe the way it can be tested -->
Load up the sabotage kit and test out the gear.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Gave the RX-01 voidboots
- remove: Removed the RX-01 from research
- tweak: Spasaka sabotage kit has gotten equipment changes to help with boarding as well as receiving the RX-01 suit. 
