### PR TITLE
Construction Bag/Box Tag Additions

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Engineering/construction_bag.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Engineering/construction_bag.yml
@@ -39,6 +39,8 @@
       - RodMetal1
       - Sheet
       - CableCoil
+      - Recyclable # Mono
+      #DRAFT: Add flatpacks
       components:
       - ConstructionMaterials
     blacklist:

--- a/Resources/Prototypes/_NF/Entities/Structures/Storage/construction_box.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Storage/construction_box.yml
@@ -41,6 +41,8 @@
       - RodMetal1
       - Sheet
       - CableCoil
+      - Recyclable # Mono
+      #DRAFT add flatpacks
       components:
       - ConstructionMaterials
       - ResearchDisk # Mono


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds the Recyclable tag to the item whitelist for Construction Box and Construction Bag, which also applies to the BS variant.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This allows construction boxes to contain items with the Recyclable tag. This does not impact the balance of recycling those items, as their material value is unchanged. It does effect potential storage density for some items.

This only expands the list to items that are explicitly recyclable. It apparently does not apply to items that gain the tag from a parent, particularly a multi-parent like Punk Goggles which should in theory fit in the box but actually don't. In testing this also applies to ammo boxes/magazines, which are recyclable but also don't fit. The only other explicitly recyclable item is AME fuel jars.

The most materially dense pieces of scrap the box can now transport are already 4x4 allowing the construction box to store at most 10 of them. That's at most 300 steel or less of any other material per collection trip.

The same applies to the construction bag and bluespace variation except for their inability to store Large and Huge items.

I do not think a special box explicitly for storing scrap is required here, that'd just be mapping bloat and mildly irritating to interact with. This does decrease the effectiveness of swinging a construction box around to collect materials from debris crates by virtue of increasing the potential number of things picked up. This does increase the sidegrade value of using the bags because they exclude the largest chunks of scrap.

#Draft
-intend to add flatpack tag to BaseFlatpack to allow construction bag/box to store flatpacks.
-might buff BS CB to include Large items.
-maybe blacklist AME fuel jars for explosion reasons.

## How to test
<!-- Describe the way it can be tested -->
Spawn construction bag/box, spawn recyclable scrap items nearby, it will be pulled in by the magnet.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Construction Bags and Boxes can now store scrap items found on debris asteroids/vgroids.


