### PR TITLE
Update StrippableBoundUserInterface.cs

### DIFF
--- a/Content.Client/Inventory/StrippableBoundUserInterface.cs
+++ b/Content.Client/Inventory/StrippableBoundUserInterface.cs
@@ -155,7 +155,7 @@ namespace Content.Client.Inventory
             // for now: shit-code
             // this breaks for drones (too many hands, lots of empty vertical space), and looks shit for monkeys and the like.
             // but the window is realizable, so eh.
-            _strippingMenu.SetSize = new Vector2(220, snare?.IsEnsnared == true ? 550 : 530);
+            _strippingMenu.SetSize = new Vector2(300, snare?.IsEnsnared == true ? 550 : 530);
         }
 
         private void AddHandButton(Hand hand)


### PR DESCRIPTION
resize the stipping UI from 220 to 300 so you can see every icons

(ignore icons not being the monolith ones)
<img width="383" height="665" alt="image" src="https://github.com/user-attachments/assets/eea9bdf4-9025-4394-b8ef-5a9c9e7914ec" />



:cl:
- fix: Fixed part of stripping UI being hiden.