### PR TITLE
Hide+farify Faction Bases

### DIFF
--- a/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
@@ -9,14 +9,15 @@
   id: HeliosFortress
   parent: BasePOI
   name: 'PDV Helios Fortress'
-  minimumDistance: 7500
-  maximumDistance: 9500
+  minimumDistance: 13000
+  maximumDistance: 15000
   spawnGamePreset: [ NFAdventure, NFPirate, MonoStandard, MonoRogueTSF, MonoRogueUSSP, MonoADS, MonoChimera, MonoMixed, MonoAllAtOnce ]
   spawnGroup: Required
   gridPath: /Maps/_Mono/POI/pdvhelios.yml
   addComponents:
   - type: IFF
     color: "#DE9E59"
+    flags: [HideLabel]
     readOnly: true # mono
 
 - type: gameMap

--- a/Resources/Prototypes/_Mono/PointsOfInterest/tsfmchalcyon.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/tsfmchalcyon.yml
@@ -14,14 +14,15 @@
   id: TSFMCHalcyon
   parent: BasePOI
   name: 'TSFMC Flagship Halcyon'
-  minimumDistance: 2500 # Mono
-  maximumDistance: 4000 # Mono
+  minimumDistance: 14500 # Mono
+  maximumDistance: 16000 # Mono
   spawnGamePreset: [ NFAdventure, NFPirate, MonoStandard, MonoRogueTSF, MonoTSFUSSP, MonoADS, MonoChimera, MonoMixed, MonoAllAtOnce ]
   spawnGroup: Required
   gridPath: /Maps/_Mono/POI/tsfmchalcyon.yml
   addComponents:
   - type: IFF
     color: "#047abd"
+    flags: [HideLabel]
     readOnly: true
   - type: SolarPoweredGrid
     doNotCull: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
hides halc and helios
moves helios to 12-13k, halc 14.5-16k

## Why / Balance
see all the discord discussions

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Both faction bases are now hidden and spawn far out.
