### PR TITLE
Fix Gunnery Server on Caput

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/caput.yml
+++ b/Resources/Maps/_Mono/Shuttles/caput.yml
@@ -1041,7 +1041,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 662
-- proto: GunneryServerLow
+- proto: GunneryServerMedium
   entities:
   - uid: 40
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Caput had to use medium-power gunnery server, not low-power gunnery server.
