### PR TITLE
Increase Detection Ranges

### DIFF
--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
@@ -123,4 +123,19 @@ public sealed partial class MonoCVars
 
     #endregion
 
+    #region Detection
+
+    /// <summary>
+    ///     Multiplier of grid thermal detection radius.
+    /// </summary>
+    public static readonly CVarDef<float> ThermalDetectionMultiplier =
+        CVarDef.Create("mono.detection.thermal_multiplier", 2f, CVar.ARCHIVE | CVar.REPLICATED);
+
+    /// <summary>
+    ///     Multiplier of grid visual detection radius.
+    /// </summary>
+    public static readonly CVarDef<float> VisualDetectionMultiplier =
+        CVarDef.Create("mono.detection.visual_multiplier", 16f, CVar.ARCHIVE | CVar.REPLICATED);
+
+    #endregion
 }

--- a/Content.Shared/_Mono/Detection/DetectionRangeMultiplierComponent.cs
+++ b/Content.Shared/_Mono/Detection/DetectionRangeMultiplierComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class DetectionRangeMultiplierComponent : Component
     ///     Visual detection radius scales linearly off a grid's diagonal.
     /// </summary>
     [DataField]
-    public float VisualMultiplier = 4f;
+    public float VisualMultiplier = 1f;
 
     /// <summary>
     ///     Whether to have effectively infinite detection range.

--- a/Content.Shared/_Mono/Detection/ThermalSignatureComponent.cs
+++ b/Content.Shared/_Mono/Detection/ThermalSignatureComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class ThermalSignatureComponent : Component
     ///     Stored heat retains this portion of itself every next second.
     /// </summary>
     [DataField]
-    public float HeatDissipation = 0.75f;
+    public float HeatDissipation = 15f / 16f;
 
     /// <summary>
     ///     For grids, the combined stored heat of all entities on the grid.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -283,8 +283,8 @@
     maxRange: 512
     followEntity: true
   - type: DetectionRangeMultiplier # same as mass scanner
-    infraredMultiplier: 0.5 # from 1
-    visualMultiplier: 3 # from 4
+    infraredMultiplier: 0.5
+    visualMultiplier: 0.75
   # </Mono>
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -19,8 +19,8 @@
     followEntity: true
   # Mono
   - type: DetectionRangeMultiplier
-    infraredMultiplier: 0.5 # from 1
-    visualMultiplier: 3 # from 4
+    infraredMultiplier: 0.5
+    visualMultiplier: 0.75
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
@@ -32,8 +32,8 @@
     maxRange: 1024
     followEntity: true
   - type: DetectionRangeMultiplier # upgraded thermal sensors
-    infraredMultiplier: 1.5 # from 1
-    visualMultiplier: 8 # from 4
+    infraredMultiplier: 1.5
+    visualMultiplier: 2
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercs.yml
@@ -28,8 +28,8 @@
     maxRange: 512
     followEntity: true
   - type: DetectionRangeMultiplier
-    infraredMultiplier: 0.5 # from 1
-    visualMultiplier: 3 # from 4
+    infraredMultiplier: 0.5
+    visualMultiplier: 0.75
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/trauma.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/trauma.yml
@@ -17,8 +17,8 @@
     maxRange: 512
     followEntity: true
   - type: DetectionRangeMultiplier
-    infraredMultiplier: 0.5 # from 1
-    visualMultiplier: 3 # from 4
+    infraredMultiplier: 0.5
+    visualMultiplier: 0.75
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -259,8 +259,8 @@
     maxRange: 256
     followEntity: true
   - type: DetectionRangeMultiplier
-    infraredMultiplier: 0.5 # from 1
-    visualMultiplier: 3 # from 4
+    infraredMultiplier: 0.5
+    visualMultiplier: 0.75
   # Only ground-based mecha so far. Don't use it in space. Can't move in space.
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
@@ -411,8 +411,8 @@
     maxRange: 2048 #It's a radar/EWAC platform.
     followEntity: true
   - type: DetectionRangeMultiplier
-    infraredMultiplier: 1.5 # from 1
-    visualMultiplier: 8 # from 4
+    infraredMultiplier: 1.5
+    visualMultiplier: 2
   # EXTREMELY slow in gravity. Only really good to taxi, and that's about it. Even worse than S2s
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.25

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/Computers/radar_computers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/Computers/radar_computers.yml
@@ -17,8 +17,8 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: DetectionRangeMultiplier
-    infraredMultiplier: 1.5 # up from 1
-    visualMultiplier: 8 # up from 4
+    infraredMultiplier: 1.5
+    visualMultiplier: 2
   - type: RadarConsole
     maxRange: 2048
     maxIffRange: 2048
@@ -36,8 +36,8 @@
   description: A visual uplink to a station's advanced, long-range intelligence suite, allowing commanders to have eyes on unfolding combat at all times.
   components:
   - type: DetectionRangeMultiplier
-    infraredMultiplier: 2 # up from 1
-    visualMultiplier: 16 # up from 4
+    infraredMultiplier: 2
+    visualMultiplier: 4
   - type: RadarConsole
     maxRange: 3072 # biiig
     maxIffRange: 3072

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -404,8 +404,8 @@
   - type: RadarConsole
     maxRange: 1024 # Mono 350->768
   - type: DetectionRangeMultiplier
-    infraredMultiplier: 1 # from 1 - doesn't really care about thermal sigs
-    visualMultiplier: 12 # from 4
+    infraredMultiplier: 1
+    visualMultiplier: 3
   - type: Computer
     board: Null
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- 4x slower thermal signature decay
- 4x higher visual detection
- 2x higher thermal detection (really 4x due to lower decay)

## Why / Balance
current detection ranges are too low

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Significantly increased ship detection ranges.
