### PR TITLE
Autoswing Mining Tools

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -11,6 +11,7 @@
     sprite: Objects/Weapons/Melee/pickaxe.rsi
     state: pickaxe
   - type: MeleeWeapon
+    autoAttack: true #Mono
     attackRate: 0.75
     wideAnimationRotation: -135
     soundHit:
@@ -136,6 +137,7 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
+    autoAttack: true #Mono
     attackRate: 1.25
     wideAnimationRotation: -135
     damage:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -20,12 +20,14 @@
     activatedShape:
     - 0,0,2,0
     - 1,1,1,2
+  - type: MeleeWeapon
+    autoAttack: true
   - type: ItemToggleMeleeWeapon
     activatedDamage:
-        types: # Slightly less total damage than wielded crusher glaive has
-          Heat: 8
-          Piercing: 2
-          Structural: 40 # +10 damage compared to crusher glaive
+        types: # Mono start: 0.5dps higher than standard wielded pickaxe with worse trading power
+          Heat: 10 # 8 >> 10
+          Piercing: 10 # 2 >> 10
+          Structural: 75 #Mono end: 40 >> 75
     deactivatedSecret: true
   - type: Sprite
     sprite: _NF/Objects/Weapons/Melee/energy_pickaxe.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Pickaxe, holopickaxe, and crushers gained autoswing. Added side effect of making crusher marking followup much more feasible because you can hold down mouse2 to finish with wideswing after shooting.

Holopickaxe damage values increased to make it a feasible option. It's as strong as the pickaxe now plus 0.5dps, but has less raw swing trading power. Structural damage went up 40 >> 75 to make it better as a demolition option. It's still weaker than concussives and diamond tipped drill in regards to this role, but comes much closer than it did before.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Reducing frequent repetitive motions is always good.

The glaive change feels GOOOOOD

Relevancy of drill is maintained because it remains being the only handheld option with no wideswing stamina cost. Diamond drill still has the highest structural damage per second.

Combat balance is preserved: there's significantly stronger melee combat options available.

## How to test
<!-- Describe the way it can be tested -->

Swang that thang

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/00a30e26-0770-4702-bc50-242ca9c78c32



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Hand-mining improvement: All non-autoswinging mining tools were given autoswing.
