### PR TITLE
Bluespace Workbags Reinstatement

### DIFF
--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -10,13 +10,13 @@
   recipeUnlocks:
   - BorgModuleGardening
   - BorgModuleHarvesting
-  #- PlantBagOfHolding
+  - PlantBagOfHolding
   - SeedExtractorMachineCircuitboard
   - HydroponicsTrayMachineCircuitboard
   - ReagentGrinderIndustrialMachineCircuitboard
   - PlantAnalyzer # Frontier
   - NFBlueprintPlantAnalyzerEmpty # Frontier
-  #- NFBlueprintPlantBagOfHolding # Frontier
+  - NFBlueprintPlantBagOfHolding # Frontier
   technologyPrerequisites:
   - BasicParts
   position: 3, -1

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -198,10 +198,10 @@
   tier: 2
   cost: 20000
   recipeUnlocks:
-  #- OreBagOfHolding
+  - OreBagOfHolding
   - MiningDrillDiamond
   - AdvancedMineralScannerEmpty
-  #- NFBlueprintOreBagOfHolding # Frontier
+  - NFBlueprintOreBagOfHolding # Frontier
   - NFBlueprintMiningDrillDiamond # Frontier
   - NFBlueprintAdvancedMineralScannerEmpty # Frontier
   - BorgModuleAdvancedMining # Frontier

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/TechDisks/tech_disks_civ.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/TechDisks/tech_disks_civ.yml
@@ -24,7 +24,7 @@
     - ClothingBackpackMessengerHolding
     - OreBagOfHolding
     - PlantBagOfHolding
-    - ConstructionBagofHolding
+    - ConstructionBagOfHolding
     - BluespaceBeaker
     - FireExtinguisherBluespace
     - BluespaceBeaker

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/TechDisks/tech_disks_civ.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Science/TechDisks/tech_disks_civ.yml
@@ -24,6 +24,7 @@
     - ClothingBackpackMessengerHolding
     - OreBagOfHolding
     - PlantBagOfHolding
+    - ConstructionBagofHolding
     - BluespaceBeaker
     - FireExtinguisherBluespace
     - BluespaceBeaker

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/blueprints.yml
@@ -21,7 +21,7 @@
   - NFBlueprintJugBluespace
   - NFBlueprintVialBluespace
   # Salvage
-#  - NFBlueprintOreBagOfHolding
+  - NFBlueprintOreBagOfHolding
   - NFBlueprintMiningDrillDiamond
   - NFBlueprintAdvancedMineralScannerEmpty
   - NFBlueprintClothingOuterHardsuitMaximPrototype
@@ -34,7 +34,7 @@
   # Service
   - NFBlueprintAdvMopItem
   - NFBlueprintPlantAnalyzerEmpty
-#  - NFBlueprintPlantBagOfHolding
+  - NFBlueprintPlantBagOfHolding
   # Armory
   - NFBlueprintWeaponLaserSvalinn
   - NFBlueprintPortableRecharger


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Reinstates bluespace plant and ore bags

Also adds bluespace construction bags to the tech disk

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

They don't really provide the level of ubiquitous power that bluespace duffels do anyway.

## How to test
<!-- Describe the way it can be tested -->

Check protolathe after researching hydroponics and mass excavation

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="350" height="326" alt="image" src="https://github.com/user-attachments/assets/4423106b-6ff1-4c9d-8314-5aebed843ca2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Bluespace ore and plant bags can be researched manually again
