### PR TITLE
Bluespace Event Adjustments First Pass

### DIFF
--- a/Resources/Prototypes/SoundCollections/traits.yml
+++ b/Resources/Prototypes/SoundCollections/traits.yml
@@ -1,6 +1,6 @@
 - type: soundCollection
   id: Paracusia
-  files:
+  files: #Mono TODO: Add additional fun sounds. Mech footstep, mono gun sounds, lasers, chatting, radio, chimera/chimera bone spikes, computer use, hypo inject, vent spray, chemical reaction, more to come.
   #- /Audio/Effects/adminhelp.ogg
   #- /Audio/Machines/Nuke/nuke_alarm.ogg
   #- /Audio/Misc/emergency_meeting.ogg

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -29,7 +29,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 5000 # Mono
         addComponents: &dungeonComponents
         - type: Gravity
           enabled: true
@@ -59,7 +59,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 5000 # Mono
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidSnow
@@ -74,7 +74,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 5000 # Mono
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidCave
@@ -89,7 +89,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 5000 # Mono
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidChromite
@@ -104,7 +104,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 5000 # Mono
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidScrap

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -8,13 +8,13 @@
       path: /Audio/Announcements/attention.ogg
     warningAnnouncement: station-event-bluespace-cache-warning-announcement
     endAnnouncement: station-event-bluespace-cache-end-announcement
-    earliestStart: 100
+    earliestStart: 60 # Mono
     weight: 5
     duration: 1350
     maxDuration: 1560
     reoccurrenceDelay: 240 # Mono: From 8 to 4 hours
-    requiredJobs:
-      Sheriff: 1
+    #requiredJobs: Mono - Remove Sheriff/Colonel requirement
+    #  Sheriff: 1
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup
@@ -50,13 +50,13 @@
       path: /Audio/Announcements/attention.ogg
     warningAnnouncement: station-event-bluespace-vault-warning-announcement
     endAnnouncement: station-event-bluespace-vault-end-announcement
-    earliestStart: 100
+    earliestStart: 60 # Mono
     weight: 5
     duration: 1020
     maxDuration: 1350
     reoccurrenceDelay: 240 # Mono: From 8 to 4 hours
-    requiredJobs:
-      Sheriff: 1
+    #requiredJobs: Mono - Remove Sheriff/Colonel requirement
+    #  Sheriff: 1
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup
@@ -90,14 +90,14 @@
       path: /Audio/Announcements/attention.ogg
     warningAnnouncement: station-event-bluespace-vault-warning-announcement
     endAnnouncement: station-event-bluespace-vault-end-announcement
-    earliestStart: 100
+    earliestStart: 60 # Mono
     maximumPlayers: 30
     weight: 5
     duration: 590
     maxDuration: 780
     reoccurrenceDelay: 240 # Mono: From 8 to 4 hours
-    requiredJobs:
-      Sheriff: 1
+    #requiredJobs: Mono - Remove Sheriff/Colonel requirement
+    #  Sheriff: 1
   - type: BluespaceErrorRule
     groups:
       grid: !type:GridSpawnGroup

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -21,7 +21,7 @@
         nameLoc:
         - station-event-bluespace-name-SyndicateWeaponsCache
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 5000 # Mono
         addComponents:
         - type: Gravity
           enabled: true
@@ -63,7 +63,7 @@
         nameLoc:
         - station-event-bluespace-name-SecureNTVault
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 5000 # Mono
         addComponents:
         - type: Gravity
           enabled: true
@@ -91,7 +91,7 @@
     warningAnnouncement: station-event-bluespace-vault-warning-announcement
     endAnnouncement: station-event-bluespace-vault-end-announcement
     earliestStart: 60 # Mono
-    maximumPlayers: 30
+    maximumPlayers: 0 # Mono
     weight: 5
     duration: 590
     maxDuration: 780
@@ -104,7 +104,7 @@
         nameLoc:
         - station-event-bluespace-name-SecureNTVault
         minimumDistance: 1500
-        maximumDistance: 2500
+        maximumDistance: 5000 # Mono
         addComponents:
         - type: Gravity
           enabled: true

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_salvage_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_salvage_events.yml
@@ -32,7 +32,7 @@
         #  preventArtifactTriggers: true
         #- type: PreventPilot
         - type: ClaimableGrid # Mono
-        paths:
+        paths: #Mono TODO: Create and add Mono scrap ships.
         - /Maps/_NF/Shuttles/Scrap/bison.yml
 #        - /Maps/_NF/Shuttles/Scrap/canister.yml # Too small
         - /Maps/_NF/Shuttles/Scrap/disciple.yml

--- a/Resources/Prototypes/_NF/Events/nf_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_events.yml
@@ -16,7 +16,7 @@
     startAnnouncement: bluespace-cargo-event-announcement
     weight: 5
     duration: 35
-    reoccurrenceDelay: 120
+    reoccurrenceDelay: 60 # Mono
   - type: BluespaceCargoRule
     spawnerPrototype: RandomCargoSpawner
     requireSafeAtmosphere: true
@@ -33,7 +33,7 @@
     weight: 5
     duration: 35
     maximumPlayers: 20
-    reoccurrenceDelay: 180
+    reoccurrenceDelay: 120 # Mono
   - type: BluespaceCargoRule
     spawnerPrototype: CrateFoodMcCargo
     flashPrototype: EffectFlashMcBluespace
@@ -49,9 +49,9 @@
       path: /Audio/Announcements/attention.ogg
     weight: 1
     duration: 35
-    earliestStart: 90
-    minimumPlayers: 20
-    reoccurrenceDelay: 480 # 8 hours
+    earliestStart: 60 # Mono
+    #minimumPlayers: 20 # Mono
+    reoccurrenceDelay: 180 # 8 hours #Mono: 3 hrs
   - type: BluespaceCargoRule
     spawnerPrototype: CrateSyndicateSurplusBundle
     maximumSpawns: 1
@@ -67,8 +67,8 @@
     minimumPlayers: 2
     reoccurrenceDelay: 50
   - type: RandomFaxRule
-    minFaxes: 1
-    maxFaxes: 2
+    minFaxes: 2 # Mono
+    maxFaxes: 3 # Mono
     name: deaddrop-faxed-hint-name
     prototypeId: PaperDeadDropFax
     content: deaddrop-faxed-hint-content # Default contents, will be edited.
@@ -88,8 +88,8 @@
     minimumPlayers: 10
     duration: 35
   - type: RandomFaxRule
-    minFaxes: 3
-    maxFaxes: 4
+    minFaxes: 4 # Mono
+    maxFaxes: 5 # Mono
     name: deaddrop-faxed-hint-name
     prototypeId: PaperDeadDropFax
     content: deaddrop-faxed-hint-content # Default contents, will be edited.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
First pass at changing Frontier bluespace event values to better fit Monolith.
1. Removed Colonel and playercount requirement for vault events to trigger
2. Adjusted max spawn radius for vaults and vgroids to 5km.
3. Reduced minimum round time needed for some events to spawn.
4. Reduced cooldown between repeating certain events, mostly bluespace crate errors. This might also reduce the number of solar storms by increasing the availability of other events.
5. Increased smuggling fax capacity to deliver faxes to more ships when the event is triggered. 

(Includes some comments for the oncoming second pass)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. Increasing the spawn radius for vgroids slightly reduces crowding around the core station spawn areas. It's still well within easy travel range and still has an enabled IFF. For vaults, it reduces the likelihood of civilians getting caught in the crossfire if a vault spawns near MD, ect.
2. Reducing minimum round time for certain events to spawn reduces downtime early on. 
3. Mono already has increased smuggling note spawn frequency, this gives the smuggling hint to more ships to promote competition.


Part 2 will include PDV vaults that pay into PDV's account and change TSF vaults to be TSF-themed. Existing vaults will likely remain purely as targets for civilians. Note that TSF will have a notably more full bank account if they successfully defend all the vaults that can now potentially spawn, now that their spawning doesn't require a Colonel.

## How to test
<!-- Describe the way it can be tested -->
Wait for the event scheduler to make things happen every 30-40 minutes then create a statistical chart of exactly when and where each event occurred. Then determine if the min/max times, locations, and hint fax rate match with the values changed here to ensure everything matches up.

Alternatively, just trust me bro, because I physically cannot gather this information. The numbers are probably working on local.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Vaults and Vgroids can now spawn up to 5km out.
- tweak: Vaults no longer require a Colonel to spawn.
- tweak: Bluespace crates occur more frequently. By extension there will be fewer solar flares. 
- tweak: Increased the number of smuggling hints sent out to ships. Happy hunting.

