### PR TITLE
Remove EMP Disable Duration Stackup.

### DIFF
--- a/Content.Server/Emp/EmpSystem.cs
+++ b/Content.Server/Emp/EmpSystem.cs
@@ -116,13 +116,14 @@ public sealed class EmpSystem : SharedEmpSystem
         if (ev.Disabled)
         {
             // Frontier: Upstream - #28984 start
-            //disabled.DisabledUntil = Timing.CurTime + TimeSpan.FromSeconds(duration);
             var disabled = EnsureComp<EmpDisabledComponent>(uid);
-            if (disabled.DisabledUntil == TimeSpan.Zero)
-            {
-                disabled.DisabledUntil = Timing.CurTime;
-            }
-            disabled.DisabledUntil = disabled.DisabledUntil + TimeSpan.FromSeconds(duration);
+            disabled.DisabledUntil = Timing.CurTime + TimeSpan.FromSeconds(duration);
+            // Mono - remove EMP effect stackup
+            // if (disabled.DisabledUntil == TimeSpan.Zero)
+            // {
+            //     disabled.DisabledUntil = Timing.CurTime;
+            // }
+            // disabled.DisabledUntil = disabled.DisabledUntil + TimeSpan.FromSeconds(duration);
 
             /// i tried my best to go through the Pow3r server code but i literally couldn't find in relation to PowerNetworkBatteryComponent that uses the event system
             /// the code is otherwise too esoteric for my innocent eyes


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes part of code that is responsible for EMP duration stackup.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Having duration stackup makes impossible to balance around EMP with infinite stunlocks.
## How to test
<!-- Describe the way it can be tested -->
load local
shoot something with emp 100 times
it recovers back in few seconds.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: EMP Disable duration no longer stacks up.