### PR TITLE
Increase Radar Max Zoomouts

### DIFF
--- a/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
+++ b/Content.Shared/Shuttles/Components/RadarConsoleComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class RadarConsoleComponent : Component
     }
 
     [DataField, AutoNetworkedField]
-    public float MaxRange = 256f;
+    public float MaxRange = 3072f; // Mono - 256->3072
 
     /// <summary>
     /// If true, the radar will be centered on the entity. If not - on the grid on which it is located.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -280,7 +280,6 @@
       enum.RadarConsoleUiKey.Key:
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: DetectionRangeMultiplier # same as mass scanner
     infraredMultiplier: 0.5

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -77,7 +77,6 @@
     initialDelay: 0
     global: true
   - type: RadarConsole
-    maxRange: 2048 # Mono: further increase admin radar range
     followEntity: true
     hideCoords: false # Frontier
     maxIffRange: null # Frontier

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -53,7 +53,6 @@
       enum.RadarConsoleUiKey.Key:
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole # Mono
-    maxRange: 768 # Mono
     followEntity: true
     maxIffRange: 0
     hideCoords: false

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -80,7 +80,6 @@
       enum.RadarConsoleUiKey.Key:
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole
-    maxRange: 768 #256->768 Mono
     followEntity: true
     hideCoords: true
   - type: ComplexInteraction # Needed to interact with innate radar console

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -156,7 +156,6 @@
   # Goobstation Change End
   # <Mono>
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: Magboots
   # </Mono>

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -15,7 +15,6 @@
         visible: true
         map: [ "enum.PowerDeviceVisualLayers.Powered" ]
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   # Mono
   - type: DetectionRangeMultiplier

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -132,7 +132,6 @@
         enum.WiresUiKey.Key:
           type: WiresBoundUserInterface
   - type: RadarConsole
-    maxRange: 1024 #256->1024 Mono
     relativePanning: true # Mono
   - type: WorldLoader
     radius: 384 # Mono
@@ -233,7 +232,6 @@
     tags:
       - Syndicate
   - type: RadarConsole
-    maxRange: 1024 #384->1024 Mono
   - type: WorldLoader
     radius: 1536
   - type: PointLight
@@ -266,7 +264,6 @@
     components:
       - type: CargoShuttle
   - type: RadarConsole
-    maxRange: 256
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -875,8 +872,6 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: RadarConsole
-    maxRange: 1024 #256->1024 Mono
-    maxIffRange: 1024 # Frontier
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/_Crescent/NPCs/Shuttle/control.yml
+++ b/Resources/Prototypes/_Crescent/NPCs/Shuttle/control.yml
@@ -89,7 +89,6 @@
       enum.DroneConsoleUiKey.Key:
         type: DroneConsoleBoundUserInterface
   - type: RadarConsole
-    maxRange: 1024
   - type: WorldLoader
     radius: 256
   - type: DeviceNetwork

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
@@ -29,7 +29,6 @@
     flashDurationMultiplier: 0.85
     isEquipment: true
   - type: RadarConsole
-    maxRange: 1024
     followEntity: true
   - type: DetectionRangeMultiplier # upgraded thermal sensors
     infraredMultiplier: 1.5

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercs.yml
@@ -25,7 +25,6 @@
     energy: 3
     color: "#e24242"
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: DetectionRangeMultiplier
     infraredMultiplier: 0.5

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/trauma.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/trauma.yml
@@ -14,7 +14,6 @@
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: DetectionRangeMultiplier
     infraredMultiplier: 0.5
@@ -67,7 +66,6 @@
     isEquipment: true
     toggleAction: PulseThermalVision
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ui.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ui.yml
@@ -46,7 +46,6 @@
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: RadarConsole
-    maxRange: 312
     followEntity: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
@@ -157,7 +156,6 @@
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ussp.yml
@@ -101,7 +101,6 @@
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
@@ -169,7 +168,6 @@
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -89,7 +89,6 @@
       enum.RadarConsoleUiKey.Key:
         toggleAction: ActionAGhostShowRadar
   - type: RadarConsole
-    maxRange: 768
     followEntity: false
   - type: DeviceNetwork
     deviceNetId: Wireless

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -126,7 +126,6 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: RadarConsole
-    maxRange: 512
     followEntity: true
   - type: Appearance
   - type: GenericVisualizer
@@ -256,7 +255,6 @@
         acts: ["Destruction"]
   # Terrible radar, mostly good for navigating planets
   - type: RadarConsole
-    maxRange: 256
     followEntity: true
   - type: DetectionRangeMultiplier
     infraredMultiplier: 0.5
@@ -340,7 +338,6 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: RadarConsole
-    maxRange: 1024
     followEntity: true
   - type: Appearance
   - type: GenericVisualizer
@@ -408,7 +405,6 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: RadarConsole
-    maxRange: 2048 #It's a radar/EWAC platform.
     followEntity: true
   - type: DetectionRangeMultiplier
     infraredMultiplier: 1.5

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/Computers/radar_computers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/Computers/radar_computers.yml
@@ -20,8 +20,6 @@
     infraredMultiplier: 1.5
     visualMultiplier: 2
   - type: RadarConsole
-    maxRange: 2048
-    maxIffRange: 2048
   - type: Computer
     board: EliteRadarCircuitboard
   - type: PointLight
@@ -39,7 +37,5 @@
     infraredMultiplier: 2
     visualMultiplier: 4
   - type: RadarConsole
-    maxRange: 3072 # biiig
-    maxIffRange: 3072
   - type: Computer
     board: StationRadarCircuitboard

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -242,7 +242,6 @@
         enum.WiresUiKey.Key:
           type: WiresBoundUserInterface
   - type: RadarConsole
-    maxRange: 1024
     relativePanning: true
   - type: WorldLoader
     radius: 384 # Mono

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
@@ -87,7 +87,6 @@
       enum.RadarConsoleUiKey.Key:
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole # Mono
-    maxRange: 384
     followEntity: true
     maxIffRange: 0
     hideCoords: false

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers.yml
@@ -10,7 +10,6 @@
     infraredMultiplier: 1.2
     visualMultiplier: 1.5
   - type: RadarConsole
-    maxRange: 1536
     maxIffRange: null # Frontier
   - type: Sprite
     layers:
@@ -402,7 +401,6 @@
   abstract: true
   components:
   - type: RadarConsole
-    maxRange: 1024 # Mono 350->768
   - type: DetectionRangeMultiplier
     infraredMultiplier: 1
     visualMultiplier: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
every radar interface now has 3072 max zoomout

## Why / Balance
no reason to limit them

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: All radar interfaces standartised to 3072 max zoomout.
