### PR TITLE
Add Standard PDV Ballistic Turret

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/turret_spawner.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/turret_spawner.yml
@@ -58,4 +58,17 @@
     prototypes:
     - WeaponTurretUSSP
 
-
+- type: entity
+  id: SpawnMobWeaponTurretPDV
+  parent: MarkerBase
+  name: PDV ballistic turret spawner
+  suffix: PDV, Frontier
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Objects/Weapons/Guns/Turrets/turrets.rsi
+      state: syndie_lethal
+  - type: ConditionalSpawner
+    prototypes:
+    - WeaponTurretPDV

--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/turrets.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/turrets.yml
@@ -52,6 +52,15 @@
     - USSPTurret
 
 - type: entity
+  parent: BaseWeaponBallisticTurret
+  id: WeaponTurretPDV
+  suffix: PDV
+  components:
+  - type: NpcFactionMember
+    factions:
+    - PirateNF
+
+- type: entity
   parent: BaseWeaponTurretNF
   id: BaseMk290Sentry
   name: MK-290 Sentry


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds non-heavy PDV ballistic turret and associated spawner for mapping.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
PDV does not have a standard ballistic turret currently.
## How to test
<!-- Describe the way it can be tested -->
Spawn as a role with the PirateNF NPCFaction, the turret does not shoot you.
Spawn as a role without the PirateNF NPCFaction, the turret shoots you.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added standard PDV ballistic turret for future mapping. They didn't have one.
