### PR TITLE
Viz Sabre - Small Buff/Fix

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Melee/sword.yml
@@ -295,7 +295,10 @@
     - Belt
     - suitStorage
   - type: Reflect
-    reflectProb: 0.50
+    reflectProb: 0.8
+    reflects:
+    - Energy
+    - NonEnergy
   - type: DisarmMalus
     malus: 0.9
   - type: StaticPrice


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Turns out reflect was only active when the power attack was prepped, so instead of working around that I have instead megabuffed the reflect while power attack is active, making it more likely to deflect away attacks at the vizier

## Why / Balance
Reflect just didn't work before

## How to test
Load up, grab sword, get shot

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Viz's sabre now has an 80% reflect while the power attack is prepped.