### PR TITLE
Contraband Rework

### DIFF
--- a/Resources/Locale/en-US/_Mono/contraband/contraband-severity.ftl
+++ b/Resources/Locale/en-US/_Mono/contraband/contraband-severity.ftl
@@ -1,2 +1,7 @@
 contraband-examine-text-Class2-Restricted = [color=#fc5e03]This item is restricted to a certain group or multiple groups, and its possession is illegal outside of them.[/color]
 contraband-examine-text-Class3-Chemical = [color=#ff0040]This is an illegal C3-level chemical. It's possession is completely illegal.[/color]
+
+contraband-examine-text-faction-gear-0 = [color=#bbaa22]This item belongs to a major faction, but isn't of any considerable technological interest.
+contraband-examine-text-faction-gear-1 = [color=#ff8833]This item belongs to a major faction and is of some technological interest.
+contraband-examine-text-faction-gear-2 = [color=#ff4422]This item belongs to a major faction and is of considerable technological interest.
+contraband-examine-text-faction-gear-3 = [color=#ff55ff]This item belongs to a major faction and is of great technological interest.

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -388,7 +388,7 @@
 
 - type: entity
   name: syndicate encryption key box
-  parent: [BoxEncryptionKeyPassenger, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BoxEncryptionKeyPassenger
   id: BoxEncryptionKeySyndie
   description: Two syndicate encryption keys for the price of one. Miniaturized for ease of use.
   components:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/syndicate.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ElectricalDisruptionKit
-  parent: [BoxCardboard, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BoxCardboard
   name: electrical disruption kit
   suffix: Filled
   components:
@@ -12,7 +12,7 @@
           amount: 1
 
 - type: entity
-  parent: [BoxVial, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BoxVial
   id: ChemicalSynthesisKit
   name: chemical synthesis kit
   description: A starter kit for the aspiring chemist, includes toxin and vestine for all your criminal needs!
@@ -33,7 +33,7 @@
       - id: SyringeStimulants
 
 - type: entity
-  parent: [BoxCardboard] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband # Mono: Removed BaseC3SyndicateContraband
+  parent: [BoxCardboard] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
   id: ThrowingKnivesKit
   name: throwing knives kit
   description: A set of 4 syndicate branded throwing knives, perfect for embedding into the body of your victims.
@@ -52,7 +52,7 @@
 
 - type: entity
   name: deathrattle implant box
-  parent: [BoxCardboard, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BoxCardboard
   id: BoxDeathRattleImplants
   description: Six deathrattle implants for the whole squad.
   components:
@@ -69,7 +69,7 @@
         amount: 6
 
 - type: entity
-  parent: [BoxCardboard, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BoxCardboard
   id: CombatBakeryKit
   name: combat bakery kit
   description: A kit of clandestine baked weapons.

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateArmorySMG
-  parent: [ CrateWeaponSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateWeaponSecure
   name: SMG crate
   description: Contains two high-powered, semiautomatic rifles with four mags. Requires Armory access to open.
   components:
@@ -13,7 +13,7 @@
 
 - type: entity
   id: CrateArmoryShotgun
-  parent: [ CrateWeaponSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateWeaponSecure
   name: shotgun crate
   description: For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer Combat Shotguns, and some standard shotgun shells. Requires Armory access to open.
   components:
@@ -26,7 +26,7 @@
 
 - type: entity
   id: CrateTrackingImplants
-  parent: [ CrateWeaponSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateWeaponSecure
   name: tracking implants
   description: Contains a handful of tracking implanters. Good for prisoners you'd like to release but still keep track of.
   components:
@@ -36,7 +36,7 @@
         amount: 5
 
 - type: entity
-  parent: [ CrateWeaponSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateWeaponSecure
   id: CrateTrainingBombs
   name: training bombs
   description: Contains three low-yield training bombs for security to learn defusal and safe ordnance disposal, EOD suit not included. Requires Armory access to open.
@@ -48,7 +48,7 @@
 
 - type: entity
   id: CrateArmoryLaser
-  parent: [ CrateWeaponSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateWeaponSecure
   name: lasers crate
   description: Contains three standard-issue laser rifles. Requires Armory access to open.
   components:
@@ -59,7 +59,7 @@
 
 - type: entity
   id: CrateArmoryPistols
-  parent: [ CrateWeaponSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateWeaponSecure
   name: pistols crate
   description: Contains two standard NT pistols with four mags. Requires Armory access to open.
   components:
@@ -72,7 +72,7 @@
 
 - type: entity
   id: CrateSecurityRiot
-  parent: [ CrateWeaponSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateWeaponSecure
   name: swat crate
   description: Contains two sets of riot armor, helmets, shields, and enforcers loaded with beanbags. Extra ammo is included. Requires Armory access to open.
   components:

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CrateSyndicateSurplusBundle
-  parent: [ CrateSyndicate, StorePresetUplink ] # Frontier: Removed BaseSyndicateContraband
+  parent: [ CrateSyndicate, StorePresetUplink ]
   name: Syndicate surplus crate
   description: Contains 250 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
   components:
@@ -24,7 +24,7 @@
 
 - type: entity
   id: CrateSyndicateSuperSurplusBundle
-  parent: [ CrateSyndicate, StorePresetUplink ] # Frontier: Removed BaseSyndicateContraband
+  parent: [ CrateSyndicate, StorePresetUplink ]
   name: Syndicate super surplus crate
   description: Contains 600 telecrystals worth of completely random Syndicate items.
   components:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -158,7 +158,7 @@
         prob: 0.5
 
 - type: entity
-  parent: [GunSafeBaseSecure, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: GunSafeBaseSecure
   id: GunSafeDisabler
   name: disabler safe
   categories: [ HideSpawnMenu ] # Frontier
@@ -169,7 +169,7 @@
       amount: 5
 
 - type: entity
-  parent: [GunSafeBaseSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: GunSafeBaseSecure
   id: GunSafePistolMk58
   name: mk58 safe
   categories: [ HideSpawnMenu ] # Frontier
@@ -182,7 +182,7 @@
       amount: 8
 
 - type: entity
-  parent: [GunSafeBaseSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: GunSafeBaseSecure
   id: GunSafeRifleLecter
   name: lecter safe
   categories: [ HideSpawnMenu ] # Frontier
@@ -195,7 +195,7 @@
       amount: 4
 
 - type: entity
-  parent: [GunSafeBaseSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: GunSafeBaseSecure
   id: GunSafeSubMachineGunDrozd
   name: drozd safe
   categories: [ HideSpawnMenu ] # Frontier
@@ -208,7 +208,7 @@
       amount: 4
 
 - type: entity
-  parent: [GunSafeBaseSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: GunSafeBaseSecure
   id: GunSafeShotgunEnforcer
   name: enforcer safe
   categories: [ HideSpawnMenu ] # Frontier
@@ -221,7 +221,7 @@
       amount: 4
 
 - type: entity
-  parent: [GunSafeBaseSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: GunSafeBaseSecure
   id: GunSafeShotgunKammerer
   name: kammerer safe
   categories: [ HideSpawnMenu ] # Frontier
@@ -236,7 +236,7 @@
 - type: entity
   id: GunSafeSubMachineGunWt550
   suffix: Wt550
-  parent: [GunSafeBaseSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: GunSafeBaseSecure
   name: wt550 safe
   categories: [ HideSpawnMenu ] # Frontier
   components:
@@ -248,7 +248,7 @@
       amount: 4
 
 - type: entity
-  parent: [GunSafeBaseSecure] # Frontier: remove BaseSecurityContraband
+  parent: [GunSafeBaseSecure]
   id: GunSafeLaserCarbine
   name: laser safe
   categories: [ HideSpawnMenu ] # Frontier

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -80,7 +80,7 @@
       collection: IanBark
 
 - type: entity
-  parent: [NFClothingBackpack, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband, ClothingBackpack<NFClothingBackpack
+  parent: NFClothingBackpack
   id: ClothingBackpackSecurity
   name: tactical backpack # Mono
   description: It's a very robust backpack.
@@ -89,7 +89,7 @@
     sprite: Clothing/Back/Backpacks/security.rsi
 
 - type: entity
-  parent: [NFClothingBackpack, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable, ClothingBackpack<NFClothingBackpack
+  parent: NFClothingBackpack
   id: ClothingBackpackBrigmedic
   name: brigmedic backpack
   description: It's a very sterile backpack.
@@ -125,7 +125,7 @@
     sprite: Clothing/Back/Backpacks/medical.rsi
 
 - type: entity
-  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack # Frontier: removed BaseCommandContraband
+  parent: NFClothingBackpack # Frontier: ClothingBackpack<NFClothingBackpack
   id: ClothingBackpackCaptain
   name: captain's backpack
   description: It's a special backpack made exclusively for TSF officers.
@@ -216,7 +216,7 @@
 
 #ERT
 - type: entity
-  parent: [ ClothingBackpack, BaseC2ContrabandUnredeemable ] # Frontier - note: NFBackpack sets max size, fails to insert some ERT loadout items # Mono - changed to C2 contra
+  parent: ClothingBackpack # Frontier - note: NFBackpack sets max size, fails to insert some ERT loadout items # Mono - changed to C2 contra
   id: ClothingBackpackERTLeader
   name: advanced tactical backpack # Mono
   description: A spacious backpack with lots of pockets. # Mono
@@ -283,7 +283,7 @@
 
 #Syndicate
 - type: entity
-  parent: [NFClothingBackpack, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, ClothingBackpack<NFClothingBackpack
+  parent: NFClothingBackpack
   id: ClothingBackpackSyndicate
   name: syndicate backpack
   description:

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -44,7 +44,7 @@
       sprite: Clothing/Back/Duffels/medical.rsi
 
 - type: entity
-  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel # Frontier: removed BaseCommandContraband
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffelNFClothingDuffel
   id: ClothingBackpackDuffelCaptain
   name: captain's duffel bag
   description: A large duffel bag for holding extra captainly goods.
@@ -65,7 +65,7 @@
         collection: BikeHorn
 
 - type: entity
-  parent: [NFClothingDuffel, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband, ClothingBackpackDuffel<NFClothingDuffel
+  parent: NFClothingDuffel
   id: ClothingBackpackDuffelSecurity
   name: tactical duffel bag # Mono
   description: A large duffel bag for holding extra security related goods.
@@ -74,7 +74,7 @@
       sprite: Clothing/Back/Duffels/security.rsi
 
 - type: entity
-  parent: [NFClothingDuffel, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable, ClothingBackpackDuffel<NFClothingDuffel
+  parent: NFClothingDuffel
   id: ClothingBackpackDuffelBrigmedic
   name: brigmedic duffel bag
   description: A large duffel bag for holding extra medical related goods.
@@ -159,7 +159,7 @@
       sprite: Clothing/Back/Duffels/salvage.rsi
 
 - type: entity
-  parent: [NFClothingDuffel, BaseC3Contraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3Contraband, added ContrabandClothing as parent
+  parent: [NFClothingDuffel]
   id: ClothingBackpackDuffelSyndicate
   name: syndicate duffel bag
   description: A large duffel bag for holding various traitor goods.
@@ -262,7 +262,7 @@
         shader: unshaded # Frontier
 
 - type: entity
-  parent: [ NFClothingDuffel, BaseCentcommContraband ] # Frontier: ClothingBackpackDuffel<NFClothingDuffel
+  parent: NFClothingDuffel # Frontier: ClothingBackpackDuffel<NFClothingDuffel
   id: ClothingBackpackDuffelCBURN
   name: CBURN duffel bag
   description: A duffel bag containing a variety of biological containment equipment.

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -106,7 +106,7 @@
     sprite: Clothing/Back/Satchels/science.rsi
 
 - type: entity
-  parent: [ClothingBackpackSatchel, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: ClothingBackpackSatchel
   id: ClothingBackpackSatchelSecurity
   name: tactical satchel # Mono
   description: A robust satchel for security related needs.
@@ -115,7 +115,7 @@
     sprite: Clothing/Back/Satchels/security.rsi
 
 - type: entity
-  parent: [ClothingBackpackSatchel, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingBackpackSatchel
   id: ClothingBackpackSatchelBrigmedic
   name: brigmedic satchel
   description: A sterile satchel for medical related needs.
@@ -124,7 +124,7 @@
     sprite: Clothing/Back/Satchels/brigmedic.rsi
 
 - type: entity
-  parent: ClothingBackpackSatchel # Frontier: removed BaseCommandContraband
+  parent: ClothingBackpackSatchel
   id: ClothingBackpackSatchelCaptain
   name: captain's satchel
   description: An exclusive satchel for TSF officers.

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -461,7 +461,7 @@
   - type: Appearance
 
 - type: entity
-  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltSecurity
   name: security belt
   description: Can hold security gear like handcuffs and flashes.
@@ -513,7 +513,7 @@
   - type: Appearance
 
 - type: entity
-  parent: [ClothingBeltBase, ClothingSlotBase, BaseC1Contraband] # Frontier: BaseCommandContraband<BaseC1Contraband
+  parent: [ClothingBeltBase, ClothingSlotBase]
   id: ClothingBeltSheath
   name: sabre sheath
   description: An ornate sheath designed to hold an officer's blade.
@@ -547,7 +547,7 @@
 # Belts without visualizers
 
 - type: entity
-  parent: [ClothingBeltAmmoProviderBase, BaseC1Contraband] # Frontier: BaseSecurityBartenderContraband<BaseC1Contraband
+  parent: ClothingBeltAmmoProviderBase
   id: ClothingBeltBandolierOld # Mono: ClothingBeltBandolierOld<ClothingBeltBandolier
   name: bandolier
   description: A bandolier for holding shotgun ammunition.
@@ -623,7 +623,7 @@
     # - 0,0,3,1 # Frontier: commented out
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [NFClothingBeltStorageBase]
   id: ClothingBeltSyndieHolster
   name: syndicate shoulder holster
   description: A deep shoulder holster capable of holding many types of ballistics.
@@ -656,7 +656,7 @@
     sprite: Clothing/Belt/securitywebbing.rsi
 
 - type: entity
-  parent: NFClothingBeltStorageBase # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, remove BaseSecurityCargoContraband
+  parent: NFClothingBeltStorageBase
   id: ClothingBeltMercenaryWebbing # Frontier: Merc to Mercenary
   name: mercenary webbing
   description: Ideal for storing everything from ammo to weapons and combat essentials.
@@ -678,7 +678,7 @@
     sprite: Clothing/Belt/salvagewebbing.rsi
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband] # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, BaseSyndicateContraband<BaseC1Contraband
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltMilitaryWebbing
   name: chest rig
   description: A set of tactical webbing worn by boarding parties. # Frontier
@@ -734,7 +734,7 @@
     sprite: Clothing/Belt/suspenders_black.rsi
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, BaseC3WizardContraband, ContrabandClothing] # Frontier: ClothingBeltStorageBase<NFClothingBeltStorageBase, BaseMagicalContraband<BaseC3WizardContraband, ContrabandClothing as parent
+  parent: [NFClothingBeltStorageBase]
   id: ClothingBeltWand
   name: wizard belt # Frontier: changed the name from 'wand belt' -> 'wizard belt'
   description: A belt designed to hold various rods of power. A veritable fanny pack of exotic magic.

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -63,7 +63,7 @@
     sprite: Clothing/Ears/Headsets/mining.rsi
 
 - type: entity
-  parent: ClothingHeadsetCargo # Frontier: remove BaseCommandContraband
+  parent: ClothingHeadsetCargo
   id: ClothingHeadsetQM
   name: qm headset
   description: A headset used by the quartermaster.
@@ -76,7 +76,7 @@
       - EncryptionKeyCommon
 
 - type: entity
-  parent: [ ClothingHeadset, BaseCentcommCommandContraband ] # Frontier: Added BaseCentcommCommandContraband, removed BaseCentcommContraband.
+  parent: ClothingHeadset
   id: ClothingHeadsetCentCom
   name: CentComm headset
   description: A headset used by the upper echelons of the Trans-Solar Federation.
@@ -92,7 +92,7 @@
     sprite: Clothing/Ears/Headsets/centcom.rsi
 
 - type: entity
-  parent: [ClothingHeadset, BaseC2ContrabandUnredeemable] # Frontier: add BaseC2ContrabandUnredeemable as a parent
+  parent: ClothingHeadset
   id: ClothingHeadsetCommand
   name: command headset
   description: A headset with a commanding channel.
@@ -123,7 +123,7 @@
     sprite: Clothing/Ears/Headsets/engineering.rsi
 
 - type: entity
-  parent: ClothingHeadsetEngineering # Frontier: removed BaseCommandContraband
+  parent: ClothingHeadsetEngineering
   id: ClothingHeadsetCE
   name: ce headset
   description: A headset for the chief engineer to ignore all emergency calls on.
@@ -152,7 +152,7 @@
     sprite: Clothing/Ears/Headsets/medical.rsi
 
 - type: entity
-  parent: ClothingHeadsetMedical # Frontier: removed BaseCommandContraband
+  parent: ClothingHeadsetMedical
   id: ClothingHeadsetCMO
   name: cmo headset
   description: A headset used by the CMO.
@@ -213,7 +213,7 @@
     sprite: Clothing/Ears/Headsets/robotics.rsi
 
 - type: entity
-  parent: ClothingHeadsetScience # Frontier: removed BaseCommandContraband
+  parent: ClothingHeadsetScience
   id: ClothingHeadsetRD
   name: rd headset
   description: Lamarr used to love chewing on this...
@@ -226,7 +226,7 @@
       - EncryptionKeyCommon
 
 - type: entity
-  parent: [ClothingHeadset, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityLawyerContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingHeadset
   id: ClothingHeadsetSecurity
   name: security headset
   description: This is used by your elite security force.
@@ -242,7 +242,7 @@
     sprite: Clothing/Ears/Headsets/security.rsi
 
 - type: entity
-  parent: [ClothingHeadset, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingHeadset
   id: ClothingHeadsetBrigmedic
   name: brigmedic headset
   description: A headset that helps to hear the death cries.
@@ -275,7 +275,7 @@
     sprite: Clothing/Ears/Headsets/service.rsi
 
 - type: entity
-  parent: [ClothingHeadset, BaseC3PirateContrabandNoValue] # Frontier: add BaseC3Contraband - Mono: Made NoValue
+  parent: ClothingHeadset
   id: ClothingHeadsetFreelance
   name: freelancer headset
   description: This is used by a roaming group of freelancers.

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -27,7 +27,7 @@
     sprite: Clothing/Ears/Headsets/cargo.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseCentcommCommandContraband] # Frontier: Added BaseCentcommCommandContraband, removed BaseCommandContraband.
+  parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltCentCom
   name: CentComm over-ear headset
   components:
@@ -56,7 +56,7 @@
 # Mono End
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseCommandContraband]
+  parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltCommand
   name: command over-ear headset
   components:
@@ -70,7 +70,7 @@
     sprite: Clothing/Ears/Headsets/command.rsi
 
 - type: entity
-  parent: ClothingHeadsetAlt # Frontier: remove BaseCommandContraband
+  parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltEngineering
   name: chief engineer's over-ear headset
   components:
@@ -86,7 +86,7 @@
     sprite: Clothing/Ears/Headsets/engineering.rsi
 
 - type: entity
-  parent: ClothingHeadsetAlt # Frontier: remove BaseCommandContraband
+  parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltMedical
   name: chief medical officer's over-ear headset
   components:
@@ -104,7 +104,7 @@
     stealGroup: ClothingHeadsetAltMedical
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltSecurity
   name: head of security's over-ear headset
   components:
@@ -120,7 +120,7 @@
     sprite: Clothing/Ears/Headsets/security.rsi
 
 - type: entity
-  parent: ClothingHeadsetAlt # Frontier: remove BaseCommandContraband
+  parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltScience
   name: research director's over-ear headset
   components:
@@ -136,7 +136,7 @@
     sprite: Clothing/Ears/Headsets/science.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingHeadsetAlt]
   id: ClothingHeadsetAltSyndicate
   name: blood-red over-ear headset
   description: An updated, modular syndicate intercom that fits over the head and takes encryption keys (there are 5 key slots.).
@@ -154,7 +154,7 @@
     sprite: Clothing/Ears/Headsets/syndicate.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseC3PirateContraband, ContrabandClothing] # Frontier: add BaseC3PirateContraband, added ContrabandClothing as parent
+  parent: [ClothingHeadsetAlt]
   id: ClothingHeadsetAltFreelancer
   name: imperial over-ear headset
   components:

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -53,7 +53,7 @@
         Blunt: 10
 
 - type: entity
-  parent: ClothingEyesBase # Frontier: removed BaseEngineeringContraband
+  parent: ClothingEyesBase
   id: ClothingEyesGlassesMeson
   name: engineering goggles #less confusion
   description: Green-tinted goggles using a proprietary polymer that provides protection from eye damage of all types.
@@ -160,7 +160,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [ClothingEyesBase, ShowSecurityIcons]
   id: ClothingEyesGlassesSecurity
   name: security glasses
   description: Upgraded sunglasses that provide flash immunity and a security HUD.
@@ -187,7 +187,7 @@
     coverage: EYES
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband ]
+  parent: ClothingEyesBase
   id: ClothingEyesGlassesCommand
   name: administration glasses
   description: Upgraded sunglasses that provide flash immunity and show ID card status.
@@ -257,7 +257,7 @@
       coverage: EYES
 
 - type: entity
-  parent: [ClothingEyesBase, BaseC3Contraband, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3Contraband added ContrabandClothing as parent
+  parent: [ClothingEyesBase]
   id: ClothingEyesVisorNinja
   name: ninja visor
   description: An advanced visor protecting a ninja's eyes from flashing lights.

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -47,7 +47,7 @@
     price: 30 # Frontier
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [ClothingEyesBase, ShowSecurityIcons]
   id: ClothingEyesHudSecurity
   name: security hud
   description: A heads-up display that scans the humanoids in view and provides accurate data about their ID status and security records.
@@ -61,7 +61,7 @@
     - HudSecurity
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband]
+  parent: ClothingEyesBase
   id: ClothingEyesHudCommand
   name: administration hud
   description: A heads-up display that scans the humanoids in view and provides accurate data about their ID status.
@@ -150,7 +150,7 @@
   - type: ShowThirstIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityCommandContraband<BaseC2ContrabandUnredeemable
+  parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons]
   id: ClothingEyesHudMedSec
   name: medsec hud
   description: An eye display that looks like a mixture of medical and security huds.
@@ -198,7 +198,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingEyesBase, ShowSecurityIcons]
   id: ClothingEyesHudSyndicate
   name: syndicate visor
   description: The syndicate's professional head-up display, designed for better detection of humanoids and their subsequent elimination.
@@ -210,7 +210,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingEyesBase, ShowSecurityIcons]
   id: ClothingEyesHudSyndicateAgent
   name: syndicate agent visor
   description: The Syndicate Agent's professional heads-up display, designed for quick diagnosis of their team's status.
@@ -223,7 +223,7 @@
   - type: ShowHealthBars
 
 - type: entity
-  parent: [ClothingEyesGlassesSunglasses, ShowSecurityIcons, ContrabandClothing] # Frontier: added ContrabandClothing as parent
+  parent: [ClothingEyesGlassesSunglasses, ShowSecurityIcons]
   id: ClothingEyesGlassesHiddenSecurity
   suffix: Syndicate
 

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -94,7 +94,7 @@
     mustBeEquippedToUse: true
 
 - type: entity
-  parent: ClothingHandsBase # remove BaseCommandContraband
+  parent: ClothingHandsBase
   id: ClothingHandsGlovesCaptain
   name: captain gloves
   description: Regal blue gloves, with a nice gold trim. Swanky.
@@ -204,7 +204,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: [ClothingHandsBase, BaseToggleClothing, BaseC3Contraband, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3Contraband, added ContrabandClothing as parent
+  parent: [ClothingHandsBase, BaseToggleClothing]
   id: ClothingHandsGlovesSpaceNinja
   name: space ninja gloves
   description: These black nano-enhanced gloves insulate from electricity and provide fire resistance.
@@ -258,7 +258,7 @@
     #   - type: CriminalRecordsHacker # Frontier
 
 - type: entity
-  parent: [ ClothingHandsGlovesColorBlack, BaseC1Contraband ] # BaseSecurityEngineeringContraband<BaseC1Contraband
+  parent: ClothingHandsGlovesColorBlack
   id: ClothingHandsGlovesCombat
   name: combat gloves
   description: These tactical gloves are fireproof and shock resistant.
@@ -291,7 +291,7 @@
     coefficient: 0.95 # *grabs ur baton* nice knife
 
 - type: entity
-  parent: ClothingHandsGlovesCombat # Frontier: Removed BaseSecurityCargoContraband
+  parent: ClothingHandsGlovesCombat
   id: ClothingHandsMercenaryGlovesCombat # Frontier - Merc to Mercenary
   name: mercenary combat gloves
   description: High-quality combat gloves to protect hands from mechanical damage during combat.
@@ -365,7 +365,7 @@
 - type: entity
   # Intentionally named after regular gloves, they're meant to be sneaky.
   # This means they can also be butchered if you need to look un-sus before a very thorough search...
-  parent: [ClothingHandsGlovesColorBlack, BaseC3Contraband, ContrabandClothing] # Frontier: added BaseC3Contraband, ContrabandClothing as parents
+  parent: [ClothingHandsGlovesColorBlack]
   id: ThievingGloves
   suffix: Thieving
   components:
@@ -386,7 +386,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: [ClothingHandsButcherable, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband added ContrabandClothing as parent
+  parent: [ClothingHandsButcherable]
   id: ClothingHandsGlovesNorthStar
   name: gloves of the north star
   description: These gloves allow you to punch incredibly fast.
@@ -422,7 +422,7 @@
     price: 0
 
 - type: entity
-  parent: [ClothingHandsBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingHandsBase
   id: ClothingHandsGlovesForensic
   name: forensic gloves
   description: Do not leave fibers or fingerprints. If you work without them, you're A TERRIBLE DETECTIVE.

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -28,7 +28,7 @@
 
 #Syndicate EVA Helmet
 - type: entity
-  parent: [ClothingHeadEVAHelmetBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingHeadEVAHelmetBase]
   id: ClothingHeadHelmetSyndicate
   name: syndicate EVA helmet
   description: A simple, stylish EVA helmet. Designed for maximum humble space-badassery.

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -605,7 +605,7 @@
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieCommander ]
+  parent: ClothingHeadHelmetHardsuitSyndieCommander
   id: ClothingHeadHelmetHardsuitERTLeader
   name: ERT leader hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
@@ -626,7 +626,7 @@
 
 #ERT Chaplain Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
+  parent: ClothingHeadHelmetHardsuitSyndie
   id: ClothingHeadHelmetHardsuitERTChaplain
   name: ERT chaplain hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
@@ -640,7 +640,7 @@
 
 #ERT Engineer Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
+  parent: ClothingHeadHelmetHardsuitSyndie
   id: ClothingHeadHelmetHardsuitERTEngineer
   name: ERT engineer hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
@@ -661,7 +661,7 @@
 
 #ERT Medical Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieElite, ShowMedicalIcons ] # Mono - Added ShowMedicalIcons
+  parent: [ ClothingHeadHelmetHardsuitSyndieElite, ShowMedicalIcons ] # Mono - Added ShowMedicalIcons
   id: ClothingHeadHelmetHardsuitERTMedical
   name: ERT medic hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team. Comes with a built-in medical HUD. # Mono
@@ -675,7 +675,7 @@
 
 #ERT Security Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
+  parent: ClothingHeadHelmetHardsuitSyndie
   id: ClothingHeadHelmetHardsuitERTSecurity
   name: ERT security hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
@@ -696,7 +696,7 @@
 
 #ERT Janitor Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
+  parent: ClothingHeadHelmetHardsuitSyndie
   id: ClothingHeadHelmetHardsuitERTJanitor
   name: ERT janitor hardsuit helmet
   description: A special hardsuit helmet worn by members of an emergency response team.
@@ -710,7 +710,7 @@
 
 #CBURN Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
+  parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetCBURN
   name: CBURN exosuit helmet
   description: A pressure resistant and fireproof hood worn by special cleanup units.
@@ -749,7 +749,7 @@
 
 #Deathsquad Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHardsuitBase ]
+  parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitDeathsquad
   name: deathsquad hardsuit helmet
   description: A robust helmet for special operations.

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -70,7 +70,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: [ClothingHeadBase, BaseC2ContrabandUnredeemable] # Frontier: added BaseC2ContrabandUnredeemable
+  parent: ClothingHeadBase
   id: ClothingHeadHatSecurityTrooper
   name: trooper hat
   description: A campaign hat for the TSF Troopers.
@@ -215,7 +215,7 @@
     sprite: Clothing/Head/Hats/bowler_hat.rsi
 
 - type: entity
-  parent: ClothingHeadBase # Frontier: removed BaseCommandContraband
+  parent: ClothingHeadBase
   id: ClothingHeadHatCaptain
   name: captain's hardhat
   description: It's good being the king.
@@ -246,7 +246,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseCentcommContraband ]
+  parent: ClothingHeadBase
   id: ClothingHeadHatCentcom
   name: CentComm brand hat
   description: "It's good to be the emperor."
@@ -326,7 +326,7 @@
     sprite: Clothing/Head/Hats/fez.rsi
 
 - type: entity
-  parent: ClothingHeadBase # Frontier: removed BaseCommandContraband
+  parent: ClothingHeadBase
   id: ClothingHeadHatHopcap
   name: head of personnel's cap
   description: A grand, stylish head of personnel's cap.
@@ -342,7 +342,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: [ClothingHeadBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingHeadBase
   id: ClothingHeadHatHoshat
   name: head of security cap
   description: The robust standard-issue cap of the Head of Security. For showing the officers who's in charge.
@@ -593,7 +593,7 @@
 
 - type: entity
   abstract: true
-  parent: [ ClothingHeadBase, BaseC3WizardContraband ] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: ClothingHeadBase
   id: ClothingHeadHatWizardBase
   components:
   - type: WizardClothes
@@ -637,7 +637,7 @@
     sprite: Clothing/Head/Hats/truckershat.rsi
 
 - type: entity
-  parent: [ClothingHeadBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingHeadBase]
   id: ClothingHeadPyjamaSyndicateBlack
   name: syndicate black pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -648,7 +648,7 @@
     sprite: Clothing/Head/Hats/pyjamasyndicateblack.rsi
 
 - type: entity
-  parent: [ClothingHeadBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingHeadBase]
   id: ClothingHeadPyjamaSyndicatePink
   name: syndicate pink pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -659,7 +659,7 @@
     sprite: Clothing/Head/Hats/pyjamasyndicatepink.rsi
 
 - type: entity
-  parent: [ClothingHeadBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingHeadBase]
   id: ClothingHeadPyjamaSyndicateRed
   name: syndicate red pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -763,7 +763,7 @@
       sprite: Clothing/Head/Hats/jester2.rsi
 
 - type: entity
-  parent: ClothingHeadBase # Frontier: removed BaseCommandContraband
+  parent: ClothingHeadBase
   id: ClothingHeadHatBeretCmo
   name: chief medical officer's beret
   description: Turquoise beret with a cross on the front. The sight of it calms you down and makes it clear that you will be cured.
@@ -820,7 +820,7 @@
         Caustic: 0.95
 
 - type: entity
-  parent: [ClothingHeadBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband added ContrabandClothing as parent
+  parent: [ClothingHeadBase]
   id: ClothingHeadHatSyndie
   name: syndicate hat
   description: A souvenir hat from "Syndieland", their production has already been closed.
@@ -831,7 +831,7 @@
     sprite: Clothing/Head/Hats/syndiecap.rsi
 
 - type: entity
-  parent: [ClothingHeadBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
+  parent: [ClothingHeadBase]
   id: ClothingHeadHatSyndieMAA
   name: master at arms hat
   description: Master at arms hat, looks intimidating, I doubt that you will like to communicate with its owner...
@@ -918,7 +918,7 @@
   - type: BlockMovement
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseCentcommContraband ]
+  parent: ClothingHeadBase
   id: ClothingHeadHatCentcomcap
   name: CentComm cap
   description: An extravagant, fancy Central Commander cap.

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -31,7 +31,7 @@
 
 #Basic Helmet (Security Helmet)
 - type: entity
-  parent: [ClothingHeadHelmetBase, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetBasic
   name: helmet
   description: Standard security gear. Protects the head from impacts.
@@ -47,7 +47,7 @@
 
 #Mercenary Helmet
 - type: entity
-  parent: [ ClothingHeadHelmetBase, BaseC1Contraband ] # Frontier: BaseMajorContraband <BaseC1Contraband
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetMercenary # Frontier - Name fix
   name: mercenary helmet
   description: The combat helmet is commonly used by mercenaries, is strong, light and smells like gunpowder and the jungle.
@@ -59,7 +59,7 @@
 
 #SWAT Helmet
 - type: entity
-  parent: [ClothingHeadBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingHeadBase
   id: ClothingHeadHelmetSwat
   name: SWAT helmet
   description: An extremely robust helmet, commonly used by paramilitary forces. This one has the Nanotrasen logo emblazoned on the top.
@@ -82,7 +82,7 @@
 
 #Syndicate SWAT Helmet
 - type: entity
-  parent: [BaseC3SyndicateContraband, ClothingHeadHelmetSwat, ContrabandClothing] # Frontier: added ContrabandClothing, BaseC3SyndicateContraband as parent
+  parent: [ClothingHeadHelmetSwat]
   id: ClothingHeadHelmetSwatSyndicate
   name: SWAT helmet
   suffix: Syndicate
@@ -95,7 +95,7 @@
 
 #Light Riot Helmet
 - type: entity
-  parent: [ClothingHeadBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingHeadBase
   id: ClothingHeadHelmetRiot
   name: light riot helmet
   description: It's a helmet specifically designed to protect against close range attacks.
@@ -154,7 +154,7 @@
 
 #Cult Helmet
 - type: entity
-  parent: [ClothingHeadBase, BaseC3CultContrabandNoValue, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3CultContrabandNoValue, ContrabandClothing as parent
+  parent: [ClothingHeadBase]
   id: ClothingHeadHelmetCult
   name: cult helmet
   description: A robust, evil-looking cult helmet.
@@ -174,7 +174,7 @@
 
 #Space Ninja Helmet
 - type: entity
-  parent: [ClothingHeadEVAHelmetBase, BaseC3Contraband, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3Contraband, add ContrabandClothing
+  parent: [ClothingHeadEVAHelmetBase]
   id: ClothingHeadHelmetSpaceNinja
   name: space ninja helmet
   description: What may appear to be a simple black garment is in fact a highly sophisticated nano-weave helmet. Standard issue ninja gear.
@@ -223,7 +223,7 @@
 
 #Wizard Helmet
 - type: entity
-  parent: [ClothingHeadBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
+  parent: [ClothingHeadBase]
   id: ClothingHeadHelmetWizardHelm
   name: wizard helm
   description: Strange-looking helmet that most certainly belongs to a real magic user.
@@ -267,7 +267,7 @@
 
 #Atmos Fire Helmet
 - type: entity
-  parent: ClothingHeadLightBase # Frontier: removed BaseEngineeringContraband
+  parent: ClothingHeadLightBase
   id: ClothingHeadHelmetAtmosFire
   name: atmos fire helmet
   description: An atmos fire helmet, able to keep the user cool in any situation.
@@ -301,7 +301,7 @@
 
 #Chitinous Helmet
 - type: entity
-  parent: [ ClothingHeadBase, BaseC3Contraband] # Frontier: BaseMajorContraband<BaseC3Contraband
+  parent: ClothingHeadBase
   id: ClothingHeadHelmetLing
   name: chitinous helmet
   description: An all-consuming chitinous mass of armor.
@@ -321,7 +321,7 @@
 #ERT HELMETS
 #ERT Leader Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetERTLeader
   name: ERT leader helmet
   description: An in-atmosphere helmet worn by the leader of a Nanotrasen Emergency Response Team. Has blue highlights.
@@ -333,7 +333,7 @@
 
 #ERT Security Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetERTSecurity
   name: ERT security helmet
   description: An in-atmosphere helmet worn by security members of the Nanotrasen Emergency Response Team. Has red highlights.
@@ -345,7 +345,7 @@
 
 #ERT Medic Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetERTMedic
   name: ERT medic helmet
   description: An in-atmosphere helmet worn by medical members of the Nanotrasen Emergency Response Team. Has white highlights.
@@ -357,7 +357,7 @@
 
 #ERT Engineer Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetERTEngineer
   name: ERT engineer helmet
   description: An in-atmosphere helmet worn by engineering members of the Nanotrasen Emergency Response Team. Has orange highlights.
@@ -369,7 +369,7 @@
 
 #ERT Janitor Helmet
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingHeadHelmetBase ]
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetERTJanitor
   name: ERT janitor helmet
   description: An in-atmosphere helmet worn by janitorial members of the Nanotrasen Emergency Response Team. Has dark purple highlights.
@@ -380,7 +380,7 @@
     sprite: Clothing/Head/Helmets/ert_janitor.rsi
 
 - type: entity
-  parent: [ BaseC3SyndicateContraband, ClothingHeadHelmetBase ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetRaid
   name: syndicate raid helmet
   description: An armored helmet for use with the syndicate raid suit. Very stylish.
@@ -399,7 +399,7 @@
 
 #Bone Helmet
 - type: entity
-  parent: [ ClothingHeadHelmetBase, BaseC1Contraband ] # Frontier: BaseMinorContraband<BaseC1Contraband
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetBone
   name: bone helmet
   description: Cool-looking helmet made of skull of your enemies.
@@ -413,7 +413,7 @@
     node: helmet
 
 - type: entity
-  parent: [ClothingHeadHelmetBase, BaseC1Contraband ] # Frontier: BaseMinorContraband<BaseC1Contraband
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetPodWars
   name: ironclad II helmet
   description: An ironclad II helmet, a relic of the pod wars.
@@ -425,7 +425,7 @@
 
 #Justice Helmet
 - type: entity
-  parent: [ ClothingHeadHelmetBase, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadHelmetJustice
   name: justice helm
   description: Advanced security gear. Protects the station from ne'er-do-wells.

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -106,7 +106,7 @@
     - Hair
 
 - type: entity
-  parent: [ClothingHeadBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
+  parent: [ClothingHeadBase]
   id: ClothingHeadHatHoodCulthood
   name: cult hood
   description: There's no cult without cult hoods.

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -172,7 +172,7 @@
     accent: MobsterAccent
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ClothingHeadBase
   id: ClothingHeadHatCatEars
   name: cat ears
   description: "NYAH!"

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -21,7 +21,7 @@
     hideOnToggle: true
 
 - type: entity
-  parent: [ClothingMaskGas, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: ClothingMaskGas
   id: ClothingMaskGasSecurity
   name: security gas mask
   description: A standard issue Security gas mask.
@@ -41,7 +41,7 @@
         Heat: 0.95
 
 - type: entity
-  parent: [ClothingMaskGas, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingMaskGas]
   id: ClothingMaskGasSyndicate
   name: syndicate gas mask
   description: A close-fitting tactical mask that can be connected to an air supply.
@@ -76,7 +76,7 @@
         Heat: 0.90 # Frontier 0.80<0.90
 
 - type: entity
-  parent: ClothingMaskGasAtmos # Frontier: removed BaseCommandContraband
+  parent: ClothingMaskGasAtmos
   id: ClothingMaskGasCaptain
   name: captain's gas mask
   description: Nanotrasen cut corners and repainted a spare atmospheric gas mask, but don't tell anyone.
@@ -89,7 +89,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: [ ClothingMaskGasAtmos, BaseCentcommContraband ]
+  parent: ClothingMaskGasAtmos
   id: ClothingMaskGasCentcom
   name: CentComm gas mask
   description: Oooh, gold and green. Fancy! This should help as you sit in your office.
@@ -102,7 +102,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: ClothingMaskGas # Frontier: removed BaseCargoContraband
+  parent: ClothingMaskGas
   id: ClothingMaskGasExplorer
   name: explorer gas mask
   description: A military-grade gas mask that can be connected to an air supply.
@@ -234,7 +234,7 @@
     node: mask
 
 - type: entity
-  parent: [ClothingMaskClown, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingMaskClown
   id: ClothingMaskClownSecurity
   name: security clown wig and mask
   description: A debatably oxymoronic but protective mask and wig.
@@ -361,7 +361,7 @@
     accent: StutteringAccent
 
 - type: entity
-  parent: [ ClothingMaskGas, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingMaskGas
   id: ClothingMaskGasSwat
   name: swat gas mask
   description: A elite issue Security gas mask.
@@ -387,7 +387,7 @@
         Heat: 0.95
 
 - type: entity
-  parent: [ ClothingMaskGas ] # Frontier: Removed BaseSecurityCargoContraband
+  parent: [ ClothingMaskGas ]
   id: ClothingMaskGasMercenary # Frontier: Merc to Mercenary
   name: mercenary gas mask
   description: Slightly outdated, but reliable military-style gas mask.
@@ -407,7 +407,7 @@
     id: ClothingMaskGasMercenary # Frontier
 
 - type: entity
-  parent: [ ClothingMaskGas, BaseCentcommContraband ]
+  parent: ClothingMaskGas
   id: ClothingMaskGasERT
   name: ert gas mask
   description: The gas mask of the elite squad of the ERT.

--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -9,13 +9,13 @@
     sprite: Clothing/Multiple/towel.rsi
   - type: Clothing
     sprite: Clothing/Multiple/towel.rsi
-    slots: 
+    slots:
     - BELT
     - INNERCLOTHING
     - HEAD
     femaleMask: UniformTop
-    equipSound: 
-    unequipSound: 
+    equipSound:
+    unequipSound:
   - type: Spillable
     solution: absorbed
   - type: Absorbent
@@ -160,7 +160,7 @@
         color: "#0089EF"
   - type: Fiber
     fiberColor: fibers-blue
-    
+
 - type: entity
   id: TowelColorDarkBlue
   name: dark blue towel
@@ -734,7 +734,7 @@
 - type: entity
   id: TowelColorSyndicate
   name: syndicate towel
-  parent: [ BaseTowel, BaseC3ContrabandNoValue ] # Frontier: BaseSyndicateContraband<BaseC3ContrabandNoValue
+  parent: BaseTowel
   components:
   - type: Sprite
     layers:
@@ -763,4 +763,3 @@
         color: "#535353"
   - type: Fiber
     fiberColor: fibers-black
-    

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -10,7 +10,7 @@
     stealGroup: HeadCloak # leaving this here because I suppose it might be interesting?
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckCloakCap
   name: captain's cloak
   description: A pompous and comfy blue cloak with a nice gold trim, while not particularly valuable as your other possessions, it sure is fancy.
@@ -21,7 +21,7 @@
     stealGroup: HeadCloak
 
 - type: entity
-  parent: [ClothingNeckBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingNeckBase
   id: ClothingNeckCloakHos
   name: head of security's cloak
   description: An exquisite dark and red cloak fitting for those who can assert dominance over wrongdoers. Take a stab at being civil in prosecution!
@@ -32,7 +32,7 @@
     stealGroup: HeadCloak
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckCloakCe
   name: chief engineer's cloak
   description: A dark green cloak with light blue ornaments, given to those who proved themselves to master the precise art of engineering.
@@ -43,7 +43,7 @@
     stealGroup: HeadCloak
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingCloakCmo
   name: chief medical officer's cloak
   description: A sterile blue cloak with a green cross, radiating with a sense of duty and willingness to help others.
@@ -54,7 +54,7 @@
     stealGroup: HeadCloak
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckCloakRd
   name: research director's cloak
   description: A white cloak with violet stripes, showing your status as the arbiter of cutting-edge technology.
@@ -65,7 +65,7 @@
     stealGroup: HeadCloak
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckCloakQm
   name: quartermaster's cloak
   description: A strong brown cloak with a reflective stripe, while not as fancy as others, it does show your managing skills.
@@ -76,7 +76,7 @@
     stealGroup: HeadCloak
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckCloakHop
   name: head of personnel's cloak
   description: A blue cloak with red shoulders and gold buttons, proving you are the gatekeeper to any airlock on the station.
@@ -105,7 +105,7 @@
     sprite: Clothing/Neck/Cloaks/nanotrasen.rsi
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckCloakCapFormal
   name: captain's formal cloak
   description: A lavish and decorated cloak for special occasions.

--- a/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/mantles.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckMantleCap
   name: captain's mantle
   description: A comfortable and chique mantle befitting of only the most experienced captain.
@@ -10,7 +10,7 @@
     sprite: Clothing/Neck/mantles/capmantle.rsi
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckMantleCE
   name: chief engineer's mantle
   description: High visibility, check. RIG system, check. High capacity cell, check. Everything a chief engineer could need in a stylish mantle.
@@ -21,7 +21,7 @@
     sprite: Clothing/Neck/mantles/cemantle.rsi
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckMantleCMO
   name: chief medical officer's mantle
   description: For a CMO that has been in enough medbays to know that more PPE means less central command dry cleaning visits when the shift is over.
@@ -32,7 +32,7 @@
     sprite: Clothing/Neck/mantles/cmomantle.rsi
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckMantleHOP
   name: head of personnel's mantle
   description: A good HOP knows that paper pushing is only half the job... petting your dog and looking fashionable is the other half.
@@ -43,7 +43,7 @@
     sprite: Clothing/Neck/mantles/hopmantle.rsi
 
 - type: entity
-  parent: [ClothingNeckBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingNeckBase
   id: ClothingNeckMantleHOS
   name: head of security's mantle
   description: Shootouts with syndicate agents are just another Tuesday for this HoS. This mantle is a symbol of commitment to the station.
@@ -54,7 +54,7 @@
     sprite: Clothing/Neck/mantles/hosmantle.rsi
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckMantleRD
   name: research director's mantle
   description: For when long days in the office consist of explosives, poisonous gas, murder robots, and a fresh pizza from cargo; this mantle will keep you comfy.
@@ -65,7 +65,7 @@
     sprite: Clothing/Neck/mantles/rdmantle.rsi
 
 - type: entity
-  parent: ClothingNeckBase # Frontier: removed BaseCommandContraband
+  parent: ClothingNeckBase
   id: ClothingNeckMantleQM
   name: quartermaster's mantle
   description: For the master of goods and materials to rule over the department, a befitting mantle to show off superiority!
@@ -84,4 +84,4 @@
   - type: Sprite
     sprite: Clothing/Neck/mantles/mantle.rsi
   - type: Clothing
-    sprite: Clothing/Neck/mantles/mantle.rsi 
+    sprite: Clothing/Neck/mantles/mantle.rsi

--- a/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
@@ -87,7 +87,7 @@
       sprite: Clothing/Neck/Scarfs/purple.rsi
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseC3SyndicateContraband, ContrabandClothing ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ ClothingScarfBase ]
   id: ClothingNeckScarfStripedSyndieGreen
   name: striped syndicate green scarf
   description: A stylish striped syndicate green scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
@@ -98,7 +98,7 @@
       sprite: Clothing/Neck/Scarfs/syndiegreen.rsi
 
 - type: entity
-  parent: [ClothingScarfBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingScarfBase]
   id: ClothingNeckScarfStripedSyndieRed
   name: striped syndicate red scarf
   description: A stylish striped syndicate red scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
@@ -109,7 +109,7 @@
       sprite: Clothing/Neck/Scarfs/syndiered.rsi
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseCentcommContraband ]
+  parent: ClothingScarfBase
   id: ClothingNeckScarfStripedCentcom
   name: striped CentComm scarf
   description: A stylish striped centcomm colored scarf. The perfect winter accessory for those with a keen fashion sense, and those who need to do paperwork in the cold.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -3,7 +3,7 @@
 
 #Basic armor vest for inheritance
 - type: entity
-  parent: [RecyclableItemClothArmor, ClothingOuterBaseMedium, AllowSuitStorageClothing, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemClothArmor
+  parent: [RecyclableItemClothArmor, ClothingOuterBaseMedium, AllowSuitStorageClothing] # added RecyclableItemClothArmor
   id: ClothingOuterArmorBase
   name: armor vest
   abstract: true
@@ -28,7 +28,7 @@
 
 #Standard armor vest, allowed for security and bartenders
 - type: entity
-  parent: [ClothingOuterArmorBase, ClothingArmorPlateLight] # Frontier: removed BaseSecurityBartenderContraband
+  parent: [ClothingOuterArmorBase, ClothingArmorPlateLight]
   id: ClothingOuterArmorBasic
   components:
   - type: Tag  # Mono
@@ -49,7 +49,7 @@
     sprite: Clothing/OuterClothing/Armor/security_slim.rsi
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
   id: ClothingOuterArmorRiot
   name: riot suit
   description: A suit of semi-flexible polycarbonate body armor with heavy padding to protect against melee attacks. Perfect for fighting delinquents around the station.
@@ -125,7 +125,7 @@
     coefficient: 0.5
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseC3SyndicateContraband, ContrabandClothing ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing ]
   id: ClothingOuterArmorRaid
   name: syndicate raid suit
   description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect its wearer from space.
@@ -208,7 +208,7 @@
     - Kevlar
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, BaseC3CultContraband, AllowSuitStorageClothing, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3CultContraband, added ContrabandClothing as parent
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
   id: ClothingOuterArmorCult
   name: acolyte armor
   description: An evil-looking piece of cult armor, made of bones.
@@ -277,7 +277,7 @@
     sprite: Clothing/OuterClothing/Armor/heavyred.rsi
 
 - type: entity
-  parent: [ClothingOuterArmorHeavy, BaseC3CultContraband, ContrabandClothing] # Frontier: added BaseC3CultContraband, ContrabandClothing as parent
+  parent: [ClothingOuterArmorHeavy]
   id: ClothingOuterArmorMagusblue
   name: blue magus armor
   description: An blue armored suit that provides good protection.
@@ -288,7 +288,7 @@
     sprite: Clothing/OuterClothing/Armor/magusblue.rsi
 
 - type: entity
-  parent: [ClothingOuterArmorHeavy, BaseC3WizardContraband, ContrabandClothing] # Frontier: added BaseC3WizardContraband, ContrabandClothing as parent
+  parent: [ClothingOuterArmorHeavy]
   id: ClothingOuterArmorMagusred
   name: red magus armor
   description: A red armored suit that provides good protection.
@@ -299,7 +299,7 @@
     sprite: Clothing/OuterClothing/Armor/magusred.rsi
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseC1Contraband] # Frontier: BaseCommandContraband<BaseC1Contraband
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
   id: ClothingOuterArmorCaptainCarapace
   name: "captain's carapace"
   description: "An armored chestpiece that provides protection whilst still offering maximum mobility and flexibility. Issued only to the captains of luxury vessels." # Frontier
@@ -329,7 +329,7 @@
     - Kevlar
 
 - type: entity
-  parent: [ ClothingOuterBaseLarge, BaseC3Contraband, AllowSuitStorageClothing ] # Frontier: BaseMajorContraband<BaseC3Contraband
+  parent: [ ClothingOuterBaseLarge, AllowSuitStorageClothing ]
   id: ClothingOuterArmorChangeling
   name: chitinous armor
   description: Inflates the changeling's body into an all-consuming chitinous mass of armor.
@@ -359,7 +359,7 @@
     coefficient: 0.8 # i mean, if the batong is electrical or whatever, and this is just hardened skin, it would probably still go through?
 
 - type: entity
-  parent: [ ClothingOuterBaseLarge, BaseC1Contraband, AllowSuitStorageClothing ] # Frontier: BaseMajorContraband<BaseC1Contraband
+  parent: [ ClothingOuterBaseLarge, AllowSuitStorageClothing ]
   id: ClothingOuterArmorBone
   name: bone armor
   description: Sits on you like a second skin.
@@ -389,7 +389,7 @@
     coefficient: 0.7
 
 - type: entity
-  parent: [ ClothingOuterBaseLarge, BaseC1Contraband, AllowSuitStorageClothing ] # Frontier: BaseMajorContraband<BaseC1Contraband
+  parent: [ ClothingOuterBaseLarge, AllowSuitStorageClothing ]
   id: ClothingOuterArmorPodWars
   name: ironclad II armor
   description: A repurposed suit of ironclad II armor, a relic of the pod wars.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -90,7 +90,7 @@
     damageCoefficient: 0.9
 
 - type: entity
-  parent: [ClothingOuterArmorHoS, ClothingOuterStorageBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityCommandContraband<BaseC2ContrabandUnredeemable
+  parent: [ClothingOuterArmorHoS, ClothingOuterStorageBase]
   id: ClothingOuterCoatHoSTrench
   name: head of security's armored trenchcoat
   description: A greatcoat enhanced with a special alloy for some extra protection and style for those with a commanding presence.
@@ -316,7 +316,7 @@
     sprite: Clothing/OuterClothing/Coats/pirate.rsi
 
 - type: entity
-  parent: [ClothingOuterArmorWarden, ClothingOuterStorageBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [ClothingOuterArmorWarden, ClothingOuterStorageBase]
   id: ClothingOuterCoatWarden
   name: warden's armored jacket
   description: A sturdy, utilitarian jacket designed to protect a warden from any brig-bound threats.
@@ -349,7 +349,7 @@
     sprite: Clothing/OuterClothing/Coats/clownpriest.rsi
 
 - type: entity
-  parent: [ClothingOuterStorageBase, BaseC3Contraband] # Frontier: BaseMajorContraband<BaseC3Contraband
+  parent: ClothingOuterStorageBase
   id: ClothingOuterDogi
   name: samurai dogi
   description: Dogi is a type of traditional Japanese clothing. The dogi is made of heavy, durable fabric, it is practical in combat and stylish in appearance. It is decorated with intricate patterns and embroidery on the back.
@@ -377,7 +377,7 @@
     sprite: Clothing/OuterClothing/Coats/windbreaker_paramedic.rsi
 
 - type: entity
-  parent: [ClothingOuterStorageBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, add ContrabandClothing as parent
+  parent: [ClothingOuterStorageBase]
   id: ClothingOuterCoatSyndieCap
   name: syndicate's coat
   description: The syndicate's coat is made of durable fabric, with gilded patterns.
@@ -388,7 +388,7 @@
     sprite: Clothing/OuterClothing/Coats/syndicate/coatsyndiecap.rsi
 
 - type: entity
-  parent: [BaseC3SyndicateContraband, ClothingOuterCoatHoSTrench, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, add ContrabandClothing as parent
+  parent: [ClothingOuterCoatHoSTrench]
   id: ClothingOuterCoatSyndieCapArmored
   name: syndicate's armored coat
   description: The syndicate's armored coat is made of durable fabric, with gilded patterns.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,5 +1,5 @@
 #When adding new hardsuits, please try to keep the organization consistent with hardsuit-helmets.yml (if possible.)
-# Mono hardsuit overhaul - see https://github.com/Monolith-Station/Monolith/pull/2694 
+# Mono hardsuit overhaul - see https://github.com/Monolith-Station/Monolith/pull/2694
 
 #CREW HARDSUITS
 #Basic Hardsuit
@@ -42,7 +42,7 @@
 
 #Atmospherics Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseEngineeringContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitAtmos
   name: atmos hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has thermal shielding.
@@ -86,7 +86,7 @@
 
 #Engineering Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseEngineeringContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitEngineering
   name: engineering hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has radiation shielding.
@@ -126,7 +126,7 @@
 
 #Spationaut Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseCargoContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSpatio
   name: spationaut hardsuit
   description: A lightweight hardsuit designed for industrial EVA in zero gravity.
@@ -169,7 +169,7 @@
 
 #Salvage Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseCargoContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSalvage
   name: mining hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has reinforced plating for wildlife encounters.
@@ -208,7 +208,7 @@
 
 #Goliath Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC1Contraband] # Frontier: BaseCargoContraband<BaseC1Contraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitGoliath
   name: goliath hardsuit
   description: A lightweight hardsuit, adorned with a patchwork of thick, chitinous goliath hide.
@@ -251,7 +251,7 @@
 
 #Maxim Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseCargoContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitMaxim
   name: salvager maxim hardsuit
   description: Fire. Heat. These things forge great weapons, they also forge great salvagers.
@@ -292,7 +292,7 @@
 
 #Security Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC2ContrabandUnredeemable] # Removed BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSecurity
   name: security hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
@@ -331,7 +331,7 @@
 
 #Brigmedic Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC2ContrabandUnredeemable] # Removed BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitBrigmedic
   name: brigmedic hardsuit
   description: Special hardsuit of the guardian angel of the brig. It is the medical version of the security hardsuit.
@@ -368,7 +368,7 @@
 
 #Warden's Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC2ContrabandUnredeemable] # BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitWarden
   name: warden's hardsuit
   description: A specialized riot suit geared to combat low pressure environments.
@@ -407,7 +407,7 @@
 
 #Captain's Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseCommandContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCap
   name: captain's armored spacesuit
   description: A formal armored spacesuit, made for the station's captain.
@@ -447,7 +447,7 @@
 
 #Chief Engineer's Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseCommandContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitEngineeringWhite
   name: chief engineer's hardsuit
   description: A special hardsuit that protects against hazardous, low pressure environments, made for the chief engineer of the station.
@@ -489,7 +489,7 @@
 
 #Chief Medical Officer's Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseCommandContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitMedical
   name: chief medical officer's hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Built with lightweight materials for faster movement.
@@ -526,7 +526,7 @@
 
 #Research Director's Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase # Removed BaseCommandContraband
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitRd
   name: experimental research hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
@@ -580,7 +580,7 @@
 
 #Head of Security's Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC2ContrabandUnredeemable] # BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSecurityRed
   name: head of security's hardsuit
   description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
@@ -660,7 +660,7 @@
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitBase]
   id: ClothingOuterHardsuitSyndie
   name: blood-red hardsuit
   description: A heavily armored hardsuit designed for work in special operations. Property of Gorlex Marauders.
@@ -707,7 +707,7 @@
 
 # Syndicate Medic Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitSyndie, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitSyndie]
   id: ClothingOuterHardsuitSyndieMedic
   name: blood-red medic hardsuit
   description: A heavily armored and agile advanced hardsuit specifically designed for field medic operations.
@@ -743,7 +743,7 @@
 
 #Syndicate Elite Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitBase]
   id: ClothingOuterHardsuitSyndieElite
   name: syndicate elite hardsuit
   description: An elite version of the blood-red hardsuit, with improved mobility and fireproofing. Property of Gorlex Marauders.
@@ -790,7 +790,7 @@
 
 #Syndicate Commander Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitBase]
   id: ClothingOuterHardsuitSyndieCommander
   name: syndicate commander hardsuit
   description: A bulked up version of the blood-red hardsuit, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
@@ -830,7 +830,7 @@
 
 #Cybersun Juggernaut Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: added BaseSyndicateContraband<BaseC3SyndicateContraband, ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitBase]
   id: ClothingOuterHardsuitJuggernaut
   name: cybersun juggernaut suit
   description: A suit originally made by the cutting edge R&D department at cybersun to be hyper resilient, now recycled and used by the Phaethon Dynasty. Hefty and durable, but not fully insulated.
@@ -873,7 +873,7 @@
 
 #Wizard Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3WizardContraband, ContrabandClothing] # Frontier: BaseMagicalContraband<BaseC3WizardContraband, ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitBase]
   id: ClothingOuterHardsuitWizard
   name: wizard hardsuit
   description: A bizarre gem-encrusted suit that radiates magical energies.
@@ -913,7 +913,7 @@
 
 #Ling Space Suit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3Contraband, ContrabandClothing] # Frontier: added BaseC3Contraband, ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitBase]
   id: ClothingOuterHardsuitLing
   name: organic space suit
   description: A spaceworthy biomass of pressure and temperature resistant tissue.
@@ -952,7 +952,7 @@
 #Pirate EVA Suit (Deep Space EVA Suit)
 #Despite visually appearing like a softsuit, it functions exactly like a hardsuit would (parents off of base hardsuit, has resistances and toggleable clothing, etc.) so it goes here.
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3PirateContraband, ContrabandClothing] # Frontier: added BaseC3PirateContraband, ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitBase]
   id:  ClothingOuterHardsuitPirateEVA
   name: deep space EVA suit
   suffix: Rogue
@@ -991,7 +991,7 @@
 
 #Pirate Captain Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3PirateContraband, ContrabandClothing] # Frontier: added BaseC3PirateContraband<ContrabandClothing as parent
+  parent: [ClothingOuterHardsuitBase]
   id: ClothingOuterHardsuitPirateCap
   name: pirate captain's hardsuit
   description: An ancient armored hardsuit, perfect for defending against space scurvy and toolbox-wielding scallywags.
@@ -1033,7 +1033,7 @@
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieCommander ]
+  parent: ClothingOuterHardsuitSyndieCommander
   id: ClothingOuterHardsuitERTLeader
   name: ERT leader's hardsuit
   description: A protective hardsuit worn by the leader of an emergency response team.
@@ -1053,7 +1053,7 @@
 
 #ERT Chaplain Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitJuggernaut ]
+  parent: ClothingOuterHardsuitJuggernaut
   id: ClothingOuterHardsuitERTChaplain
   name: ERT chaplain's hardsuit
   description: A protective hardsuit worn by the chaplains of an Emergency Response Team.
@@ -1094,7 +1094,7 @@
 
 #ERT Medic Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieMedic ]
+  parent: ClothingOuterHardsuitSyndieMedic
   id: ClothingOuterHardsuitERTMedical
   name: ERT medic's hardsuit
   description: A protective hardsuit worn by the medics of an emergency response team.
@@ -1114,7 +1114,7 @@
 
 #ERT Security Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndie ]
+  parent: ClothingOuterHardsuitSyndie
   id: ClothingOuterHardsuitERTSecurity
   name: ERT security's hardsuit
   description: A protective hardsuit worn by the security officers of an emergency response team.
@@ -1158,7 +1158,7 @@
 
 #Deathsquad
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitBase ]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitDeathsquad
   name: death squad hardsuit
   description: An advanced hardsuit favored by commandos for use in special operations.
@@ -1203,7 +1203,7 @@
 
 #CBURN Hardsuit
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingOuterHardsuitBase ]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCBURN
   name: CBURN exosuit
   description: A lightweight yet strong exosuit used for special cleanup operations.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -105,7 +105,7 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/chaplain_hoodie.rsi
   - type: ToggleableClothing # Goobstation - Modsuits change
-    clothingPrototypes: 
+    clothingPrototypes:
       head: ClothingHeadHatHoodChaplainHood
 
 - type: entity
@@ -122,7 +122,7 @@
     accent: SpanishAccent
 
 - type: entity
-  parent: [ClothingOuterBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
+  parent: [ClothingOuterBase]
   id: ClothingOuterRobesCult
   name: cult robes
   description: There's no cult without classic red/crimson cult robes.
@@ -169,14 +169,14 @@
 
 - type: entity
   abstract: true
-  parent: [ ClothingOuterBase, AllowSuitStorageClothingGasTanks, BaseC3WizardContraband ] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: [ ClothingOuterBase, AllowSuitStorageClothingGasTanks ]
   id: ClothingOuterWizardBase
   components:
   - type: WizardClothes
 
 # Is this wizard wearing a fanny pack???
 - type: entity
-  parent: [ClothingOuterWizardBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
+  parent: [ClothingOuterWizardBase]
   id: ClothingOuterWizardViolet
   name: violet wizard robes
   description: A bizarre gem-encrusted violet robe that radiates magical energies.
@@ -187,7 +187,7 @@
     sprite: Clothing/OuterClothing/Misc/violetwizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
+  parent: [ClothingOuterWizardBase]
   id: ClothingOuterWizard
   name: wizard robes
   description: A bizarre gem-encrusted blue robe that radiates magical energies.
@@ -198,7 +198,7 @@
     sprite: Clothing/OuterClothing/Misc/wizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ContrabandClothing] # Frontier: added ContrabandClothing as parent
+  parent: [ClothingOuterWizardBase]
   id: ClothingOuterWizardRed
   name: red wizard robes
   description: Strange-looking, red, hat-wear that most certainly belongs to a real magic user.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -20,7 +20,7 @@
 
 #Syndicate EVA
 - type: entity
-  parent: [ClothingOuterEVASuitBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: added BaseC3SyndicateContraband, ContrabandClothing as parent
+  parent: [ClothingOuterEVASuitBase]
   id: ClothingOuterHardsuitSyndicate # TODO: rename to ClothingOuterEVASuitSyndicate
   name: syndicate EVA suit
   description: "Has a tag on the back that reads: 'Totally not property of an enemy corporation, honest!'"

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -128,7 +128,7 @@
     slots: WITHOUT_POCKET
 
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseToggleClothing, BaseC3Contraband, ContrabandClothing] # Frontier: BaseMajorContraband<BaseC3Contraband, added ContrabandClothing as parent
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseToggleClothing]
   id: ClothingOuterSuitSpaceNinja
   name: space ninja suit
   description: This black technologically advanced, cybernetically-enhanced suit provides many abilities like invisibility or teleportation.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -1,6 +1,6 @@
 #Web vest
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, add ContrabandClothing
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing]
   id: ClothingOuterVestWeb
   name: web vest
   description: A synthetic armor vest. This one has added webbing and ballistic plates.
@@ -21,7 +21,7 @@
 
 #Mercenary web vest
 - type: entity
-  parent: [ BaseC1Contraband, ClothingOuterStorageBase, AllowSuitStorageClothing] #web vest so it should have some pockets for ammo # Frontier: ClothingOuterVestWeb < "ClothingOuterStorageBase, AllowSuitStorageClothing"
+  parent: [ ClothingOuterStorageBase, AllowSuitStorageClothing] #web vest so it should have some pockets for ammo # Frontier: ClothingOuterVestWeb < "ClothingOuterStorageBase, AllowSuitStorageClothing"
   id: ClothingOuterVestWebMercenary # Frontier: Merc<Mercenary
   name: mercenary web vest
   description: A high-quality armored vest made from a hard synthetic material. It's surprisingly flexible and light, despite formidable armor plating.
@@ -43,7 +43,7 @@
 
 #Detective's vest
 - type: entity
-  parent: [ClothingOuterArmorBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingOuterArmorBase
   id: ClothingOuterVestDetective
   name: detective's vest
   description: A hard-boiled private investigator's armored vest.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -78,7 +78,7 @@
       head: ClothingHeadHatHoodWinterBartender
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterCap
   name: captain's winter coat
   components:
@@ -106,7 +106,7 @@
       head: ClothingHeadHatHoodWinterCargo
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterCE
   name: chief engineer's winter coat
   components:
@@ -120,7 +120,7 @@
       head: ClothingHeadHatHoodWinterCE
 
 - type: entity
-  parent: [ ClothingOuterWinterCoatToggleable, BaseCentcommContraband ]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterCentcom
   name: CentComm winter coat
   components:
@@ -167,7 +167,7 @@
       head: ClothingHeadHatHoodWinterChem
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterCMO
   name: chief medical officer's winter coat
   components:
@@ -233,7 +233,7 @@
       head: ClothingHeadHatHoodWinterSci
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterHoP
   name: head of personnel's winter coat
   components:
@@ -249,7 +249,7 @@
 
 ##########################################################
 - type: entity
-  parent: [ClothingOuterArmorHoS, ClothingOuterWinterCoatToggleable, BaseC2ContrabandUnredeemable]
+  parent: [ClothingOuterArmorHoS, ClothingOuterWinterCoatToggleable]
   id: ClothingOuterWinterHoS
   name: head of security's armored winter coat
   description: A sturdy, utilitarian winter coat designed to protect a head of security from any brig-bound threats and hypothermic events.
@@ -271,7 +271,7 @@
 ##########################################################
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseC2ContrabandUnredeemable]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterHoSUnarmored
   name: head of security's winter coat
   description: A sturdy coat, a warm coat, but not an armored coat.
@@ -390,7 +390,7 @@
       head: ClothingHeadHatHoodWinterPara
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterQM
   name: quartermaster's winter coat
   components:
@@ -405,7 +405,7 @@
 
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterRD
   name: research director's winter coat
   components:
@@ -462,7 +462,7 @@
       head: ClothingHeadHatHoodWinterSci
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseC2ContrabandUnredeemable]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterSec
   name: security winter coat
   components:
@@ -498,7 +498,7 @@
 
 ################################################################
 - type: entity
-  parent: [ClothingOuterArmorWarden, ClothingOuterWinterCoatToggleable, BaseC2ContrabandUnredeemable]
+  parent: [ClothingOuterArmorWarden, ClothingOuterWinterCoatToggleable]
   id: ClothingOuterWinterWarden
   name: warden's armored winter coat
   description: A sturdy, utilitarian winter coat designed to protect a warden from any brig-bound threats and hypothermic events.
@@ -520,7 +520,7 @@
 ################################################################
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseC2ContrabandUnredeemable]
+  parent: ClothingOuterWinterCoatToggleable
   id: ClothingOuterWinterWardenUnarmored
   name: warden's winter coat
   description: A sturdy coat, a warm coat, but not an armored coat.
@@ -535,7 +535,7 @@
       head: ClothingHeadHatHoodWinterWarden
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseC3SyndicateContraband, ContrabandClothing]
+  parent: [ClothingOuterWinterCoatToggleable]
   id: ClothingOuterWinterSyndieCap
   name: syndicate's winter coat
   description: "The syndicate's winter coat is made of durable fabric, with gilded patterns, and coarse wool."
@@ -551,7 +551,7 @@
 
 ##############################################################
 - type: entity
-  parent: [ClothingOuterWinterWarden, BaseC3SyndicateContraband, ContrabandClothing]
+  parent: [ClothingOuterWinterWarden]
   id: ClothingOuterWinterSyndieCapArmored
   name: syndicate's armored winter coat
   description: "The syndicate's armored winter coat is made of durable fabric, with gilded patterns, and coarse wool."
@@ -566,7 +566,7 @@
 ##############################################################
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseC3SyndicateContraband, ContrabandClothing]
+  parent: [ClothingOuterWinterCoatToggleable]
   id: ClothingOuterWinterSyndie
   name: syndicate's winter coat
   description: Insulated winter coat, looks like a merch from "Syndieland".

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -11,7 +11,7 @@
   - type: Matchbox
 
 - type: entity
-  parent: [ClothingShoesMilitaryBase, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: ClothingShoesMilitaryBase
   id: ClothingShoesBootsJack
   name: jackboots
   # description: Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time. # Frontier
@@ -22,7 +22,7 @@
   - type: Clothing
     sprite: Clothing/Shoes/Boots/jackboots.rsi
   # - type: ClothingSlowOnDamageModifier # Mono: Added to parent
-  #   modifier: 0.5 
+  #   modifier: 0.5
 
 - type: entity
   parent: ClothingShoesBaseButcherable
@@ -48,7 +48,7 @@
     sprite: Clothing/Shoes/Boots/performer.rsi
 
 - type: entity
-  parent: [ClothingShoesMilitaryBase, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: ClothingShoesMilitaryBase
   id: ClothingShoesBootsCombat
   name: combat boots
   description: Robust combat boots for combat scenarios or combat situations. All combat, all the time.
@@ -79,7 +79,7 @@
         variation: 0.09
 
 - type: entity
-  parent: [ ClothingShoesMilitaryBase ] # Frontier: removed BaseRestrictedContraband
+  parent: [ ClothingShoesMilitaryBase ]
   id: ClothingShoesBootsMercenary # Frontier: Merc to Mercenary
   name: mercenary boots
   description: Boots that have gone through many conflicts and that have proven their combat reliability.
@@ -151,7 +151,7 @@
     sprite: Clothing/Shoes/Boots/winterbootssci.rsi
 
 - type: entity
-  parent: [ClothingShoesBaseWinterBoots, ClothingShoesMilitaryBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [ClothingShoesBaseWinterBoots, ClothingShoesMilitaryBase]
   id: ClothingShoesBootsWinterSec
   name: security winter boots
   components:
@@ -161,7 +161,7 @@
     sprite: Clothing/Shoes/Boots/winterbootssec.rsi
 
 - type: entity
-  parent: [ClothingShoesBaseWinterBoots, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ClothingShoesBaseWinterBoots
   id: ClothingShoesBootsWinterSyndicate
   name: syndicate's winter boots
   description: Durable heavy boots, looks like merch from "Syndieland".

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -40,7 +40,7 @@
   id: ClothingShoesBootsMag
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase] # Frontier: removed BaseGrandTheftContraband
+  parent: [ClothingShoesBootsMagBase]
   id: ClothingShoesBootsMagAdv
   name: advanced magboots
   description: State-of-the-art magnetic boots that do not slow down their wearer.
@@ -84,7 +84,7 @@
     price: 3000
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [ClothingShoesBootsMagBase, BaseJetpack]
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
   description: Reverse-engineered magnetic boots that have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -209,8 +209,6 @@
   description: Stylish black shoes.
   components:
   - type: NoSlip
-  - type: Contraband # Frontier
-    hideValues: true # Frontier
 
 - type: entity
   parent: ClothingShoesClown

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -93,7 +93,7 @@
     netsync: false
 
 - type: entity
-  parent: [ClothingShoesBaseButcherable, BaseC3CultContraband, ContrabandClothing ] # Frontier: added BaseC3CultContraband, ContrabandClothing
+  parent: [ClothingShoesBaseButcherable ]
   id: ClothingShoesCult
   name: cult shoes
   description: A pair of boots worn by the followers of Nar'Sie.
@@ -104,7 +104,7 @@
     sprite: Clothing/Shoes/Specific/cult.rsi
 
 - type: entity
-  parent: ClothingShoesBase # Frontier: remove BaseJanitorContraband
+  parent: ClothingShoesBase
   id: ClothingShoesGaloshes
   name: galoshes
   description: Rubber boots.
@@ -121,7 +121,7 @@
     maxContactWalkSlowdown: 0.7
 
 - type: entity
-  parent: [ClothingShoesBaseButcherable, BaseC3Contraband, ContrabandClothing ] # Frontier: BaseMajorContraband<BaseC3Contraband, added ContrabandClothing
+  parent: [ClothingShoesBaseButcherable ]
   id: ClothingShoesSpaceNinja
   name: space ninja shoes
   description: A pair of nano-enhanced boots with built-in magnetic suction cups.
@@ -140,7 +140,7 @@
     footstepSoundCollection: null
 
 - type: entity
-  parent: [ClothingShoesBaseButcherable, BaseC2ContrabandUnredeemable] # Frontier: BaseMajorContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingShoesBaseButcherable
   id: ClothingShoesSwat
   name: swat shoes
   description: When you want to turn up the heat.
@@ -151,7 +151,7 @@
     sprite: Clothing/Shoes/Specific/swat.rsi
 
 - type: entity
-  parent: [ClothingShoesBaseButcherable, BaseC3WizardContraband] # Frontier: added BaseC3WizardContraband
+  parent: ClothingShoesBaseButcherable
   id: ClothingShoesWizard
   name: wizard shoes
   description: A pair of magic shoes.
@@ -202,7 +202,7 @@
           type: ChameleonBoundUserInterface
 
 - type: entity
-  parent: [ClothingShoesChameleon, BaseC3SyndicateContraband] # Frontier: add BaseC3SyndicateContraband
+  parent: ClothingShoesChameleon
   id: ClothingShoesChameleonNoSlips
   name: black shoes #actual name and description in uplink_catalog.yml
   suffix: No-slip, Chameleon

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -10,7 +10,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/bartender.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtCaptain
   name: captain's jumpskirt
   description: It's a blue jumpskirt with some gold markings denoting the rank of "Captain".
@@ -32,7 +32,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/cargotech.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtChiefEngineer
   name: chief engineer's jumpskirt
   description: It's a high visibility jumpskirt given to those engineers insane enough to achieve the rank of Chief Engineer.
@@ -43,7 +43,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/ce.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtChiefEngineerTurtle
   name: chief engineer's turtleneck
   description: A yellow turtleneck designed specifically for work in conditions of the engineering department.
@@ -109,7 +109,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/genetics.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtCMO
   name: chief medical officer's jumpskirt
   description: It's a jumpskirt worn by those with the experience to be Chief Medical Officer. It provides minor biological protection.
@@ -120,7 +120,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/cmo.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtCMOTurtle
   name: chief medical officer's turtleneck jumpskirt
   description: It's a turtleneck worn by those with the experience to be Chief Medical Officer. It provides minor biological protection.
@@ -164,7 +164,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/engineering.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: removed BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtHoP
   name: head of personnel's jumpskirt
   description: Rather bland and inoffensive. Perfect for vanishing off the face of the universe.
@@ -175,7 +175,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/hop.rsi
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtHoS
   name: head of security's jumpskirt
   description: It's bright red and rather crisp, much like security's victims tend to be.
@@ -200,7 +200,7 @@
         sprite: Clothing/Uniforms/Jumpsuit/hos.rsi
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtHoSAlt
   name: head of security's turtleneck
   description: It's a turtleneck worn by those strong and disciplined enough to achieve the position of Head of Security.
@@ -211,7 +211,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/hos_alt.rsi
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtHoSParadeMale
   name: head of security's parade uniform
   description: A head of security's luxury-wear, for special occasions.
@@ -327,7 +327,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtQM
   name: quartermaster's jumpskirt
   description: 'What can brown do for you?'
@@ -338,7 +338,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/qm.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtQMTurtleneck
   name: quartermasters's turtleneck
   description: A sharp turtleneck made for the hardy work environment of supply.
@@ -349,7 +349,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/qmturtleskirt.rsi
 
 - type: entity
-  parent: ClothingUniformSkirtBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtResearchDirector
   name: research director's turtleneck
   description: It's a turtleneck worn by those with the know-how to achieve the position of Research Director. Its fabric provides minor protection from biological contaminants.
@@ -382,7 +382,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/roboticist.rsi
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtSec
   name: security jumpskirt
   description: A jumpskirt made of strong material, providing robust protection.
@@ -408,7 +408,7 @@
 
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtWarden
   name: warden's uniform
   description: A formal security suit for officers complete with shiny Star belt buckle.
@@ -489,7 +489,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/centcomformaldress.rsi
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtHosFormal
   name: hos's formal dress
   description: A dress for special occasions.
@@ -500,7 +500,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/hosformaldress.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformSkirtBase, BaseC3SyndicateContraband, ContrabandClothing ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, ContrabandClothing
+  parent: [UnsensoredClothingUniformSkirtBase ]
   id: ClothingUniformJumpskirtOperative
   name: operative jumpskirt
   description: Uniform for elite syndicate operatives performing tactical operations in deep space.
@@ -614,7 +614,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyergood.rsi
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: added BaseC3SyndicateContraband, ContrabandClothing
+  parent: [ClothingUniformSkirtBase]
   id: ClothingUniformJumpskirtSyndieFormalDress
   name: syndicate formal dress
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."
@@ -680,7 +680,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/senior_physician.rsi
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtSeniorOfficer
   name: senior officer jumpskirt
   description: A sign of skill and prestige within the security department.
@@ -691,7 +691,7 @@
     sprite: Clothing/Uniforms/Jumpskirt/senior_officer.rsi
 
 - type: entity
-  parent: [ClothingUniformSkirtBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtSecGrey
   name: grey security jumpskirt
   description: A tactical relic of years past before military groups decided it was cheaper to dye the suits red instead of washing out the blood.

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -58,7 +58,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/bartender_purple.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitCaptain
   name: captain's jumpsuit
   description: It's a blue jumpsuit with some gold markings denoting the rank of "Captain".
@@ -91,7 +91,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/salvage.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitChiefEngineer
   name: chief engineer's jumpsuit
   description: It's a high visibility jumpsuit given to those engineers insane enough to achieve the rank of Chief Engineer.
@@ -102,7 +102,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ce.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitChiefEngineerTurtle
   name: chief engineer's turtleneck
   description: A yellow turtleneck designed specifically for work in conditions of the engineering department.
@@ -124,7 +124,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/chaplain.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseCentcommContraband ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitCentcomAgent
   name: CentComm agent's jumpsuit
   description: A suit worn by CentComm's legal team. Smells of burnt coffee.
@@ -135,7 +135,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/centcom_agent.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseCentcommContraband ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitCentcomOfficial
   name: CentComm official's jumpsuit
   description: It's a jumpsuit worn by CentComm's officials.
@@ -146,7 +146,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/centcom_official.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseCentcommContraband ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitCentcomOfficer
   name: CentComm officer's jumpsuit
   description: It's a jumpsuit worn by CentComm Officers.
@@ -253,7 +253,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/jester2.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitCMO
   name: chief medical officer's jumpsuit
   description: It's a jumpsuit worn by those with the experience to be Chief Medical Officer. It provides minor biological protection.
@@ -264,7 +264,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/cmo.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitCMOTurtle
   name: chief medical officer's turtleneck jumpsuit
   description: It's a turtleneck worn by those with the experience to be Chief Medical Officer. It provides minor biological protection.
@@ -319,7 +319,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/engineering_hazard.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoP
   name: head of personnel's jumpsuit
   description: Rather bland and inoffensive. Perfect for vanishing off the face of the universe.
@@ -330,7 +330,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hop.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoS
   name: head of security's jumpsuit
   description: It's bright red and rather crisp, much like security's victims tend to be.
@@ -353,7 +353,7 @@
       - state: overlay-inhand-right
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoSAlt
   name: head of security's turtleneck
   description: It's a turtleneck worn by those strong and disciplined enough to achieve the position of Head of Security.
@@ -364,7 +364,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hos_alt.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoSBlue
   name: head of security's blue jumpsuit
   description: A blue jumpsuit of Head of Security.
@@ -375,7 +375,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hos_blue.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoSGrey
   name: head of security's grey jumpsuit
   description: A grey jumpsuit of Head of Security, which make him look somewhat like a passenger.
@@ -386,7 +386,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hos_grey.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHoSParadeMale
   name: head of security's parade uniform
   description: A male head of security's luxury-wear, for special occasions.
@@ -513,7 +513,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitQM
   name: quartermaster's jumpsuit
   description: 'What can brown do for you?'
@@ -524,7 +524,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/qm.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitQMTurtleneck
   name: quartermasters's turtleneck
   description: A sharp turtleneck made for the hardy work environment of supply.
@@ -535,7 +535,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/qmturtle.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitQMFormal
   name: quartermasters's formal suit
   description: Inspired by the quartermasters of military's past, the perfect outfit for supplying a formal occasion.
@@ -546,7 +546,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/qmformal.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: remove BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitResearchDirector
   name: research director's turtleneck
   description: It's a turtleneck worn by those with the know-how to achieve the position of Research Director. Its fabric provides minor protection from biological contaminants.
@@ -590,7 +590,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/roboticist.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitSec
   name: security jumpsuit
   description: A jumpsuit made of strong material, providing robust protection.
@@ -624,7 +624,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/security_blue.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitSecGrey
   name: grey security jumpsuit
   description: A tactical relic of years past before military groups decided it was cheaper to dye the suits red instead of washing out the blood.
@@ -635,7 +635,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/security_grey.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformSecurityTrooper
   name: trooper uniform
   description: A formal uniform issued to the TSF Troopers. It used to come with a car.
@@ -646,7 +646,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/security_trooper.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitWarden
   name: warden's uniform
   description: A formal security suit for officers complete with Nanotrasen belt buckle.
@@ -757,7 +757,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/lawyergood.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [UnsensoredClothingUniformBase]
   id: ClothingUniformJumpsuitPyjamaSyndicateBlack
   name: black syndicate pyjamas
   description: For those long nights in perma.
@@ -768,7 +768,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicateblack.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [UnsensoredClothingUniformBase]
   id: ClothingUniformJumpsuitPyjamaSyndicatePink
   name: pink syndicate pyjamas
   description: For those long nights in perma.
@@ -779,7 +779,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicatepink.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [UnsensoredClothingUniformBase]
   id: ClothingUniformJumpsuitPyjamaSyndicateRed
   name: red syndicate pyjamas
   description: For those long nights in perma.
@@ -801,7 +801,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/nanotrasen.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: removed BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitCapFormal
   name: captain's formal suit
   description: A suit for special occasions.
@@ -812,7 +812,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/capformal.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: added BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitCentcomFormal
   name: central command formal suit
   description: A suit for special occasions.
@@ -823,7 +823,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/centcomformal.rsi
 
 - type: entity
-  parent: ClothingUniformBase # Frontier: removed BaseCommandContraband
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitHosFormal
   name: hos's formal suit
   description: A suit for special occasions.
@@ -834,7 +834,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hosformal.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as parent
+  parent: [UnsensoredClothingUniformBase]
   id: ClothingUniformJumpsuitOperative
   name: operative jumpsuit
   description: Uniform for elite syndicate operatives performing tactical operations in deep space.
@@ -981,7 +981,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/musician.rsi
 
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingUniformBase ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitERTChaplain
   name: ERT chaplain uniform
   description: A special suit made for Central Command's elite chaplain corps.
@@ -992,7 +992,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ert_chaplain.rsi
 
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingUniformBase ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitERTEngineer
   name: ERT engineering uniform
   description: A special suit made for the elite engineers under CentComm.
@@ -1003,7 +1003,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ert_engineer.rsi
 
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingUniformBase ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitERTJanitor
   name: ERT janitorial uniform
   description: A special suit made for the elite janitors under CentComm.
@@ -1014,7 +1014,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ert_janitor.rsi
 
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingUniformBase ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitERTLeader
   name: ERT leader uniform
   description: A special suit made for the best of the elites under CentComm.
@@ -1025,7 +1025,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ert_leader.rsi
 
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingUniformBase ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitERTMedic
   name: ERT medical uniform
   description: A special suit made for the elite medics under CentComm.
@@ -1036,7 +1036,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/ert_medic.rsi
 
 - type: entity
-  parent: [ BaseCentcommContraband, ClothingUniformBase ]
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitERTSecurity
   name: ERT security uniform
   description: A special suit made for the elite security under CentComm.
@@ -1142,7 +1142,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hawaiyellow.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC3SyndicateContraband, ContrabandClothing] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added ContrabandClothing as a parent
+  parent: [ClothingUniformBase]
   id: ClothingUniformJumpsuitSyndieFormal
   name: syndicate formal suit
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."
@@ -1197,7 +1197,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/senior_physician.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ClothingUniformBase
   id: ClothingUniformJumpsuitSeniorOfficer
   name: senior officer jumpsuit
   description: A sign of skill and prestige within the security department.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2386,7 +2386,7 @@
 
 - type: entity
   name: grenade penguin
-  parent: [ MobPenguin, MobCombat, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [ MobPenguin, MobCombat ]
   id: MobGrenadePenguin
   description: A small penguin with a grenade strapped around its neck. Harvested by the Syndicate from icy shit-hole planets.
   components:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -260,7 +260,7 @@
 
 - type: entity
   id: AntimovCircuitBoard
-  parent: [BaseElectronics, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseElectronics
   name: law board (Antimov)
   description: An electronics board containing the Antimov lawset.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -274,7 +274,7 @@
       prob: 0.10
       orGroup: Pizza
     - id: KnifePlastic
-  
+
 - type: entity
   name: pizza box
   parent: FoodBoxPizzaFilled
@@ -589,7 +589,7 @@
 
 - type: entity
   id: HappyHonkNukie
-  parent: [HappyHonk, BaseC3SyndicateContrabandUnredeemable] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContrabandUnredeemable
+  parent: HappyHonk
   name: robust nukie meal
   description: A sus meal with a potentially explosive surprise.
   suffix: Toy Unsafe

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -286,7 +286,7 @@
 - type: entity
   name: prime-cut corgi meat
   # can't rot since that would be very bad for syndies
-  parent: [FoodMeatBase, BaseC3Contraband] # Frontier: BaseGrandTheftContraband<BaseC3Contraband
+  parent: FoodMeatBase
   id: FoodMeatCorgi
   description: The tainted gift of an evil crime. The meat may be delicious, but at what cost?
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1752,7 +1752,7 @@
 
 - type: entity
   name: gatfruit
-  parent: [ FoodProduceBase, BaseC3SyndicateContrabandUnredeemable ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContrabandUnredeemable
+  parent: FoodProduceBase
   id: FoodGatfruit
   description: A delicious, gun-shaped fruit with a thick wooden stem.
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -184,7 +184,7 @@
 
 - type: entity
   id: CigPackSyndicate
-  parent: [CigPackBase, BaseC3SyndicateContrabandNoValue] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: CigPackBase
   name: Interdyne herbals packet
   description: Elite cigarettes for elite syndicate agents. Infused with medicine for when you need to do more than calm your nerves.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -286,7 +286,7 @@
       prototype: ComputerWallmountCrewMonitoring # Frontier
 
 - type: entity
-  parent: [BaseComputerCircuitboard, BaseC2ContrabandUnredeemable] # Frontier: BaseGrandTheftContraband<BaseC2ContrabandUnredeemable
+  parent: BaseComputerCircuitboard
   id: IDComputerCircuitboard
   name: ID card computer board
   description: A computer printed circuit board for an ID card console.
@@ -318,7 +318,7 @@
       prototype: ComputerTabletopBodyScanner # Frontier
 
 - type: entity
-  parent: [BaseComputerCircuitboard, BaseC2ContrabandUnredeemable] # Frontier: BaseGrandTheftContraband<BaseC2ContrabandUnredeemable
+  parent: BaseComputerCircuitboard
   id: CommsComputerCircuitboard
   name: communications computer board
   description: A computer printed circuit board for a communications console.
@@ -331,7 +331,7 @@
       prototype: ComputerTabletopComms # Frontier
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseComputerCircuitboard
   id: SyndicateCommsComputerCircuitboard
   name: syndicate communications computer board
   description: A computer printed circuit board for a syndicate communications console.
@@ -344,7 +344,7 @@
       prototype: SyndicateComputerTabletopComms # Frontier
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseC3WizardContraband ] # Frontier: BaseSyndicateContraband<BaseC3WizardContraband
+  parent: BaseComputerCircuitboard
   id: WizardCommsComputerCircuitboard
   name: wizard communications computer board
   description: A computer printed circuit board for a wizard communications console.
@@ -355,7 +355,7 @@
     prototype: WizardComputerComms
 
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseCentcommContraband ]
+  parent: BaseComputerCircuitboard
   id: CentcommCommsComputerCircuitboard
   name: central command communications computer board
   description: A computer printed circuit board for a central command communications console.
@@ -555,7 +555,7 @@
 
 #Mono
 - type: entity
-  parent: [ BaseComputerCircuitboard, BaseC3PirateContrabandHighValue ] # Mono: From C3Syndicate
+  parent: BaseComputerCircuitboard # Mono: From C3Syndicate
   id: RogueCommsComputerCircuitboard
   name: imperial vanguard communications computer board
   description: A computer printed circuit board for a pdv console.

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/camera_bug.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/camera_bug.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: CameraBug
-  parent: [ BaseItem, BaseC3ContrabandNoValue ] # Frontier: BaseSyndicateContraband<BaseC3ContrabandNoValue
+  parent: BaseItem
   name: camera bug
   description: An illegal syndicate device that allows you to hack into the station's camera network.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/chimp_upgrade_kit.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/chimp_upgrade_kit.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: C.H.I.M.P. handcannon upgrade chip
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: WeaponPistolCHIMPUpgradeKit
   description: An experimental upgrade kit for the C.H.I.M.P.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/guardian_activators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/guardian_activators.yml
@@ -2,7 +2,7 @@
   name: holoparasite injector
   suffix: Ghost # Frontier
   id: HoloparasiteInjector
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   description: A complex artwork of handheld machinery allowing the user to host a holoparasite guardian.
   components:
   - type: Sprite
@@ -38,7 +38,7 @@
 - type: entity
   name: holoparasite box
   suffix: Ghost # Frontier
-  parent: [BoxCardboard, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BoxCardboard
   id: BoxHoloparasite
   description: A box containing a holoparasite injector.
   components:
@@ -55,7 +55,7 @@
 - type: entity
   name: holoclown box
   suffix: Ghost # Frontier
-  parent: [BoxCardboard, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BoxCardboard
   id: BoxHoloclown
   description: A box containing a holoclown injector.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   abstract: true
   id: ReinforcementRadio
   name: syndicate reinforcement radio

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/singularity_beacon.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: SingularityBeacon
-  parent: [BaseMachinePowered, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseMachinePowered
   name: singularity beacon
   description: A syndicate device that attracts the singularity. If it's loose and you're seeing this, run.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: ChameleonProjector
   name: chameleon projector
   description: Holoparasite technology used to create a hard-light replica of any object around you. Disguise is destroyed when picked up or deactivated.
@@ -12,7 +12,7 @@
       components:
       - Anchorable
       - Item
-      tags: 
+      tags:
       - Bot # for funny bot moments
     blacklist:
       components:

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -15,7 +15,7 @@
     stealGroup: DoorRemote
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteCommand
   name: command door remote
   components:
@@ -31,7 +31,7 @@
     - Command
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteSecurity
   name: security door remote
   components:
@@ -47,7 +47,7 @@
     - Security
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteArmory
   name: armory door remote
   components:
@@ -63,7 +63,7 @@
     - Armory
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteService
   name: service door remote
   components:
@@ -79,7 +79,7 @@
     - Service
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteResearch
   name: research door remote
   components:
@@ -95,7 +95,7 @@
     - Research
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteCargo
   name: cargo door remote
   components:
@@ -111,7 +111,7 @@
     - Cargo
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteMedical
   name: medical door remote
   components:
@@ -127,7 +127,7 @@
     - Medical
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteEngineering
   name: engineering door remote
   components:
@@ -143,7 +143,7 @@
     - Engineering
 
 - type: entity
-  parent: [DoorRemoteDefault, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: DoorRemoteDefault
   id: DoorRemoteAll
   name: super door remote
   suffix: Admeme

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -31,7 +31,7 @@
     - state: common_label
 
 - type: entity
-  parent: [EncryptionKey, RecyclableItemDeviceTiny] # Frontier: added RecyclableItemDeviceTiny, removed BaseCargoContraband
+  parent: [EncryptionKey, RecyclableItemDeviceTiny]
   id: EncryptionKeyCargo
   name: cargo encryption key
   categories: [ DoNotMap ] # Frontier
@@ -47,7 +47,7 @@
     - state: cargo_label
 
 - type: entity
-  parent: [EncryptionKey, BaseCentcommCommandContraband] # Frontier: Added BaseCentcommCommandContraband, removed BaseCentcommContraband.
+  parent: EncryptionKey
   id: EncryptionKeyCentCom
   name: central command encryption key
   categories: [ DoNotMap ] # Frontier
@@ -63,7 +63,7 @@
     - state: nano_label
 
 - type: entity
-  parent: [EncryptionKey, BaseC2ContrabandUnredeemable] # Frontier: BaseCentcommCommandContraband<BaseC2ContrabandUnredeemable
+  parent: EncryptionKey
   id: EncryptionKeyStationMaster
   name: station master encryption key
   categories: [ DoNotMap ] # Frontier
@@ -108,7 +108,7 @@
 # Mono end
 
 - type: entity
-  parent: [EncryptionKey, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: EncryptionKey
   id: EncryptionKeyCommand
   name: TSF command encryption key # mono
   categories: [ DoNotMap ] # Frontier
@@ -126,7 +126,7 @@
     id: EncryptionKeyFaction
 
 - type: entity
-  parent: [EncryptionKey, RecyclableItemDeviceTiny] # Frontier: added RecyclableItemDeviceTiny, removed BaseEngineeringContraband
+  parent: [EncryptionKey, RecyclableItemDeviceTiny]
   id: EncryptionKeyEngineering
   name: engineering encryption key
   categories: [ DoNotMap ] # Frontier
@@ -142,7 +142,7 @@
     - state: eng_label
 
 - type: entity
-  parent: [EncryptionKey, RecyclableItemDeviceTiny] # Frontier: added RecyclableItemDeviceTiny, removed BaseMedicalContraband
+  parent: [EncryptionKey, RecyclableItemDeviceTiny]
   id: EncryptionKeyMedical
   name: medical encryption key
   description: An encryption key used by those who save lives.
@@ -157,7 +157,7 @@
     - state: med_label
 
 - type: entity
-  parent: [EncryptionKey, RecyclableItemDeviceTiny] # Frontier: added RecyclableItemDeviceTiny, removed BaseMedicalScienceContraband
+  parent: [EncryptionKey, RecyclableItemDeviceTiny]
   id: EncryptionKeyMedicalScience
   name: med-sci encryption key
   categories: [ DoNotMap ] # Frontier
@@ -174,7 +174,7 @@
     - state: medsci_label
 
 - type: entity
-  parent: [EncryptionKey, RecyclableItemDeviceTiny] # Frontier: added RecyclableItemDeviceTiny, removed BaseScienceContraband
+  parent: [EncryptionKey, RecyclableItemDeviceTiny]
   id: EncryptionKeyScience
   name: science encryption key
   categories: [ DoNotMap ] # Frontier
@@ -190,7 +190,7 @@
     - state: sci_label
 
 - type: entity
-  parent: [EncryptionKey, RecyclableItemDeviceTiny] # Frontier: added RecyclableItemDeviceTiny, removed BaseScienceContraband
+  parent: [EncryptionKey, RecyclableItemDeviceTiny]
   id: EncryptionKeyRobo
   name: robotech encryption key
   categories: [ DoNotMap ] # Frontier
@@ -206,7 +206,7 @@
     - state: robotics_label
 
 - type: entity
-  parent: [ EncryptionKey, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityLawyerContraband<BaseC2ContrabandUnredeemable
+  parent: EncryptionKey
   id: EncryptionKeySecurity
   name: colonial security encryption key # mono
   categories: [ DoNotMap ] # Frontier
@@ -222,7 +222,7 @@
     - state: sec_label
 
 - type: entity
-  parent: [EncryptionKey, RecyclableItemDeviceTiny] # Frontier: added RecyclableItemDeviceTiny, removed BaseCivilianContraband
+  parent: [EncryptionKey, RecyclableItemDeviceTiny]
   id: EncryptionKeyService
   name: colonial staff encryption key # Mono
   categories: [ DoNotMap ] # Frontier
@@ -238,7 +238,7 @@
     - state: service_label
 
 - type: entity
-  parent: [EncryptionKey, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: EncryptionKey
   id: EncryptionKeySyndie
   name: blood-red encryption key
   categories: [ DoNotMap ] # Frontier
@@ -254,7 +254,7 @@
     - state: synd_label
 
 #- type: entity
-#  parent: [EncryptionKey, RecyclableItemDeviceTiny] # Frontier: added RecyclableItemDeviceTiny, removed BaseSiliconScienceContraband
+#  parent: [EncryptionKey, RecyclableItemDeviceTiny]
 #  id: EncryptionKeyBinary
 #  name: binary translator key
 #  categories: [ DoNotMap ] # Frontier
@@ -270,7 +270,7 @@
 #    - state: ai_label
 
 #- type: entity
-#  parent: [ EncryptionKey, BaseC3SyndicateContrabandNoValue ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContrabandNoValue
+#  parent: EncryptionKey
 #  id: EncryptionKeyBinarySyndicate
 #  name: binary translator key
 #  description: A syndicate encryption key that translates binary signals used by silicons.
@@ -285,7 +285,7 @@
 #    - state: ai_label
 
 - type: entity
-  parent: [EncryptionKey, BaseC3PirateContrabandHighValue] # Frontier: added BaseC3PirateContraband - Mono: Changed to HighValue
+  parent: EncryptionKey
   id: EncryptionKeyFreelance
   name: Vanguard encryption key # mono
   description: An encryption key used by imperials. # Mono

--- a/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/forensic_scanner.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: forensic scanner
-  parent: [BaseItem, RecyclableItemDeviceSmall] # Frontier: added RecyclableItemDeviceSmall, removed BaseSecurityContraband
+  parent: [BaseItem, RecyclableItemDeviceSmall]
   id: ForensicScanner
   description: A handheld device that can scan objects for fingerprints and fibers.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: HandTeleporter
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseC2ContrabandUnredeemable
+  parent: BaseItem
   name: hand teleporter
   description: "A Nanotrasen signature item--only the finest bluespace tech. Instructions: Use once to create a portal which teleports at random. Use again to link it to a portal at your current location. Use again to clear all portals."
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -21,7 +21,7 @@
 
 - type: entity
   name: explosive payload
-  parent: [BasePayload, BaseC2ContrabandUnredeemable] # Frontier: Added BaseC2ContrabandUnredeemable
+  parent: BasePayload
   id: ExplosivePayload
   components:
   - type: Sprite
@@ -87,7 +87,7 @@
 
 - type: entity
   name: flash payload
-  parent: [BasePayload, BaseC2ContrabandUnredeemable] # Frontier: Added BaseC2ContrabandUnredeemable
+  parent: BasePayload
   id: FlashPayload
   description: A single-use flash payload.
   components:

--- a/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pinpointer.yml
@@ -42,7 +42,7 @@
 - type: entity
   name: pinpointer
   id: PinpointerNuclear
-  parent: [ BaseC2ContrabandUnredeemable, PinpointerBase ] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: PinpointerBase
   components:
   - type: Pinpointer
     component: NukeDisk
@@ -52,7 +52,7 @@
   name: syndicate pinpointer
   description: Produced specifically for nuclear operative missions, get that disk!
   id: PinpointerSyndicateNuclear
-  parent: [ BaseC3SyndicateContraband, PinpointerBase ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: PinpointerBase
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Devices/radio.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/radio.yml
@@ -28,7 +28,7 @@
 - type: entity
   name: security radio
   description: A handy security radio.
-  parent: [ RadioHandheld, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: RadioHandheld
   id: RadioHandheldSecurity
   components:
   - type: RadioMicrophone

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -114,7 +114,7 @@
     sprite: Objects/Fun/Darts/dart_yellow.rsi
 
 - type: entity
-  parent: [Dart, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
+  parent: Dart
   id: HypoDart
   suffix: HypoDart
   components:
@@ -191,7 +191,7 @@
         acts: [ "Destruction" ]
 
 - type: entity
-  parent: [ BaseItem, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: HypoDartBox
   name: hypodart box
   suffix: HypoDart

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -115,7 +115,7 @@
   # Einstein Engines - Language end
 
 - type: entity
-  parent: [ PersonalAI, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: PersonalAI
   id: SyndicatePersonalAI
   name: syndicate personal ai device
   description: Your Syndicate pal who's fun to be with!

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1226,7 +1226,7 @@
       revolver-ammo: !type:Container
 
 - type: entity
-  parent: [RevolverCapGun, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
+  parent: RevolverCapGun
   id: RevolverCapGunFake
   name: cap gun
   suffix: Fake
@@ -1240,8 +1240,6 @@
         - Cartridge45_magnumFMJ
         - SpeedLoader45_magnumFMJ
     proto: Cartridge45_magnumAP
-  - type: Contraband # Frontier
-    hideValues: true # Frontier
 
 - type: entity
   parent: BaseItem
@@ -1424,7 +1422,7 @@
         volume: -10
 
 - type: entity
-  parent: BaseItem # Frontier: remove BaseMagicalContraband
+  parent: BaseItem
   id: PonderingOrb
   name: pondering orb
   description: Ponderous, man... Really ponderous.
@@ -1444,7 +1442,7 @@
     modifier: 0.001
 
 - type: entity
-  parent: [PonderingOrb, BaseC3WizardContraband] # Frontier: add BaseC3WizardContraband
+  parent: PonderingOrb
   id: PonderingOrbWizard
   name: pondering orb
   description: Ponderous, man... Really ponderous. Magically shows the station's camera network.

--- a/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/whistles.yml
@@ -42,7 +42,7 @@
     distance: 5
 
 - type: entity
-  parent: BaseWhistle # Frontier: removed BaseMinorContraband
+  parent: BaseWhistle
   id: SyndicateWhistle
   name: trench whistle
   description: A whistle used by Syndicate commanders to draw attention. Avanti!

--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: BaseSpellbook
   name: spellbook
-  parent: [ BaseItem, BaseC3WizardContraband ] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: BaseItem
   abstract: true
   components:
     - type: Sprite
@@ -25,7 +25,7 @@
   id: WizardsGrimoire
   name: wizards grimoire
   suffix: Wizard
-  parent: [ BaseItem, StorePresetSpellbook, BaseC3WizardContraband ] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: [ BaseItem, StorePresetSpellbook ]
   components:
     - type: Sprite
       sprite: Objects/Misc/books.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: nuclear authentication disk
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseGrandTheftContraband<BaseC2ContrabandUnredeemable
+  parent: BaseItem
   id: NukeDisk
   description: A nuclear auth disk, capable of arming a nuke if used along with a code. Note from nanotrasen reads "THIS IS YOUR MOST IMPORTANT POSESSION"
   components:
@@ -48,7 +48,7 @@
 
 - type: entity
   name: nuclear authentication disk
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseGrandTheftContraband<BaseC2ContrabandUnredeemable
+  parent: BaseItem
   id: NukeDiskFake
   suffix: Fake
   description: A nuclear auth disk, capable of arming a nuke if used along with a code. Note from nanotrasen reads "THIS IS YOUR MOST IMPORTANT POSESSION"

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -131,7 +131,7 @@
 - type: entity
   name: interrogator lamp
   id: LampInterrogator
-  parent: BaseLamp # Frontier: removed BaseSecurityContraband
+  parent: BaseLamp
   description: Ultra-bright lamp for the bad cop.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -2,7 +2,7 @@
   name: handcuffs
   description: Used to detain criminals and other assholes.
   id: Handcuffs
-  parent: [BaseItem, BaseC1Contraband] # Frontier: BaseSecurityCommandContraband<BaseC1Contraband
+  parent: BaseItem
   components:
   # Goobstation edit start
   - type: EmitSoundOnPickup

--- a/Resources/Prototypes/Entities/Objects/Misc/handy_flags.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handy_flags.yml
@@ -23,7 +23,7 @@
     sprite: Objects/Misc/Handy_Flags/NT_handy_flag.rsi
 
 - type: entity
-  parent: [BaseItem, BaseC3SyndicateContraband, RecyclableItemClothSmall] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband added RecyclableItemClothSmall
+  parent: [BaseItem, RecyclableItemClothSmall]
   id: SyndieHandyFlag
   name: syndicate handheld flag
   description: "For truly rebellious patriots. Death to NT!"

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -123,7 +123,7 @@
     - state: idintern-service
 
 - type: entity
-  parent: [IDCardStandard, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityCommandContraband<BaseC2ContrabandUnredeemable
+  parent: IDCardStandard
   id: CaptainIDCard
   name: captain ID card
   components:
@@ -605,7 +605,7 @@
 
 - type: entity
   name: contractor ID card # Frontier: passenger<contractor
-  parent: [IDCardStandard, BaseC3SyndicateContraband]
+  parent: IDCardStandard
   id: AgentIDCard
   suffix: Agent
   components:
@@ -637,8 +637,6 @@
         type: AgentIDCardBoundUserInterface
       enum.ChameleonUiKey.Key:
         type: ChameleonBoundUserInterface
-  - type: Contraband # Frontier
-    hideValues: true # Frontier
 
 - type: entity
   name: contractor ID card # Frontier: passenger<contractor
@@ -665,7 +663,7 @@
     job: AtmosphericTechnician
 
 - type: entity
-  parent: [IDCardStandard, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
+  parent: IDCardStandard
   id: SyndicateIDCard
   name: syndicate ID card
   components:
@@ -678,7 +676,7 @@
     - SyndicateAgent
 
 - type: entity
-  parent: [IDCardStandard, BaseC3PirateContraband] # Frontier: added BaseC3PirateContraband
+  parent: IDCardStandard
   id: PirateIDCard
   name: pirate ID card
   categories: [ HideSpawnMenu ] # Frontier

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -127,7 +127,7 @@
 
 - type: entity
   id: BaseImplantOnlyImplanterSyndi
-  parent: [BaseImplantOnlyImplanter, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseImplantOnlyImplanter
   name: syndicate implanter
   description: A compact disposable syringe exclusively designed for the injection of subdermal implants.
   abstract: true
@@ -186,7 +186,7 @@
 
 - type: entity
   id: TrackingImplanter
-  parent: [ BaseImplantOnlyImplanter, BaseC2ContrabandUnredeemable] # Frontier: BaseRestrictedContraband<BaseC2ContrabandUnredeemable
+  parent: BaseImplantOnlyImplanter
   suffix: tracking
   components:
     - type: Implanter
@@ -296,7 +296,7 @@
 
 - type: entity
   id: MindShieldImplanter
-  parent: [ BaseImplantOnlyImplanter, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityCommandContraband<BaseC2ContrabandUnredeemable
+  parent: BaseImplantOnlyImplanter
   suffix: mindshield
   components:
     - type: Implanter

--- a/Resources/Prototypes/Entities/Objects/Misc/medalcase.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/medalcase.yml
@@ -2,7 +2,7 @@
   id: MedalCase
   name: medal case
   description: Case with medals.
-  parent: [ BaseStorageItem, BaseBagOpenClose, BaseC2ContrabandUnredeemable ] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: [ BaseStorageItem, BaseBagOpenClose ]
   components:
   - type: Sprite
     sprite: _NF/Objects/Storage/medalcase.rsi # Frontier: add _NF prefix

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -565,7 +565,7 @@
 
 - type: entity
   id: BoxFolderQmClipboard
-  parent: [BoxFolderClipboard, BaseC2ContrabandUnredeemable] # Frontier: BaseGrandTheftContraband<BaseC2ContrabandUnredeemable
+  parent: BoxFolderClipboard
   name: requisition digi-board
   description: A bulky electric clipboard, filled with shipping orders and financing details. With so many compromising documents, you ought to keep this safe.
   components:
@@ -636,7 +636,7 @@
     stealGroup: BoxFolderQmClipboard
 
 - type: entity
-  parent: [Paper, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband # eat or burn your damn piece of paper damn thieves
+  parent: Paper # eat or burn your damn piece of paper damn thieves
   id: TraitorCodePaper
   name: syndicate codeword
   description: A leaked codeword to possibly get in touch with the Syndicate.
@@ -645,7 +645,7 @@
   - type: TraitorCodePaper
 
 - type: entity
-  parent: [Paper, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: Paper
   id: AllTraitorCodesPaper
   name: syndicate codewords registry
   description: A registry of all active Syndicate codewords.

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -107,8 +107,8 @@
 
 - type: entity
   name: Cybersun pen
-  # parent: [BaseAdvancedPen, BaseSyndicateContraband] # Frontier
-  parent: [NFBaseUnprotectedAdvancedPen, BaseC3SyndicateContraband] # Frontier
+  # parent: BaseAdvancedPen # Frontier
+  parent: NFBaseUnprotectedAdvancedPen # Frontier
   id: CyberPen
   description: A high-tech pen straight from Cybersun's legal department, capable of refracting hard-light at impossible angles through its diamond tip in order to write. So powerful, it's even able to rewrite officially stamped documents should the need arise.
   components:
@@ -119,7 +119,7 @@
 
 - type: entity
   name: CentComm pen
-  parent: [BaseAdvancedPen, BaseCentcommCommandContraband] # Frontier: Added BaseCentcommCommandContraband, removed BaseCentcommContraband.
+  parent: BaseAdvancedPen
   id: PenCentcom
   description: In an attempt to keep up with the "power" of the cybersun bureaucracy, NT made a replica of cyber pen, in their corporate style.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -43,7 +43,7 @@
 
 - type: entity
   name: captain's rubber stamp
-  parent: RubberStampBase # Frontier: remove BaseCommandContraband
+  parent: RubberStampBase
   id: RubberStampCaptain
   categories: [ DoNotMap ]
   components:
@@ -112,7 +112,7 @@
 
 - type: entity
   name: chief engineer's rubber stamp
-  parent: RubberStampBase # Frontier: remove BaseCommandContraband
+  parent: RubberStampBase
   id: RubberStampCE
   categories: [ DoNotMap ]
   components:
@@ -125,7 +125,7 @@
 
 - type: entity
   name: chief medical officer's rubber stamp
-  parent: RubberStampBase # Frontier: remove BaseCommandContraband
+  parent: RubberStampBase
   id: RubberStampCMO
   categories: [ DoNotMap ]
   components:
@@ -138,7 +138,7 @@
 
 - type: entity
   name: head of personnel's rubber stamp
-  parent: RubberStampBase # Frontier: remove BaseCommandContraband
+  parent: RubberStampBase
   id: RubberStampHop
   categories: [ DoNotMap ]
   components:
@@ -151,7 +151,7 @@
 
 - type: entity
   name: head of security's rubber stamp
-  parent: [RubberStampBase, BaseC2ContrabandUnredeemable] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: RubberStampBase
   id: RubberStampHos
   categories: [ DoNotMap ]
   components:
@@ -178,7 +178,7 @@
 
 - type: entity
   name: quartermaster's rubber stamp
-  parent: RubberStampBase # Frontier: remove BaseCommandContraband
+  parent: RubberStampBase
   id: RubberStampQm
   categories: [ DoNotMap ]
   components:
@@ -191,7 +191,7 @@
 
 - type: entity
   name: research director's rubber stamp
-  parent: RubberStampBase # Frontier: remove BaseCommandContraband
+  parent: RubberStampBase
   id: RubberStampRd
   categories: [ DoNotMap ]
   components:
@@ -216,7 +216,7 @@
 
 - type: entity
   name: syndicate rubber stamp
-  parent: [RubberStampBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: RubberStampBase
   id: RubberStampSyndicate
   categories: [ DoNotMap ]
   components:
@@ -229,7 +229,7 @@
 
 - type: entity
   name: warden's rubber stamp
-  parent: [RubberStampBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: RubberStampBase
   id: RubberStampWarden
   categories: [ DoNotMap ]
   components:
@@ -268,7 +268,7 @@
 
 - type: entity
   name: detective's rubber stamp
-  parent: [RubberStampBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: RubberStampBase
   id: RubberStampDetective
   categories: [ DoNotMap ]
   components:
@@ -300,7 +300,7 @@
   description: A rubber stamp for stamping important documents. Prescribe those treatments!
   components:
   - type: Stamp
-    stampedName: stamp-component-stamped-name-psychologist 
+    stampedName: stamp-component-stamped-name-psychologist
     stampedColor: "#3366FF" # Frontier: 5B97BC<3366FF
     stampState: "paper_stamp-nf-psychologist" # Frontier: psychologist<nf-psychologist
   - type: Sprite
@@ -309,7 +309,7 @@
 
 - type: entity
   name: wizard's rubber stamp
-  parent: [RubberStampBase, BaseC3WizardContraband] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: RubberStampBase
   id: RubberStampWizard
   description: A chaotic wizard stamp for serving unchaotic paperwork, how ironic.
   categories: [ DoNotMap ]

--- a/Resources/Prototypes/Entities/Objects/Power/powersink.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powersink.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: PowerSink
-  parent: [BaseMachine, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseMachine
   name: power sink
   description: Drains immense amounts of electricity from the grid.
   components:

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -64,7 +64,7 @@
 
 - type: entity
   name: riot shield
-  parent: [ BaseShield, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseShield
   id: RiotShield
   description: A large tower shield. Good for controlling crowds.
   components:
@@ -85,7 +85,7 @@
 
 - type: entity
   name: laser shield
-  parent: [ BaseShield, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseShield
   id: RiotLaserShield
   description: A shield built for withstanding lasers, but not much else.
   components:
@@ -105,7 +105,7 @@
 
 - type: entity
   name: ballistic shield
-  parent: [ BaseShield, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseShield
   id: RiotBulletShield
   description: A shield built for protecting against ballistics, but not much else.
   components:
@@ -368,7 +368,7 @@
 
 - type: entity
   name: energy shield
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: EnergyShield
   description: Exotic energy shield, when folded, can even fit in your pocket.
   components:
@@ -478,7 +478,7 @@
 
 - type: entity
   name: telescopic shield
-  parent: [BaseShield, BaseC2ContrabandUnredeemable] # Frontier: BaseC2ContrabandUnredeemable
+  parent: BaseShield
   id: TelescopicShield
   description: An advanced riot shield made of lightweight materials that collapses for easy storage.
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -56,7 +56,7 @@
     stealGroup: Bible
 
 - type: entity
-  parent: [Bible, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: Bible
   name: necronomicon
   description: "There's a note: Klatuu, Verata, Nikto -- Don't forget it again!"
   id: BibleNecronomicon

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -528,7 +528,7 @@
       sprite: Objects/Specific/Hydroponics/fly_amanita.rsi
 
 - type: entity
-  parent: [SeedBase, BaseC3SyndicateContrabandUnredeemable] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContrabandUnredeemable
+  parent: SeedBase
   name: packet of gatfruit seeds
   description: "These are no peashooters."
   id: GatfruitSeeds

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -117,7 +117,7 @@
 - type: entity
   name: soap
   id: SoapSyndie
-  parent: [Soap, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: Soap
   description: An untrustworthy bar of soap. Smells of fear.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -163,7 +163,7 @@
 
 - type: entity
   id: MechRipley
-  parent: [ BaseMech, IndustrialMech, BaseCargoContraband ] # Goobstation
+  parent: [ BaseMech, IndustrialMech ] # Goobstation
   name: Ripley APLU
   description: Versatile and lightly armored, the Ripley is useful for almost any heavy work scenario. The "APLU" stands for Autonomous Power Loading Unit.
   components:
@@ -216,7 +216,7 @@
       - PowerCellHigh
 
 - type: entity
-  parent: [ BaseMech, SpecialMech, BaseCivilianContraband ] # Goobstation
+  parent: [ BaseMech, SpecialMech ] # Goobstation
   id: MechHonker
   name: H.O.N.K.
   description: "Produced by \"Tyranny of Honk, INC\", this exosuit is designed as heavy clown-support. Used to spread the fun and joy of life. HONK!"

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -105,7 +105,7 @@
 
 - type: entity
   id: DefibrillatorSyndicate
-  parent: [DefibrillatorCompact, BaseC3SyndicateContraband] # Mono: BaseC3SyndicateContraband
+  parent: DefibrillatorCompact
   name: interdyne defibrillator
   description: Doubles as a self-defense weapon against war-crime inclined tiders.
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: handheld crew monitor
   # categories: [ DoNotMap ] # Frontier
-  parent: BaseHandheldComputer # Frontier: remove BaseGrandTheftContraband
+  parent: BaseHandheldComputer
   # CMO-only bud, don't add more.
   id: HandheldCrewMonitor
   description: A hand-held crew monitor displaying the status of suit sensors.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -1069,7 +1069,7 @@
 
 #this is where all the syringes are so i didn't know where to put it
 - type: entity
-  parent: [PrefilledSyringe, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: PrefilledSyringe
   suffix: romerol
   id: SyringeRomerol
   components:
@@ -1085,7 +1085,7 @@
 
 # Mono start
 - type: entity
-  parent: [PrefilledSyringe, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: PrefilledSyringe
   suffix: letoferol
   id: SyringeLetoferol
   components:
@@ -1101,7 +1101,7 @@
 # Mono end
 
 - type: entity
-  parent: [PrefilledSyringe, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: PrefilledSyringe
   suffix: hyperzine
   id: SyringeStimulants
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: hypospray
-  parent: BaseItem # Frontier: remove BaseGrandTheftContraband
+  parent: BaseItem
   description: The base, unrestricted hypospray. Designed by top Nanotrasen researchers, it features a large chemical storage, along with a next-to-zero injection delay. It has a warning on its side reading "FOR MEDICAL USE ONLY.".
   id: Hypospray
   components:
@@ -29,7 +29,7 @@
 
 - type: entity
   name: gorlex hypospray
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: add BaseC3SyndicateContraband
+  parent: BaseItem
   description: Using reverse engineered designs from NT, Cybersun produced these in limited quantities for Gorlex Marauder operatives.
   id: SyndiHypo
   components:
@@ -78,7 +78,7 @@
 - type: entity
   name: experimental hypospray
   suffix: Admeme
-  parent: [BaseClearContraband, SyndiHypo] # Frontier: added BaseClearContraband
+  parent: SyndiHypo
   description: The ultimate application of bluespace technology and rapid chemical administration.
   id: AdminHypo
   components:
@@ -414,7 +414,7 @@
 
 - type: entity
   name: hyperzine injector
-  parent: [ChemicalMedipen, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ChemicalMedipen
   id: Stimpack
   description: Contains enough hyperzine for you to have the chemical's effect for 30 seconds. Use it when you're sure you're ready to throw down.
   components:
@@ -446,7 +446,7 @@
 
 - type: entity
   name: hyperzine microinjector
-  parent: [ChemicalMedipen, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ChemicalMedipen
   id: StimpackMini
   description: A microinjector of hyperzine that give you about 15 seconds of the chemical's effects.
   components:
@@ -473,7 +473,7 @@
 
 - type: entity
   name: combat medipen
-  parent: [ChemicalMedipen] #Mono Removed C3SyndieContraband
+  parent: [ChemicalMedipen]
   id: CombatMedipen
   description: A single-use medipen containing chemicals that regenerate most types of damage.
   components:
@@ -508,7 +508,7 @@
 - type: entity
   name: pen
   suffix: Hypopen
-  parent: [Pen, BaseC3SyndicateContraband] # It is just like normal pen, isn't it?
+  parent: Pen # It is just like normal pen, isn't it?
   description: A dark ink pen.
   id: Hypopen
   components:
@@ -529,11 +529,9 @@
     price: 75
   - type: EmitSoundOnUse
     handle: false # don't want the sound to stop the self-inject from triggering
-  - type: Contraband # Frontier
-    hideValues: true # Frontier - stealthy
 
 - type: entity
-  parent: [ BaseItem, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: HypopenBox
   name: hypopen box
   description: A small box containing a hypopen. Packaging disintegrates when opened, leaving no evidence behind.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -317,7 +317,7 @@
 - type: entity
   name: advanced circular saw
   id: SawAdvanced
-  parent: [ SawElectric, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: SawElectric
   description: You think you can cut anything with it.
   components:
   - type: Sprite
@@ -479,7 +479,7 @@
     price: 200
 
 - type: entity
-  parent: [ OmnimedTool, BaseSyndicateContraband ]
+  parent: OmnimedTool
   id: OmnimedToolSyndie
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -721,7 +721,7 @@
 #syndicate modules
 - type: entity
   id: BorgModuleSyndicateWeapon
-  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [ BaseBorgModule, BaseProviderBorgModule ]
   name: weapon cyborg module
   components:
   - type: Sprite
@@ -738,7 +738,7 @@
 
 - type: entity
   id: BorgModuleOperative
-  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: operative cyborg module
   description: A module that comes with a crowbar, an Emag, an Access Breaker and a syndicate pinpointer.
   components:
@@ -758,7 +758,7 @@
 
 - type: entity
   id: BorgModuleEsword
-  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: energy sword cyborg module
   description: A module that comes with a double energy sword.
   components:
@@ -776,7 +776,7 @@
 
 - type: entity
   id: BorgModuleL6C
-  parent: [ BaseBorgModuleSyndicateAssault, BaseProviderBorgModule, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [ BaseBorgModuleSyndicateAssault, BaseProviderBorgModule ]
   name: L6C ROW cyborg module
   description: A module that comes with a L6C.
   components:
@@ -794,7 +794,7 @@
 
 - type: entity
   id: BorgModuleMartyr
-  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [ BaseBorgModule, BaseProviderBorgModule ]
   name: martyr cyborg module
   description: "A module that comes with an explosive you probably don't want to handle yourself."
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/rehydrateable.yml
@@ -162,7 +162,7 @@
     - MobAbomination
 
 - type: entity
-  parent: [PlushieCarp, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: PlushieCarp
   id: DehydratedSpaceCarp
   name: dehydrated space carp
   description: Looks like a plush toy carp, but just add water and it becomes a real-life space carp!

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -1,7 +1,7 @@
 
 - type: entity
   name: telecrystal
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: Telecrystal
   suffix: 100 TC # Mono
   description: It seems to be pulsing with suspiciously enticing energies.
@@ -22,10 +22,6 @@
   - type: Currency
     price:
       Telecrystal: 1
-  - type: Contraband
-    turnInValues:
-      FederationMilitaryCredit: 1
-      Doubloon: 1
 
 - type: entity
   parent: Telecrystal
@@ -53,7 +49,7 @@
 
 # Uplinks
 - type: entity
-  parent: [BaseItem, StorePresetUplink, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [BaseItem, StorePresetUplink]
   id: BaseUplinkRadio
   name: syndicate uplink
   description: Suspiciously looking old radio...

--- a/Resources/Prototypes/Entities/Objects/Tools/access_breaker.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_breaker.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: AccessBreakerUnlimited
   suffix: Unlimited
   name: authentication disruptor

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseCommandContraband] # Frontier: Added BaseCommandContraband
+  parent: BaseItem
   id: AccessConfigurator
   name: access configurator
   description: Used to modify the access level requirements for airlocks and other lockable devices.

--- a/Resources/Prototypes/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: EmagUnlimited
   suffix: Unlimited
   name: cryptographic sequencer

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -76,7 +76,7 @@
 
 - type: entity
   name: seclite
-  parent: [FlashlightLantern, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: FlashlightLantern
   id: FlashlightSeclite
   description: A robust flashlight used by security.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: radio jammer
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: RadioJammer
   description: This device will disrupt any nearby outgoing radio communication as well as suit sensors when activated.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -54,7 +54,7 @@
 
 - type: entity
   name: advanced jaws of life # Mono
-  parent: [JawsOfLife, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: JawsOfLife
   id: SyndicateJawsOfLife
   description: Useful for entering the station or its departments.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -105,7 +105,7 @@
 #Empty black
 - type: entity
   id: JetpackBlack
-  parent: [BaseJetpack, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseJetpack
   name: jetpack
   suffix: Empty
   components:
@@ -140,7 +140,7 @@
 #Empty captain
 - type: entity
   id: JetpackCaptain
-  parent: BaseJetpack # Frontier: remove BaseGrandTheftContraband
+  parent: BaseJetpack
   name: captain's jetpack
   suffix: Empty
   components:
@@ -224,7 +224,7 @@
 #Empty security
 - type: entity
   id: JetpackSecurity
-  parent: [BaseJetpack, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseJetpack
   name: security jetpack
   suffix: Empty
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/thief_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/thief_beacon.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseC3SyndicateContraband # Frontier: BaseMinorContraband<BaseC3SyndicateContraband
+  parent: BaseC3SyndicateContraband
   id: ThiefBeacon
   name: thieving beacon
   description: A device that will teleport everything around it to the thief's vault at the end of the shift.

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -123,7 +123,7 @@
 
 - type: entity
   name: suspicious toolbox
-  parent: [ToolboxBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ToolboxBase
   id: ToolboxSyndicate
   description: A sinister looking toolbox filled with elite syndicate tools.
   components:
@@ -158,7 +158,7 @@
   id: ToolboxThief
   name: thief undetermined toolbox
   description: This is where your favorite thief's supplies lie. Try to remember which ones.
-  parent: [ BaseItem, BaseC3SyndicateContraband ] # Frontier: BaseMinorContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   components:
   - type: Sprite
     sprite: _Impstation/Objects/Tools/Toolboxes/toolbox_thief.rsi
@@ -179,5 +179,3 @@
     interfaces:
       enum.ThiefBackpackUIKey.Key:
         type: ThiefBackpackBoundUserInterface
-  - type: Contraband # Frontier
-    hideValues: true # Frontier

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -351,7 +351,7 @@
 
 - type: entity
   id: RCD
-  parent: BaseItem # Frontier: remove BaseEngineeringContraband
+  parent: BaseItem
   name: RCD
   description: The rapid construction device can be used to quickly place and remove various structures and fixtures. Requires compressed matter to function. Does not require swiping an ID to work.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/firebomb.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/firebomb.yml
@@ -2,7 +2,7 @@
 # ideally it would be dynamic and work by actually sparking the solution but that doesnt exist yet :(
 # with that you could make napalm ied instead of welding fuel with no additional complexity
 - type: entity
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: Added BaseC2ContrabandUnredeemable
+  parent: BaseItem
   id: FireBomb
   name: fire bomb
   description: A weak, improvised incendiary device.
@@ -57,7 +57,7 @@
 
 # has igniter but no fuel or wires
 - type: entity
-  parent: [DrinkColaCanEmpty, BaseC2ContrabandUnredeemable] # Frontier: Added BaseC2ContrabandUnredeemable
+  parent: DrinkColaCanEmpty
   id: FireBombEmpty
   name: fire bomb
   suffix: empty
@@ -85,7 +85,7 @@
     # no DrinkCan, prevent using it to make another ied
 
 - type: entity
-  parent: [FireBombEmpty, BaseC2ContrabandUnredeemable] # Frontier: Added BaseC2ContrabandUnredeemable
+  parent: FireBombEmpty
   id: FireBombFuel
   suffix: fuel
   description: A weak, improvised incendiary device. This one is missing wires.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/funny.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/funny.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: hot potato
   description: Once activated, you can't drop this time bomb - hit someone else with it to save yourself! Don't burn your hands!
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: HotPotato
   components:
     - type: WeaponCaseInsertable # Frontier

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -25,7 +25,7 @@
     handle: false # don't want the sound to stop the explosion from triggering
 
 - type: entity
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: PenExplodingBox
   name: exploding pen box
   description: A small box containing an exploding pen. Packaging disintegrates when opened, leaving no evidence behind.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pipebomb.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pipebomb.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [GrenadeBase, BaseC2ContrabandUnredeemable] # Frontier: Added BaseC2ContrabandUnredeemable
+  parent: GrenadeBase
   id: PipeBomb
   name: pipe bomb
   description: An improvised explosive made from pipes and wire.
@@ -33,7 +33,7 @@
     node: pipebomb
 
 - type: entity
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: Added BaseC2ContrabandUnredeemable
+  parent: BaseItem
   id: PipeBombGunpowder
   name: pipe bomb
   description: An improvised explosive made from a pipe. This one has no gunpowder.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -39,7 +39,7 @@
 - type: entity
   name: composition C-4
   description: Used to put holes in specific areas without too much extra hole. A saboteur's favorite.
-  parent: [BasePlasticExplosive, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BasePlasticExplosive
   id: C4
   components:
   - type: Sprite
@@ -82,7 +82,7 @@
 - type: entity
   name: seismic charge
   description: Concussion based explosive designed to destroy large amounts of rock.
-  parent: [BasePlasticExplosive, BaseC2ContrabandUnredeemable] # Frontier: Added BaseC2ContrabandUnredeemable
+  parent: BasePlasticExplosive
   id: SeismicCharge
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_staff.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_staff.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: WeaponStaffBase
   abstract: true
-  parent: [BaseItem, BaseC3WizardContraband] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: BaseItem
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Basic/staves.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wand.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wand.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: WeaponWandBase
   abstract: true
-  parent: [BaseItem, BaseC3WizardContraband] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: BaseItem
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Basic/wands.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: proto-kinetic accelerator
   id: WeaponProtoKineticAccelerator
-  parent: [WeaponProtoKineticAcceleratorBase, BaseC1Contraband] # Frontier: BaseCargoContraband<BaseC1Contraband
+  parent: WeaponProtoKineticAcceleratorBase
   description: Fires low-damage kinetic bolts at a short range.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -132,7 +132,7 @@
 
 - type: entity
   name: svalinn laser pistol
-  parent: [ BaseWeaponPowerCellSmall, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseWeaponPowerCellSmall
   id: WeaponLaserSvalinn
   description: A cheap and widely used laser pistol.
   components:
@@ -155,7 +155,7 @@
 
 - type: entity
   name: retro laser blaster
-  parent: [ BaseWeaponBatterySmall, BaseC1Contraband ] # Frontier: BaseMajorContraband<BaseC1Contraband
+  parent: BaseWeaponBatterySmall
   id: WeaponLaserGun
   description: A civilian grade weapon using light amplified by the stimulated emission of radiation.
   components:
@@ -180,7 +180,7 @@
 
 - type: entity
   name: makeshift laser pistol
-  parent: [BaseWeaponBatterySmall, BaseC1Contraband] # Frontier: added BaseC1Contraband
+  parent: BaseWeaponBatterySmall
   id: WeaponMakeshiftLaser
   description: Better pray it won't burn your hands off. At least it's legal.
   components:
@@ -208,7 +208,7 @@
 
 - type: entity
   name: tesla gun
-  parent: [BaseWeaponBattery, BaseC3Contraband] # Frontier: added BaseC3Contraband
+  parent: BaseWeaponBattery
   id: WeaponTeslaGun
   description: The power of the primordial element of lightning in your hands. An experimental and illegal weapon.
   components:
@@ -268,7 +268,7 @@
 
 - type: entity
   name: laser rifle
-  parent: [WeaponLaserCarbinePractice, BaseGunWieldable, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: [WeaponLaserCarbinePractice, BaseGunWieldable]
   id: WeaponLaserCarbine
   description: A simple civilian grade laser carbine, the workhorse of many private security organizations. # Frontier: description
   components:
@@ -282,7 +282,7 @@
 
 - type: entity
   name: LWC pulse pistol
-  parent: [BaseWeaponBatterySmall, BaseC2ContrabandUnredeemable] # Frontier: added BaseC2ContrabandUnredeemable
+  parent: BaseWeaponBatterySmall
   id: WeaponPulsePistol
   description: A state of the art energy pistol favoured as a sidearm by the TSFN and TSFMC. # Mono
   components:
@@ -325,7 +325,7 @@
 
 - type: entity
   name: LWC pulse carbine
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseC2ContrabandUnredeemable] # Frontier: added BaseC2ContrabandUnredeemable
+  parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponPulseCarbine
   description: A common sight in the hands of higher ranked TSF, the pulse carbine is a punchy laser weapon salvaged from the remnants of Nanotrasen. # Mono
   components:
@@ -374,7 +374,7 @@
 
 - type: entity
   name: NT pulse rifle
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseC2ContrabandUnredeemable] # Frontier: added BaseC2ContrabandUnredeemable
+  parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponPulseRifle
   description: A weapon that used to be used by the special operations units of NT, but now commonly seen in the hands of the TSF. # Mono
   components:
@@ -421,7 +421,7 @@
 
 - type: entity
   name: laser cannon
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponLaserCannon
   description: A heavy duty, high powered laser weapon. On the handle is a label that says 'for authorized use only.' # Frontier: added label sentence
   components:
@@ -456,7 +456,7 @@
 
 - type: entity
   name: portable particle decelerator
-  parent: [BaseWeaponBattery, BaseC2ContrabandUnredeemable] # Frontier: BaseRestrictedContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponBattery
   id: WeaponParticleDecelerator
   description: A portable particle decelerator capable of decomposing a tesla or singularity. On the handle is a label that says 'for authorized use only.' # Frontier: added label sentence
   components:
@@ -487,7 +487,7 @@
 
 - type: entity
   name: x-ray cannon
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseC3Contraband] # Frontier: added BaseSecurityContraband<BaseC3Contraband
+  parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponXrayCannon
   description: An illegal and experimental weapon that uses concentrated x-ray energy against its target.
   components:
@@ -557,7 +557,7 @@
 
 - type: entity
   name: disabler
-  parent: [ WeaponDisablerPractice, BaseC1Contraband ] # Frontier: BaseSecurityCommandContraband<BaseC1Contraband
+  parent: WeaponDisablerPractice
   id: WeaponDisabler
   description: A civilian grade self-defense weapon that exhausts organic targets, weakening them until they collapse.
   components:
@@ -585,7 +585,7 @@
 
 - type: entity
   name: disabler SMG
-  parent: [ BaseWeaponBattery, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponBattery
   id: WeaponDisablerSMG
   description: Advanced weapon that exhausts organic targets, weakening them until they collapse. On the handle is a label that says 'for authorized use only.'
   components:
@@ -623,7 +623,7 @@
 
 - type: entity
   name: taser
-  parent: [ BaseWeaponBatterySmall, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponBatterySmall
   id: WeaponTaser
   description: A low-capacity, energy-based stun gun used by security teams to subdue targets at range. On the handle is a label that says 'for authorized use only.'
   components:
@@ -659,7 +659,7 @@
 
 - type: entity
   name: antique laser pistol
-  parent: [BaseWeaponBatterySmall, BaseC1Contraband] # Frontier: BaseGrandTheftContraband<BaseC1Contraband
+  parent: BaseWeaponBatterySmall
   id: WeaponAntiqueLaser
   description: This is an antique laser pistol. All craftsmanship is of the highest quality. It is decorated with a mahogany grip and chrome filigree. The object menaces with spikes of energy. On the item is an image of a captain and a clown. The clown is dead. The captain is striking a heroic pose.
   components:
@@ -706,7 +706,7 @@
 
 - type: entity
   name: advanced laser pistol
-  parent: [ BaseWeaponBatterySmall, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseWeaponBatterySmall
   id: WeaponAdvancedLaser
   description: An experimental civilian grade high-energy laser pistol with a self-charging nuclear battery.
   components:
@@ -743,7 +743,7 @@
 
 - type: entity
   name: C.H.I.M.P. handcannon
-  parent: [BaseWeaponBatterySmall, BaseC1Contraband] # Frontier: BaseScienceContraband<BaseC1Contraband
+  parent: BaseWeaponBatterySmall
   id: WeaponPistolCHIMP
   description: Just because it's a little C.H.I.M.P. doesn't mean it can't punch like an A.P.E.
   components:
@@ -789,7 +789,7 @@
 
 - type: entity
   name: experimental C.H.I.M.P. handcannon
-  parent: [WeaponPistolCHIMP, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: WeaponPistolCHIMP
   id: WeaponPistolCHIMPUpgraded
   description: This C.H.I.M.P. seems to have a greater punch than is usual...
   components:
@@ -808,7 +808,7 @@
 
 - type: entity
   name: eye of a behonker
-  parent: [BaseWeaponBatterySmall, BaseC3Contraband] # Frontier: added BaseC3Contraband
+  parent: BaseWeaponBatterySmall
   id: WeaponBehonkerLaser
   description: The eye of a behonker, it fires a laser when squeezed. An illegal weapon often used by the cult of the Honkmother.
   components:
@@ -832,7 +832,7 @@
 
 - type: entity
   name: NT energy shotgun
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseC2ContrabandUnredeemable] # Frontier: BaseGrandTheftContraband<BaseC2ContrabandUnredeemable
+  parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponEnergyShotgun
   description: A one-of-a-kind prototype energy weapon that uses various shotgun configurations. It offers the possibility of both lethal and non-lethal shots, making it a versatile weapon.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: bow
-  parent: [BaseItem, BaseC1Contraband] # Frontier: BaseMinorContraband<BaseC1Contraband
+  parent: BaseItem
   id: BaseBow
   description: The original rooty tooty point and shooty.
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -40,7 +40,7 @@
 - type: entity
   name: minigun
   id: WeaponMinigun
-  parent: [ BaseWeaponHeavyMachineGun, BaseC3Contraband ] # Frontier: BaseMajorContraband<BaseC3Contraband
+  parent: BaseWeaponHeavyMachineGun
   description: Vzzzzzt! Rahrahrahrah! Vrrrrr! Uses .10 rifle ammo. Illegal for use in the Frontier sector. # Frontier: edit description
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -95,7 +95,7 @@
 - type: entity
   name: PA L6B SAW (7.62x39mm)
   id: WeaponLightMachineGunL6
-  parent: [BaseWeaponLightMachineGun, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponLightMachineGun
   description: A rather traditionally made LMG with a pleasantly lacquered wooden pistol grip. Uses 7.62x39mm ammo. No longer in production, it serves as a remnant of humanity's greed and ambition during The Fracture.
   components:
   - type: Sprite
@@ -117,7 +117,7 @@
 - type: entity
   name: PA L6C ROW (7.62x39mm)
   id: WeaponLightMachineGunL6C
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
+  parent: BaseItem
   description: A L6 SAW for use by cyborgs. Creates 762x39mm ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
     - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -26,7 +26,7 @@
 
 - type: entity
   name: PA china lake
-  parent: [BaseWeaponLauncher, BaseGunWieldable, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [BaseWeaponLauncher, BaseGunWieldable]
   id: WeaponLauncherChinaLake
   description: PLOOP.
   components:
@@ -59,7 +59,7 @@
 
 - type: entity
   name: PA RPG-7
-  parent: [ BaseWeaponLauncher, BaseC3Contraband ] # Frontier: BaseMajorContraband<BaseC3Contraband
+  parent: BaseWeaponLauncher
   id: WeaponLauncherRocket
   description: A modified ancient rocket-propelled grenade launcher.
   components:
@@ -128,7 +128,7 @@
 
 - type: entity
   name: pirate cannon
-  parent: [BaseC3PirateContraband, BaseWeaponLauncher] # Frontier: added C3PirateContraband
+  parent: BaseWeaponLauncher
   id: WeaponLauncherPirateCannon
   description: Kaboom!
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -89,7 +89,7 @@
 
 - type: entity
   name: LWC PT-45A viper (9x19mm)
-  parent: [BaseWeaponPistol, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponPistol
   id: WeaponPistolViper
   description: A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses 9x19mm ammo. While the schematics to build new Vipers has been lost, they are so abundant from the Corporate War that building new ones is no longer required.
   components:
@@ -127,7 +127,7 @@
 
 - type: entity
   name: LWC PT-45C echis (9x19mm)
-  parent: [ BaseItem, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: WeaponPistolEchis
   description: A viper for use by cyborgs. Creates 9x19mm on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
@@ -162,7 +162,7 @@
 
 - type: entity
   name: LWC mercenary PT-45C echis (9x19mm)
-  parent: [ BaseItem, BaseC1Contraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: WeaponPistolMercenaryEchis
   description: A viper for use by cyborgs, redesigned for mercenary use. Creates 9x19mm on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
@@ -197,7 +197,7 @@
 
 - type: entity
   name: CS PT-72 cobra (635x40mm)
-  parent: [ BaseWeaponPistol, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponPistol
   id: WeaponPistolCobra
   description: A rugged, robust spec-ops handgun with an inbuilt silencer. Uses 6.35x40mm Caseless ammo. A common sight among Phaethon imperials, they are the most commonly seen sidearm among boarding crews or agents.
   components:
@@ -247,7 +247,7 @@
 
 - type: entity
   name: MA Mk-58 (.45 ACP)
-  parent: [BaseWeaponPistol, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable<BaseC1Contraband to match weapon description
+  parent: BaseWeaponPistol
   id: WeaponPistolMk58
   description: The Mark 58 Offensive Handgun, the most abundant sidearm in the entire galaxy. Commonly called a Corporate War fragment, it was used until the bitter end. Uses .45 ACP ammo.
   components:
@@ -293,7 +293,7 @@
 
 - type: entity
   name: NT N1984 (.45 magnum)
-  parent: [BaseWeaponPistol, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponPistol
   id: WeaponPistolN1984 # the spaces in description are for formatting.
   description: The sidearm of any self respecting officer. Comes in .45 magnum, the lord's caliber. On the handle is a label that says 'for authorized use only.'
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -72,7 +72,7 @@
 
 - type: entity
   name: NT Deckard (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC1Contraband] # Frontier: BaseSecurityCommandContraband<BaseC1Contraband
+  parent: BaseWeaponRevolver
   id: WeaponRevolverDeckard
   description: A rare, civilian grade custom-built revolver. Use when there is no time for Voight-Kampff test. Uses .45 magnum ammo.
   components:
@@ -100,7 +100,7 @@
 
 - type: entity
   name: Inspector (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponRevolver
   id: WeaponRevolverInspector
   description: A detective's best friend. Uses .45 magnum ammo. On the handle is a label that says 'for authorized use only.'
   components:
@@ -115,7 +115,7 @@
 
 - type: entity
   name: NT Mateba (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC2ContrabandUnredeemable] # Frontier: BaseMajorContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponRevolver
   id: WeaponRevolverMateba
   description: A legendary sidearm from the Corporate Era, once used by corporate kill-teams, it now belongs to TSF Officers across the galaxy. Uses .45 magnum ammo. On the handle is a label that says 'for authorized use only.'
   components:
@@ -138,7 +138,7 @@
 
 - type: entity
   name: LWC Python (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponRevolver
   id: WeaponRevolverPython
   description: A revolver that is commonly found around Phaethon Dynasty space, it's typically used by high-ranking imperials. Uses .45 magnum ammo. # Frontier
   components:
@@ -161,7 +161,7 @@
 # Mono: Gatfruit revolver variant, little FMC worth
 - type: entity
   name: LWC Python (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC3SyndicateContrabandUnredeemable]
+  parent: BaseWeaponRevolver
   id: WeaponRevolverPythonGatfruit
   suffix: Low Value
   description: A revolver that is commonly found around Phaethon Dynasty space, it's typically used by high-ranking imperials. Uses .45 magnum ammo. It seems to be made of fragile plant matter, and isn't as valuable for contraband recycling.
@@ -197,7 +197,7 @@
 
 - type: entity
   name: pirate revolver (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC3PirateContraband] # Frontier: BaseMinorContraband<BaseC3PirateContraband
+  parent: BaseWeaponRevolver
   id: WeaponRevolverPirate
   description: An odd, illegal, old-looking revolver, favoured by pirate crews. Uses .45 magnum ammo. # Frontier
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -72,7 +72,7 @@
 
 - type: entity
   name: LWC AKM (7.62x39mm)
-  parent: [BaseWeaponRifle, BaseC3SyndicateContraband] # Frontier: BaseSecurityContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponRifle
   id: WeaponRifleAk
   description: An old Pre-Fracture Era rifle. Uses 7.62x39mm ammo. When the Fracture began to spread across the Old Earth territories, few weapons were as reliable as the AKM
   components:
@@ -128,7 +128,7 @@
 
 - type: entity
   name: TCA M-6 Lecter (6.8x52mm Caseless)
-  parent: [BaseWeaponRifle, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponRifle
   id: WeaponRifleLecter
   description: The result of a project to make a new standard rifle for the branches of the TSF military. Accurate, easy to use, and firing the 6.8x52mm STANAG round. Also accepts 5.56x45mm magazines to assist with standardization.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -79,7 +79,7 @@
 
 - type: entity
   name: MA PDW-58 Atreides (5.7x28mm)
-  parent: [BaseWeaponSubMachineGun, BaseC3SyndicateContraband] # Frontier: BaseMajorContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunAtreides
   description: Midnight Arms Co. Streamlined SMG that's commonly found use among uprisings and criminals. Uses 5.7x28mm ammo.
   components:
@@ -123,7 +123,7 @@
 
 - type: entity
   name: CS C-20r submachine gun (9x19mm)
-  parent: [BaseWeaponSubMachineGun, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunC20r
   description: A Corporate-Era SMG, once used by Nuclear Operatives, it now finds purchase among the Phaethon Dynasty. Uses 9x19mm ammo.
   components:
@@ -163,7 +163,7 @@
 
 - type: entity
   name: TCA M-5 Drozd (.45 ACP)
-  parent: [BaseWeaponSubMachineGun, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunDrozd
   description: An SMG that once found use among NT security forces, now has found itself as one of the most reliable boarding and anti-boarding weapons on the market. Uses .45 ACP ammo.
   components:
@@ -232,7 +232,7 @@
 
 - type: entity
   name: UI WT550 (4.6x30mm)
-  parent: [ BaseWeaponSubMachineGun, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunWt550
   description: An excellent SMG, produced by a Black Market Arms Company known as Ullman Industries. Uses 4.6x30mm ammo. On the receiver is a label that says 'for authorized use only.'
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -79,7 +79,7 @@
 - type: entity
   name: PA M-12 Bulldog (12 gauge)
   # Don't parent to BaseWeaponShotgun because it differs significantly
-  parent: [BaseItem, BaseGunWieldable, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [BaseItem, BaseGunWieldable]
   id: WeaponShotgunBulldog
   description: An automatic magazine-fed shotgun for close-quarters combat. Kicks like a mule on steroids. Uses 12 gauge shotgun shells.
   components:
@@ -136,7 +136,7 @@
 
 - type: entity
   name: double-barreled shotgun (12 gauge)
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseC1Contraband] # Frontier: BaseSecurityBartenderContraband<BaseC1Contraband
+  parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunDoubleBarreled
   description: An immortal classic. A civilian grade shotgun. Uses 12 gauge shotgun shells.
   components:
@@ -172,7 +172,7 @@
 
 - type: entity
   name: Enforcer (12 gauge)
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunEnforcer
   description: A premium semi-automatic shotgun, and the pride of all security forces. Uses 12 gauge shotgun shells.
   components: # intend for Enforcer to have wider choke for semi-auto function
@@ -204,7 +204,7 @@
 
 - type: entity
   name: Kammerer (12 gauge)
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunKammerer
   description: An old yet faithful design, and a favorite among irregular forces on many worlds. Uses 12 gauge shotgun shells.
   components: # intend for Kammerer to have tighter choke for slower fire rate and/or manual cycling
@@ -230,7 +230,7 @@
 
 - type: entity
   name: sawn-off shotgun (12 gauge)
-  parent: [ BaseWeaponShotgun, BaseC1Contraband ] # Frontier: BaseSecurityBartenderContraband<BaseC1Contraband
+  parent: BaseWeaponShotgun
   id: WeaponShotgunSawn
   description: Groovy! Uses 12 gauge shotgun shells.
   components: # needs to be super inaccurate because you don't need to wield it
@@ -269,7 +269,7 @@
 
 - type: entity
   name: handmade pistol (12 gauge)
-  parent: [BaseWeaponShotgun, BaseC1Contraband] # Frontier: BaseMinorContraband<BaseC1Contraband
+  parent: BaseWeaponShotgun
   id: WeaponShotgunHandmade
   description: Looks unreliable, but legal. Uses 12 gauge shotgun shells.
   components:
@@ -294,7 +294,7 @@
 
 - type: entity
   name: blunderbuss (12 gauge)
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseC3PirateContraband] # Frontier: BaseMinorContraband<BaseC3PirateContraband
+  parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunBlunderbuss
   suffix: Pirate
   description: Deadly at close range, an illegal shotgun often found at the side of a pirate.
@@ -316,7 +316,7 @@
 
 - type: entity
   name: improvised shotgun (12 gauge)
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseC1Contraband] # Frontier: BaseMinorContraband<BaseC1Contraband
+  parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunImprovised
   description: A shitty, but legal, hand-made shotgun that uses 12 gauge shotgun shells. It can only hold one round in the chamber.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -59,7 +59,7 @@
 
 - type: entity
   name: NCI Kardashev-Mosin (7.62x54mmR)
-  parent: [BaseWeaponSniper, BaseGunWieldable, BaseGunMelee, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband, added BaseGunMelee
+  parent: [BaseWeaponSniper, BaseGunWieldable, BaseGunMelee] # added BaseGunMelee
   id: WeaponSniperMosin
   description: A weapon for hunting, or endless trench warfare. Uses 762x54mmR ammo. Equipped with bayonet. # Frontier: bayonet
   components:
@@ -82,7 +82,7 @@
 
 - type: entity
   name: SKR-WS M96 Hristov (14.5x114mm)
-  parent: [BaseWeaponSniper, BaseGunWieldable, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [BaseWeaponSniper, BaseGunWieldable]
   id: WeaponSniperHristov
   description: A portable anti-material rifle. Fires high velocity 14.5mm shells. Uses 145x114mm ammo.
   components:
@@ -117,7 +117,7 @@
 
 - type: entity
   name: musket
-  parent: [ BaseWeaponSniper, BaseGunWieldable, BaseGunMelee, BaseC2Contraband ] # Frontier: BaseMinorContraband<BaseC2Contraband, add BaseGunMelee
+  parent: [ BaseWeaponSniper, BaseGunWieldable, BaseGunMelee ] # add BaseGunMelee
   id: Musket
   description: This should've been in a museum long before you were born. Uses 145x114mm ammo.
   components:
@@ -158,7 +158,7 @@
 
 - type: entity
   name: flintlock pistol
-  parent: [BaseWeaponSniper, BaseC3PirateContraband] # Frontier: BaseMinorContraband<BaseC3PirateContraband
+  parent: BaseWeaponSniper
   id: WeaponPistolFlintlock
   description: A pirate's companion. Yarrr! Uses 145x114mm ammo. An illegal weapon often used by pirates.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseWeaponBallisticTurret, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponBallisticTurret
   id: WeaponTurretSyndicate
   suffix: Syndicate
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
@@ -69,7 +69,7 @@
 
 - type: entity
   name: security shell gun
-  parent: [WeaponFlareGun, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: WeaponFlareGun
   id: WeaponFlareGunSecurity
   description: A modified flare gun originally designed to be used by security to launch non-lethal shotgun shells, however it can also fire lethal shells without risk.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: improvised pneumatic cannon
-  parent: [BaseStorageItem, BaseC1Contraband] # Frontier: BaseMinorContraband<BaseC1Contraband
+  parent: BaseStorageItem
   id: WeaponImprovisedPneumaticCannon
   description: Improvised using nothing but a pipe, some zipties, and a pneumatic cannon. Doesn't accept tanks without enough gas.
   components:
@@ -103,7 +103,7 @@
     containers:
       storagebase: !type:Container
         ents: []
-        
+
 - type: entity
   name: syringe gun
   parent: BaseStorageItem

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: baseball bat
-  parent: [BaseItem, BaseC1Contraband] # Frontier: BaseMinorContraband<BaseC1Contraband
+  parent: BaseItem
   id: BaseBallBat
   description: A robust baseball bat.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -28,7 +28,7 @@
 
 - type: entity
   name: cane blade
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: CaneBlade
   description: A sharp blade with a cane shaped hilt.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: ritual dagger
-  parent: [BaseItem, BaseC3CultContraband] # Frontier: added BaseC3CultContraband
+  parent: BaseItem
   id: RitualDagger
   description: A strange dagger used by sinister groups for rituals and sacrifices.
   components:
@@ -24,7 +24,7 @@
 
 - type: entity
   name: eldritch blade
-  parent: [BaseItem, BaseC3CultContraband] # Frontier: added BaseC3CultContraband
+  parent: BaseItem
   id: EldritchBlade
   description: A sword humming with unholy energy.
   components:
@@ -39,7 +39,7 @@
       types:
         Slash: 38
     soundHit: # Mono nearly forgot, this weapon makes no noise so i gave it the slash sound, i had been planning on adding this but i forgot until i re-opened the file
-      collection: MetalThud 
+      collection: MetalThud
   - type: Item
     size: Large # Mono Increased from normal to large to make damage make more sense
   - type: Clothing
@@ -50,7 +50,7 @@
 
 - type: entity
   name: unholy halberd
-  parent: [BaseItem, BaseC3CultContraband] # Frontier: added BaseC3CultContraband
+  parent: BaseItem
   id: UnholyHalberd
   description: A poleaxe that seems to be linked to its wielder.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -87,7 +87,7 @@
 
 - type: entity
   name: energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseMeleeWeaponEnergy
   id: EnergySword
   description: A very loud & dangerous sword with a beam made of pure, concentrated plasma. Cuts through unarmored targets like butter.
   components:
@@ -110,7 +110,7 @@
 
 - type: entity
   name: energy dagger
-  parent: [BaseMeleeWeaponEnergy, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseMeleeWeaponEnergy
   id: EnergyDaggerLoud
   description: A not as loud and dangerous dagger with a beam made of pure, concentrated plasma. This one is completely undisguised.
   components:
@@ -176,7 +176,7 @@
 
 - type: entity
   name: pen
-  parent: [BaseMeleeWeaponEnergy, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
+  parent: BaseMeleeWeaponEnergy
   id: EnergyDagger
   suffix: E-Dagger
   description: 'A dark ink pen.'
@@ -212,8 +212,6 @@
       malus: 0.4
     - type: Execution
       doAfterDuration: 4.0
-    # - type: Contraband # Frontier
-    #   severity: Syndicate # Frontier
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_dagger.rsi
     layers:
@@ -243,11 +241,9 @@
   - type: Tag
     tags:
     - Write
-  - type: Contraband # Frontier
-    hideValues: true # Frontier
 
 - type: entity
-  parent: [BaseItem, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseItem
   id: EnergyDaggerBox
   name: e-dagger box
   suffix: E-Dagger
@@ -266,7 +262,7 @@
 
 - type: entity
   name: energy cutlass
-  parent: [BaseMeleeWeaponEnergy, BaseC3PirateContraband] # Frontier: BaseMajorContraband<BaseC3PirateContraband
+  parent: BaseMeleeWeaponEnergy
   id: EnergyCutlass
   description: An exotic energy weapon.
   components:
@@ -291,7 +287,7 @@
 
 - type: entity
   name: double-bladed energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseMeleeWeaponEnergy
   id: EnergySwordDouble
   description: This energy sword has been modified to have blades on both ends, it's unwieldy and dangerous... This can be stored in pockets.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: fireaxe
-  parent: [BaseItem, BaseC1Contraband] # Frontier: BaseEngineeringContraband<BaseC1Contraband
+  parent: BaseItem
   id: FireAxe
   description: Truly, the weapon of a madman. Who would think to fight fire with an axe?
   components:
@@ -62,7 +62,7 @@
 - type: entity
   id: FireAxeFlaming
   name: fire axe
-  parent: [BaseC3SyndicateContraband, FireAxe] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: FireAxe
   description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
   components:
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -26,7 +26,7 @@
 
 - type: entity
   id: Mjollnir
-  parent: [ BaseItem, BaseC3WizardContraband ] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: BaseItem
   name: Mjollnir
   description: A weapon worthy of a god, able to strike with the force of a lightning bolt. It crackles with barely contained energy.
   components:
@@ -69,7 +69,7 @@
 
 - type: entity
   id: SingularityHammer
-  parent: [ BaseItem, BaseC3WizardContraband ] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: BaseItem
   name: Singularity Hammer
   description: The pinnacle of close combat technology, the hammer harnesses the power of a miniaturized singularity to deal crushing blows.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -105,7 +105,7 @@
 
 - type: entity
   name: combat knife
-  parent: [BaseKnife, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseKnife
   id: CombatKnife
   description: A deadly knife intended for melee confrontations.
   components:
@@ -142,7 +142,7 @@
 
 - type: entity
   name: survival knife
-  parent: [BaseC1Contraband, CombatKnife] # BaseSecurityCargoContraband<BaseC1Contraband
+  parent: CombatKnife
   id: SurvivalKnife
   description: Weapon of first and last resort for combatting space carp.
   components:
@@ -171,7 +171,7 @@
 
 - type: entity
   name: kukri knife
-  parent: [BaseC1Contraband, CombatKnife] # BaseSecurityCargoContraband <BaseC1Contraband
+  parent: CombatKnife
   id: KukriKnife
   description: Professionals have standards. Be polite. Be efficient. Have a plan to kill everyone you meet.
   components:
@@ -196,7 +196,7 @@
     storedSprite: null
 
 - type: entity
-  parent: [ClothingHeadHatGreyFlatcap, BaseC1Contraband] # Frontier: BaseSyndicateContraband<BaseC1Contraband
+  parent: ClothingHeadHatGreyFlatcap
   id: BladedFlatcapGrey
   name: grey flatcap
   description: Fashionable for both the working class and old man Jenkins. It has glass shards hidden in the brim.
@@ -236,7 +236,7 @@
 
 - type: entity
   name: shiv
-  parent: [BaseKnife, BaseC1Contraband] # BaseMinorContraband<BaseC1Contraband
+  parent: BaseKnife
   id: Shiv
   description: A crude weapon fashioned from a piece of cloth and a glass shard.
   components:
@@ -321,7 +321,7 @@
 
 - type: entity
   name: throwing knife
-  parent: [BaseKnife, BaseC1Contraband] # Frontier: BaseSyndicateContraband<BaseC1Contraband
+  parent: BaseKnife
   id: ThrowingKnife
   description: This blood-red knife is very aerodynamic and easy to throw, but good luck trying to fight someone hand-to-hand.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -94,7 +94,7 @@
 
 - type: entity
   abstract: true
-  parent: [ BaseItem, BaseC1Contraband ] # Frontier: BaseSecurityCargoContraband<BaseC1Contraband
+  parent: BaseItem
   id: BaseWeaponCrusher # Crusher? But I...
   name: crusher
   description: An early design of the proto-kinetic accelerator.
@@ -107,7 +107,7 @@
     radius: 4
 
 - type: entity
-  parent: [BaseWeaponCrusher, BaseC1Contraband] # Frontier: BaseSecurityCargoContraband<BaseC1Contraband
+  parent: BaseWeaponCrusher
   id: WeaponCrusher
   components:
   - type: Tag
@@ -167,7 +167,7 @@
     - suitStorage # Frontier
 
 - type: entity
-  parent: [ BaseKnife, BaseWeaponCrusher, BaseC1Contraband] # Frontier: BaseSecurityCargoContraband<BaseC1Contraband
+  parent: [ BaseKnife, BaseWeaponCrusher]
   id: WeaponCrusherDagger
   name: crusher dagger
   description: A scaled down version of a proto-kinetic crusher. Uses kinetic energy to vibrate the blade at high speeds.
@@ -197,7 +197,7 @@
 
 # Like a crusher... but better
 - type: entity
-  parent: [ WeaponCrusher, BaseC1Contraband] # Frontier: BaseSecurityCargoContraband<BaseC1Contraband
+  parent: WeaponCrusher
   id: WeaponCrusherGlaive
   name: crusher glaive
   description: An early design of the proto-kinetic accelerator, in glaive form.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: spear
-  parent: [BaseItem, BaseC1Contraband] # BaseMinorContraband<BaseC1Contraband
+  parent: BaseItem
   id: Spear
   description: Definition of a Classic. Keeping murder affordable since 200,000 BCE.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: stun prod
-  parent: [BaseItem, BaseC1Contraband] # Frontier: BaseMinorContraband<BaseC1Contraband
+  parent: BaseItem
   id: Stunprod
   description: A stun prod for questionably legal incapacitation. # Frontier: illegal<questionably legal
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -21,7 +21,7 @@
 
 - type: entity
   name: captain's sabre
-  parent: [ BaseSword, BaseC1Contraband ] # Frontier: BaseCommandContraband<BaseC1Contraband
+  parent: BaseSword
   id: CaptainSabre
   description: A common sighting among ship captains. Once ceremonial, it now has common use for self-defense.
   components:
@@ -62,7 +62,7 @@
 
 - type: entity
   name: katana
-  parent: [ BaseSword, BaseC1Contraband ] # Frontier: BaseMajorContraband<BaseC1Contraband
+  parent: BaseSword
   id: Katana
   description: Ancient craftwork made with not so ancient plasteel.
   components:
@@ -117,7 +117,7 @@
 
 - type: entity
   name: machete
-  parent: [ BaseSword, BaseC1Contraband ] # Frontier: BaseMajorContraband<BaseC1Contraband
+  parent: BaseSword
   id: Machete
   description: A large, vicious looking blade.
   components:
@@ -143,7 +143,7 @@
 
 - type: entity
   name: claymore # Mono TODO: make this a wieldable weapon
-  parent: [ BaseSword, BaseC1Contraband ] # Frontier: BaseMajorContraband<BaseC1Contraband
+  parent: BaseSword
   id: Claymore
   description: An ancient war blade.
   components:
@@ -167,7 +167,7 @@
 
 - type: entity
   name: cutlass
-  parent: [ BaseSword, BaseC1Contraband ] # Frontier: BaseMajorContraband<BaseC1Contraband
+  parent: BaseSword
   id: Cutlass
   description: A wickedly curved blade, often seen in the hands of space pirates.
   components:
@@ -193,7 +193,7 @@
 
 - type: entity
   name: throngler
-  parent: [ BaseSword, BaseC3Contraband ] # Frontier: BaseMajorContraband<BaseC3Contraband
+  parent: BaseSword
   id: Throngler
   description: Why would you make this?
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: bola
-  parent: [BaseItem, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseItem
   id: Bola
   description: Linked together with some spare cuffs and metal.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -40,7 +40,7 @@
 - type: entity
   name: explosive grenade
   description: Grenade that creates a small but devastating explosion.
-  parent: [GrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: GrenadeBase
   id: ExGrenade
   components:
   - type: ExplodeOnTrigger
@@ -61,7 +61,7 @@
 - type: entity
   name: flashbang
   description: Eeeeeeeeeeeeeeeeeeeeee.
-  parent: [ GrenadeBase, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: GrenadeBase
   id: GrenadeFlashBang
   components:
   - type: Sprite
@@ -105,7 +105,7 @@
 - type: entity
   name: syndicate minibomb
   description: A syndicate-manufactured explosive used to stow destruction and cause chaos.
-  parent: [GrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: GrenadeBase
   id: SyndieMiniBomb
   components:
   - type: Sprite
@@ -166,7 +166,7 @@
 
 
 - type: entity
-  parent: [ GrenadeBase, BaseC3SyndicateContraband ] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: GrenadeBase
   id: SingularityGrenade
   name: singularity grenade
   description: Grenade that simulates the power of a singularity, pulling things in a heap.
@@ -273,7 +273,7 @@
 - type: entity
   name: the nuclear option
   description: Please don't throw it, think of the children.
-  parent: [GrenadeBase, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
+  parent: GrenadeBase
   id: NuclearGrenade
   components:
   - type: Sprite
@@ -349,7 +349,7 @@
 - type: entity
   name: EMP grenade
   description: A grenade designed to wreak havoc on electronic systems.
-  parent: [GrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: GrenadeBase
   id: EmpGrenade
   components:
   - type: Sprite
@@ -366,7 +366,7 @@
 - type: entity
   name: holy hand grenade
   description: O Lord, bless this thy hand grenade, that with it thou mayst blow thine enemies to tiny bits, in thy mercy.
-  parent: [GrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: GrenadeBase
   id: HolyHandGrenade
   components:
   - type: Sprite
@@ -389,7 +389,7 @@
       path: /Audio/Effects/hallelujah.ogg
 
 - type: entity
-  parent: [ GrenadeBase, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: GrenadeBase
   id: SmokeGrenade
   name: smoke grenade
   description: A tactical grenade that releases a large, long-lasting cloud of smoke when used.
@@ -407,7 +407,7 @@
       path: /Audio/Items/smoke_grenade_prime.ogg
 
 - type: entity
-  parent: SmokeGrenade # Frontier: removed BaseCivilianContraband
+  parent: SmokeGrenade
   id: CleanerGrenade
   name: cleanade
   description: Special grenade for janitors, releasing large cloud of space cleaner foam.
@@ -440,7 +440,7 @@
         Quantity: 50
 
 - type: entity
-  parent: SmokeGrenade # Frontier: removed BaseEngineeringContraband
+  parent: SmokeGrenade
   id: MetalFoamGrenade
   name: metal foam grenade
   description: An emergency tool used for patching up holes. Almost as good as real walls.
@@ -478,7 +478,7 @@
 - type: entity
   name: syndicate trickybomb
   description: A syndicate-manufactured explosive used to make an excellent distraction.
-  parent: [GrenadeDummy, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: GrenadeDummy
   id: SyndieTrickyBomb
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -27,7 +27,7 @@
           Unprimed: { state: icon }
 
 - type: entity
-  parent: [ProjectileGrenadeBase, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: ProjectileGrenadeBase
   id: GrenadeStinger
   name: stinger grenade
   description: Nothing to see here, please disperse.
@@ -56,7 +56,7 @@
       path: /Audio/Effects/countdown.ogg
 
 - type: entity
-  parent: [ProjectileGrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ProjectileGrenadeBase
   id: GrenadeIncendiary
   name: incendiary grenade
   description: Guaranteed to light up the mood.
@@ -82,7 +82,7 @@
       path: "/Audio/Weapons/Guns/Gunshots/batrifle.ogg"
 
 - type: entity
-  parent: [ProjectileGrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ProjectileGrenadeBase
   id: GrenadeShrapnel
   name: shrapnel grenade
   description: Releases a deadly spray of shrapnel that causes severe bleeding.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -20,7 +20,7 @@
   - type: ScatteringGrenade
 
 - type: entity
-  parent: [ScatteringGrenadeBase, BaseC2ContrabandUnredeemable, RecyclableItemSteelMedium] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable added RecyclableItemSteelMedium
+  parent: [ScatteringGrenadeBase, RecyclableItemSteelMedium]
   id: ClusterBang
   name: clusterbang
   description: Can be used only with flashbangs. Explodes several times.
@@ -72,7 +72,7 @@
       path: "/Audio/Machines/door_lock_off.ogg"
 
 - type: entity
-  parent: [ScatteringGrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ScatteringGrenadeBase
   id: ClusterGrenade
   name: clustergrenade
   description: Why use one grenade when you can use three at once!
@@ -98,7 +98,7 @@
       path: "/Audio/Machines/door_lock_off.ogg"
 
 - type: entity
-  parent: [ScatteringGrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: ScatteringGrenadeBase
   id: ClusterBananaPeel
   name: cluster banana peel
   description: Splits into 6 explosive banana peels after throwing, guaranteed fun!
@@ -120,7 +120,7 @@
       path: "/Audio/Items/bikehorn.ogg"
 
 - type: entity
-  parent: [SoapSyndie, ScatteringGrenadeBase, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: [SoapSyndie, ScatteringGrenadeBase]
   id: SlipocalypseClusterSoap
   name: slipocalypse clustersoap
   description: Spreads small pieces of syndicate soap over an area upon landing on the floor.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/throwing_stars.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/throwing_stars.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseC3Contraband] # Frontier: BaseMinorContraband<BaseC3Contraband
+  parent: BaseItem
   id: ThrowingStar
   name: throwing star
   description: An ancient weapon still used to this day, due to its ease of lodging itself into its victim's body parts.

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: stun baton
-  parent: [BaseItem, BaseC1Contraband] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseItem
   id: Stunbaton
   description: A stun baton for incapacitating people with. Actively harming with this is considered bad tone.
   components:
@@ -93,7 +93,7 @@
 
 - type: entity
   name: cyborg stun baton
-  parent: [BaseItem, BaseC1Contraband]
+  parent: BaseItem
   id: CyborgStunbaton
   description: A stun baton for incapacitating people with, designed for cyborgs. Actively harming with this is considered bad tone.
   components:
@@ -183,7 +183,7 @@
 
 - type: entity
   name: truncheon
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseItem
   id: Truncheon
   description: A rigid, steel-studded baton, meant to harm. On the handle is a label that says 'for authorized use only.'
   components:
@@ -220,7 +220,7 @@
 
 - type: entity
   name: flash
-  parent: [BaseItem, BaseC1Contraband] # Frontier: BaseSecurityScienceCommandContraband<BaseC1Contraband
+  parent: BaseItem
   id: Flash
   description: An ultrabright flashbulb with a trigger, which causes the victim to be dazed and lose their eyesight for a moment. Useless when burnt out.
   components:
@@ -287,7 +287,7 @@
 
 - type: entity
   name: portable flasher
-  parent: [BaseMachine, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseMachine
   id: PortableFlasher
   description: An ultrabright flashbulb with a proximity trigger, useful for making an area security-only.
   components:

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -46,7 +46,7 @@
 # one department restricted contraband
 - type: entity
   id: BaseCentcommContraband
-  parent: BaseC2ContrabandUnredeemable # Frontier: BaseRestrictedContraband<BaseC2ContrabandUnredeemable
+  parent: BaseC2ContrabandUnredeemable
   abstract: true
   components:
   - type: Contraband
@@ -54,7 +54,7 @@
 
 - type: entity
   id: BaseCommandContraband
-  parent: BaseC2ContrabandUnredeemable # Frontier: BaseRestrictedContraband<BaseC2ContrabandUnredeemable
+  parent: BaseC2ContrabandUnredeemable
   abstract: true
   components:
   - type: Contraband
@@ -111,7 +111,7 @@
 # multiple departments restricted contraband
 - type: entity
   id: BaseCentcommCommandContraband
-  parent: BaseC2ContrabandUnredeemable # Frontier: BaseRestrictedContraband<BaseC2ContrabandUnredeemable
+  parent: BaseC2ContrabandUnredeemable
   abstract: true
   components:
   - type: Contraband

--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -92,7 +92,7 @@
       disposable: false
 
 - type: entity
-  parent: [BaseHardBomb, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseHardBomb
   id: SyndicateBomb
   name: syndicate bomb
   description: A bomb for Syndicate operatives and agents alike. The real deal, no more training, get to it!

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseStructure, StructureWheeled, BaseC3ContrabandUnredeemable ] # Frontier: BaseMajorContraband<BaseC3ContrabandUnredeemable
+  parent: [BaseStructure, StructureWheeled ]
   id: NuclearBomb
   name: nuclear fission explosive
   description: You probably shouldn't stick around to see if this is armed.

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -59,7 +59,7 @@
 - type: entity
   id: StealthBox
   suffix: stealth
-  parent: [BaseBigBox, BaseC3SyndicateContraband] # Frontier: added BaseC3SyndicateContraband
+  parent: BaseBigBox
   description: Kept ya waiting, huh?
   components:
     - type: Damageable

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -195,7 +195,7 @@
 # Secure Crates
 
 - type: entity
-  parent: [ CrateBaseSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateBaseSecure
   id: CrateSecgear
   name: secgear crate
   components:
@@ -311,7 +311,7 @@
     access: [["Armory"]]
 
 - type: entity
-  parent: [ CrateBaseSecure, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: CrateBaseSecure
   suffix: Armory, Secure
   id: CrateContrabandStorageSecure
   name: contraband storage crate
@@ -603,7 +603,7 @@
     state: base
 
 - type: entity
-  parent: [ BaseC3SyndicateContraband, CrateGenericSteel ] # Frontier: Added BaseC3SyndicateContraband
+  parent: CrateGenericSteel
   id: CrateSyndicate
   name: Syndicate crate
   description: A dark steel crate with red bands and a letter S embossed on the front.

--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -34,7 +34,7 @@
 
 - type: entity
   id: AnimationStaff
-  parent: [ BaseItem, BaseC3WizardContraband ] # Frontier: BaseMagicalContraband<BaseC3WizardContraband
+  parent: BaseItem
   name: staff of animation
   description: Brings inanimate objects to life!
   components:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
@@ -90,7 +90,7 @@
         Piercing: 0.95
 
 - type: entity
-  parent: [ClothingHeadBase, BaseC2Contraband] # Frontier: added BaseC2Contraband
+  parent: ClothingHeadBase
   id: ClothingHeadHelmetKabuto
   name: kabuto and menpo
   description: A modern replica of a kabuto and menpo.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/armor.yml
@@ -35,7 +35,7 @@
     sprintModifier: 0.85
 
 - type: entity
-  parent: [ClothingOuterBase, BaseC2Contraband] # Frontier: added BaseC2Contraband
+  parent: ClothingOuterBase
   id: ClothingOuterArmorTouseiGusoku
   name: tousei-gusoku
   description: A modern replica of a Ni-mai-do Gusoku armor set.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/blunt.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/blunt.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: kanabou
-  parent: [BaseItem, BaseC2Contraband] # Frontier: added BaseC2Contraband
+  parent: BaseItem
   id: Kanabou
   description: The classic oni weapon, for those that forgo subtlety.
   components:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/breaching_hammer.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/breaching_hammer.yml
@@ -1,7 +1,7 @@
 # mono edit
 - type: entity
   name: breaching hammer
-  parent: [BaseItem, BaseC2ContrabandUnredeemable]
+  parent: BaseItem
   id: SecBreachingHammer
   description: A large, heavy hammer with a long handle, used for breaking stones or other heavy material such as the skulls of violent criminals, also perfect for forcing your way trough airlocks.
   components:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: breaching charge
   description: A breaching explosive for security officers to break through walls.
-  parent: [SeismicCharge, BaseC2ContrabandUnredeemable] # Frontier: added BaseC2ContrabandUnredeemable
+  parent: SeismicCharge
   id: BreachingCharge
   components:
   - type: Sprite

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: energy gun
-  parent: [BaseWeaponBattery, BaseC2ContrabandUnredeemable] # Frontier: added BaseC2ContrabandUnredeemable
+  parent: BaseWeaponBattery
   id: WeaponEnergyGun
   description: "A basic hybrid energy gun with two settings: disable and kill. On the handle is a label that says 'for authorized use only.'"
   components:
@@ -60,7 +60,7 @@
 
 - type: entity
   name: cyborg energy gun
-  parent: [BaseWeaponBattery, BaseC1Contraband]
+  parent: BaseWeaponBattery
   id: WeaponCyborgEnergyGun
   description: "A basic hybrid energy gun with two settings: disable and kill. Designed for cyborgs. On the handle is a label that says 'for authorized use only.'"
   components:
@@ -120,7 +120,7 @@
 
 - type: entity
   name: LWC X-01 multiphase energy gun
-  parent: [BaseWeaponBatterySmall, BaseCommandContraband] # Frontier: added BaseCommandContraband
+  parent: BaseWeaponBatterySmall
   categories: [DoNotMap] # Frontier / Monolith - this is the colonel /sheriff's gun
   id: WeaponEnergyGunMultiphase
   description: This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time in exchange for a larger battery. On the handle is a label that says 'for authorized use only.'

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: MA Mk32 "Universal" (9x19mm)
-  parent: [BaseWeaponPistol, BaseC1Contraband]
+  parent: BaseWeaponPistol
   id: WeaponPistolMk32
   description: A cheap, civilian grade, ubiquitous sidearm, produced by Midnight Arms Co. While it shares similarities to the MK58, it has been fully improved upon from it's Corporate War counterpart. Uses 9x19mm ammo.
   components:
@@ -48,7 +48,7 @@
 
 - type: entity
   name: LWC C17 Pollock (9x19mm)
-  parent: [BaseWeaponPistol, BaseC1Contraband]
+  parent: BaseWeaponPistol
   id: WeaponPistolPollock
   description: A compact and mass-produced combat pistol. Uses 9x19mm ammo.
   components:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: Fitz Special (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC1Contraband]
+  parent: BaseWeaponRevolver
   id: WeaponRevolverFitz
   description: A compact and concealable self defence snub revolver. Uses .45 magnum ammo.
   components:
@@ -23,7 +23,7 @@
 
 - type: entity
   name: Faith (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC1Contraband]
+  parent: BaseWeaponRevolver
   id: WeaponRevolverFaith
   description: Delivers blessings in bullet form. Uses .45 magnum ammo.
   components:
@@ -46,7 +46,7 @@
 
 - type: entity
   name: Lucky 37 (.45 magnum)
-  parent: [BaseWeaponRevolver, BaseC1Contraband]
+  parent: BaseWeaponRevolver
   id: WeaponRevolverLucky
   description: Luck always beats skill, ya weasel. Uses .45 magnum ammo.
   components:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: HWM FCM "Vulcan" (7.62x51mm)
-  parent: [BaseWeaponRifle, BaseGunWieldable, BaseC1Contraband] # Frontier: add BaseC1Contraband
+  parent: [BaseWeaponRifle, BaseGunWieldable]
   id: WeaponRifleVulcan
   description: One of the heaviest small arms to grace Security's armory, The Herstal Weapon Manufacture FCM (Fusil de Combat Moyen) "Vulcan", this rifle is a modern take on a classic, informally dubbed the "Right Arm of the Free World". Uses 7.62x51mm ammo.
   components:
@@ -72,7 +72,7 @@
 
 - type: entity
   name: ceremonial rifle (7.62x51mm)
-  parent: [BaseWeaponSniper, BaseGunWieldable, BaseC1Contraband] # Frontier: add BaseGunWieldable, BaseC1Contraband
+  parent: [BaseWeaponSniper, BaseGunWieldable]
   id: WeaponSniperCeremonial
   description: A ceremonial variant of the Mark 1 Rifle, in tasteful blue and white. Uses 7.62x51mm ammo.
   components:
@@ -103,7 +103,7 @@
 
 - type: entity
   name: CS CAWS-25 Jackdaw (635x40mm)
-  parent: [BaseWeaponRifle, BaseGunWieldable, BaseC3Contraband] # Frontier: add BaseC3Contraband
+  parent: [BaseWeaponRifle, BaseGunWieldable]
   id: WeaponRifleJackdaw
   description: The beginning of the end is heralded by the song of a Jackdaw. Uses 6.35x40mm Caseless ammo.
   components:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: PA Typewriter (.45 ACP)
-  parent: [BaseWeaponSubMachineGun, BaseGunWieldable, BaseC2Contraband] # Frontier: added BaseC2Contraband
+  parent: [BaseWeaponSubMachineGun, BaseGunWieldable]
   id: WeaponSubMachineGunTypewriter
   description: A modern take on the classic design used by mobsters throughout space and time. Uses .45 ACP ammo.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -53,7 +53,7 @@
 # cybersun stealth
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3PirateContrabandHighValue]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCybersunStealth
   suffix: stealth
   name: cybersun stealth hardsuit

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/Crafting/ghetto_stuff.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/Crafting/ghetto_stuff.yml
@@ -109,7 +109,7 @@
 
 - type: entity
   id: ContrabandBag
-  parent: [ BaseStorageItem, BaseBagOpenClose, BaseC1Contraband ]
+  parent: [ BaseStorageItem, BaseBagOpenClose ]
   name: makeshift bag
   description: A makeshift bag, made out of steel and cables in such way, to block contraband scanners.
   components:
@@ -131,7 +131,7 @@
 
 - type: entity
   id: ContrabandBagUnfinished
-  parent: [ BaseItem, BaseC1Contraband ]
+  parent: BaseItem
   name: makeshift something
   description: Something made out of steel and plastic, you are not sure what is this supposed to be.
   components:
@@ -191,7 +191,7 @@
 
 - type: entity
   id: TideFlipperZero
-  parent: [ DoorRemoteDefault, BaseC1Contraband ]
+  parent: DoorRemoteDefault
   name: tide flipper
   description: A makeshift device that can hack doors without access.
   components:
@@ -254,7 +254,7 @@
 
 - type: entity
   id: MakeshiftJammer
-  parent: [ BaseItem, BaseC3Contraband ]
+  parent: BaseItem
   name: makeshift radio jammer
   description: A cheap looking device that can spam radio waves, essentially blocking all signal. Yeah its not effective.
   components:
@@ -349,7 +349,7 @@
 
 # heavy boots
 - type: entity
-  parent: [ClothingShoesMilitaryBase, BaseC1Contraband]
+  parent: ClothingShoesMilitaryBase
   id: ClothingShoesHeavyBoots
   name: tide boots
   description: Metal is scraping through the floor as you walk with them, who thought this was a good idea?
@@ -367,7 +367,7 @@
 # helmet
 
 - type: entity
-  parent: [ ClothingHeadHelmetBase, BaseC1Contraband ]
+  parent: ClothingHeadHelmetBase
   id: ClothingHeadMakeshiftHelmet
   name: makeshift light helmet
   description: A bunch of steel connected with wires, surprisingly durable, and stylish.
@@ -388,7 +388,7 @@
 # light armor
 
 - type: entity
-  parent: [ ClothingOuterArmorBase, BaseC1Contraband ]
+  parent: ClothingOuterArmorBase
   id: ClothingOuterArmorMakeshiftVestLight
   name: makeshift light vest
   description: A light handmade vest made with steel and cables. Durable, but not that efficient.
@@ -414,7 +414,7 @@
 # heavy armor
 
 - type: entity
-  parent: [ ClothingOuterArmorBase, BaseC1Contraband ]
+  parent: ClothingOuterArmorBase
   id: ClothingOuterArmorMakeshiftVestHeavy
   name: makeshift heavy vest
   description: A heavy makeshift vest, made to withstand bullets.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/implanters.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: BaseImplantOnlyImplanterCentcomm
-  parent: [ BaseImplantOnlyImplanter, BaseCentcommContraband ]
+  parent: BaseImplantOnlyImplanter
   name: centcomm implanter
   description: A compact disposable syringe exclusively designed for the injection of subdermal implants. The insertion needle is coated with an anesthetic.
   abstract: true

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -41,7 +41,7 @@
 # Ripley MK-II
 - type: entity
   id: MechRipley2
-  parent: [ BaseMech, IndustrialMech, BaseCargoContraband ]
+  parent: [ BaseMech, IndustrialMech ]
   name: Ripley APLU MK-II
   description: The "MK-II" has a pressurized cabin for space operations, but the added weight has slowed it down.
   components:
@@ -106,7 +106,7 @@
 # Clarke
 - type: entity
   id: MechClarke
-  parent: [ BaseMech, IndustrialMech, BaseCargoContraband ]
+  parent: [ BaseMech, IndustrialMech ]
   name: Clarke
   description: A fast-moving mech for space travel. It has built-in trusts.
   components:
@@ -190,7 +190,7 @@
 # Gygax
 - type: entity
   id: MechGygax
-  parent: [ BaseMech, CombatMech, BaseRestrictedContraband ]
+  parent: [ BaseMech, CombatMech ]
   name: Gygax
   description: While lightly armored, the Gygax has incredible mobility thanks to its ability to punch through walls at high speeds.
   components:
@@ -266,7 +266,7 @@
 # Durand
 - type: entity
   id: MechDurand
-  parent: [ BaseMech, CombatMech, BaseRestrictedContraband ]
+  parent: [ BaseMech, CombatMech ]
   name: Durand
   description: A slow but beefy combat exosuit that is extra scary in confined spaces due to its punches. Xenos hate it!
   components:
@@ -346,7 +346,7 @@
 # Marauder
 - type: entity
   id: MechMarauder
-  parent: [ BaseMech, CombatMech, BaseCentcommContraband ]
+  parent: [ BaseMech, CombatMech ]
   name: Marauder
   description: Looks like we're all saved. # ERT mech
   components:
@@ -436,7 +436,7 @@
 # Seraph
 - type: entity
   id: MechSeraph
-  parent: [ BaseMech, CombatMech, BaseCentcommContraband ]
+  parent: [ BaseMech, CombatMech ]
   name: Seraph
   description: That's the last thing you'll see. # Death Squad mech
   components:
@@ -529,7 +529,7 @@
 # Dark Gygax
 - type: entity
   id: MechGygaxSyndie
-  parent: [ BaseMech, CombatMech, BaseSyndicateContraband ]
+  parent: [ BaseMech, CombatMech ]
   name: Dark Gygax
   description: A modified Gygax used for nefarious purposes.
   components:
@@ -552,7 +552,7 @@
     brokenState: darkgygax-broken
     mechToPilotDamageMultiplier: 0.15
     airtight: true
-    maxIntegrity: 900 
+    maxIntegrity: 900
     maxEquipmentAmount: 4
     pilotWhitelist:
       components:
@@ -619,7 +619,7 @@
 # Mauler
 - type: entity
   id: MechMaulerSyndie
-  parent: [ BaseMech, CombatMech, BaseSyndicateContraband ]
+  parent: [ BaseMech, CombatMech ]
   name: Mauler
   description: A modified Marauder once used by the Syndicate. Not as maneuverable as the Dark Gygax, but it makes up for its speed in armor and sheer firepower.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/smartgun.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: MagazineSmart
   name: "magazine (.160 smart)"
-  parent: [ BaseItem, BaseRestrictedContraband ]
+  parent: BaseItem
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: VFD EG-4 energy revolver
-  parent: [BaseWeaponBatterySmall, BaseC2ContrabandUnredeemable] # Mono - C2 contra instead of command contra
+  parent: BaseWeaponBatterySmall # Mono - C2 contra instead of command contra
   id: WeaponEnergyRevolver
   description: A highly advanced energy revolver capable of firing both lethal and disabling bullets.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/magfed_lasers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/magfed_lasers.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: ER-5 Torrent
-  parent: [ BaseWeaponPowerCell, BaseC2ContrabandUnredeemable ]
+  parent: BaseWeaponPowerCell
   id: WeaponLaserCellSMG
   description: A high-tech laser SMG, compatible with specialized SMG power cells.
   components:
@@ -57,7 +57,7 @@
 
 - type: entity
   name:  ES-7 Multilens
-  parent: [ BaseWeaponPowerCell, BaseGunWieldable, BaseC2ContrabandUnredeemable ]
+  parent: [ BaseWeaponPowerCell, BaseGunWieldable ]
   id: WeaponLaserCellSniper
   description: A high-tech burst laser sniper rifle, compatible with specialized sniper power cells.
   components:
@@ -123,7 +123,7 @@
 
 - type: entity
   name: EG-1 Taro
-  parent: [ BaseWeaponPowerCellSmall, BaseC2ContrabandUnredeemable ]
+  parent: BaseWeaponPowerCellSmall
   id: WeaponLaserCellRevolver
   description: A high-tech laser revolver, compatible with specialized revolver power cells.
   components:
@@ -194,7 +194,7 @@
 
 - type: entity
   name: EL-20 HAMRR
-  parent: [BaseItem, BaseC2ContrabandUnredeemable]
+  parent: BaseItem
   id: WeaponLaserLMG
   description: A high-tech laser LMG, that draws power from specialized backpack.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseItem, BaseC3PirateContraband ]
+  parent: BaseItem
   id: WeaponPistolAnaconda
   name: LWC Anaconda
   description: A heavy pistol capable of supplying itself with the ammo on the way using a built-in fabricator. Technology once belonging to Cybersun now supplies the Imperial forces of the Phaethon Dynasty.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: TCA M27 Annie (7.62x39mm)
-  parent: [BaseC2ContrabandUnredeemable, BaseWeaponRifle] # Mono - C2 contra
+  parent: BaseWeaponRifle # Mono - C2 contra
   id: WeaponRifleAnnie
   description: A beast designed to shoulder the weight of impossible missions. Uses 7.62x39mm ammo.
   components:
@@ -62,7 +62,7 @@
 
 - type: entity
   name: CS KMP-WSPR (7.62x39mm)
-  parent: [BaseC3PirateContraband, BaseWeaponRifle] # Mono - C3
+  parent: BaseWeaponRifle # Mono - C3
   id: WeaponRifleWSPR
   description: A cutting-edge rifle from Cybersun, versatile, reliable, and Syndicate-approved. Uses 7.62x39mm subsonic ammo.
   components:
@@ -117,7 +117,7 @@
 
 - type: entity
   name: PA M-90 (7.62x51mm) # mono - 762x51mm
-  parent: [BaseWeaponRifle, BaseC3PirateContraband] # Mono - pirate contra
+  parent: BaseWeaponRifle # Mono - pirate contra
   id: WeaponRifleM90
   description: A compact bullpup design. Uses 7.62x51mm rifle ammo. # mono
   components:
@@ -170,7 +170,7 @@
 
 - type: entity
   name: CS Burner (12.7x99mm)
-  parent: [BaseWeaponRifle, BaseC3PirateContrabandHighValue] # Mono - Changed to HighValue
+  parent: BaseWeaponRifle # Mono - Changed to HighValue
   id: WeaponRifleBurner
   description: A high caliber syndicate gun chambered in 12.7x99mm, capable of firing anti-material and high explosive rounds.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: TCA M27 Annie (7.62x39mm)
-  parent: BaseWeaponRifle # Mono - C2 contra
+  parent: [BaseWeaponRifle, BaseFactionGearTSFT2] # Mono
   id: WeaponRifleAnnie
   description: A beast designed to shoulder the weight of impossible missions. Uses 7.62x39mm ammo.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: PA Abielle Smart-SMG (.160 smart) # Mono
-  parent: [BaseWeaponSubMachineGun, BaseRestrictedContraband]
+  parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineSmart
   description: An experiment in smart-weapon technology that guides bullets towards the target the gun was aimed at when fired. While the tracking functions work fine, the gun is prone to insanely wide spread thanks to its practically non-existant barrel.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: welder energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseC1Contraband]
+  parent: BaseMeleeWeaponEnergy
   id: EnergySwordWelder
   description: Roughly converted from a welding tool, this energy sword hums an unstable flame. It looks like it's about to fall apart.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/sword.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: navy officer's sabre
-  parent: [ BaseSword, BaseCentcommContraband ]
+  parent: BaseSword
   id: NavyOfficerSabre
   description: Plastitanium sabre used primarily in ceremonies by naval officers, it remains a proven weapon. # Mono added mention of plastitanium to description to explain its heightened damage
   components:

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseWeaponRifle, BaseC2ContrabandUnredeemable] # Mono
+  parent: BaseWeaponRifle # Mono
   id: WeaponRifleMR3C # Mono
   name: SKR-WS MR-3C Bandit (8x65mm SKR) # Mono
   description: A precise and reliable bullpup DMR, developed as a production model from early MR-8C prototypes. Feeds from 8x65mm STANAG magazines. # Mono

--- a/Resources/Prototypes/_Mono/Body/Organs/chimera.yml
+++ b/Resources/Prototypes/_Mono/Body/Organs/chimera.yml
@@ -5,7 +5,7 @@
 - type: entity
   id: BaseChimeraOrgan
   name: chimera organ
-  parent: [BaseItem, BaseC3SyndicateContraband]
+  parent: BaseItem
   abstract: true
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Back/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Back/modsuit.yml
@@ -186,7 +186,7 @@
             - PowerCell
 
 - type: entity
-  parent: [Clothing, ContentsExplosionResistanceBase, BaseC3PirateContrabandHighValue]
+  parent: [Clothing, ContentsExplosionResistanceBase]
   id: ClothingModsuitRogue
   name: RX-01 hardsuit control unit
   description: Core control unit for the RX-01. Survives power spikes, hull breaches, and black market ingenuity. Somehow. Also has built in experimental voidboots.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Belt/belts.yml
@@ -12,7 +12,7 @@
 #small chest rigs
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsNormalBlack
   name: black chest rig
   description: A set of tactical webbing worn by boarding parties.
@@ -30,7 +30,7 @@
 #small chest rigs
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC2ContrabandUnredeemable]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsNormalTSFMC
   name: TSFMC chest rig
   description: A set of tactical webbing worn by marines.
@@ -46,7 +46,7 @@
     damageCoefficient: 0.5
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsNormalTan
   name: tan chest rig
   description: A set of tactical webbing worn by boarding parties.
@@ -62,7 +62,7 @@
     damageCoefficient: 0.5
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsNormalRangerGreen
   name: ranger green chest rig
   description: A set of tactical webbing worn by boarding parties.
@@ -78,7 +78,7 @@
     damageCoefficient: 0.5
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsNormalOlive
   name: olive chest rig
   description: A set of tactical webbing worn by boarding parties.
@@ -96,7 +96,7 @@
 #Big chest rigs
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsBigBase
   name: large chest rig
   description: A set of tactical webbing worn by boarding parties.
@@ -117,7 +117,7 @@
     sprintModifier: 0.95
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsBigBlack
   name: black large chest rig
   description: A set of tactical webbing worn by boarding parties.
@@ -138,7 +138,7 @@
     sprintModifier: 0.95
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC2ContrabandUnredeemable]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsBigTSFMC
   name: TSFMC large chest rig
   description: A set of tactical webbing worn by marines.
@@ -159,7 +159,7 @@
     sprintModifier: 0.95
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsBigTan
   name: tan large chest rig
   description: A set of tactical webbing worn by boarding parties.
@@ -180,7 +180,7 @@
     sprintModifier: 0.95
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsBigRangerGreen
   name: ranger green large chest rig
   description: A set of tactical webbing worn by boarding parties.
@@ -201,7 +201,7 @@
     sprintModifier: 0.95
 
 - type: entity
-  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseC1Contraband]
+  parent: [NFClothingBeltStorageBase, ContentsExplosionResistanceBase]
   id: ClothingBeltWebbingsBigOlive
   name: olive large chest rig
   description: A set of tactical webbing worn by boarding parties.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Hands/gloves.yml
@@ -23,7 +23,7 @@
 #tactical gloves
 
 - type: entity
-  parent: [ ClothingHandsGlovesCombat, BaseC1Contraband ] # BaseSecurityEngineeringContraband<BaseC1Contraband
+  parent: ClothingHandsGlovesCombat
   id: ClothingHandsGlovesTacticalCombatTan
   name: tan tactical combat gloves
   description: These tactical gloves are fireproof and shock resistant.
@@ -50,7 +50,7 @@
     vendPrice: 1950
 
 - type: entity
-  parent: [ ClothingHandsGlovesCombat, BaseC1Contraband ] # BaseSecurityEngineeringContraband<BaseC1Contraband
+  parent: ClothingHandsGlovesCombat
   id: ClothingHandsGlovesTacticalCombatBlack
   name: black tactical combat gloves
   description: These tactical gloves are fireproof and shock resistant.
@@ -77,7 +77,7 @@
     vendPrice: 1950
 
 - type: entity
-  parent: [ ClothingHandsGlovesCombat, BaseC1Contraband ] # BaseSecurityEngineeringContraband<BaseC1Contraband
+  parent: ClothingHandsGlovesCombat
   id: ClothingHandsGlovesTacticalCombatRangerGreen
   name: ranger green tactical combat gloves
   description: These tactical gloves are fireproof and shock resistant.
@@ -104,7 +104,7 @@
     vendPrice: 1950
 
 - type: entity
-  parent: [ ClothingHandsGlovesCombat, BaseC1Contraband ] # BaseSecurityEngineeringContraband<BaseC1Contraband
+  parent: ClothingHandsGlovesCombat
   id: ClothingHandsGlovesTacticalCombatOlive
   name: olive tactical combat gloves
   description: These tactical gloves are fireproof and shock resistant.
@@ -131,7 +131,7 @@
     vendPrice: 1950
 
 - type: entity
-  parent: [ ClothingHandsGlovesCombat, BaseC1Contraband ] # BaseSecurityEngineeringContraband<BaseC1Contraband
+  parent: ClothingHandsGlovesCombat
   id: ClothingHandsGlovesTacticalCombatCoyoteBrown
   name: coyote brown tactical combat gloves
   description: These tactical gloves are fireproof and shock resistant.
@@ -158,7 +158,7 @@
     vendPrice: 1950
 
 - type: entity
-  parent: [ ClothingHandsGlovesCombat, BaseC1Contraband ] # BaseSecurityEngineeringContraband<BaseC1Contraband
+  parent: ClothingHandsGlovesCombat
   id: ClothingHandsGlovesTacticalCombatWhite
   name: white tactical combat gloves
   description: These tactical gloves are fireproof and shock resistant.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/TSFMC/m82series.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/TSFMC/m82series.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingHeadHardsuitBase, BaseC2ContrabandUnredeemable]
+  parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitM82
   name: M82 helmet
   description: The interchangeable helmet system for the majority of M82 hardsuits. Outfitted with a basic NVG system.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/TSFMC/m86.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/TSFMC/m86.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingHeadHardsuitBase, BaseC2ContrabandUnredeemable, ShowMedicalIcons]
+  parent: [ClothingHeadHardsuitBase, ShowMedicalIcons]
   id: ClothingHeadHelmetHardsuitM86
   name: M86 helmet
   description: Modified from M82 series helmets, outfitted with night-vision equipment and refined gel-layers.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingHeadHardsuitBase, BaseC3SyndicateContraband, ShowMedicalIcons]
+  parent: [ClothingHeadHardsuitBase, ShowMedicalIcons]
   id: ClothingHelmetHardsuitAsakim
   name: kasature-pattern combat harness helmet
   description: Part of an advanced pre-fracture combat harness.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercs.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingHeadHardsuitBase, BaseC3SyndicateContraband, ClothingHeadSuitWithLightBase]
+  parent: [ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase]
   id: ClothingHelmetHardsuitMercenaryWarlord
   name: WL-01 helmet
   description: A heavy headgear piece accompanying the Warlord suit, it offers flash inmunity aswell mass scanner support.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/scaf_pirate.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingHeadHardsuitBase
+  parent: [ ClothingHeadHardsuitBase, BaseFactionGearPDVT2 ]
   id: ClothingHeadHelmetHardsuitPirateScaf
   name: PDV SCAF hardsuit helmet
   description: An old SCAF suit painted in an PDV tan color scheme. The lighting systems have been replaced with a thermal pulse.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/scaf_pirate.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingHeadHardsuitBase, BaseC3SyndicateContraband]
+  parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitPirateScaf
   name: PDV SCAF hardsuit helmet
   description: An old SCAF suit painted in an PDV tan color scheme. The lighting systems have been replaced with a thermal pulse.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/viper_group.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/viper_group.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase, BaseC3SyndicateContraband]
+  parent: [ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase]
   id: ClothingHeadHelmetHardsuitViperGroupStandard
   name: JACKAL mk.II viper hardsuit helmet
   description: A hardsuit helmet with signature markings of the Viper Group. Has a built-in nightvision system.
@@ -31,7 +31,7 @@
     - HeadSide
 
 - type: entity
-  parent: [ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase, BaseC3SyndicateContraband, ShowMedicalIcons]
+  parent: [ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase, ShowMedicalIcons]
   id: ClothingHeadHelmetHardsuitViperGroupMedic
   name: IMP mk.III viper hardsuit helmet
   description: A hardsuit helmet with signature markings of the Viper Group. Has a built-in medical HUD complemented by thermal pulse systems.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Masks/masks.yml
@@ -13,7 +13,7 @@
     coverage: MOUTH
 
 - type: entity
-  parent: [ ClothingMaskDrakeIndustries , BaseC3ContrabandNoValue ]
+  parent: [ ClothingMaskDrakeIndustries  ]
   id: ClothingMaskDrakeIndustriesWatchdog
   name: watchdog respirator
   description: A clunky respirator following the original design from Drake Industries. This one comes wih a polarized visor to protect the eyes during hostile encounters.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Neck/cloaks.yml
@@ -1,6 +1,6 @@
 
 - type: entity
-  parent: [ClothingNeckBase] # Frontier: BaseCommandContraband<BaseC2ContrabandUnredeemable
+  parent: [ClothingNeckBase]
   id: ClothingNeckCloakUssp
   name: Commissar parade cloak
   description: An exquisite white, red, blue and gold cloak fitting for those who can assert dominance over their troops.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Armor/exosuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Armor/exosuit.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseC2ContrabandUnredeemable, ContrabandClothing ]
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing ]
   id: ClothingOuterExosuitAurora
   name: M-320X AURORA exosuit
   suffix: SelfUnremovable

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearTSFT2]
   id: ClothingOuterHardsuitM82c
   name: M82c hardsuit
   description: A hardsuit issued to marines operating in low-pressure and high-risk environments. Specialized in bullet protection.
@@ -43,7 +43,7 @@
     vendPrice: 7500
 
 - type: entity
-  parent: ClothingOuterHardsuitM82c
+  parent: [ ClothingOuterHardsuitM82c, BaseFactionGearTSFT2 ]
   id: ClothingOuterHardsuitM82b
   name: M82b hardsuit
   description: Corpsman variant of the M82c outfitted with caustic and radiological shielding. Some of the blunt-absorbent gel layer is sacrificed for the NBC protection.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m82series.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC2ContrabandUnredeemable]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitM82c
   name: M82c hardsuit
   description: A hardsuit issued to marines operating in low-pressure and high-risk environments. Specialized in bullet protection.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m86.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m86.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ClothingOuterHardsuitBase, BaseFactionGearTSFT3]
   id: ClothingOuterHardsuitM86
   name: M86 Mk.3(R) hardsuit
   description: An armored hardsuit, designed to be an upgrade for the M82 series. The extra armor gives it some more weight to move around.
@@ -46,7 +46,7 @@
 # MARSOC only
 
 - type: entity
-  parent: [EnergyShieldClothing, ClothingOuterHardsuitM86]
+  parent: [EnergyShieldClothing, ClothingOuterHardsuitM86, BaseFactionGearTSFT3]
   id: ClothingOuterHardsuitM86Mk4
   name: M86 Mk.4(B) hardsuit
   description: A limited-production redesign proposal for the M86 Mk.3(R), outfitted with an inbuilt personal shield generator.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m86.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/TSFMC/m86.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC2ContrabandUnredeemable]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitM86
   name: M86 Mk.3(R) hardsuit
   description: An armored hardsuit, designed to be an upgrade for the M82 series. The extra armor gives it some more weight to move around.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3SyndicateContraband]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitAsakim
   name: kasature-pattern combat harness
   description: An advanced pre-fracture harness. Incredibly rare, and practically alien in technology compared to modern tacsuits. Once equipped, the armor binds itself with the wearer and cannot be removed without external release.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT3 ]
   id: ClothingOuterHardsuitAsakim
   name: kasature-pattern combat harness
   description: An advanced pre-fracture harness. Incredibly rare, and practically alien in technology compared to modern tacsuits. Once equipped, the armor binds itself with the wearer and cannot be removed without external release.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asr_copies.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asr_copies.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitSyndie
+  parent: [ ClothingOuterHardsuitSyndie, BaseFactionGearPDVT2 ]
   id: ClothingOuterHardsuitAshen
   name: PDV CV-32 combat tacsuit
   description: A combat tacsuit designed by the Phaethon Dynasty. A heavier but still general-purpose hardsuit.
@@ -21,7 +21,7 @@
     - RogueHardsuit
 
 - type: entity
-  parent: [ ClothingOuterHardsuitSyndieElite, EnergyShieldClothing ]
+  parent: [ ClothingOuterHardsuitSyndieElite, EnergyShieldClothing, BaseFactionGearPDVT3 ]
   id: ClothingOuterHardsuitAshenElite
   name: PDV CV-53 combat hardsuit
   description: Originally based off of the CV-32, the CV-53 sacrifices conventional armor plating for environmental protection, and a rechargeable hard-shield.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3SyndicateContraband]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitPirateScaf
   name: PDV SCAF hardsuit
   description: An old SCAF suit painted in an PDV tan color scheme. The armor feels degraded, but lighter.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT2 ]
   id: ClothingOuterHardsuitPirateScaf
   name: PDV SCAF hardsuit
   description: An old SCAF suit painted in an PDV tan color scheme. The armor feels degraded, but lighter.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ui.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ui.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT2 ]
   id: ClothingOuterHardsuitUIEnforcer
   name: U.I. ENFORCER combat tacsuit
   description: Infamously one of the most reliable combat tacsuits that the Black Market has to offer, developed by Ullman Industries. "Heads up display sold seperately!"
@@ -38,7 +38,7 @@
     coefficient: 0.55
 
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, EnergyShieldClothing ]
+  parent: [ ClothingOuterHardsuitBase, EnergyShieldClothing, BaseFactionGearOtherFactionT2 ]
   id: ClothingOuterHardsuitUIEnforcerMKII
   name: U.I. ENFORCER MKII combat tacsuit
   description: Based off of the infamous MKI design with versatility in mind. This is Ullman Industries' top of the line combat suit. Whether it be slipping away from the feds, taking out the competition, or serving your corporate overlords, this marvel of engineering will make sure that you get it done.
@@ -96,7 +96,7 @@
     coefficient: 0.45
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT0 ]
   id: ClothingOuterHardsuitUllmanEngineer
   name: U.I. engineering hardsuit
   description: A protective hardsuit worn by black market engineering specialists. Developed by Ullman Industries.
@@ -135,7 +135,7 @@
     coefficient: 0.8
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT0 ]
   id: ClothingOuterHardsuitUIPilot
   name: U.I. pilot voidsuit
   description: A voidsuit made for black market pilots. Developed by Ullman Industries
@@ -175,7 +175,7 @@
     coefficient: 0.7
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT2 ]
   id: ClothingOuterHardsuitUIDirector
   name: U.I. VK-1 experimental hardsuit
   description: Felix Ullman's top of the line personal hardsuit. A warning label engraved on the chestplate reads "Theft of this suit has a high chance of death! Seriously, I will find you. You will die."

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ussp.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT2 ]
   id: ClothingOuterHardsuitUsspL27
   name: USSP L-27 tacsuit
   description: The standard combat suit of USSP naval operations.
@@ -45,7 +45,7 @@
     id: ClothingOuterHardsuitTacsuit
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT0 ]
   id: ClothingOuterHardsuitUsspL10
   name: USSP L-10 lightsuit
   description: An old USSP model of combat suit that is still in use in the frontlines.
@@ -91,7 +91,7 @@
     id: ClothingOuterHardsuitTacsuit
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT0 ]
   id: ClothingOuterHardsuitUsspL10A
   name: USSP L-10-A lightsuit
   description: An old USSP model of combat suit that is still in use in the frontlines.
@@ -137,7 +137,7 @@
     id: ClothingOuterHardsuitTacsuit
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT0 ]
   id: ClothingOuterHardsuitUsspM10
   name: USSP M-10 scoutsuit
   description: A new prototype of combat suit using the old L-10 as a baseline. It has a integrated mass scanner in his helmet.
@@ -182,7 +182,7 @@
     id: ClothingOuterHardsuitTacsuitHighValue
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT2 ]
   id: ClothingOuterHardsuitUsspL30
   name: USSP L-30 Naval Commissar parade hardsuit.
   description: A highly decorated hardsuit with upgraded mobility and higher quality lighter armor plates to quickly convey orders on the frontline. (or not be sweaty in a parade)
@@ -228,7 +228,7 @@
     id: ClothingOuterHardsuitTacsuitHighValue
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT3 ]
   id: ClothingOuterHardsuitOfficerCombat
   name: USSP UF-16 "Voenkom" commissar tacsuit
   description: Developed by Union armament manufacturers for use by members of the commissariat on the frontlines. Features enhanced plating for survivability, allowing commanders to continue to give orders even while under heavy fire.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/viper_group.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/viper_group.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3SyndicateContraband]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitViperGroupStandard
   name: JACKAL mk.II viper hardsuit
   description: A heavy hardsuit adorned with signature markings of the Viper Group. The armor is remarkably flexible for the protection it offers.
@@ -46,7 +46,7 @@
     - RogueHardsuit
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseC3SyndicateContraband]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitViperGroupMedic
   name: IMP mk.III viper hardsuit
   description: A combat medical hardsuit adorned with signature markings of the Viper Group. The armor features various reinforced plating in vital areas.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/viper_group.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/viper_group.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearPDVT2 ]
   id: ClothingOuterHardsuitViperGroupStandard
   name: JACKAL mk.II viper hardsuit
   description: A heavy hardsuit adorned with signature markings of the Viper Group. The armor is remarkably flexible for the protection it offers.
@@ -46,7 +46,7 @@
     - RogueHardsuit
 
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearPDVT2 ]
   id: ClothingOuterHardsuitViperGroupMedic
   name: IMP mk.III viper hardsuit
   description: A combat medical hardsuit adorned with signature markings of the Viper Group. The armor features various reinforced plating in vital areas.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
@@ -109,7 +109,7 @@
     reduction: 0.5
 
 - type: entity
-  parent: [ ClothingOuterBase, GeigerCounterClothing ] # Mono - add geiger
+  parent: [ ClothingOuterBase, GeigerCounterClothing, BaseFactionGearPDVT3 ] # Mono - add geiger
   id: ClothingModsuitChestplateRogue
   name: RX-01 modsuit chestplate
   description: The chestpiece has some warning label on the inside about radiation leaks- and a note next to it 'Remove this label in the final product - Felix

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Shoes/magboots.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingShoesBootsMagBase]
+  parent: [ ClothingShoesBootsMagBase, BaseFactionGearOtherFactionT0 ]
   id: ClothingShoesBootsMagDrakeIndustries
   name: painted magboots
   description: Yep, that's just repainted science boots.
@@ -23,7 +23,7 @@
     sprite: _Mono/Clothing/Shoes/Boots/voidboots.rsi
 
 - type: entity
-  parent: ClothingShoesBootsMagAdv
+  parent: [ ClothingShoesBootsMagAdv, BaseFactionGearOtherFactionT2 ]
   id: ClothingShoesBootsMagAsakim
   name: pre-fracture magboots
   description: State-of-the-art magnetic boots made for combat with advanced harnesses.
@@ -35,7 +35,7 @@
     modifier: 0.35
 
 - type: entity
-  parent: [ClothingShoesBootsMagSyndie]
+  parent: [ ClothingShoesBootsMagSyndie, BaseFactionGearPDVT1 ]
   id: ClothingShoesBootsMagAshen
   name: tactical magboots
   description: Tactical magnetic boots that have a heavy magnetic pull and integrated thrusters for boarding. It can hold 0.75 L of gas.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Misc/identification_cards.yml
@@ -56,7 +56,7 @@
     - state: idseniorofficer
 
 - type: entity
-  parent: [IDCardStandard, BaseCommandContraband]
+  parent: IDCardStandard
   id: USSPCommissarIDCard
   name: USSP commissar ID card
   components:
@@ -199,7 +199,7 @@
 
 - type: entity
   name: spasaka ID card
-  parent: [IDCardStandard, BaseC3SyndicateContraband]
+  parent: IDCardStandard
   id: PDVSpasakaIDCard
   suffix: Chameleon
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Misc/identification_cards.yml
@@ -199,7 +199,7 @@
 
 - type: entity
   name: spasaka ID card
-  parent: IDCardStandard
+  parent: [ IDCardStandard, BaseFactionGearPDVT2 ]
   id: PDVSpasakaIDCard
   suffix: Chameleon
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/pda.yml
@@ -183,7 +183,7 @@
     attachedToSuit: true # Mono
 
 - type: entity
-  parent: [BaseC2ContrabandUnredeemable, SheriffPDA]
+  parent: SheriffPDA
   id: MarsocFTLPDA
   name: TSFMC MARSOC fire team leader PDA
   description: A standard TSFMC personal computer.
@@ -208,7 +208,7 @@
     attachedToSuit: true # Mono
 
 - type: entity
-  parent: [BaseC2ContrabandUnredeemable, SheriffPDA]
+  parent: SheriffPDA
   id: MarsocPDA
   name: TSFMC MARSOC operative PDA
   description: A standard TSFMC personal computer.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: fentanyl crystal
-  parent: [ BaseItem, BaseC3ChemContraband ]
+  parent: BaseItem
   id: FentanylSolidified
   description: 5u of Fentanyl solidified with Tricordrazine. Worth a lot.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/turrets.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/turrets.yml
@@ -27,7 +27,6 @@
   name: laser turret
   suffix: Frontier, Silicon
   parent:
-  - BaseC3Contraband
   - WeaponTurretLaserSyndicateNF
   components:
   - type: NpcFactionMember
@@ -178,7 +177,6 @@
   description: A disassembled and packed MK-290 sentry system.
   suffix: TSFMC, Packed
   parent:
-  - BaseC2ContrabandUnredeemable
   - BaseItem
   components:
   - type: WeaponCaseInsertable

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -60,7 +60,7 @@
 # S2 Mechas
 - type: entity
   id: BaseAFInterceptor
-  parent: [ BaseMech, LightMechMount, BaseRestrictedContraband ]
+  parent: [ BaseMech, LightMechMount ]
   abstract: true
   categories: [ HideSpawnMenu ]
   name: AF-28 "Broadsword"
@@ -276,7 +276,7 @@
 #4x4 mechas
 - type: entity
   id: AFFlail
-  parent: [ BaseMech, HeavyMechMount, BaseRestrictedContraband ]
+  parent: [ BaseMech, HeavyMechMount ]
   name: ASF-59 "Flail"
   description: Newest mech on the market, the Armored Strike Frame is built to tackle ship-sized foes with it's oversized weapon mounts. Slow as a pig however, it tacks on generous armor plating to survive it's runs.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BorgModuleAdvancedWeapon
-  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseC3SyndicateContraband ]
+  parent: [ BaseBorgModule, BaseProviderBorgModule ]
   name: advanced weapon cyborg module
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Bombs/bottlebomb.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Bombs/bottlebomb.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [GrenadeBase, BaseC3SyndicateContraband]
+  parent: GrenadeBase
   id: BottleBomb
   name: bottle bomb
   description: Cheap alternative to nukes.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Bombs/nailbomb.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Bombs/nailbomb.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ProjectileGrenadeBase, BaseC3SyndicateContraband]
+  parent: ProjectileGrenadeBase
   id: NailBomb
   name: nail bomb
   description: An improvised explosive made from nails and gunpowder.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Bombs/pyrogelbomb.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Bombs/pyrogelbomb.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [GrenadeBase, BaseC3SyndicateContraband]
+  parent: GrenadeBase
   id: PyrogelBomb
   name: pyrogel bomb
   description: Experimental bottle bomb technology.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/12.7x99mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/12.7x99mm.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [ BaseItem, BaseC3PirateContraband ]
+  parent: BaseItem
   id: BaseAmmoBox127x99mm
   name: ammunition box (12.7x99mm anti-material)
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/12.7x99mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/12.7x99mm.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseCartridge, BaseC3PirateContrabandNoValue ]
+  parent: BaseCartridge
   description: Large anti-material round, capable of punching through armor and walls easily.
   id: Cartridge127x99mm
   name: cartridge (12.7x99mm anti-material)
@@ -21,7 +21,7 @@
     price: 20
 
 - type: entity
-  parent: [ BaseCartridge, BaseC3PirateContrabandNoValue ]
+  parent: BaseCartridge
   id: Cartridge127x99mmExplosive
   name: cartridge (12.7x99mm high-explosive)
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/12_gauge.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/12_gauge.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseShellShotgun12_gauge
   name: shotgun shell (12 gauge)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: added BaseC1Contraband
+  parent: BaseCartridge
   description: Standard shotgun round practically everywhere.
   abstract: true
   components:
@@ -33,7 +33,7 @@
 - type: entity
   id: ShellShotgun12_gaugeBeanbag
   name: shotgun shell (12 gauge beanbag)
-  parent: BaseShellShotgun12_gauge # Frontier: remove BaseSecurityBartenderContraband
+  parent: BaseShellShotgun12_gauge
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/14.5x114mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/14.5x114mm.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseCartridge, BaseC2Contraband ] # Frontier: BaseMajorContraband<BaseC2Contraband
+  parent: BaseCartridge
   id: Cartridge145x114mm
   name: cartridge (14.5x114mm)
   description: Even larger anti-material round, capable of punching through any armor and barriers without difficulty.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/4.6x30mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge46x30mm
   name: cartridge (4.6x30mm FMJ)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: A light AP round developed for PDWs in the 1990s, by an older world.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/45_ACP.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge45_ACP
   name: cartridge (.45 ACP FMJ)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: Heavier alternative to 9x19mm for handguns and SMGs.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/45_magnum.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/45_magnum.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge45_magnum
   name: cartridge (.45 magnum)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: Heavy magnum round, usually only seen in magnums or manually-cycled rifles.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/4_gauge.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/4_gauge.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseShellShotgun23x75mm
   name: shotgun shell (4 gauge)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: added BaseC1Contraband
+  parent: BaseCartridge
   description: Large shotgun round. Kicks like a mule, and will tear a chunk out of anything that doesnt have the armor to protect it.
   abstract: true
   components:
@@ -33,7 +33,7 @@
 - type: entity
   id: ShellShotgun23x75mmBeanbag
   name: shotgun shell (4 gauge beanbag)
-  parent: BaseShellShotgun23x75mm # Frontier: remove BaseSecurityBartenderContraband
+  parent: BaseShellShotgun23x75mm
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/5.56x45mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/5.56x45mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge556x45mm
   name: cartridge (5.56x45mm FMJ)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: An extremely-common intermediate cartridge for rifles.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/5.7x28mm.yml
@@ -2,7 +2,7 @@
   id: BaseCartridge57x28mm
   name: cartridge (5.7x28mm FMJ)
   description: A small PDW cartridge. More internal damage than 4.6, but less armor-piercing capabilities. Formerly infamous for its high cost.
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/55_SAM.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/55_SAM.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseCartridge, BaseRestrictedContraband ]
+  parent: BaseCartridge
   id: Cartridge55_SAM
   name: cartridge (.55 Smart Magnum Action)
   description: A .55 smart bullet with a quite heavy charge of booster propellant at the bottom.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/6.35x40mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/6.35x40mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge635x40mmCaseless
   name: cartridge (.25 rifle)
-  parent: [ BaseCartridge, BaseC3SyndicateContrabandNoValue ] # Frontier: BaseSecurityContraband<BaseC3SyndicateContraband
+  parent: BaseCartridge
   description: Developed during corporate wars for subsonic weapons to keep a low-profile during operations.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/7.62x39mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge762x39mm
   name: cartridge (7.62x39mm FMJ)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: Originating from over 400 years ago, this round has seen use in the rifles of multiple militias and militaries alike.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/7.62x51mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/7.62x51mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge762x51mm
   name: cartridge (7.62x51mm FMJ)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: A decently sized full-power round.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/7.62x54mmR.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/7.62x54mmR.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge762x54mmR
   name: cartridge (7.62x54mmR FMJ)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: A full-power rifle round commonly used in DMRs and civilian bolt-action rifles.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/8x65mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/8x65mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge8x65mmSKR
   name: cartridge (8x65mm SKR)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: An experimental high performance round. Standard round for high-power rifles across all branches of the TSF's armed forces.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/9x19mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridge9x19mm
   name: cartridge (9x19mm FMJ)
-  parent: [ BaseCartridge, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseCartridge
   description: Generic pistol round. Easy to handle, with a decent effect on unarmored flesh.
   abstract: true
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/smartgun.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/smartgun.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ BaseCartridge, BaseRestrictedContraband ]
+  parent: BaseCartridge
   id: CartridgeSmart
   name: cartridge (.160 smart)
   description: A .160 smart bullet with a small charge of booster propellant at the bottom.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/12.7x99mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/12.7x99mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine127x99mm
   name: "magazine (12.7x99mm)"
-  parent: [ BaseItem, BaseC3PirateContraband ]
+  parent: BaseItem
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/12_gauge.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/12_gauge.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine12_gauge
   name: ammo drum (12 gauge shells)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/4.6x30mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine46x30mm
   name: pistol magazine (4.6x30mm FMJ)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag
@@ -173,7 +173,7 @@
 - type: entity
   id: BaseMagazine46x30mmPistolHighCapacityFMJ
   name: machine pistol magazine (4.6x30mm FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -266,7 +266,7 @@
 - type: entity
   id: BaseMagazine46x30mmSubMachineGunFMJ
   name: SMG magazine (4.6x30mm FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseSecurityContraband<BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -457,7 +457,7 @@
 - type: entity
   id: Magazine46x30mmSubMachineGunTopMountedFMJ
   name: WT550 magazine (4.6x30mm top-mounted)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/40mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/40mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine40mm
   name: 40mm grenade cartridge
-  parent: [ BaseCartridge, BaseC2ContrabandUnredeemable ] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: BaseCartridge
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/45_ACP.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine45_ACP
   name: pistol magazine (.45 ACP FMJ)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag
@@ -173,7 +173,7 @@
 - type: entity
   id: BaseMagazine45_ACPPistolHighCapacityFMJ
   name: machine pistol magazine (.45 ACP FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -266,7 +266,7 @@
 - type: entity
   id: BaseMagazine45_ACPSubMachineGunFMJ
   name: SMG magazine (.45 ACP FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseSecurityContraband<BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -457,7 +457,7 @@
 - type: entity
   id: Magazine45_ACPSubMachineGunTopMountedFMJ
   name: top-mounted magazine (.45 ACP top-mounted)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/45_magnum.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/45_magnum.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine45_magnum
   name: pistol magazine (.45 magnum FMJ)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag
@@ -188,7 +188,7 @@
 - type: entity
   id: BaseMagazine45_magnumPistolHighCapacityFMJ
   name: machine pistol magazine (.45 magnum FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -281,7 +281,7 @@
 - type: entity
   id: BaseMagazine45_magnumSubMachineGunFMJ
   name: SMG magazine (.45 magnum FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseSecurityContraband<BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/5.56x45mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/5.56x45mm.yml
@@ -2,7 +2,7 @@
 - type: entity
   id: BaseMagazine556x45mm
   name: "magazine (5.56x45mm FMJ)"
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/5.7x28mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine57x28mm
   name: pistol magazine (5.7x28mm FMJ)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag
@@ -173,7 +173,7 @@
 - type: entity
   id: BaseMagazine57x28mmPistolHighCapacityFMJ
   name: machine pistol magazine (5.7x28mm FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -266,7 +266,7 @@
 - type: entity
   id: BaseMagazine57x28mmSubMachineGunFMJ
   name: SMG magazine (5.7x28mm FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseSecurityContraband<BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -457,7 +457,7 @@
 - type: entity
   id: Magazine57x28mmSubMachineGunTopMountedFMJ
   name: top-mounted magazine (5.7x28mm top-mounted)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/55_SAM.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/55_SAM.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: Magazine55_SAMPistol
   name: pistol magazine (.55 SAM)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   description: A standard magazine for the MK5 smart magnum, holding 12 rounds.
   components:
   - type: Tag
@@ -33,7 +33,7 @@
 - type: entity
   id: Magazine55_SAMPistolHighCapacity
   name: machine pistol magazine (.55 SAM)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   description: An extended magazine for the MK5 smart magnum, holding 18 rounds.
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/6.35x40mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/6.35x40mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine635x40mmCaseless
   name: "magazine (635x40mm Caseless)"
-  parent: [ BaseCartridge, BaseC3SyndicateContrabandNoValue, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC3SyndicateContraband, added RecyclableItemSteelTiny
+  parent: [ BaseCartridge, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/7.62x39mm.yml
@@ -2,7 +2,7 @@
 - type: entity
   id: BaseMagazine762x39mm
   name: "magazine (7.62x39mm FMJ)"
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/7.62x51mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/7.62x51mm.yml
@@ -2,7 +2,7 @@
 - type: entity
   id: BaseMagazine762x51mm
   name: "magazine (7.62x51mm FMJ)"
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/7.62x54mmR.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/7.62x54mmR.yml
@@ -2,7 +2,7 @@
 - type: entity
   id: BaseMagazine762x54mmR
   name: "magazine (7.62x54mmR FMJ)"
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/9x19mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazine9x19mm
   name: pistol magazine (9x19mm FMJ)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   abstract: true
   components:
   - type: Tag
@@ -173,7 +173,7 @@
 - type: entity
   id: BaseMagazine9x19mmPistolHighCapacityFMJ
   name: machine pistol magazine (9x19mm FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -266,7 +266,7 @@
 - type: entity
   id: BaseMagazine9x19mmSubMachineGunFMJ
   name: SMG magazine (9x19mm FMJ)
-  parent: [BaseItem, BaseC1Contraband, RecyclableItemSteelTiny] # Frontier: added RecyclableItemSteelTiny, BaseSecurityContraband<BaseC1Contraband
+  parent: [BaseItem, RecyclableItemSteelTiny]
   abstract: true
   components:
   - type: Tag
@@ -457,7 +457,7 @@
 - type: entity
   id: Magazine9x19mmSubMachineGunTopMountedFMJ
   name: top-mounted magazine (9x19mm top-mounted)
-  parent: [ BaseItem, BaseC1Contraband, RecyclableItemSteelTiny ] # Frontier: BaseSecurityContraband<BaseC1Contraband, added RecyclableItemSteelTiny
+  parent: [ BaseItem, RecyclableItemSteelTiny ]
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/45_magnum.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/45_magnum.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseSpeedLoader45_magnum
   name: "speed loader (.45 magnum)"
-  parent: [ BaseItem, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseItem
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/7.62x39mm.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: SpeedLoader762x39mmFMJ
   name: "speed loader (7.62x39mm FMJ)"
-  parent: [ BaseItem, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseItem
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/7.62x54mmR.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/7.62x54mmR.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: SpeedLoader762x54mmRFMJ
   name: "speed loader (7.62x54mmR FMJ)"
-  parent: [ BaseItem, BaseC1Contraband ] # Frontier: BaseSecurityContraband<BaseC1Contraband
+  parent: BaseItem
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -3,7 +3,7 @@
 - type: entity
   id: CartridgeRocket
   name: PG-7VL grenade
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseMajorContraband<BaseC2ContrabandUnredeemable
+  parent: BaseItem
   description: A 1.5 warhead designed for the RPG-7 launcher. Has tubular shape.
   components:
   - type: Tag
@@ -23,7 +23,7 @@
 - type: entity
   id: CartridgeRocketSlow
   name: PG-7VL grenade "Snail-Rocket"
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseMajorContraband<BaseC2ContrabandUnredeemable
+  parent: BaseItem
   description: A 1.5 warhead designed for the RPG-7 launcher. It's unusually slow.
   components:
     - type: Tag
@@ -45,7 +45,7 @@
 - type: entity
   id: BaseGrenade
   name: base grenade
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseMajorContraband<BaseC2ContrabandUnredeemable
+  parent: BaseItem
   abstract: true
   components:
   - type: Tag
@@ -158,7 +158,7 @@
 - type: entity
   id: BaseCannonBall
   name: base cannon ball
-  parent: [BaseItem, BaseC3PirateContrabandNoValue] # Frontier: BaseMajorContraband<BaseC3PirateContrabandNoValue
+  parent: BaseItem
   abstract: true
   components:
   - type: Tag
@@ -251,7 +251,7 @@
 - type: entity
   id: CartridgeMPSSMMissile
   name: MPSSM ASM-19 missile tube
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseMajorContraband<BaseC2ContrabandUnredeemable
+  parent: BaseItem
   description: A missile tube designed for the MPSSM launcher. Fires a ship-tracking EMP-HE missile with a lockon range of 1.2km
   components:
   - type: Tag
@@ -275,7 +275,7 @@
 - type: entity
   id: CartridgeMPSSMHEAT
   name: MPSSM Mk.248 rocket tube
-  parent: [BaseItem, BaseC2ContrabandUnredeemable] # Frontier: BaseMajorContraband<BaseC2ContrabandUnredeemable
+  parent: BaseItem
   description: A missile tube designed for the MPSSM launcher. Fires an unguided HEAT rocket for precise structural destruction and AT usage.
   components:
   - type: Tag

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/frost.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/frost.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: VFD EN-5 FROST
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseCommandContraband] # Frontier: added BaseCommandContraband
+  parent: [BaseWeaponBattery, BaseGunWieldable]
   id: WeaponEnergyGunFrost
   description: A self-recharging energy gun with lethal rounds that can inflict serious damage. Comes with disabling munitions and improved accuracy compared to it's previous versions.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/magfed_lasers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/magfed_lasers.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: EM72 Ashstorm
-  parent: [ BaseWeaponPowerCell, BaseC2ContrabandUnredeemable ]
+  parent: BaseWeaponPowerCell
   id: WeaponLaserCellMG
   description: EM72 Ashstorm, The TSF-EM72 Ashstorm is a directed-energy light machine gun developed by Aetherion Dynamics under TSF weapons contract 934A. Designed for sustained suppressive fire in void or planetary combat. The signature green glow of the Ashstorm's thermal capacitors is feared across imperial lines in the Helion Belt.
   components:
@@ -67,7 +67,7 @@
 
 - type: entity
   name: NT-WS LRC-21 PPL
-  parent: [ BaseWeaponPowerCell, BaseGunWieldable, BaseC2ContrabandUnredeemable ]
+  parent: [ BaseWeaponPowerCell, BaseGunWieldable ]
   id: WeaponLRC21PPL
   description: A heavy pulsed plasma lance rifle. Eviscerates targets with ease.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: NCI DP-29
-  parent: [BaseWeaponLightMachineGun, BaseGunWieldable, BaseC3Contraband]
+  parent: [BaseWeaponLightMachineGun, BaseGunWieldable]
   id: WeaponDP29
   description: A staple of USSP military doctrine, the DP-29 is a mass-produced light machine gun designed for reliability, ease of use, and battlefield endurance. Featuring a distinctive top-mounted pan magazine and a folding bipod, the DP-29 excels at providing suppressive fire in both urban and open combat scenarios. While its design dates back decades, its reliability and ease of maintenance make it a favorite among USSP infantry squads.
   components:
@@ -68,7 +68,7 @@
 
 - type: entity
   name: VFD MR-8B LWMMG (8x65mm SKR)
-  parent: [BaseWeaponLightMachineGun, BaseGunWieldable, BaseC2ContrabandUnredeemable]
+  parent: [BaseWeaponLightMachineGun, BaseGunWieldable]
   id: WeaponLMGMR8B
   description: The LWMMG variant of the MR-8 series. Chambered in 8x65mm SKR, and accepts both box and STANAG magazines. A label on the side reads "FOR MILITARY USE ONLY".
   components:
@@ -139,7 +139,7 @@
 
 - type: entity
   name: NCI AK-150 HAMMER (7.62x39mm)
-  parent: [BaseWeaponLightMachineGun, BaseGunWieldable, BaseC2ContrabandUnredeemable]
+  parent: [BaseWeaponLightMachineGun, BaseGunWieldable]
   id: WeaponLMGHammer
   description: A modified old style AK from earth which has been improved with USSP engineering and new design philosophies. At a base level? It's been turned into an LMG with a box magazine attached alongside various recoil lessening upgrades and a stylized chassis. Hail The Commissariat.
   components:
@@ -212,7 +212,7 @@
 
 - type: entity
   name: TCA MMG-68 "Grizzly" (6.8x52mm Caseless)
-  parent: [BaseWeaponLightMachineGun, BaseGunWieldable, BaseC2ContrabandUnredeemable]
+  parent: [BaseWeaponLightMachineGun, BaseGunWieldable]
   id: WeaponLMGGrizzly
   description: A medium machine gun chambered in 6.8x52mm Caseless, accepts both box and standard magazines. A label on the side reads "FOR MILITARY USE ONLY". The weight of the machine gun make it hard to wield easily. To assist with standardization, it also accepts 5.56x45mm and 7.62x39mm.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/smartgun.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/smartgun.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: SKR-WS MLA-79 smart LMG (.160 smart)
-  parent: [BaseWeaponLightMachineGun, BaseGunWieldable, BaseC2Contraband]
+  parent: [BaseWeaponLightMachineGun, BaseGunWieldable]
   id: WeaponSmartLmg
   description: A military prototype that saw rare use in front-lines field testing. This is a refined version for standard production.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Launchers/mpssm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Launchers/mpssm.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: NT-WS SM-27 MPSSM missile launcher
-  parent: [ BaseWeaponLauncher, BaseGunWieldable, BaseC2ContrabandUnredeemable ]
+  parent: [ BaseWeaponLauncher, BaseGunWieldable ]
   id: WeaponLauncherMPSSM
   suffix: HEAT
   description: A multipurpose man-portable launcher, capable of firing both guided anti-ship and unguided HEAT warheads.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: U.I Smart Pistol MK5 (.55 SAM)
-  parent: [BaseWeaponPistol, BaseGunWieldable, BaseC3SyndicateContraband]
+  parent: [BaseWeaponPistol, BaseGunWieldable]
   id: WeaponPistolUllmanSmartMagnumMK5
   description: A prototype smart pistol developed by Ullman Industries that uses .55 Smart Action Magnum, designed for precision and adaptability in combat situations. It features advanced targeting systems and a sleek design.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/recharging.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/recharging.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ WeaponPistolAnaconda, BaseC3PirateContraband ]
+  parent: WeaponPistolAnaconda
   id: WeaponPistolHawk4
   name: LWC HAWK-4 I.S
   description: A modified, heavy Anaconda for the purpose of assassinating high value targets. This rare prototype is capable of printing armor penetrating bullets. A laser and holographic sight alongside a matte black chassis with a custom-built integrated silencer make for an exceedingly deadly stealth weapon, only fit for a true Commander of the Phaethon Dynasty Imperial Vanguard.

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -134,7 +134,7 @@
 
 - type: entity
   name: VFD XLR-556 ICWS (5.56x45mm)
-  parent: [BaseWeaponRifle, BaseGunWieldable]
+  parent: [BaseWeaponRifle, BaseGunWieldable, BaseFactionGearTSFT1]
   id: WeaponRifleXlr556
   description: A proposed next-gen "rifle" for TSF standard infantry. Chambered in 5.56x45mm rifle rounds, its RPM is incredible - but with great firerate comes great fire control...
   components:
@@ -410,7 +410,7 @@
 
 - type: entity
   name: NTSF-LTR-556 (5.56x45mm,6.8x52mm Caseless)
-  parent: BaseWeaponRifle
+  parent: [BaseWeaponRifle, BaseFactionGearOtherFactionT1]
   id: WeaponRifleNtsfLtr
   description: An old corporate war era rifle. The Nano Trasen Security Forces and Special Forces's Light Tactical Rifle chambered in 5.56x45mm, also accepts 6.8x52mm due to it being a brand new caliber of its time and being a prototype. This rifle is of high-quality with plastitanium internal and plasteel furnitures.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: VFD MR-8C DMR (8x65mm SKR)
-  parent: [BaseWeaponRifle, BaseGunWieldable, BaseC2ContrabandUnredeemable]
+  parent: [BaseWeaponRifle, BaseGunWieldable]
   id: WeaponRifleMR8C
   description: The DMR variant of the MR-8 series, firing with incredible accuracy. Chambered in 8x65mm SKR. A label on the side reads "FOR MILITARY USE ONLY".
   components:
@@ -72,7 +72,7 @@
 
 - type: entity
   name: NCI AK-502 (7.62x39mm)
-  parent: [BaseWeaponRifle, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
+  parent: BaseWeaponRifle
   id: WeaponRifleAK502
   description: A standard-issue USSP combat rifle. Uses 7.62x39mm ammo.
   components:
@@ -134,7 +134,7 @@
 
 - type: entity
   name: VFD XLR-556 ICWS (5.56x45mm)
-  parent: [BaseWeaponRifle, BaseGunWieldable, BaseC2ContrabandUnredeemable]
+  parent: [BaseWeaponRifle, BaseGunWieldable]
   id: WeaponRifleXlr556
   description: A proposed next-gen "rifle" for TSF standard infantry. Chambered in 5.56x45mm rifle rounds, its RPM is incredible - but with great firerate comes great fire control...
   components:
@@ -255,7 +255,7 @@
 #Mercenary lecter
 - type: entity
   name: HWM FCL "Prometheus" (5.56x45mm)
-  parent: [BaseWeaponRifle, BaseC1Contraband]
+  parent: BaseWeaponRifle
   id: WeaponRiflePrometheus
   description: The Herstal Weapon Manufacture "Prometheus" Light combat rifle (Fusil de Combat Léger) in 556x45mm. Made to be mass producable for fight against xenos. Its firerate is decent with burst being superior and accuracy poor.
   components:
@@ -326,7 +326,7 @@
 
 - type: entity
   name: SKR-WS MLA-34 smartgun (.160 smart) # TODO - make like 5.56 level smartgun ammo for these
-  parent: [BaseWeaponRifle, BaseGunWieldable, BaseC2Contraband]
+  parent: [BaseWeaponRifle, BaseGunWieldable]
   id: WeaponRifleMla34
   description: A limited-production special smartgun made as a self-defense weapon for untrained ship crew.
   components:
@@ -410,7 +410,7 @@
 
 - type: entity
   name: NTSF-LTR-556 (5.56x45mm,6.8x52mm Caseless)
-  parent: [BaseWeaponRifle, BaseC2ContrabandUnredeemable]
+  parent: BaseWeaponRifle
   id: WeaponRifleNtsfLtr
   description: An old corporate war era rifle. The Nano Trasen Security Forces and Special Forces's Light Tactical Rifle chambered in 5.56x45mm, also accepts 6.8x52mm due to it being a brand new caliber of its time and being a prototype. This rifle is of high-quality with plastitanium internal and plasteel furnitures.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: SKR-WS MLA-73 (635x40mm caseless)
-  parent: [BaseWeaponSubMachineGun, BaseGunWieldable, BaseC2Contraband] # Frontier: added BaseC2Contraband
+  parent: [BaseWeaponSubMachineGun, BaseGunWieldable]
   id: WeaponSubMachineGunMla73
   description: A reliable PDW design, commonly issued to pilots and AFV crewmen. This one has been modified with an integral suppressor. Legends around this weapons say it's a Corporate-Era schematic that's been built by the Phaethon Dynasty.
   components:
@@ -52,7 +52,7 @@
 
 - type: entity
   name: NCI AK-220 (9x19mm)
-  parent: [BaseWeaponSubMachineGun, BaseGunWieldable, BaseC1Contraband]
+  parent: [BaseWeaponSubMachineGun, BaseGunWieldable]
   id: WeaponSubMachineGunAK220
   description: A mass produced 9x19mm bullpup SMG. The design originates from the USSP, but various TSF and PDV manufacturers produce it via licenses or suspiciously similar "original" designs.
   components:
@@ -111,7 +111,7 @@
 
 - type: entity
   name: LWC Vector (9x19mm)
-  parent: [BaseWeaponSubMachineGun, BaseGunWieldable, BaseC2Contraband] # Frontier: added BaseC2Contraband
+  parent: [BaseWeaponSubMachineGun, BaseGunWieldable]
   id: WeaponSubMachineGunVector9x19mm
   description: An excellent fully automatic SMG. Uses 9x19mm ammo.
   components:
@@ -168,7 +168,7 @@
 
 - type: entity
   name: LWC Vector (.45 ACP)
-  parent: [BaseWeaponSubMachineGun, BaseGunWieldable, BaseC2Contraband] # Frontier: added BaseC2Contraband
+  parent: [BaseWeaponSubMachineGun, BaseGunWieldable]
   id: WeaponSubMachineGunVector45_ACP
   description: An excellent fully automatic SMG. Uses .45 ACP ammo.
   components:
@@ -226,7 +226,7 @@
 # Corpo War .45 Mag Vector
 - type: entity
   name: NTSF-HCLM-45 (.45 magnum)
-  parent: [BaseWeaponSubMachineGun, BaseGunWieldable, BaseC2ContrabandUnredeemable]
+  parent: [BaseWeaponSubMachineGun, BaseGunWieldable]
   id: WeaponSubMachineGunVectorNtsfHclm
   description: The NTSF Heavy Caliber Light Machinegun. A very high-quality heavy SMG chambered in .45 magnum for use for the Nano Trasen Security Force and NT spec-ops, from the corporate war.
   components:
@@ -280,7 +280,7 @@
 
 - type: entity
   name: LWC Knallstock (9x19mm/.45 ACP)
-  parent: [ BaseWeaponSubMachineGun, BaseGunWieldable, BaseC2Contraband ] # Frontier: added BaseC2Contraband
+  parent: [ BaseWeaponSubMachineGun, BaseGunWieldable ]
   id: WeaponSubMachineGunKnallstock
   description: A rugged and reliable SMG using large, rapid fire bursts. Accepts 9x19 or .45 ACP pistol magazines. Watch out for its ammo consumption.
   components:
@@ -364,7 +364,7 @@
 #old drozd sprite SMG
 - type: entity
   name: HWM Firestarter (.45 ACP)
-  parent: [BaseWeaponSubMachineGun, BaseGunWieldable, BaseC2Contraband] # Frontier: added BaseC2Contraband
+  parent: [BaseWeaponSubMachineGun, BaseGunWieldable]
   id: WeaponSubMachineGunFirestarter
   description: An excellent fully automatic SMG. Uses .45 ACP ammo.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: Big Leady (4 gauge)
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseC3SyndicateContraband]
+  parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunBigLeady
   description: A massive 4 gauge (23x75mm) shotgun made to kill what any caliber bellow autocannon cant.
   components: # intend for BigLeady to have tighter choke for slower fire rate and/or manual cycling
@@ -36,7 +36,7 @@
 
 - type: entity
   name: Big Johnny (4 gauge)
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseC1Contraband]
+  parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunBigJohnny
   description: A massive 4 gauge (23x75mm) shotgun made to kill what any caliber bellow autocannon cant. This one is outfitted with various tactical additions and is made for CQC at the cost of low ammo capacity.
   components: # intend for BigLeady to have tighter choke for slower fire rate and/or manual cycling
@@ -75,7 +75,7 @@
 
 - type: entity
   name: Big Buddy (4 gauge)
-  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseC3SyndicateContraband]
+  parent: [BaseWeaponShotgun, BaseGunWieldable]
   id: WeaponShotgunBigBuddy
   description: A massive 4 gauge (23x75mm) shotgun made to kill what any caliber bellow autocannon cant.
   components: # intend for BigBuddy to have tighter choke for slower fire rate and/or manual cycling
@@ -111,7 +111,7 @@
 
 - type: entity
   name: UW12-B Helopolis (12 gauge)
-  parent: [BaseWeaponShotgun, BaseC1Contraband]
+  parent: BaseWeaponShotgun
   id: WeaponShotgunHelopolis
   description: The Union Wrightworks 12-gauge breaching model "Helopolis", a compact shotgun that sacrifices all combat ergonomics to better serve as a breaching tool. Breaks doors with slugs. Combat use unadvised.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: WeaponRifleAK410
   name: NCI AK-410 (7.62x54mmR)
-  parent: [ BaseWeaponRifle, BaseC1Contraband ]
+  parent: BaseWeaponRifle
   description: "Bullpup DMR feeding from 762x54mmR magazines, developed to modernize USSP long-range infantry weapons."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Turrets/ballistics.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Turrets/ballistics.yml
@@ -92,7 +92,7 @@
     - HostileUniversally
 
 - type: entity
-  parent: [BallisticTurretHeavyBase, BaseC3SyndicateContraband]
+  parent: BallisticTurretHeavyBase
   id: WeaponTurretHeavySyndicate
   suffix: Syndicate
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/registered.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/registered.yml
@@ -4,7 +4,6 @@
 
 - type: entity #Viper
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponPistolViper
   id: WeaponPistolViperPMC
   suffix: Registered
@@ -16,7 +15,6 @@
 
 - type: entity #WT-550
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponSubMachineGunWt550
   id: WeaponSubMachineGunWt550PMC
   suffix: Registered
@@ -26,7 +24,6 @@
 
 - type: entity #Drozd
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponSubMachineGunDrozd
   id: WeaponSubMachineGunDrozdPMC
   suffix: Registered
@@ -36,7 +33,6 @@
 
 - type: entity #C-20r
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponSubMachineGunC20r
   id: WeaponSubMachineGunC20rPMC
   suffix: Registered
@@ -50,7 +46,6 @@
 
 - type: entity #Lecter
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponRifleLecter
   id: WeaponRifleLecterPMC
   suffix: Registered
@@ -62,7 +57,6 @@
 
 - type: entity #Kammerer
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponShotgunKammerer
   id: WeaponShotgunKammererPMC
   suffix: Registered
@@ -72,7 +66,6 @@
 
 - type: entity #Enforcer
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponShotgunEnforcer
   id: WeaponShotgunEnforcerPMC
   suffix: Registered
@@ -84,7 +77,6 @@
 
 - type: entity #Energy Gun
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponEnergyGun
   id: WeaponEnergyGunPMC
   suffix: Registered
@@ -94,7 +86,6 @@
 
 - type: entity #Laser Cannon
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponLaserCannon
   id: WeaponLaserCannonPMC
   suffix: Registered
@@ -104,7 +95,6 @@
 
 - type: entity #Disabler SMG
   parent:
-  - BaseC2ContrabandMercenary
   - WeaponDisablerSMG
   id: WeaponDisablerSMGPMC
   suffix: Registered

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/registered_loadout.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/registered_loadout.yml
@@ -1,5 +1,4 @@
 - type: entity
-  parent: BaseC2ContrabandMercenary
   id: WeaponLoadoutRegisteredBase
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Melee/sword.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: high-frequency blade
-  parent: [BaseC2ContrabandUnredeemable, Katana]
+  parent: Katana
   id: WeaponHFKatana
   description: A high-frequency blade. It's incredibly powerful. # Why the glorp would a katana be modified to have a HF blade :nerd::point_up:
   components:
@@ -36,7 +36,7 @@
 
 - type: entity
   name: VT-7 high-frequency blade
-  parent: [BaseC3SyndicateContraband, Katana] # we dont want the construction node, so we dont copy off the other HF katana
+  parent: Katana # we dont want the construction node, so we dont copy off the other HF katana
   id: WeaponVT7
   description: A high-frequency blade tuned with ill-advised modifications designed to sunder armor.
   components:
@@ -71,7 +71,7 @@
 
 - type: entity
   name: VT-7 HF blade "Murasama"
-  parent: [BaseC3SyndicateContraband, Katana] # we dont want the construction node, so we dont copy off the other HF katana
+  parent: Katana # we dont want the construction node, so we dont copy off the other HF katana
   id: WeaponMurasama
   description: You're the boss.
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: SmokeGrenade # Frontier: removed BaseEngineeringContraband
+  parent: SmokeGrenade
   id: NanolaminateFoamGrenade
   name: nanolaminate foam grenade
   description: An advanced version of a metal foam grenade. Instead of aluminium, the foam grows a nano-reinforced alloy in a large area, capable of sustaining much more damage than aluminium.

--- a/Resources/Prototypes/_Mono/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/base_contraband.yml
@@ -1,56 +1,187 @@
-- type: entity
-  parent: BaseC2ContrabandUnredeemable
-  id: BaseC2ContrabandMercenary
-  abstract: true
-  components:
-  - type: Contraband
-    severity: Class2Restricted
-    allowedDepartments: [ PMC, Security, Command, CentralCommand ]
+# Frontier-specific contraband targets.
+# If you need multiple currency types, specify them in the actual object instead of inheriting multiple parents here.
 
-- type: entity
-  parent: BaseC3Contraband
-  id: BaseC3ChemContraband
+- type: entity # Mono
+  id: BaseFactionGearT0
   abstract: true
   components:
   - type: Contraband
-    severity: Class3Chem
+    hideCarryStatus: true
+    severity: FactionGear0
     turnInValues:
-      FederationMilitaryCredit: 1 # set to 1 now that FMC values are multiplied by 5
+      FederationMilitaryCredit: 0
+      Doubloon: 0
 
-# These are compatibility prototypes to work with ported definitions
-# They simply map to the appropriate NF/Mono contraband equivalents
+#region PDV
 
-# non-stealth syndicate stuff
 - type: entity
-  id: BaseSyndicateContraband
-  parent: BaseC3SyndicateContraband
-  abstract: true
-
-# base department restricted contraband
-- type: entity
-  id: BaseRestrictedContraband
-  parent: BaseC2ContrabandUnredeemable
-  abstract: true
-
-# civilian department contraband
-- type: entity
-  id: BaseCivilianContraband
-  parent: BaseC1Contraband
-  abstract: true
-
-# cargo department contraband
-- type: entity
-  id: BaseCargoContraband
-  parent: BaseC1Contraband
-  abstract: true
-
-# near-worthless syndicate contraband
-- type: entity
-  id: BaseC3SyndicateContrabandLowValue
-  parent: BaseC3ChemContraband
+  parent: BaseFactionGearT0
+  id: BaseFactionGearPDVT0
   abstract: true
   components:
   - type: Contraband
-    severity: Class3Syndicate
+    allowedDepartments: [ Antag ]
+
+- type: entity
+  parent: BaseFactionGearPDVT0
+  id: BaseFactionGearPDVT1
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear1
     turnInValues:
-      FederationMilitaryCredit: 1
+      FederationMilitaryCredit: 5
+
+- type: entity
+  parent: BaseFactionGearPDVT0
+  id: BaseFactionGearPDVT2
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear2
+    turnInValues:
+      FederationMilitaryCredit: 15
+
+- type: entity
+  parent: BaseFactionGearPDVT0
+  id: BaseFactionGearPDVT3
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear3
+    turnInValues:
+      FederationMilitaryCredit: 45
+
+#endregion
+
+#region TSF
+
+- type: entity
+  parent: BaseFactionGearT0
+  id: BaseFactionGearTSFT0
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security ]
+
+- type: entity
+  parent: BaseFactionGearTSFT0
+  id: BaseFactionGearTSFT1
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear1
+    turnInValues:
+      Doubloon: 5
+
+- type: entity
+  parent: BaseFactionGearTSFT0
+  id: BaseFactionGearTSFT2
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear2
+    turnInValues:
+      Doubloon: 15
+
+- type: entity
+  parent: BaseFactionGearTSFT0
+  id: BaseFactionGearTSFT3
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear3
+    turnInValues:
+      Doubloon: 45
+
+#endregion
+
+#region non-faction
+
+- type: entity
+  parent: BaseFactionGearT0
+  id: BaseFactionGearOtherFactionT0
+  abstract: true
+
+- type: entity
+  parent: BaseFactionGearOtherFactionT0
+  id: BaseFactionGearOtherFactionT1
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear1
+    turnInValues:
+      FederationMilitaryCredit: 5
+      Doubloon: 5
+
+- type: entity
+  parent: BaseFactionGearOtherFactionT0
+  id: BaseFactionGearOtherFactionT2
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear2
+    turnInValues:
+      FederationMilitaryCredit: 15
+      Doubloon: 15
+
+- type: entity
+  parent: BaseFactionGearOtherFactionT0
+  id: BaseFactionGearOtherFactionT3
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear3
+    turnInValues:
+      FederationMilitaryCredit: 45
+      Doubloon: 45
+
+#endregion
+
+#region taxed contraband
+
+- type: entity
+  parent: BaseFactionGearOtherFactionT0
+  id: BaseFactionGearTaxedT0
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear0
+  - type: ItemTax
+    taxAccounts:
+      nfsd: -0.2
+
+- type: entity
+  parent: BaseFactionGearTaxedT0
+  id: BaseFactionGearTaxedT1
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear1
+    turnInValues:
+      FederationMilitaryCredit: 5
+      Doubloon: 5
+
+- type: entity
+  parent: BaseFactionGearTaxedT0
+  id: BaseFactionGearTaxedT2
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear2
+    turnInValues:
+      FederationMilitaryCredit: 15
+      Doubloon: 15
+
+- type: entity
+  parent: BaseFactionGearTaxedT0
+  id: BaseFactionGearTaxedT3
+  abstract: true
+  components:
+  - type: Contraband
+    severity: FactionGear3
+    turnInValues:
+      FederationMilitaryCredit: 45
+      Doubloon: 45
+
+#endregion

--- a/Resources/Prototypes/_Mono/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/base_contraband.yml
@@ -102,6 +102,9 @@
   parent: BaseFactionGearT0
   id: BaseFactionGearOtherFactionT0
   abstract: true
+  components:
+  - type: Contraband
+    severity: OtherFactionGear0
 
 - type: entity
   parent: BaseFactionGearOtherFactionT0
@@ -109,7 +112,7 @@
   abstract: true
   components:
   - type: Contraband
-    severity: FactionGear1
+    severity: OtherFactionGear1
     turnInValues:
       FederationMilitaryCredit: 5
       Doubloon: 5
@@ -120,7 +123,7 @@
   abstract: true
   components:
   - type: Contraband
-    severity: FactionGear2
+    severity: OtherFactionGear2
     turnInValues:
       FederationMilitaryCredit: 15
       Doubloon: 15
@@ -131,7 +134,7 @@
   abstract: true
   components:
   - type: Contraband
-    severity: FactionGear3
+    severity: OtherFactionGear3
     turnInValues:
       FederationMilitaryCredit: 45
       Doubloon: 45
@@ -145,8 +148,6 @@
   id: BaseFactionGearTaxedT0
   abstract: true
   components:
-  - type: Contraband
-    severity: FactionGear0
   - type: ItemTax
     taxAccounts:
       nfsd: -0.2
@@ -157,7 +158,7 @@
   abstract: true
   components:
   - type: Contraband
-    severity: FactionGear1
+    severity: OtherFactionGear1
     turnInValues:
       FederationMilitaryCredit: 5
       Doubloon: 5
@@ -168,7 +169,7 @@
   abstract: true
   components:
   - type: Contraband
-    severity: FactionGear2
+    severity: OtherFactionGear2
     turnInValues:
       FederationMilitaryCredit: 15
       Doubloon: 15
@@ -179,7 +180,7 @@
   abstract: true
   components:
   - type: Contraband
-    severity: FactionGear3
+    severity: OtherFactionGear3
     turnInValues:
       FederationMilitaryCredit: 45
       Doubloon: 45

--- a/Resources/Prototypes/_Mono/Entities/Objects/contraband_severities.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/contraband_severities.yml
@@ -1,15 +1,19 @@
 - type: contrabandSeverity
   id: FactionGear0
   examineText: contraband-examine-text-faction-gear-0
+  showDepartmentsAndJobs: true
 
 - type: contrabandSeverity
   id: FactionGear1
   examineText: contraband-examine-text-faction-gear-1
+  showDepartmentsAndJobs: true
 
 - type: contrabandSeverity
   id: FactionGear2
   examineText: contraband-examine-text-faction-gear-2
+  showDepartmentsAndJobs: true
 
 - type: contrabandSeverity
   id: FactionGear3
   examineText: contraband-examine-text-faction-gear-3
+  showDepartmentsAndJobs: true

--- a/Resources/Prototypes/_Mono/Entities/Objects/contraband_severities.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/contraband_severities.yml
@@ -1,0 +1,15 @@
+- type: contrabandSeverity
+  id: FactionGear0
+  examineText: contraband-examine-text-faction-gear-0
+
+- type: contrabandSeverity
+  id: FactionGear1
+  examineText: contraband-examine-text-faction-gear-1
+
+- type: contrabandSeverity
+  id: FactionGear2
+  examineText: contraband-examine-text-faction-gear-2
+
+- type: contrabandSeverity
+  id: FactionGear3
+  examineText: contraband-examine-text-faction-gear-3

--- a/Resources/Prototypes/_Mono/Entities/Objects/contraband_severities.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/contraband_severities.yml
@@ -17,3 +17,19 @@
   id: FactionGear3
   examineText: contraband-examine-text-faction-gear-3
   showDepartmentsAndJobs: true
+
+- type: contrabandSeverity
+  id: OtherFactionGear0
+  examineText: contraband-examine-text-faction-gear-0
+
+- type: contrabandSeverity
+  id: OtherFactionGear1
+  examineText: contraband-examine-text-faction-gear-1
+
+- type: contrabandSeverity
+  id: OtherFactionGear2
+  examineText: contraband-examine-text-faction-gear-2
+
+- type: contrabandSeverity
+  id: OtherFactionGear3
+  examineText: contraband-examine-text-faction-gear-3

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Magazine/20mm_ammo.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Magazine/20mm_ammo.yml
@@ -38,7 +38,7 @@
 - type: entity
   id: 20mmCartridge
   name: cartridge (20mm Solid)
-  parent: [ BaseCartridge, BaseC1Contraband ]
+  parent: BaseCartridge
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Magazine/30mm_ammo.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Magazine/30mm_ammo.yml
@@ -36,7 +36,7 @@
 - type: entity
   id: 30mmCartridge
   name: cartridge (30x173mm AP)
-  parent: [ BaseCartridge, BaseC1Contraband ]
+  parent: BaseCartridge
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Magazine/57mm_ammo.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Magazine/57mm_ammo.yml
@@ -36,7 +36,7 @@
 - type: entity
   id: 57mmCartridge
   name: cartridge (57mm)
-  parent: [ BaseCartridge, BaseC1Contraband ]
+  parent: BaseCartridge
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Magazine/90mm_ammo.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Magazine/90mm_ammo.yml
@@ -36,7 +36,7 @@
 - type: entity
   id: 90mmCartridge
   name: cartridge (90mm)
-  parent: [ BaseCartridge, BaseC1Contraband ]
+  parent: BaseCartridge
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/Computers/rogue_comm_computer.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/Computers/rogue_comm_computer.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ComputerComms, BaseC3PirateContrabandHighValue ]
+  parent: ComputerComms
   id: RogueComputerComms
   name: imperial vanguard communications computer
   description: A computer capable of remotely hacking into the station's communications systems. Using this to make an announcement will alert the station to your presence.

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/nuke.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseStructure, StructureWheeled, BaseC3ContrabandUnredeemable ]
+  parent: [BaseStructure, StructureWheeled ]
   id: ScuttleDeviceWyvern
   name: antimatter annihilation assembly
   description: Uses the power of antimatter to completely scuttle a ship. Will sell for more if unlocked.

--- a/Resources/Prototypes/_Mono/Entities/Structures/Storage/Crates/crate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Storage/Crates/crate.yml
@@ -40,7 +40,7 @@
         - MachineLayer
 
 - type: entity
-  parent: [ BaseC3SyndicateContraband, CrateGenericSteel ] 
+  parent: CrateGenericSteel 
   id: CrateNanotrasen
   name: NT crate
   description: A white and blue crate with the Nanotrasen Symbol.
@@ -51,7 +51,7 @@
     sprite: _Mono/Structures/Storage/Crates/nanotrasen.rsi
 
 - type: entity
-  parent: [ BaseC3SyndicateContraband, CrateGenericSteel ] 
+  parent: CrateGenericSteel 
   id: CrateNanotrasenDS
   name: menacing NT crate
   description: A red and black crate with a menacing aura, it sends chills down your spine looking at it

--- a/Resources/Prototypes/_NF/Body/Organs/synthetic_organs.yml
+++ b/Resources/Prototypes/_NF/Body/Organs/synthetic_organs.yml
@@ -1,7 +1,7 @@
 # Organs with boosted metabolizm
 - type: entity
   id: OrganSyntheticHeart
-  parent: [BaseHumanOrgan, BaseC3SyndicateContraband] # Frontier: add BaseC3SyndicateContraband
+  parent: BaseHumanOrgan
   name: synthetic heart
   description: "Whirrs and pumps blood."
   components:
@@ -19,7 +19,7 @@
 
 - type: entity
   id: OrganSyntheticLiver
-  parent: [BaseHumanOrgan, BaseC3SyndicateContraband] # Frontier: add BaseC3SyndicateContraband
+  parent: BaseHumanOrgan
   name: synthetic liver
   description: "Filters toxins from the bloodstream at higher rate than old 'ganic liver."
   components:
@@ -40,7 +40,7 @@
 
 - type: entity
   id: OrganSyntheticKidneys
-  parent: [BaseHumanOrgan, BaseC3SyndicateContraband] # Frontier: add BaseC3SyndicateContraband
+  parent: BaseHumanOrgan
   name: synthetic kidneys
   description: "Filters toxins from the bloodstream at higher rate than old 'ganic liver."
   components:

--- a/Resources/Prototypes/_NF/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Crates/armory.yml
@@ -16,7 +16,6 @@
 - type: entity
   id: CrateArmorySMGExpedition
   parent:
-  - BaseC2ExpeditionContraband
   - CrateFirearmsSecure
   name: SMG crate
   description: Contains two high-powered, SMGs with four mags. Requires Armory access to open. Unregistered.
@@ -32,7 +31,6 @@
 - type: entity
   id: CrateArmoryShotgunExpedition
   parent:
-  - BaseC2ExpeditionContraband
   - CrateFirearmsSecure
   name: shotgun crate
   description: For when the enemy absolutely needs to be replaced with lead. Contains two Enforcer Combat Shotguns, and some standard shotgun shells. Requires Armory access to open. Unregistered.
@@ -48,7 +46,6 @@
 - type: entity
   id: CrateArmoryLaserExpedition
   parent:
-  - BaseC2ExpeditionContraband
   - CrateFirearmsSecure
   name: lasers crate
   description: Contains three standard-issue laser carbines. Requires Armory access to open. Unregistered.
@@ -62,7 +59,6 @@
 - type: entity
   id: CrateArmoryEnergyGunExpedition
   parent:
-  - BaseC2ExpeditionContraband
   - CrateFirearmsSecure
   name: energy guns crate
   description: Contains three energy guns. Requires Armory access to open. Unregistered.
@@ -76,7 +72,6 @@
 - type: entity
   id: CrateArmoryPistolsExpedition
   parent:
-  - BaseC2ExpeditionContraband
   - CrateFirearmsSecure
   name: pistols crate
   description: Contains two standard NT pistols with four mags. Requires Armory access to open. Unregistered.
@@ -92,7 +87,6 @@
 - type: entity
   id: CrateArmoryRifleGestioExpedition
   parent:
-  - BaseC2ExpeditionContraband
   - CrateFirearmsSecure
   name: gestio rifle crate
   description: Contains two old prototype, burst-fire rifles with six low capacity mags. Requires Armory access to open. Unregistered.
@@ -108,7 +102,6 @@
 - type: entity
   id: CrateArmoryRifleNovaliteC1Expedition
   parent:
-  - BaseC2ExpeditionContraband
   - CrateFirearmsSecure
   name: novalite rifle crate
   description: Contains two civilian grade rifles with six low capacity clips. Requires Armory access to open. Unregistered.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/backpacks.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingBackpackArcadia
   name: arcadia backpack
-  parent: [ NFClothingBackpack, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ NFClothingBackpack ]
   description: A backpack produced by Arcadia Industries
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/duffel.yml
@@ -10,7 +10,7 @@
 - type: entity
   id: ClothingBackpackDuffelArcadia
   name: arcadia duffel
-  parent: [ NFClothingDuffel, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ NFClothingDuffel ]
   description: A duffelbag produced by Arcadia Industries
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/messenger.yml
@@ -622,9 +622,7 @@
 ## Antagonists / Contraband
 - type: entity
   parent:
-  - BaseC3SyndicateContrabandUnredeemable
   - ClothingBackpackMessengerContractor
-  - ContrabandClothing
   id: ClothingBackpackMessengerSyndicate
   name: syndicate messenger bag
   description: A robust messenger bag for waging war against oppressors.
@@ -663,9 +661,7 @@
 
 - type: entity
   parent:
-  - BaseC3CultContrabandUnredeemable
   - ClothingBackpackMessengerContractor
-  - ContrabandClothing
   id: ClothingBackpackMessengerBloodCult
   name: cultist messenger bag
   description: A watertight messenger bag for loyal Nar'Sie followers.
@@ -705,7 +701,7 @@
 - type: entity
   id: ClothingBackpackMessengerArcadia
   name: arcadia messenger bag
-  parent: [ ClothingBackpackMessengerContractor, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingBackpackMessengerContractor ]
   components:
   - type: Sprite
     sprite: _NF/Clothing/Back/Messenger/color.rsi

--- a/Resources/Prototypes/_NF/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Back/satchel.yml
@@ -10,7 +10,7 @@
 - type: entity
   id: ClothingBackpackSatchelArcadia
   name: arcadia satchel
-  parent: [ ClothingBackpackSatchel, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingBackpackSatchel ]
   description: A satchel produced by Arcadia Industries.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingBeltArcadia
   name: arcadia webbing
-  parent: [ NFClothingBeltStorageBase, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ NFClothingBeltStorageBase ]
   description: A webbing created by Arcadia Industries. Seems very capable of fitting many items.
   components:
   - type: Sprite
@@ -63,7 +63,7 @@
     sprite: _NF/Clothing/Belt/pilot.rsi
 
 - type: entity
-  parent: [ BaseC2ContrabandUnredeemable, ClothingBeltAssault ]
+  parent: ClothingBeltAssault
   id: ClothingBeltNfsd
   name: TSFMC belt
   description: A tactical assault belt.
@@ -74,7 +74,7 @@
     sprite: _NF/Clothing/Belt/nfsd_belt.rsi
 
 - type: entity
-  parent: [ BaseC2ContrabandUnredeemable, ClothingBeltSecurityWebbing ]
+  parent: ClothingBeltSecurityWebbing
   id: ClothingBeltNfsdWebbing
   name: TSFMC webbing
   description: A tactical assault webbing.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_blood_cult.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Belt/belts_blood_cult.yml
@@ -1,8 +1,6 @@
 - type: entity
   parent:
-  - BaseC3CultContraband
   - ClothingBeltBase
-  - ContrabandClothing
   id: ClothingBeltCultForceField
   name: cult runic belt buckle
   components:
@@ -17,9 +15,7 @@
 
 - type: entity
   parent:
-  - BaseC3CultContrabandUnredeemable
   - NFClothingBeltStorageBase
-  - ContrabandClothing
   id: ClothingBeltCultWebbing
   name: cult webbing
   description: A webbing with pockets lined with waterproof (water, huh?) material.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets.yml
@@ -123,7 +123,7 @@
 #doc headset
 
 - type: entity
-  parent: [ClothingHeadsetCMO, BaseCommandContraband]
+  parent: ClothingHeadsetCMO
   id: ClothingHeadsetDoc
   name: doc's headset
   description: Letting the DoC know what's up. Takes encryption keys.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Ears/headsets_alt.yml
@@ -53,7 +53,7 @@
     sprite: _NF/Clothing/Ears/Headsets/nfsd_h_cb.rsi
 
 - type: entity
-  parent: [ClothingHeadsetAlt, BaseCommandContraband]
+  parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltNfsdBrownCentcom
   name: sheriff's over-ear headset
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingEyesArcadiaVisor
   name: arcadia visor
-  parent: [ ClothingEyesBase, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingEyesBase ]
   description: A visor produced by Arcadia Industries, with some high tech optics systems built in.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Hands/gloves.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingHandsGlovesArcadiaCombat
   name: arcadia combat gloves
-  parent: [ ClothingHandsGlovesCombat, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingHandsGlovesCombat ]
   description: Combat gloves produced by Arcadia Industries.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hats.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingHeadHatBH
   name: "bounty hunter's hat"
-  parent: [ BaseC1Contraband, ClothingHeadHatHoshat ]
+  parent: ClothingHeadHatHoshat
   description: "There's a new bounty hunter in the sector."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/headwear_blood_cult.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/headwear_blood_cult.yml
@@ -1,9 +1,6 @@
 - type: entity
   parent:
-  - BaseC3CultContrabandUnredeemable
   - ClothingHeadHelmetBasic
-  - BaseC3CultContraband
-  - ContrabandClothing
   id: ClothingHeadHelmetCultJanitor
   name: cult janitor helmet
   components:
@@ -17,10 +14,7 @@
 
 - type: entity
   parent:
-  - BaseC3CultContrabandUnredeemable
   - ClothingHeadBase
-  - BaseC3CultContraband
-  - ContrabandClothing
   id: ClothingHeadHatHoodBloodCulthood
   name: cult hood
   categories: [ HideSpawnMenu ]
@@ -34,7 +28,7 @@
     - Hair
 
 - type: entity # for looks only
-  parent: [ ClothingHeadHatHoodBloodCulthood, ClothingHeadHelmetBasic, BaseC3CultContraband, ContrabandClothing ]
+  parent: [ ClothingHeadHatHoodBloodCulthood, ClothingHeadHelmetBasic ]
   id: ClothingHeadHatHoodBloodCulthoodUnremoveable
   categories: [ HideSpawnMenu ]
   name: cult hood

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/headwear_syndicate.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/headwear_syndicate.yml
@@ -1,9 +1,7 @@
 # Syndicate Bomb Suit Helmet
 - type: entity
   parent:
-  - BaseC3SyndicateContrabandUnredeemable
   - ClothingHeadHelmetBombSuit
-  - ContrabandClothing
   id: ClothingHeadHelmetBombSuitSyndie
   name: syndicate bombsuit helmet
   components:
@@ -18,9 +16,7 @@
 # Syndicate armored bio suit hood
 - type: entity
   parent:
-  - BaseC3SyndicateContrabandUnredeemable
   - ClothingHeadHatHoodBioGeneral
-  - ContrabandClothing
   id: ClothingHeadHatHoodBioArmoredSyndicate
   name: bio hood
   suffix: Syndicate
@@ -38,9 +34,7 @@
 # Syndicate NPC unremoveable headwear for looks only
 - type: entity
   parent:
-  - BaseC3SyndicateContrabandUnredeemable
   - ClothingHeadHelmetHardsuitSyndieElite
-  - ContrabandClothing
   id: ClothingHeadHelmetHardsuitSyndieEliteUnremoveable
   categories: [ HideSpawnMenu ]
   components:
@@ -48,9 +42,7 @@
 
 - type: entity
   parent:
-  - BaseC3SyndicateContrabandUnredeemable
   - ClothingHeadHelmetHardsuitSyndie
-  - ContrabandClothing
   id: ClothingHeadHelmetHardsuitSyndieUnremoveable
   categories: [ HideSpawnMenu ]
   components:
@@ -58,9 +50,7 @@
 
 - type: entity
   parent:
-  - BaseC3SyndicateContrabandUnredeemable
   - ClothingHeadHelmetHardsuitSyndieMedic
-  - ContrabandClothing
   id: ClothingHeadHelmetHardsuitSyndieMedicUnremoveable
   categories: [ HideSpawnMenu ]
   components:
@@ -68,9 +58,7 @@
 
 - type: entity
   parent:
-  - BaseC3SyndicateContrabandUnredeemable
   - ClothingHeadHatHoodWinterSyndie
-  - ContrabandClothing
   id: ClothingHeadHatHoodWinterSyndieUnremoveable
   categories: [ HideSpawnMenu ]
   name: syndicate coat hood

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/helmets.yml
@@ -3,7 +3,7 @@
 
 #ERT Mail Carrier Helmet
 - type: entity
-  parent: [ BaseC2ContrabandUnredeemable, ClothingHeadHelmetBasic ]
+  parent: ClothingHeadHelmetBasic
   id: ClothingHeadHelmetERTMailCarrier
   name: ERT mail carrier helmet
   description: An in-atmosphere helmet worn by mail members of the Colonial Emergency Response Team. Has dark purple highlights.
@@ -14,7 +14,7 @@
     sprite: _NF/Clothing/Head/Helmets/ert_mailcarrier.rsi
 
 - type: entity
-  parent: [ BaseC2ContrabandUnredeemable, ClothingHeadHelmetBasic ]
+  parent: ClothingHeadHelmetBasic
   id: ClothingHeadHelmetNfsd
   name: TSFMC helmet
   description: An TSFMC issued helmet to protect your head.
@@ -26,7 +26,7 @@
 
 #Mercenary Helmet
 - type: entity
-  parent: [ BaseC1Contraband, ClothingHeadHelmetMercenary ]
+  parent: ClothingHeadHelmetMercenary
   id: ClothingHeadHelmetMercenaryBlack
   name: combat helmet
   description: The combat helmet is commonly used by mercenaries, is strong, light and smells like gunpowder and the urban sprawl.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hoods.yml
@@ -1,7 +1,6 @@
 - type: entity
   parent:
   - ClothingHeadHatHoodWinterBase
-  - ContrabandClothing
   id: ClothingHeadHatHoodArcadia
   categories: [ HideSpawnMenu ]
   name: arcadia coat hood

--- a/Resources/Prototypes/_NF/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Masks/masks.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingMaskArcadia
   name: arcadia battle mask
-  parent: [ ClothingMaskGasExplorer, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingMaskGasExplorer ]
   description: A close-fitting high tech mask designed by Arcadia Industries for spacefaring operators.
   components:
   - type: Sprite
@@ -44,7 +44,7 @@
     coverage: MOUTH
 
 - type: entity
-  parent: [ BaseC2ContrabandUnredeemable, ClothingMaskGasSecurity ]
+  parent: ClothingMaskGasSecurity
   id: ClothingMaskGasNfsd
   name: TSFMC gas mask
   description: A standard issue TSFMC gas mask.
@@ -56,7 +56,7 @@
   - type: CatWearable
 
 - type: entity
-  parent: [ BaseC2ContrabandUnredeemable, ClothingMaskGasSwat ]
+  parent: ClothingMaskGasSwat
   id: ClothingMaskGasSheriff
   name: TSFMC colonel gas mask
   description: A gas mask worthy of a colonel.
@@ -67,7 +67,7 @@
     sprite: _NF/Clothing/Mask/nfsd_sheriff.rsi
 
 - type: entity
-  parent: [ BaseC3CultContrabandUnredeemable, ContrabandClothing, ClothingMaskGasExplorer ]
+  parent: [ ClothingMaskGasExplorer ]
   id: ClothingMaskCultJanitor
   name: cult janitor mask
   description: A close-fitting, imposing breath mask designed for accursed custodians who value style.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Neck/mantles.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Neck/mantles.yml
@@ -61,7 +61,7 @@
 - type: entity
   id: ClothingNeckMantleBH
   name: "bounty hunter's mantle"
-  parent: [ BaseC1Contraband, ClothingNeckMantleHOS ]
+  parent: ClothingNeckMantleHOS
   description: "I can bring you in warm or I can bring you in cold. Or you can outbid the bounty."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Neck/misc.yml
@@ -35,9 +35,7 @@
 
 - type: entity
   parent:
-  - BaseC3CultContraband
   - ClothingNeckBase
-  - ContrabandClothing
   id: ClothingNeckAmuletBloodCult
   name: ascended cultist amulet
   description: "Every time you gaze upon it, you feel as if it is gazing back at you. Summons a drained one that follows the user for a brief period of time. Has a cooldown."

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingOuterBaseLarge, BaseC2ContrabandUnredeemable ]
+  parent: ClothingOuterBaseLarge
   id: ClothingOuterArmorSrCarapace
   name: "colonial liaison's carapace"
   description: "A premium armored chest-piece that provides above average protection for its size. It offers maximum mobility and flexibility thanks to the premium composite materials. Issued only to the colonial liaison."
@@ -27,10 +27,7 @@
 
 # Syndicate armored bio suit
 - type: entity
-  parent:
-  - BaseC3SyndicateContraband
-  - ClothingOuterBioGeneral
-  - ContrabandClothing
+  parent: ClothingOuterBioGeneral
   id: ClothingOuterBioArmoredSyndicate
   name: bio suit
   suffix: Syndicate
@@ -56,7 +53,7 @@
     coefficient: 0.6
 
 - type: entity
-  parent: [ ClothingOuterBaseLarge, BaseC2ContrabandUnredeemable ]
+  parent: ClothingOuterBaseLarge
   id: ClothingOuterArmorNfsd
   name: TSFMC armor
   description: Get shot, maybe survive?
@@ -83,7 +80,7 @@
     coefficient: 0.4
 
 - type: entity
-  parent: [ BaseC1Contraband, ClothingOuterVestWebMercenary ]
+  parent: ClothingOuterVestWebMercenary
   id: ClothingOuterVestWebMercenaryBlack
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor_punk.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/armor_punk.yml
@@ -1,7 +1,7 @@
 
 - type: entity
   id: ClothingOuterArmorPunkGreen
-  parent: [ ClothingOuterVestWebMercenary, RecyclableItemClothArmor, BaseC1Contraband ]
+  parent: [ ClothingOuterVestWebMercenary, RecyclableItemClothArmor ]
   name: punk armor
   components:
   - type: Sprite
@@ -81,7 +81,7 @@
 
 - type: entity
   id: ClothingOuterArmorElitePunkRandomized
-  parent: [ ClothingOuterStorageBase, ClothingOuterArmorBulletproof, RecyclableItemClothArmor, BaseC1Contraband ]
+  parent: [ ClothingOuterStorageBase, ClothingOuterArmorBulletproof, RecyclableItemClothArmor ]
   name: punk heavy armor
   suffix: Random visuals
   components:

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -5,7 +5,7 @@
 
 - type: entity
   abstract: true
-  parent: [ClothingOuterHardsuitBaseNF, BaseC2ContrabandUnredeemable]
+  parent: ClothingOuterHardsuitBaseNF
   id: ClothingOuterHardsuitBaseNFNfsd
   components:
   - type: PressureProtection

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/coats.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingOuterCoatBHTrench
   name: "bounty hunter's flak trenchcoat"
-  parent: [ BaseC1Contraband, ClothingOuterCoatHoSTrench ]
+  parent: ClothingOuterCoatHoSTrench
   description: A greatcoat enhanced with a bulletproof alloy for some extra protection and style for those with a charismatic presence.
   components:
   - type: Sprite
@@ -58,7 +58,7 @@
       head:  ClothingHeadHatHoodCardinalHood
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, BaseC2ContrabandUnredeemable ]
+  parent: ClothingOuterStorageBase
   id: ClothingOuterCoatNfsdBomber
   name: TSFMC bomber
   description: Lookin' slick Tom.
@@ -69,7 +69,7 @@
     sprite: _NF/Clothing/OuterClothing/Misc/nfsd_bomber.rsi
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, BaseC2ContrabandUnredeemable ]
+  parent: ClothingOuterStorageBase
   id: ClothingOuterCoatNfsdBomberBrigmed
   name: TSFMC brigmedic bomber
   description: Blood may stain.
@@ -80,7 +80,7 @@
     sprite: _NF/Clothing/OuterClothing/Misc/nfsd_brigmed_bomber.rsi
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, BaseC2ContrabandUnredeemable ]
+  parent: ClothingOuterStorageBase
   id: ClothingOuterCoatNfsdFormal
   name: TSFMC formal coat
   description: Snazzy.
@@ -91,7 +91,7 @@
     sprite: _NF/Clothing/OuterClothing/Misc/nfsd_formal.rsi
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, BaseC2ContrabandUnredeemable ]
+  parent: ClothingOuterStorageBase
   id: ClothingOuterCoatNfsdFormalSheriff
   name: TSFMC colonel's formal coat
   description: Very snazzy.
@@ -102,7 +102,7 @@
     sprite: _NF/Clothing/OuterClothing/Misc/nfsd_sheriff_formal.rsi
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, BaseC2ContrabandUnredeemable ]
+  parent: ClothingOuterStorageBase
   id: ClothingOuterCoatNfsdLongCoat
   name: TSFMC long coat
   description: Big iron on his hip...
@@ -113,7 +113,7 @@
     sprite: _NF/Clothing/OuterClothing/Misc/nfsd_long.rsi
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, BaseC2ContrabandUnredeemable ]
+  parent: ClothingOuterStorageBase
   id: ClothingOuterJacketSr
   name: colonial liaison's jacket
   description: The upper part of the colonial liaison's uniform.
@@ -129,7 +129,7 @@
       - state: equipped-OUTERCLOTHING
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, BaseC3PirateContrabandNoValue ]
+  parent: ClothingOuterStorageBase
   id: ClothingOuterCoatPirateCaptain
   name: pirate captain's coat
   description: Y'arrgh har fiddle di dee.
@@ -140,7 +140,7 @@
     sprite: _NF/Clothing/OuterClothing/Misc/pirate_captain.rsi
 
 - type: entity
-  parent: [ ClothingOuterStorageFoldableBase, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingOuterStorageFoldableBase ]
   id: ClothingOuterCoatArcadiaTrench
   name: arcadia flak trenchcoat
   description: A flak trenchcoat produced by Arcadia Industries, enhanced with a bulletproof alloy for some extra protection.

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/coats_blood_cult.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/coats_blood_cult.yml
@@ -2,10 +2,8 @@
   id: ClothingOuterCoatCultJanitor
   name: cult janitor robes
   parent:
-  - BaseC3CultContraband
   - ClothingOuterStorageBase
   - ClothingOuterArmorBulletproof
-  - ContrabandClothing
   description: An unholy custodian's garb. Surprisingly comfortable.
   components:
   - type: Sprite
@@ -17,10 +15,8 @@
   id: ClothingOuterCoatBloodCultRobes
   name: cult robes
   parent:
-  - BaseC3CultContraband
   - ClothingOuterStorageToggleableBase
   - ClothingOuterArmorBasic
-  - ContrabandClothing
   description: There's no cult without classic red/crimson cult robes with bulletproof vests.
   suffix: Frontier
   components:

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -158,7 +158,6 @@
 - type: entity
   parent:
   - ClothingOuterHardsuitSyndie
-  - ContrabandClothing
   id: ClothingOuterHardsuitSyndieEliteUnremoveable
   name: syndicate hardsuit
   categories: [ HideSpawnMenu ]
@@ -172,7 +171,6 @@
 - type: entity
   parent:
   - ClothingOuterHardsuitSyndie
-  - ContrabandClothing
   id: ClothingOuterHardsuitSyndieBloodRedUnremoveable
   name: syndicate hardsuit
   categories: [ HideSpawnMenu ]
@@ -331,7 +329,7 @@
     sprintModifier: 0.93
 
 - type: entity
-  parent: [BaseC2ContrabandUnredeemable, ClothingOuterHardsuitJuggernaut, EnergyShieldClothing ] # Jugger Suit
+  parent: [ClothingOuterHardsuitJuggernaut, EnergyShieldClothing ] # Jugger Suit
   id: ClothingOuterHardsuitNfsdExperimental
   name: TSFMC M92-X tacsuit
   description: An experimental modification of the M92 tacsuit for spec-ops units of the TSFMC. Durable, and comes with an integrated soft-shield, but at the cost of insulation and heft.
@@ -568,7 +566,7 @@
     coefficient: 0.4
 
 - type: entity
-  parent: [BaseC3PirateContraband, ClothingOuterHardsuitBaseNF]
+  parent: ClothingOuterHardsuitBaseNF
   id: ClothingOuterHardsuitPirateElite
   name: elite pirate hardsuit
   description: An ancient elite armored hardsuit, designed by an unknown bearded man and built like a brick house.

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/suits.yml
@@ -1,9 +1,7 @@
 # Syndicate bomb suit
 - type: entity
   parent:
-  - BaseC3SyndicateContraband
   - ClothingOuterSuitBomb
-  - ContrabandClothing
   id: ClothingOuterSuitBombSyndie
   name: syndicate bomb suit
   components:

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingOuterWinterArcadia
   name: arcadia winter coat
-  parent: [ ClothingOuterWinterCoatToggleable, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingOuterWinterCoatToggleable ]
   description: A coat produced by Arcadia Industries, seems soft.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Shoes/clown_shoes_mods.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Shoes/clown_shoes_mods.yml
@@ -1,6 +1,5 @@
 - type: entity
   parent:
-  - BaseC3ContrabandNoValue
   - ClothingShoesClown
   id: ClothingShoesClownModWhoopie
   suffix: "Whoopie"
@@ -17,7 +16,6 @@
 
 - type: entity
   parent:
-  - BaseC3ContrabandNoValue
   - ClothingShoesClown
   id: ClothingShoesClownModKetchup
   suffix: "Ketchup"
@@ -47,7 +45,6 @@
 
 - type: entity
   parent:
-  - BaseC3ContrabandNoValue
   - ClothingShoesClown
   id: ClothingShoesClownModMustarchup
   suffix: "Mustarchup"
@@ -79,7 +76,6 @@
 
 - type: entity
   parent:
-  - BaseC3ContrabandNoValue
   - ClothingShoesClown
   id: ClothingShoesClownModUltimate
   suffix: "Ultimate"

--- a/Resources/Prototypes/_NF/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Shoes/magboots.yml
@@ -60,7 +60,7 @@
 #    sprintModifier: 0.9
 
 - type: entity
-  parent: [BaseC3PirateContraband, ClothingShoesBootsMagNfsd]
+  parent: ClothingShoesBootsMagNfsd
   id: ClothingShoesBootsMagPirate
   name: pirate magboots
   description: Pirate magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle.

--- a/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingUniformJumpskirtArcadia
   name: arcadia jumpskirt
-  parent: [ ClothingUniformSkirtBase, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingUniformSkirtBase ]
   description: A jumpskirt produced by Arcadia Industries. Designed to reduce chaffing between the legs for the comfort of skin, slime, scales, fluff, and wood.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: ClothingUniformJumpsuitArcadia
   name: arcadia jumpsuit
-  parent: [ ClothingUniformBase, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingUniformBase ]
   description: A jumpsuit produced by Arcadia Industries. Designed to reduce chaffing between the legs for the comfort of skin, slime, scales, fluff, and wood.
   components:
   - type: Sprite
@@ -157,7 +157,6 @@
 - type: entity
   parent:
   - ClothingUniformJumpsuitRecruitSyndie
-  - ContrabandClothing
   id: ClothingUniformJumpsuitRecruitSyndieNF
   components:
   - type: SuitSensor
@@ -167,7 +166,6 @@
 - type: entity
   parent:
   - ClothingUniformJumpsuitRepairmanSyndie
-  - ContrabandClothing
   id: ClothingUniformJumpsuitRepairmanSyndieNF
   components:
   - type: SuitSensor
@@ -177,7 +175,6 @@
 - type: entity
   parent:
   - ClothingUniformJumpsuitParamedicSyndie
-  - ContrabandClothing
   id: ClothingUniformJumpsuitParamedicSyndieNF
   components:
   - type: SuitSensor
@@ -187,7 +184,6 @@
 - type: entity
   parent:
   - ClothingUniformJumpsuitChiefEngineerSyndie
-  - ContrabandClothing
   id: ClothingUniformJumpsuitChiefEngineerSyndieNF
   components:
   - type: SuitSensor
@@ -197,7 +193,6 @@
 - type: entity
   parent:
   - ClothingUniformJumpsuitSyndieFormal
-  - ContrabandClothing
   id: ClothingUniformJumpsuitSyndieFormalNF
   components:
   - type: SuitSensor

--- a/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/military_jumpsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Uniforms/military_jumpsuits.yml
@@ -2085,7 +2085,7 @@
 - type: entity
   id: ClothingUniformJumpsuitMilitaryArcadiaTac
   name: arcadia tactical jumpsuit
-  parent: [ ClothingUniformBase, BaseC3ContrabandNoValue, ContrabandClothing ]
+  parent: [ ClothingUniformBase ]
   description: A tactical jumpsuit produced by Arcadia Industries.
   suffix: Military, Tac
   components:

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_bloodcultist.yml
@@ -494,7 +494,6 @@
 # Look for magic bolt here:\Resources\Prototypes\_NF\Entities\Objects\Weapons\Guns\Projectiles\magic.yml
 - type: entity
   parent:
-  - BaseC3CultContraband
   - BaseWeaponTurretNF
   #- MobBloodCultistTimedDespawn
   id: BloodCultTurret

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/silicon.yml
@@ -46,7 +46,6 @@
 - type: entity
   parent:
   - MobCleanBot
-  - BaseC3SyndicateContrabandNoValue
   - NFMobRestrictions
   id: MobCleanBotSyndie
   name: syndicate cleanbot

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/Misc/identification_cards.yml
@@ -128,7 +128,7 @@
     - state: idnfsdbailiff
 
 - type: entity
-  parent: [CadetIDCard, BaseCommandContraband]
+  parent: CadetIDCard
   id: ShriffIDCard
   name: TSFMC colonel ID card
   components:
@@ -177,7 +177,7 @@
     - state: ert_mailcarrier
 
 - type: entity
-  parent: [HoPIDCard, BaseCommandContraband]
+  parent: HoPIDCard
   id: SrIDCard
   name: colonial liaison ID card
   components:
@@ -226,7 +226,7 @@
     name: Yip Yip
 
 - type: entity
-  parent: [IDCardStandard, BaseCommandContraband]
+  parent: IDCardStandard
   id: DocIDCard
   name: director of care ID card
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/door_remote.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [DoorRemoteDefault, BaseCommandContraband]
+  parent: DoorRemoteDefault
   id: DoorRemoteNfsd
   name: TSFMC door remote
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/holoprojectors.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ HoloprojectorSecurity, BaseC2ContrabandUnredeemable ]
+  parent: HoloprojectorSecurity
   id: HoloprojectorNfsd
   name: TSFMC holobarrier projector
   description: Creates a solid but fragile holographic barrier.

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/pda.yml
@@ -116,7 +116,7 @@
         - Write
 
 - type: entity
-  parent: [BaseSecurityPDA, BaseCommandContraband]
+  parent: BaseSecurityPDA
   id: SheriffPDA
   name: TSFMC colonel PDA
   description: A standard TSFMC personal computer.
@@ -338,7 +338,7 @@
     state: pda-prosecutor
 
 - type: entity
-  parent: [BaseSecurityPDA, BaseCommandContraband]
+  parent: BaseSecurityPDA
   id: SrPDA
   name: colonial liaison PDA
   description: Looks like it's been clawed on.
@@ -409,7 +409,7 @@
         pda-janitor
 
 - type: entity
-  parent: [CMOPDA, BaseCommandContraband]
+  parent: CMOPDA
   id: DocPDA
   name: director of care PDA
   description: It smells like disinfectant.

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
@@ -251,7 +251,7 @@
 
 - type: entity
   id: PortableGeneratorDKMachineCircuitboard
-  parent: [ BaseMachineCircuitboard, BaseC2ContrabandUnredeemable ]
+  parent: BaseMachineCircuitboard
   name: D-K-type portable generator machine board
   description: A machine printed circuit board for a D-K-type portable generator.
   components:
@@ -273,7 +273,7 @@
 
 - type: entity
   id: PortableGeneratorDKJrMachineCircuitboard
-  parent: [ BaseMachineCircuitboard, BaseC1Contraband ]
+  parent: BaseMachineCircuitboard
   name: D-K Jr.-type portable generator machine board
   description: A machine printed circuit board for a D-K Jr.-type portable generator.
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/spaceblade.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/spaceblade.yml
@@ -134,7 +134,6 @@
   id: SpaceBladeSec
   parent:
   - SpaceBlade
-  - BaseC2ContrabandUnredeemable
   components:
   - type: Sprite
     state: secblade
@@ -147,7 +146,6 @@
   id: SpaceBladeContra
   parent:
   - SpaceBlade
-  - BaseC3SyndicateContraband
   description: Let it reap
   components:
   - type: Sprite
@@ -230,7 +228,7 @@
 
 - type: entity
   id: SpaceBladeSingularity
-  parent: [BaseC3Contraband, SpaceBlade]
+  parent: SpaceBlade
   name: space blade
   description: Let it consume
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Fun/toys.yml
@@ -105,7 +105,7 @@
     tags:
     - Soap
   - type: Slippery
-    slipData: 
+    slipData:
       paralyzeTime: 0.7
       launchForwardsMultiplier: 0.5
   - type: StepTrigger
@@ -553,7 +553,7 @@
 
 - type: entity
   name: toy RPG
-  parent: [BaseClearContraband, WeaponLauncherRocket]
+  parent: WeaponLauncherRocket
   id: WeaponLauncherRocketToy
   suffix: Toy
   description: A plush toy, this launches foam "grenades". There are stitches on the side that spell out "SAM".
@@ -605,7 +605,7 @@
 
 # Grown cap gun, in toys.yml for consistency with fake parent
 - type: entity
-  parent: [BaseC3SyndicateContrabandNoValue, RevolverCapGunFake] # Frontier: added BaseC3SyndicateContraband
+  parent: RevolverCapGunFake
   id: RevolverCapGunFakeGrown
   categories: [ HideSpawnMenu ]
   suffix: Fake, Grown

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/implanters.yml
@@ -85,7 +85,7 @@
 - type: entity
   id: RadioImplanterFreelance
   suffix: radio Freelance
-  parent: [ BaseImplantOnlyImplanter, BaseC3PirateContrabandHighValue ] # Mono - Added Pirate Contraband
+  parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter
     implant: RadioImplantFreelance

--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/rubber_stamp.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: colonial liaison's rubber stamp
-  parent: [RubberStampHop, BaseCommandContraband]
+  parent: RubberStampHop
   id: RubberStampSr
   components:
   - type: Stamp
@@ -27,7 +27,7 @@
 
 - type: entity
   name: colonel's rubber stamp
-  parent: [RubberStampBase, BaseCommandContraband]
+  parent: RubberStampBase
   id: RubberStampSheriff
   categories: [ DoNotMap ]
   components:
@@ -82,7 +82,7 @@
 
 - type: entity
   name: director of care's rubber stamp
-  parent: [RubberStampBase, BaseCommandContraband]
+  parent: RubberStampBase
   id: RubberStampDoc
   categories: [ DoNotMap ]
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Shields/shields.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: TSFMC energy shield
-  parent: [BaseC2ContrabandUnredeemable, EnergyShield]
+  parent: EnergyShield
   id: EnergyShieldNfsd
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
@@ -29,7 +29,7 @@
 
 - type: entity
   name: NTCS-102 hypospray
-  parent: [HypoMini, BaseC2ContrabandUnredeemable]
+  parent: HypoMini
   description: A commercial hypospray designed by Nanotrasen Chemical Supply. It has a larger chemical reservoir compared to its commercial version and a slightly lowered injection delay. # Mono
   id: HypoBrigmedic
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/access_configurator.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseC3PirateContraband, AccessConfigurator]
+  parent: AccessConfigurator
   id: AccessConfiguratorAntag
   name: Black market access configurator
   suffix: Antag

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/blueprints/blueprints_base.yml
@@ -336,7 +336,7 @@
 # Non-faxable variants (obtainable from expeditions)
 
 - type: entity # Armory
-  parent: [ BaseC3Contraband, NFBaseBlueprint ]
+  parent: NFBaseBlueprint
   id: BaseBlueprintExpedition
   abstract: true
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/emag.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseItem, BaseCommandContraband]
+  parent: BaseItem
   id: DemagUnlimited
   name: cryptographic resequencer
   suffix: Unlimited

--- a/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
@@ -439,7 +439,6 @@
 - type: entity
   parent:
   - VehicleHoverbikeMailcarrier
-  - BaseC2ContrabandUnredeemable
   id: VehicleHoverbikeNfsd
   name: TSFMC hoverbike
   description: An TSFMC issued turbine with bike handles. Very safe.
@@ -531,7 +530,6 @@
 - type: entity
   parent:
   - VehicleHoverbikeMailcarrier
-  - BaseC3PirateContraband
   id: VehicleHoverbikePirate
   name: pirate hoverbike
   description: Yarr! Dis be me sovereign space shuttle. Now, whaur me rum?
@@ -611,7 +609,6 @@
 - type: entity
   parent:
   - VehicleHoverbikeMailcarrier
-  - BaseC3SyndicateContraband
   id: VehicleHoverbikeSyndicate
   name: syndicate hoverbike
   description: This thing screams style. And war crimes.

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Basic/sawn_pka.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Basic/sawn_pka.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: WeaponProtoKineticAcceleratorSawn
-  parent: [ BaseC1Contraband, WeaponProtoKineticAcceleratorBase ]
+  parent: WeaponProtoKineticAcceleratorBase
   name: sawn-off proto-kinetic accelerator
   #description: boundaries and rules are ment to be broken otherwise there will be no progress, but this thing here is a good argumant against that statement. #Mono out
   description: A proto-kinetic accelerator pared down to its minimum operating parts. Easy to handle in one hand, but brutal on the wrist. #Mono in

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: emp emitter
-  parent: [BaseC2ContrabandUnredeemable, BaseWeaponBattery]
+  parent: BaseWeaponBattery
   id: WeaponEmpEmitter
   description: Releases electromagnetic pulses that disrupt or damage many electronic devices or drain power cells, has a slow self charging nuclear powered battery.
   components:
@@ -44,7 +44,7 @@
 
 - type: entity
   id: WeaponLaserTurboNF
-  parent: [ BaseC3Contraband, BaseWeaponBattery ]
+  parent: BaseWeaponBattery
   name: turbo laser mk3
   description: "A turbo laser ripped from the guardian unit. Appears to be a rather old model. Doesn't seem to be working properly. Supposedly highly illegal."
   components:
@@ -111,7 +111,7 @@
 
 - type: entity
   id: WeaponLaserPistolNF
-  parent: [ BaseC1Contraband, WeaponLaserGun ]
+  parent: WeaponLaserGun
   name: laser pistol
   suffix: Frontier
   description: An older model of civilian-grade laser pistol.
@@ -140,7 +140,7 @@
 
 - type: entity
   id: NFWeaponHoloflareGun
-  parent: [ BaseC1Contraband, BaseWeaponBatterySmall ]
+  parent: BaseWeaponBatterySmall
   name: holoflare pistol
   suffix: Frontier
   description: A modification of a civilian-grade laser pistol that can project holoflares onto surfaces.

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Crossbow/crossbow.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Crossbow/crossbow.yml
@@ -267,7 +267,7 @@
 # Wieldable
 - type: entity
   id: CrossbowModern
-  parent: [ BaseCrossbowWieldable, BaseC1Contraband ]
+  parent: BaseCrossbowWieldable
   components:
   - type: UseDelay
     delay: 0.5
@@ -280,7 +280,7 @@
 
 - type: entity
   id: CrossbowImprovised
-  parent: [ BaseCrossbowWieldable, BaseC1Contraband ]
+  parent: BaseCrossbowWieldable
   name: impovised crossbow
   components:
   - type: UseDelay
@@ -293,7 +293,7 @@
 
 - type: entity
   id: CrossbowBloodCult
-  parent: [ BaseCrossbowWieldable, BaseC3CultContraband ]
+  parent: BaseCrossbowWieldable
   name: blood cult crossbow
   components:
   - type: Sprite
@@ -308,7 +308,7 @@
 # Hand crossbows
 - type: entity
   id: CrossbowModernHand
-  parent: [ BaseCrossbow, BaseC1Contraband ]
+  parent: BaseCrossbow
   name: hand crossbow
   components:
   - type: UseDelay
@@ -321,7 +321,7 @@
 
 - type: entity
   id: CrossbowImprovisedHand
-  parent: [ BaseCrossbow, BaseC1Contraband ]
+  parent: BaseCrossbow
   name: impovised hand crossbow
   components:
   - type: UseDelay
@@ -334,7 +334,7 @@
 
 - type: entity
   id: CrossbowBloodCultHand
-  parent: [ BaseCrossbow, BaseC3CultContraband ]
+  parent: BaseCrossbow
   name: blood cult hand crossbow
   components:
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -8,7 +8,7 @@
 
 - type: entity
   suffix: EMP
-  parent: [BaseC2ContrabandUnredeemable, WeaponLauncherRocket]
+  parent: WeaponLauncherRocket
   id: WeaponLauncherRocketEmp
   components:
   - type: Gun
@@ -21,7 +21,7 @@
 
 - type: entity
   name: mail RPDS
-  parent: [BaseC1Contraband, WeaponLauncherChinaLake]
+  parent: WeaponLauncherChinaLake
   id: WeaponMailLake
   description: Rap(b?)id Parcel Delivery System
   components:
@@ -43,7 +43,7 @@
 
 - type: entity
   name: TSFMC grenade launcher
-  parent: [BaseC2ContrabandUnredeemable, WeaponLauncherChinaLake]
+  parent: WeaponLauncherChinaLake
   id: WeaponLauncherNfsdLake
   description: Able to lob both grenades and darts!
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/crossbow_bolts.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Projectiles/crossbow_bolts.yml
@@ -99,7 +99,7 @@
         Piercing: 35
 
 - type: entity
-  parent: [ BaseBoltProjectile, BaseBoltEmbeddable, BaseBoltLiquidInjector, BaseC1Contraband ]
+  parent: [ BaseBoltProjectile, BaseBoltEmbeddable, BaseBoltLiquidInjector ]
   id: BaseCrossbowBolt
   abstract: true
   components:
@@ -279,7 +279,7 @@
   id: CrossbowBoltUraniumGlassShard
 
 - type: entity
-  parent: [ BaseC3ContrabandNoValue, CrossbowBolt ]
+  parent: CrossbowBolt
   id: CrossbowBoltUraniumGlassShard
   name: uranium glass shard bolt
   description: A bolt with a uranium glass shard as a tip. God have mercy on thy victims for you won't.
@@ -347,7 +347,7 @@
   id: CrossbowBoltPlasteel
 
 - type: entity
-  parent: [ BaseC3ContrabandNoValue, CrossbowBolt ]
+  parent: CrossbowBolt
   id: CrossbowBoltPlasteel
   name: plasteel tipped bolt
   description: A bolt with plasteel tip. Has armor penetrating capabilities.
@@ -379,7 +379,7 @@
   id: CrossbowBoltExplosive
 
 - type: entity
-  parent: [ BaseC3ContrabandNoValue, BaseCrossbowBoltTrigger ]
+  parent: BaseCrossbowBoltTrigger
   id: CrossbowBoltExplosive
   name: explosive bolt
   description: A bolt with small explosive charge.
@@ -424,7 +424,7 @@
   id: CrossbowBoltEMP
 
 - type: entity
-  parent: [ BaseC3ContrabandNoValue, BaseCrossbowBoltTrigger ]
+  parent: BaseCrossbowBoltTrigger
   id: CrossbowBoltEMP
   name: EMP bolt
   description: A bolt with small power cell attached to it.
@@ -473,7 +473,7 @@
   id: CrossbowBoltIncendiary
 
 - type: entity
-  parent: [ BaseC3ContrabandNoValue, BaseCrossbowBolt ]
+  parent: BaseCrossbowBolt
   id: CrossbowBoltIncendiary
   name: incendiary bolt
   description: A bolt with a flare attached to it.
@@ -565,7 +565,6 @@
 # Blood cult
 - type: entity
   parent:
-  - BaseC3CultContrabandNoValue
   - CrossbowBolt
   - ConjuredObject10 # Despawns in 10 seconds
   id: CrossbowBoltBloodDrinker

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: Argenti (5.56x45mm)
-  parent: [ BaseC1Contraband, BaseWeaponRevolver ]
+  parent: BaseWeaponRevolver
   id: WeaponRevolverArgenti
   description: The civilian grade Argenti Type 20 revolver. Manufactured by Silver Industries. While the design with expanded cylinder is quite ancient, the right gunslinger will know how to utilise it well. Uses 5.56x45mm ammo.
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -54,7 +54,7 @@
 # Frontier
 - type: entity
   name: PA Gestio (7.62x39mm)
-  parent: [ BaseWeaponRifle, BaseC1Contraband ]
+  parent: BaseWeaponRifle
   id: WeaponRifleGestio
   description: An old burst-fire rifle that never left trials. Accepts low capacity 762x39mm magazines.
   components:
@@ -136,7 +136,7 @@
             - Cartridge762x39mmFMJ
 
 - type: entity
-  parent: [ BaseWeaponRifle, BaseC1Contraband ]
+  parent: BaseWeaponRifle
   id: WeaponRifleNovaliteC1
   name: LWC Novalite C1 (5.56x45mm)
   description: A modification to the Lecter from LWC, a civilian grade semi-automatic rifle with an internal magazine. Uses 5.56x45mm ammo.
@@ -216,7 +216,7 @@
 - type: entity
   id: WeaponRifleSVS
   name: NCI SVS-42 (7.62x54mmR)
-  parent: [ BaseWeaponRifle, BaseGunMelee, BaseC1Contraband ]
+  parent: [ BaseWeaponRifle, BaseGunMelee ]
   description: "Originally designed by Samonov, this old surplus rifle looks like it's seen a few wars. Uses low capacity 10 rounder 762x54mmR magazines. Equipped with bayonet."
   components:
   - type: Sprite
@@ -285,7 +285,7 @@
 # Monolith: PMC variants
 - type: entity
   name: PA Gestio (7.62x39mm)
-  parent: [ BaseWeaponRifle, BaseC1Contraband ]
+  parent: BaseWeaponRifle
   id: WeaponRifleGestioPMC
   description: An old burst-fire rifle that never left trials. Accepts low capacity 762x39mm magazines. Acquired legally from a licensed provider.
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -10,7 +10,7 @@
 # Frontier
 - type: entity
   name: N2524 Pattern Repeater (.45 magnum)
-  parent: [ BaseC1Contraband, BaseWeaponSniper, BaseGunWieldable ]
+  parent: [ BaseWeaponSniper, BaseGunWieldable ]
   id: WeaponSniperRepeater
   description: A civilian grade lever action firearm, favored by space cowboys across the Frontier for its reliability and stopping power. Uses .45 magnum ammo.
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
@@ -4,21 +4,18 @@
 # Pistols
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponPistolMk58
   categories: [ HideSpawnMenu ]
   id: WeaponPistolMk58Expedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponPistolPollock
   categories: [ HideSpawnMenu ]
   id: WeaponPistolPollockExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponPistolMk32
   categories: [ HideSpawnMenu ]
   id: WeaponPistolUniversalExpedition
@@ -26,49 +23,42 @@
 # Revolvers
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponRevolverArgenti
   categories: [ HideSpawnMenu ]
   id: WeaponRevolverArgentiExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponRevolverDeckard
   categories: [ HideSpawnMenu ]
   id: WeaponRevolverDeckardExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponRevolverFitz
   categories: [ HideSpawnMenu ]
   id: WeaponRevolverFitzExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponRevolverFaith
   categories: [ HideSpawnMenu ]
   id: WeaponRevolverFaithExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponRevolverLucky
   categories: [ HideSpawnMenu ]
   id: WeaponRevolverLuckyExpedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponRevolverMateba
   categories: [ HideSpawnMenu ]
   id: WeaponRevolverMatebaExpedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponRevolverPirate
   categories: [ HideSpawnMenu ]
   id: WeaponRevolverPirateExpedition
@@ -76,35 +66,30 @@
 # Shotguns
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponShotgunDoubleBarreled
   categories: [ HideSpawnMenu ]
   id: WeaponShotgunDoubleBarreledExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponShotgunSawn
   categories: [ HideSpawnMenu ]
   id: WeaponShotgunSawnExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponShotgunHandmade
   categories: [ HideSpawnMenu ]
   id: WeaponShotgunHandmadeExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponShotgunKammerer
   categories: [ HideSpawnMenu ]
   id: WeaponShotgunKammererExpedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponShotgunEnforcer
   categories: [ HideSpawnMenu ]
   id: WeaponShotgunEnforcerExpedition
@@ -112,21 +97,18 @@
 # Rifles
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponRifleGestio
   categories: [ HideSpawnMenu ]
   id: WeaponRifleGestioExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponRifleNovaliteC1
   categories: [ HideSpawnMenu ]
   id: WeaponRifleNovaliteC1Expedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponRifleVulcan
   categories: [ HideSpawnMenu ]
   id: WeaponRifleVulcanExpedition
@@ -134,28 +116,24 @@
 # SMGs
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponSubMachineGunWt550
   categories: [ HideSpawnMenu ]
   id: WeaponSubMachineGunWt550Expedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponSubMachineGunAtreides
   categories: [ HideSpawnMenu ]
   id: WeaponSubMachineGunAtreidesExpedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponSubMachineGunDrozd
   categories: [ HideSpawnMenu ]
   id: WeaponSubMachineGunDrozdExpedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponSubMachineGunTypewriter
   categories: [ HideSpawnMenu ]
   id: WeaponSubMachineGunTypewriterExpedition
@@ -163,21 +141,18 @@
 # Energy
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponLaserPistolNF
   categories: [ HideSpawnMenu ]
   id: WeaponLaserGunExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponLaserSvalinn
   categories: [ HideSpawnMenu ]
   id: WeaponLaserSvalinnExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponEnergyGun
   categories: [ HideSpawnMenu ]
   id: WeaponEnergyGunExpedition
@@ -185,28 +160,24 @@
 - type: entity
   name: laser carbine
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponLaserCarbine
   categories: [ HideSpawnMenu ]
   id: WeaponLaserCarbineExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponAdvancedLaser
   categories: [ HideSpawnMenu ]
   id: WeaponAdvancedLaserExpedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponLaserCannon
   categories: [ HideSpawnMenu ]
   id: WeaponLaserCannonExpedition
 
 - type: entity
   parent:
-  - BaseC3ExpeditionContraband
   - WeaponXrayCannon
   categories: [ HideSpawnMenu ]
   id: WeaponXrayCannonExpedition
@@ -214,28 +185,24 @@
 # Sniper
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponSniperMosin
   categories: [ HideSpawnMenu ]
   id: WeaponSniperMosinExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponSniperCeremonial
   categories: [ HideSpawnMenu ]
   id: WeaponSniperCeremonialExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - WeaponSniperRepeater
   categories: [ HideSpawnMenu ]
   id: WeaponSniperRepeaterExpedition
 
 - type: entity
   parent:
-  - BaseC2ExpeditionContraband
   - Musket
   categories: [ HideSpawnMenu ]
   id: WeaponMusketExpedition

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/turrets.yml
@@ -6,7 +6,6 @@
   description: |-
    A Contraband Denying Energy Turret (CDET). A disabler turret with built-in microreactor. Use screwdriver to disassemble.
   parent:
-  - BaseC2ContrabandUnredeemable
   - BaseWeaponTurretEnergyNF
   components:
   - type: HTN
@@ -41,7 +40,6 @@
    A disassembled and packed Contraband Denying Energy Turret (CDET).
   suffix: NT, Packed
   parent:
-  - BaseC2ContrabandUnredeemable
   - BaseItem
   components:
   - type: WeaponCaseInsertable
@@ -85,7 +83,6 @@
    A Self-Recharging Laser Auto Turret (SLAT). A laser turret with built-in microreactor. Use screwdriver to disassemble.
   suffix: Frontier, NT
   parent:
-  - BaseC2ContrabandUnredeemable
   - BaseTurretSearchBeam
   - BaseWeaponTurretEnergyNF
   categories: [ HideSpawnMenu ]
@@ -116,7 +113,6 @@
    A disassembled and packed Self-Recharging Laser Auto Turret (SLAT).
   suffix: NT, Packed
   parent:
-  - BaseC2ContrabandUnredeemable
   - BaseItem
   components:
   - type: WeaponCaseInsertable
@@ -157,7 +153,6 @@
   name: laser turret
   suffix: Frontier, Syndicate
   parent:
-  - BaseC3SyndicateContraband
   - BaseTurretSearchBeam
   - BaseWeaponTurretEnergyNF
   categories: [ HideSpawnMenu ]
@@ -182,7 +177,6 @@
   name: laser turret
   suffix: Frontier, Hostile
   parent:
-  - BaseC3Contraband
   - WeaponTurretLaserSyndicateNF
   components:
   - type: NpcFactionMember
@@ -197,7 +191,6 @@
    An Autonomous Sentry Machine Gun Turret (ASMGT) is a magazine-fed turret with barrels compatible with 5.56x45mm, 7.62x39mm, 9x19mm and 6.35x40mm cartridges. Use screwdriver to disassemble.
   suffix: NT
   parent:
-  - BaseC2ContrabandUnredeemable
   - BaseWeaponTurretMagazineFed
   components:
   - type: NPCImprintingOnSpawnBehaviour
@@ -243,7 +236,6 @@
    A disassembled and packed Autonomous Sentry Machine Gun Turret (ASMGT).
   suffix: NT, Packed
   parent:
-  - BaseC2ContrabandUnredeemable
   - BaseItem
   components:
   - type: WeaponCaseInsertable
@@ -284,7 +276,6 @@
   id: WeaponTurretAsmgtHostileUniversallyDeployed
   suffix: Universally Hostile
   parent:
-  - BaseC3Contraband
   - WeaponTurretAsmgtNtDeployed
   components:
   - type: NPCImprintingOnSpawnBehaviour
@@ -305,7 +296,6 @@
   description: |-
    A disassembled and packed Autonomous Sentry Machine Gun Turret (ASMGT). WARNING! Unpacked turret will be hostile towards anyone who wasn't in close proximity (within 3 m) after unpacking!
   parent:
-  - BaseC3Contraband
   - WeaponTurretAsmgtNtPacked
   components:
   - type: WeaponCaseInsertable

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/caveman_club.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/caveman_club.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: caveman club
-  parent: [BaseItem, BaseC1Contraband]
+  parent: BaseItem
   id: CavemanClub
   description: Big stick make big hurt. # Frontier: changed description
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: TSFMC energy sword
-  parent: [BaseC2ContrabandUnredeemable, EnergySword]
+  parent: EnergySword
   id: EnergySwordNfsd
   description: A very loud & dangerous sword with a beam made of pure, concentrated plasma. Cuts through unarmored targets like butter.
   components:
@@ -11,7 +11,7 @@
 
 - type: entity
   id: NFEnergyPickaxe
-  parent: [EnergySword, BaseC1Contraband] # Has a reflect chance
+  parent: EnergySword # Has a reflect chance
   name: holopickaxe
   description: A holographic mining tool with blades comprised of hard light. Doesn't pack the same punch as an energy weapon, but more compact than most mining tools when turned off.
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/pirate_anchor.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/pirate_anchor.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: pirate anchor
-  parent: [BaseC3PirateContraband, SecBreachingHammer]
+  parent: SecBreachingHammer
   id: PirateBreachingAnchor
   description: A large, heavy anchor to beat down anyone and anything standing between you and your plunder.
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/wizard_staff.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/wizard_staff.yml
@@ -2,7 +2,6 @@
   name: wizard staff
   parent:
   - Shovel
-  - BaseC3WizardContraband
   id: WizardStaffMeleeBase
   description: Symbol of wizard's mastery of arcane arts.
   components:
@@ -59,7 +58,6 @@
   id: WizardStaffMeleeBlood
   name: inert cultist staff
   parent:
-  - BaseC3CultContraband
   - WizardStaffMeleeRed
   components:
   - type: Sharp
@@ -77,7 +75,6 @@
   id: WizardStaffDarkBolt
   name: cultist staff
   parent:
-  - BaseC3CultContraband
   - WizardStaffMeleeBlood
   suffix: "Dark bolt"
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Throwable/clusterbang.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Throwable/clusterbang.yml
@@ -1,11 +1,11 @@
 - type: entity
-  parent: [BaseC2ContrabandUnredeemable, ClusterGrenade]
+  parent: ClusterGrenade
   id: ClusterGrenadeNfsd
 
 - type: entity
-  parent: [BaseC2ContrabandUnredeemable, GrenadeIncendiary]
+  parent: GrenadeIncendiary
   id: GrenadeIncendiaryNfsd
 
 - type: entity
-  parent: [BaseC2ContrabandUnredeemable, GrenadeShrapnel]
+  parent: GrenadeShrapnel
   id: GrenadeShrapnelNfsd

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -1,7 +1,7 @@
 - type: entity
-  parent: [BaseC2ContrabandUnredeemable, ExGrenade]
+  parent: ExGrenade
   id: ExGrenadeNfsd
 
 - type: entity
-  parent: [BaseC2ContrabandUnredeemable, EmpGrenade]
+  parent: EmpGrenade
   id: EmpGrenadeNfsd

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Throwable/pirate_bombs.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Throwable/pirate_bombs.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [GrenadeBase, BaseC3PirateContraband]
+  parent: GrenadeBase
   id: PirateGrenadeBase
   abstract: true
   components:

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -101,10 +101,10 @@
     mod: 0.70 # Mono 0.5->0.7
 
 - type: entity
-  name: contraband exchange computer
+  name: technology exchange computer
   parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseComputer]
   id: ComputerContrabandPalletConsole
-  description: Used to exchange contraband for Federation Military Credits.
+  description: Sends off faction gear in exchange for FMC.
   components:
   - type: Sprite
     sprite: _NF/Structures/Machines/computers.rsi
@@ -273,10 +273,10 @@
   #   - Pirate # Frontier: eventually?  maybe?
 
 - type: entity
-  name: contraband exchange console
+  name: technology hand-in console
   parent: ComputerContrabandPalletConsole
   id: ComputerContrabandPalletConsolePirate
-  description: Upload contraband and blacklisted tech. Pays well if you know what you're doing.
+  description: Takes faction tech to be sent off to research and grants DC in exchange.
   components:
   - type: Sprite
     sprite: _NF/Structures/Machines/computers.rsi

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/m_emp.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/m_emp.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseMachinePowered, ConstructibleMachine, BaseC2ContrabandUnredeemable]
+  parent: [BaseStructureDisableToolUse, BaseStructureIndestructible, BaseMachinePowered, ConstructibleMachine]
   id: M_Emp
   name: M_EMP Generator
   description: Mobile EMP generator.

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/vending_machines.yml
@@ -194,7 +194,7 @@
 - type: entity
   id: VendingMachineArcadia
   name: ArcadiaDrobe
-  parent: [ VendingMachine, BaseC3Contraband ]
+  parent: VendingMachine
   description: Selling clothes from another reality for cheap prices!
   components:
     - type: VendingMachine

--- a/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/base.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/base.yml
@@ -100,7 +100,6 @@
 - type: entity
   parent:
   - CrateTradeBaseSecure
-  - BaseC3SyndicateContraband
   id: CrateTradeBaseSecureContraband
   name: Syndicate contraband crate
   description: Contains goods made in the Spinward sector, ready to be smuggled to a cargo depot for profit. MAKE SURE THE CRATE IS INTACT.

--- a/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/crates.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/crates.yml
@@ -88,7 +88,7 @@
 
 # region Contraband Crates
 - type: entity
-  parent: CrateTradeBaseSecureContraband
+  parent: [ CrateTradeBaseSecureContraband, BaseFactionGearTaxedT2 ]
   id: CrateTradeContrabandSecure1
   categories: [ HideSpawnMenu ]
   components:
@@ -117,7 +117,7 @@
     valueElsewhere: 45000
 
 - type: entity
-  parent: CrateTradeBaseSecureContraband
+  parent: [ CrateTradeBaseSecureContraband, BaseFactionGearTaxedT2 ]
   id: CrateTradeContrabandSecure2
   categories: [ HideSpawnMenu ]
   components:
@@ -149,7 +149,7 @@
     expressLatePenalty: 75000
 
 - type: entity
-  parent: CrateTradeBaseSecureContraband
+  parent: [ CrateTradeBaseSecureContraband, BaseFactionGearTaxedT2 ]
   id: CrateTradeContrabandSecure3
   categories: [ HideSpawnMenu ]
   components:
@@ -181,7 +181,7 @@
     expressLatePenalty: 30000
 
 - type: entity
-  parent: CrateTradeBaseSecureContraband
+  parent: [ CrateTradeBaseSecureContraband, BaseFactionGearTaxedT2 ]
   id: CrateTradeContrabandSecure4
   name: Donk Co. contraband crate
   categories: [ HideSpawnMenu ]
@@ -214,7 +214,7 @@
     expressLatePenalty: 30000
 
 - type: entity
-  parent: CrateTradeBaseSecureContraband
+  parent: [ CrateTradeBaseSecureContraband, BaseFactionGearTaxedT3 ] # the only t3
   id: CrateTradeContrabandSecure5
   name: Cybersun Industries contraband crate
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_White/Entities/Objects/Weapons/Melee/daggers.yml
+++ b/Resources/Prototypes/_White/Entities/Objects/Weapons/Melee/daggers.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: betrayal knife
   description: Watch your back!
-  parent: [BaseKnife, BaseSyndicateContraband]
+  parent: BaseKnife
   id: BetrayalKnife
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- kills all contraband
- adds new generic TSF/PDV/other/other+taxed categories for faction items
- puts a few faction items under contra status

this will need further tweaks and marking of way more items, but i'd say we merge this as-is so people/other maints/etc can PR it themselves
currently this only marks hardsuits, a few weapons, and contra crates

## Why / Balance
contra doesn't make sense
and we need both factions to be able to hand in other faction gear

## Media
<img width="379" height="186" alt="image" src="https://github.com/user-attachments/assets/b8df5e4d-72cf-4143-a3c6-2d799d43fc22" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reworked contraband. Almost all items are no longer contraband, and instead some items are marked as faction gear and can be handed in by the opposite faction. More will be marked soon.

