### PR TITLE
Stop Breaking Hub Rules

### DIFF
--- a/Resources/Prototypes/_Mono/Guidebook/rules.yml
+++ b/Resources/Prototypes/_Mono/Guidebook/rules.yml
@@ -26,6 +26,12 @@
 #MARK: Core Rules
 
 - type: guideEntry
+  id: MonolithRuleCoreZeroAgeThreshold
+  name: guide-entry-monolith-rule-core-zero-age-threshold
+  text: "/ServerInfo/_Mono/Guidebook/Rules/Zero_AgeThreshold.xml"
+  ruleEntry: true
+
+- type: guideEntry
   id: MonolithRuleCoreOneCommonSense
   name: guide-entry-monolith-rule-core-one-common-sense
   text: "/ServerInfo/_Mono/Guidebook/Rules/One_CommonSense.xml"

--- a/Resources/ServerInfo/_Mono/Guidebook/Rules/MonolithRuleset.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Rules/MonolithRuleset.xml
@@ -18,6 +18,7 @@ All of the below rules apply at all times, including between rounds, in-game, an
 
 ## Core Rules
 These are the core rules of Monolith:
+- 0. [textlink="Players must be, and act, 16 or above to play Monolith." link="MonolithRuleCoreZeroAgeThreshold"]
 - 1. [textlink="Use common sense." link="MonolithRuleCoreOneCommonSense"]
 - 2. [textlink="Respect each other." link="MonolithRuleCoreTwoRespect"]
 - 3. [textlink="Do not engage in cheating or exploits." link="MonolithRuleCoreThreeCheatingExploits"]

--- a/Resources/ServerInfo/_Mono/Guidebook/Rules/Zero_AgeThreshold.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Rules/Zero_AgeThreshold.xml
@@ -1,0 +1,9 @@
+<Document>
+# Core Rule 0
+## Players must be, and act, 16 or above to play Monolith.
+
+A player's real life chronological age must be 16 years old to play the server. Secondly, you must act as you are 16, or above. Players with immature personalities can be removed with admin discretion under this rule.
+
+Finally, if you are proven to be intentionally withholding information that a player is under 16 in Monolith, you may be banned under this rule.
+
+</Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
add 16yo age threshold rule
selfmerging on linter pass

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added 16 year old age threshold rule.