### PR TITLE
Neutron Minor Buff

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -494,7 +494,7 @@
   name: Curio-8640 plasma lance "Malice"
   parent: BallisticArtilleryUnanchorable
   suffix: ADS ONLY
-  description: A devastating weapon, known for glassign whoel fleets when used en masse
+  description: A devastating weapon, known for glassing whole fleets when used en masse
   components:
   - type: StaticPrice
     price: 50000
@@ -810,7 +810,7 @@
     range: 500
   - type: Gun
     fireRate: 1
-    projectileSpeed: 100
+    projectileSpeed: 150
     minAngle: 0
     maxAngle: 6
     shootThermalSignature: 500000 # ~5.6km with continuous fire


### PR DESCRIPTION
Extends the neutron repeater range by 300 meters. Entirely because of multiple players reporting that wyvern is being bullied by bofors and cryexa. Also because 600 meter range is horrid dogshit to play with. 
Also fixed minor typo I saw for the other ADS weapon.

extends range from 600 meters (DOGSHIT) to 900 meters (respectable)
Easy calculation: Take the SPEED of the projectile a multiply it by the lifetime. 
In this case take 150*6=900. This is your range.

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**

:cl:
- tweak: I got bored so I buffed neutron repeater range from 600 to 900 meters
