### PR TITLE
Mech Speed Penalty on Low Battery.

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -68,7 +68,7 @@ public sealed partial class MechSystem : SharedMechSystem
         SubscribeLocalEvent<MechComponent, DamageChangedEvent>(OnDamageChanged);
         SubscribeLocalEvent<MechComponent, EmpAttemptEvent>(OnEmpAttempt);
         SubscribeLocalEvent<MechComponent, MechEquipmentRemoveMessage>(OnRemoveEquipmentMessage);
-        SubscribeLocalEvent<MechComponent, RefreshMovementSpeedModifiersEvent>(OnMechCanMoveEvent); // Mono
+        SubscribeLocalEvent<MechComponent, RefreshMovementSpeedModifiersEvent>(OnMechRefreshMovementSpeed); // Mono
 
 
         SubscribeLocalEvent<MechPilotComponent, ToolUserAttemptUseEvent>(OnToolUseAttempt);
@@ -85,7 +85,7 @@ public sealed partial class MechSystem : SharedMechSystem
     }
 
     // Mono
-    private void OnMechCanMoveEvent(EntityUid uid, MechComponent component, RefreshMovementSpeedModifiersEvent args)
+    private void OnMechRefreshMovementSpeed(EntityUid uid, MechComponent component, RefreshMovementSpeedModifiersEvent args)
     {
         if (component.CriticalPowerState)
             args.ModifySpeed(component.CriticalPowerStateSpeedPenalty);

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -28,7 +28,9 @@ using Robust.Shared.Player;
 using Content.Shared.Whitelist;
 using Content.Shared.Mobs.Components; // Frontier
 using Content.Shared.NPC.Components; // Frontier
-using Content.Shared.Mobs; // Frontier
+using Content.Shared.Mobs;
+using Content.Shared.Movement.Systems;
+using Content.Shared.PowerCell.Components; // Frontier
 
 namespace Content.Server.Mech.Systems;
 
@@ -45,6 +47,7 @@ public sealed partial class MechSystem : SharedMechSystem
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly SharedToolSystem _toolSystem = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -58,14 +61,14 @@ public sealed partial class MechSystem : SharedMechSystem
         SubscribeLocalEvent<MechComponent, MechOpenUiEvent>(OnOpenUi);
         SubscribeLocalEvent<MechComponent, MechOpenRadarEvent>(OnOpenRadar);
         SubscribeLocalEvent<MechComponent, RemoveBatteryEvent>(OnRemoveBattery);
+        SubscribeLocalEvent<MechComponent, PowerCellChangedEvent>(OnPowerCellChanged); // Mono
         SubscribeLocalEvent<MechComponent, MechEntryEvent>(OnMechEntry);
         SubscribeLocalEvent<MechComponent, MechExitEvent>(OnMechExit);
 
         SubscribeLocalEvent<MechComponent, DamageChangedEvent>(OnDamageChanged);
         SubscribeLocalEvent<MechComponent, EmpAttemptEvent>(OnEmpAttempt);
         SubscribeLocalEvent<MechComponent, MechEquipmentRemoveMessage>(OnRemoveEquipmentMessage);
-
-        SubscribeLocalEvent<MechComponent, UpdateCanMoveEvent>(OnMechCanMoveEvent);
+        SubscribeLocalEvent<MechComponent, RefreshMovementSpeedModifiersEvent>(OnMechCanMoveEvent); // Mono
 
 
         SubscribeLocalEvent<MechPilotComponent, ToolUserAttemptUseEvent>(OnToolUseAttempt);
@@ -81,10 +84,11 @@ public sealed partial class MechSystem : SharedMechSystem
         #endregion
     }
 
-    private void OnMechCanMoveEvent(EntityUid uid, MechComponent component, UpdateCanMoveEvent args)
+    // Mono
+    private void OnMechCanMoveEvent(EntityUid uid, MechComponent component, RefreshMovementSpeedModifiersEvent args)
     {
-        if (component.Broken || component.Integrity <= 0 || component.Energy <= 0)
-            args.Cancel();
+        if (component.CriticalPowerState)
+            args.ModifySpeed(0.25f, 0.25f);
     }
 
     private void OnInteractUsing(EntityUid uid, MechComponent component, InteractUsingEvent args)
@@ -95,7 +99,6 @@ public sealed partial class MechSystem : SharedMechSystem
         if (component.BatterySlot.ContainedEntity == null && TryComp<BatteryComponent>(args.Used, out var battery))
         {
             InsertBattery(uid, args.Used, component, battery);
-            _actionBlocker.UpdateCanMove(uid);
             return;
         }
 
@@ -112,6 +115,18 @@ public sealed partial class MechSystem : SharedMechSystem
         }
     }
 
+    // Mono edit
+    private void OnPowerCellChanged(Entity<MechComponent> ent, ref PowerCellChangedEvent args)
+    {
+        if (!TryComp<BatteryComponent>(ent.Comp.BatterySlot.ContainedEntity, out var battery))
+            return;
+
+        ent.Comp.CriticalPowerState = battery.CurrentCharge / battery.MaxCharge <= 0.05f;
+
+        Dirty(ent);
+        _movementSpeed.RefreshMovementSpeedModifiers(ent);
+    }
+
     private void OnInsertBattery(EntityUid uid, MechComponent component, EntInsertedIntoContainerMessage args)
     {
         if (args.Container != component.BatterySlot || !TryComp<BatteryComponent>(args.Entity, out var battery))
@@ -119,9 +134,10 @@ public sealed partial class MechSystem : SharedMechSystem
 
         component.Energy = battery.CurrentCharge;
         component.MaxEnergy = battery.MaxCharge;
-
+        component.CriticalPowerState = battery.CurrentCharge / battery.MaxCharge <= 0.05f; // Mono
         Dirty(uid, component);
-        _actionBlocker.UpdateCanMove(uid);
+
+        _movementSpeed.RefreshMovementSpeedModifiers(uid); // Mono
     }
 
     private void OnRemoveBattery(EntityUid uid, MechComponent component, RemoveBatteryEvent args)
@@ -130,7 +146,8 @@ public sealed partial class MechSystem : SharedMechSystem
             return;
 
         RemoveBattery(uid, component);
-        _actionBlocker.UpdateCanMove(uid);
+
+        _movementSpeed.RefreshMovementSpeedModifiers(uid); // Mono
 
         args.Handled = true;
     }
@@ -395,7 +412,6 @@ public sealed partial class MechSystem : SharedMechSystem
             Dirty(uid, component);
             UpdateUserInterface(uid, component);
         }
-        _actionBlocker.UpdateCanMove(uid);
         return true;
     }
 
@@ -411,8 +427,6 @@ public sealed partial class MechSystem : SharedMechSystem
         component.Energy = battery.CurrentCharge;
         component.MaxEnergy = battery.MaxCharge;
 
-        _actionBlocker.UpdateCanMove(uid);
-
         Dirty(uid, component);
         UpdateUserInterface(uid, component);
     }
@@ -425,8 +439,7 @@ public sealed partial class MechSystem : SharedMechSystem
         _container.EmptyContainer(component.BatterySlot);
         component.Energy = 0;
         component.MaxEnergy = 0;
-
-        _actionBlocker.UpdateCanMove(uid);
+        component.CriticalPowerState = true; // Mono
 
         Dirty(uid, component);
         UpdateUserInterface(uid, component);

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -88,7 +88,7 @@ public sealed partial class MechSystem : SharedMechSystem
     private void OnMechCanMoveEvent(EntityUid uid, MechComponent component, RefreshMovementSpeedModifiersEvent args)
     {
         if (component.CriticalPowerState)
-            args.ModifySpeed(0.25f, 0.25f);
+            args.ModifySpeed(component.CriticalPowerStateSpeedPenalty);
     }
 
     private void OnInteractUsing(EntityUid uid, MechComponent component, InteractUsingEvent args)

--- a/Content.Server/PowerCell/PowerCellSystem.cs
+++ b/Content.Server/PowerCell/PowerCellSystem.cs
@@ -10,6 +10,7 @@ using Content.Server.Kitchen.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.UserInterface;
 using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Mech.Components;
 using Content.Shared.Popups;
 using ActivatableUISystem = Content.Shared.UserInterface.ActivatableUISystem;
 
@@ -74,6 +75,12 @@ public sealed partial class PowerCellSystem : SharedPowerCellSystem
         {
             if (itemSlot.Item == uid)
                 RaiseLocalEvent(container.Owner, new PowerCellChangedEvent(false));
+        }
+        // Mono edit - Also check if there are any batteries in mech
+        else if (_containerSystem.TryGetContainingContainer((uid, null, null), out var mechContainer)
+                 && mechContainer.Contains(uid))
+        {
+            RaiseLocalEvent(mechContainer.Owner, new PowerCellChangedEvent(false));
         }
     }
 

--- a/Content.Shared/Mech/Components/MechComponent.cs
+++ b/Content.Shared/Mech/Components/MechComponent.cs
@@ -50,6 +50,12 @@ public sealed partial class MechComponent : Component
     public FixedPoint2 MaxEnergy = 0;
 
     /// <summary>
+    /// Monolith - State that activates at 5% of mech battery remaining.
+    /// </summary>
+    [DataField]
+    public bool CriticalPowerState = false;
+
+    /// <summary>
     /// The slot the battery is stored in.
     /// </summary>
     [ViewVariables]

--- a/Content.Shared/Mech/Components/MechComponent.cs
+++ b/Content.Shared/Mech/Components/MechComponent.cs
@@ -56,6 +56,12 @@ public sealed partial class MechComponent : Component
     public bool CriticalPowerState = false;
 
     /// <summary>
+    /// Monolith - Speed penalty that applies when CriticalPowerState is true.
+    /// </summary>
+    [DataField]
+    public float CriticalPowerStateSpeedPenalty = 0.65f;
+
+    /// <summary>
     /// The slot the battery is stored in.
     /// </summary>
     [ViewVariables]

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -584,7 +584,7 @@ public abstract class SharedMechSystem : EntitySystem
         _eye.SetZoom(uid, component.Zoom);
     }
     // Mono edit end
-    
+
     private void OnCanDragDrop(EntityUid uid, MechComponent component, ref CanDropTargetEvent args)
     {
         args.Handled = true;

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -212,6 +212,7 @@
     openState: gygax-open
     brokenState: gygax-broken
     mechToPilotDamageMultiplier: 0.1 # Mono
+    criticalPowerStateSpeedPenalty: 0.5 # Mono
     maxIntegrity: 500 # Mono
     airtight: true
     pilotWhitelist:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -97,6 +97,7 @@
     openState: broadsword-open
     brokenState: broadsword-broken
     mechToPilotDamageMultiplier: 0
+    criticalPowerStateSpeedPenalty: 0.85
     maxEquipmentAmount: 3
     airtight: true
     maxIntegrity: 1500
@@ -186,6 +187,7 @@
     openState: broadsword-open
     brokenState: broadsword-broken
     mechToPilotDamageMultiplier: 0
+    criticalPowerStateSpeedPenalty: 0.85
     maxEquipmentAmount: 3
     airtight: true
     maxIntegrity: 1100
@@ -233,6 +235,7 @@
     openState: broadsword-open
     brokenState: broadsword-broken
     mechToPilotDamageMultiplier: 0
+    criticalPowerStateSpeedPenalty: 0.45
     maxEquipmentAmount: 3
     airtight: false
     maxIntegrity: 1400
@@ -311,6 +314,7 @@
     openState: flail-open
     brokenState: flail-broken
     mechToPilotDamageMultiplier: 0
+    criticalPowerStateSpeedPenalty: 0.85
     maxEquipmentAmount: 3
     airtight: true
     maxIntegrity: 4000
@@ -387,6 +391,7 @@
     openState: flail-open
     brokenState: flail-broken
     mechToPilotDamageMultiplier: 0
+    criticalPowerStateSpeedPenalty: 0.85
     maxEquipmentAmount: 3
     airtight: true
     maxIntegrity: 2250
@@ -436,6 +441,7 @@
     openState: flail-open
     brokenState: flail-broken
     mechToPilotDamageMultiplier: 0
+    criticalPowerStateSpeedPenalty: 0.95
     maxEquipmentAmount: 1
     airtight: true
     maxIntegrity: 2000


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Now all mechs receive speed penalty on low charge (<=5%). Penalty is 0.65 by default, 0.5 for gygax, 0.4 for sabre and 0.85 for other S2/S4.
Added two fields to mech component for this implementation
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Since EMP damage got wiped, we need a better and more logic alternative to it.
## How to test
<!-- Describe the way it can be tested -->
load local
spawn gygax
shoot
you slow now
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Now all mechs receive speed penalty on low charge (<=5%). Penalty is 0.65 by default, 0.5 for gygax, 0.4 for sabre and 0.85 for other S2/S4.
