### PR TITLE
Port Wizden #37616:  Give Kammerer Tighter Spread so It's Not a Complete Downgrade to the Enforcer

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunSpreadModifierComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunSpreadModifierComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+/// <summary>
+/// This component modifies the spread of the gun it is attached to.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class GunSpreadModifierComponent: Component
+{
+    /// <summary>
+    /// A scalar value multiplied by the spread built into the ammo itself.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Spread = 1;
+}

--- a/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/GunSpreadModifierSystem.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Examine;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
+
+namespace Content.Shared.Weapons.Ranged.Systems;
+
+
+public sealed class GunSpreadModifierSystem: EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GunSpreadModifierComponent, GunGetAmmoSpreadEvent>(OnGunGetAmmoSpread);
+        SubscribeLocalEvent<GunSpreadModifierComponent, ExaminedEvent>(OnExamine);
+    }
+
+    private void OnGunGetAmmoSpread(EntityUid uid, GunSpreadModifierComponent comp, ref GunGetAmmoSpreadEvent args)
+    {
+        args.Spread *= comp.Spread;
+    }
+
+    private void OnExamine(EntityUid uid, GunSpreadModifierComponent comp, ExaminedEvent args)
+    {
+        var percentage = Math.Round(comp.Spread * 100);
+        var loc = percentage < 100 ? "examine-gun-spread-modifier-reduction" : "examine-gun-spread-modifier-increase";
+        percentage = percentage < 100 ? 100 - percentage : percentage - 100;
+        var msg = Loc.GetString(loc, ("percentage", percentage));
+        args.PushMarkup(msg);
+    }
+}

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -49,3 +49,7 @@ gun-revolver-insert = Inserted
 gun-revolver-spin = Spin revolver
 gun-revolver-spun = Spun
 gun-speedloader-empty = Speedloader empty
+
+# GunSpreadModifier
+examine-gun-spread-modifier-reduction = The spread has been reduced by [color=yellow]{$percentage}%[/color].
+examine-gun-spread-modifier-increase = The spread has been increased by [color=yellow]{$percentage}%[/color].

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -150,6 +150,8 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 3.5 #3->3.5 Mono
+  - type: GunSpreadModifier #Mono
+    spread: 0.4
   - type: BallisticAmmoProvider
     soundRack: /Audio/Weapons/Guns/Cock/smg_cock.ogg #Mono
     capacity: 2
@@ -220,6 +222,8 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 1.4
+  - type: GunSpreadModifier
+    spread: 0.7
   - type: Tag
     tags:
     - WeaponShotgunKammerer

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -223,7 +223,7 @@
   - type: Gun
     fireRate: 1.4
   - type: GunSpreadModifier
-    spread: 0.7
+    spread: 0.7 #Mono: 0.6 >> 0.7
   - type: Tag
     tags:
     - WeaponShotgunKammerer

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -54,6 +54,8 @@
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/bigshotgun_fire.ogg
     #fireRate: 1 # Goobstation
+  - type: GunSpreadModifier
+    spread: 0.7
   - type: Tag
     tags:
     - WeaponShotgunBigLeady


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Ports https://github.com/space-wizards/space-station-14/pull/37616 by [SpeltIncorrectyl](https://github.com/SpeltIncorrectyl)

Applies the component ported by this PR to the Big Johnny and Kammerer for 30% spread reduction, and Double-Barrel for 60%.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Shotguns were hella constrained in means of differentiation and balancing so this should be a good port

Kammerer outclassed by Enforcer and Bulldog in terms of burst kill and sustain. This gives it something to bite back with, even if it isn't much.

Double-barrel is just "convert to sawnoff immediately"

Big Johnny was completely outclassed by its siblings with hardly a difference in terms of availability. The laser sight is also a huge disadvantage due to how much it reveals your position when in use.

## How to test
<!-- Describe the way it can be tested -->

Shoot targets at varying ranges with shotguns and get a feel for it yourself

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/68f30c52-446c-4e50-bc6e-0010499ae205

https://github.com/user-attachments/assets/4051a451-41b1-4d4d-90ce-c9f8f7fc8caf

https://github.com/user-attachments/assets/1d3478a7-d0c3-4552-ac97-839ab713bf75

https://github.com/user-attachments/assets/7ce7b2d8-09f6-46a2-b7d0-9b4884730a87

https://github.com/user-attachments/assets/aea1510e-5a36-41b4-910a-93f38c794c5f



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

No alterations to existing systems, only additions.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Kammerer and Big Johnny 30% spread reduction. Double-Barrel 60% spread reduction. All credit to SpeltIncorrectyl for the spread reduction system ported
