### PR TITLE
Evil Saw Traps Pt 1

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -17,6 +17,10 @@
     - Belt
   - type: OnUseTimerTrigger
     delay: 3.5
+  - type: TimerStartOnSignal # Mono
+  - type: DeviceLinkSink # Mono
+    ports:
+      - Timer
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -4,6 +4,10 @@
   id: ProjectileGrenadeBase
   components:
   - type: Appearance
+  - type: TimerStartOnSignal # Mono
+  - type: DeviceLinkSink # Mono
+    ports:
+      - Timer
   - type: Damageable
     damageContainer: Inorganic
   - type: DeleteOnTrigger

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -107,6 +107,7 @@
     receiveFrequencyId: BasicDevice
   - type: WirelessNetworkConnection
     range: 200
+  - type: NoSignalOnLink # Mono
   - type: DeviceLinkSink
     ports:
       - Open


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
First part of Evil Saw Traps.
1. Adds NoSignalOnLink comp to all Airlocks, which just makes them not send a trigger signal when they're initially linked with something. This is shared with Shuttle Consoles.
2. Adds TimerStartOnSignal and DeviceLinkSink to GrenadeBase and ProjectileGrenadeBase, allowing them to receive network signals to start their detonation timer. This starts the standard timer as if they were triggered in-hand, not an instant detonation.

The full list of grenades this affects is:
Grenades: Explosive, Flashbang, Minibomb, Singularity, Whitehole, Nuclear Option, Modular Grenades, EMP, Holy Hand Grenade, Smoke, Tear Gas, Metal Foam, Trick, Trickybomb, Pipebomb, Bottlebomb, Pyrogel Bomb, Pirate Bomb.

Projectile Grenades: Stinger, Incendiary, Shrapnel, Nailbomb.

It is entirely possible to reduce the list to only a few cherry picked grenades if removing certain items is requested.

I do not know what is going on with Line 233 in base_structureairlocks.yml.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I wanted to add the ability for mappers to create even more evil saw traps, but figured the opportunity for terrorism in-game is also hilarious. 

This requires more effort to utilize in combat than simply pulling the pin and throwing as any other grenade needs, and is directly comparable to what Composition C4 could already accomplish given its availability. There are plenty of possibilities for situations when a remotely activated grenade could be used to creatively explode your enemies (that IS the intent, after all) and this does add flexibility to the use of grenades, but again, that's directly comparable to what C4 could already accomplish.

This doesn't exclude Scattering Grenades (Clusterbang, ect) for any particular reason.

## How to test
<!-- Describe the way it can be tested -->

Spawn a grenade, and use a Multitool to link it to a Door. The menu will show Door Status and Timer. When linked, opening or closing the door will cause the linked grenade to trigger.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added NoSignalOnLink component to Airlocks, causing them to not immediately trigger networks when linked.
- add: Added signal network compatibility to most grenades. Happy saw trapping!

