### PR TITLE
Borer Sugar Loophole Closure And VIM License

### DIFF
--- a/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
@@ -12,10 +12,11 @@ using Content.Shared._Mono.CorticalBorer;
 using Content.Shared._Starlight.CollectiveMind;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
+using Content.Shared.Chat; // Einstein Engines - Languages
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
-using Content.Shared.Chat; // Einstein Engines - Languages
 using Content.Shared.Database;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.MedicalScanner;
 using Content.Shared.Mind;
@@ -61,6 +62,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         SubscribeLocalEvent<CorticalBorerComponent, CheckTargetedSpeechEvent>(OnSpeakEvent);
 
         SubscribeLocalEvent<CorticalBorerComponent, MindRemovedMessage>(OnMindRemoved);
+        SubscribeLocalEvent<CorticalBorerComponent, AttackAttemptEvent>(OnBorerAttackAttempt);
     }
 
     private void OnStartup(Entity<CorticalBorerComponent> ent, ref ComponentStartup args)
@@ -185,6 +187,23 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
 
         UpdateChems(ent, -((int)chemAmount * chemicalPrototype.Cost));
         return true;
+    }
+
+    /// <summary>
+    /// Checks if host has borer protection before allowing attack damage vs hosts
+    /// </summary>
+    private void OnBorerAttackAttempt(EntityUid uid, CorticalBorerComponent component, AttackAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (component.Host is EntityUid host && args.Target == host)
+        {
+            if (!CanUseAbility((uid, component), host))
+            {
+                args.Cancel();
+            }
+        }
     }
 
     private void OnInjectReagentMessage(Entity<CorticalBorerComponent> ent, ref CorticalBorerDispenserInjectMessage message)

--- a/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
@@ -188,9 +188,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         UpdateChems(ent, -((int)chemAmount * chemicalPrototype.Cost));
         return true;
     }
-
-
-
+    
     private void OnInjectReagentMessage(Entity<CorticalBorerComponent> ent, ref CorticalBorerDispenserInjectMessage message)
     {
         CorticalBorerChemicalPrototype? chemProto = null;

--- a/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
+++ b/Content.Server/_Mono/CorticalBorer/CorticalBorerSystem.cs
@@ -16,7 +16,6 @@ using Content.Shared.Chat; // Einstein Engines - Languages
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Database;
-using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.MedicalScanner;
 using Content.Shared.Mind;
@@ -51,6 +50,8 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
 
     public override void Initialize()
     {
+        base.Initialize();
+
         SubscribeAbilities();
 
         SubscribeLocalEvent<CorticalBorerComponent, ComponentStartup>(OnStartup);
@@ -62,7 +63,6 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         SubscribeLocalEvent<CorticalBorerComponent, CheckTargetedSpeechEvent>(OnSpeakEvent);
 
         SubscribeLocalEvent<CorticalBorerComponent, MindRemovedMessage>(OnMindRemoved);
-        SubscribeLocalEvent<CorticalBorerComponent, AttackAttemptEvent>(OnBorerAttackAttempt);
     }
 
     private void OnStartup(Entity<CorticalBorerComponent> ent, ref ComponentStartup args)
@@ -189,22 +189,7 @@ public sealed partial class CorticalBorerSystem : SharedCorticalBorerSystem
         return true;
     }
 
-    /// <summary>
-    /// Checks if host has borer protection before allowing attack damage vs hosts
-    /// </summary>
-    private void OnBorerAttackAttempt(EntityUid uid, CorticalBorerComponent component, AttackAttemptEvent args)
-    {
-        if (args.Cancelled)
-            return;
 
-        if (component.Host is EntityUid host && args.Target == host)
-        {
-            if (!CanUseAbility((uid, component), host))
-            {
-                args.Cancel();
-            }
-        }
-    }
 
     private void OnInjectReagentMessage(Entity<CorticalBorerComponent> ent, ref CorticalBorerDispenserInjectMessage message)
     {

--- a/Resources/Prototypes/_Mono/CorticalBorer/cortical_borer_species.yml
+++ b/Resources/Prototypes/_Mono/CorticalBorer/cortical_borer_species.yml
@@ -67,6 +67,7 @@
   - type: Tag
     tags:
     - Meat
+    - VimPilot
   - type: ThermalVision
     lightRadius: 15
     activateSound: null


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Sugar now truly counters cortical borers: no more attacking your host to death as a last resort when you're cornered with sugar.

Cortical borers received a VIM piloting license. Possible win for worm diplomacy?

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Making the counterplay work, and adding a possible means of worm diplomacy. Seeing a worm in a VIM's probably less intimidating in general?

## How to test
<!-- Describe the way it can be tested -->

Spawn a borer, pick it up, then admin control it
Infest the holder with your conveniently held borer
Solution edit sugar into the host and add enough to last the entire test session
Start attacking the host: you should be blocked
Attempt other normally blocked functions in case of Heisenfuckery while you're at it
Aghost to eject the borer from host. Recontrol the borer.
Attack the host: it should work since they aren't host

Spawn a VIM
Hop in the VIM as borer

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/38114f48-5b99-4592-a53e-41e752bf7622

https://github.com/user-attachments/assets/7373e22f-e2a8-4db3-9431-c7ff29791a78

https://github.com/user-attachments/assets/d6df7a05-f697-4ea4-b235-f11e119f682f




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Cortical borer hosts consuming sugar now blocks their borer from attacking them
- tweak: Cortical borers can now pilot VIM mechs!