### PR TITLE
Lowered Select Monolithic Entity Health and Damage

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/monolithic.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/monolithic.yml
@@ -134,7 +134,7 @@
     allowRevives: false
   - type: SlowOnDamage
     speedModifierThresholds:
-      250: 0.9
+      150: 0.9
   - type: DamageStateVisuals
     states:
       Alive:
@@ -378,8 +378,8 @@
       collection: Punch
     damage:
       types:
-        Blunt: 50
-        Structural: 300
+        Blunt: 25
+        Structural: 150
     altDisarm: false
     angle: 20
     animation: WeaponArcFist
@@ -387,7 +387,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 600
+        damage: 400
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -402,7 +402,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Dead
+      300: Dead
   - type: MovementSpeedModifier
     baseSprintSpeed: 2
     baseWalkSpeed: 1.5
@@ -466,7 +466,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 250
+            damage: 200
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
@@ -481,7 +481,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        200: Dead
+        150: Dead
     - type: MovementSpeedModifier
       baseSprintSpeed: 4.5
       baseWalkSpeed: 3
@@ -563,8 +563,8 @@
       collection: Punch
     damage:
       types:
-        Blunt: 50
-        Structural: 300
+        Blunt: 25
+        Structural: 150
     altDisarm: false
     angle: 0
     animation: WeaponArcPunch
@@ -572,7 +572,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 600
+        damage: 400
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -587,7 +587,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      500: Dead
+      300: Dead
   - type: MovementSpeedModifier
     baseSprintSpeed: 2
     baseWalkSpeed: 1.5

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -153,13 +153,13 @@
   - type: Ammo
     muzzleFlash: null
   - type: StaminaDamageOnCollide
-    damage: 65
+    damage: 35
   - type: Projectile
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
         Blunt: 5
-        Caustic: 15
+        Caustic: 10
         Cellular: 5
     soundHit:
       collection: ExplosionSmall


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Lowered the health and damage of the golum and lowered the health of the hell locust. Gestalts are largely fine IMO.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Holy fuck these things are overtuned.
Anyways, I understand that these things are supposed to be powerful but either version of the golum was previously able to crit someone without armor with two attacks, of course you're unlikely to not have damage reduction when dealing with these but big damage still leads to big damage, even if reduced. On top of the (frankly absurd) amount of damage a monolithic entity can deal, they were also incredibly tanky, with golums being able to eat an entire 7.62x39 magazine without dying. Hell locusts were less bad, but I think that something that fast should be a little easier to kill.

## How to test
<!-- Describe the way it can be tested -->
Open local host, spawn monolithic entity, kill/fail to kill it

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Monolithic entities are generally easier, but still difficult, to fight.