### PR TITLE
Ion Balance Change

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -179,7 +179,7 @@
     color: "#FB00FF"
   - type: EmpOnTrigger
     range: 4
-    energyConsumption: 2700000
+    energyConsumption: 3000000
     disableDuration: 10
 
 # DYMERE
@@ -291,8 +291,8 @@
     color: "#FB00FF"
   - type: EmpOnTrigger
     range: 3
-    energyConsumption: 6000000
-    disableDuration: 27.5
+    energyConsumption: 1000000
+    disableDuration: 8
   - type: LightningOnTrigger
     chance: 1
     count: 5


### PR DESCRIPTION
Noticed while playing against worms in a nebula that 2 hits hardlocked me from everything and kept me permanently stunlocked until the ship was dead. They fired faster than their EMP wore off, very literally keeping me pinned forever.

Therefor: Ion no longer hardlocks you for 27.5 seconds out of consoles and no longer draws 6 million watts.

Also buffed poor rubicon which was WORSE than the ion both in lockout and in power drawn! Rubicon now draws 3 million instead of 2.7 while ion only draws 1 million instead of 6 MILLION. Nerfed Ion hard lockout on consoles down to 8 seconds, which clearly defines the 220 rubicon as a better, heavier, slower firing EMP for ships.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**

:cl:
- tweak: Ions have been nerfed down from stunlock master tier.