### PR TITLE
Fix Standing

### DIFF
--- a/Content.IntegrationTests/Tests/Body/LegTest.cs
+++ b/Content.IntegrationTests/Tests/Body/LegTest.cs
@@ -14,6 +14,7 @@ namespace Content.IntegrationTests.Tests.Body
     public sealed class LegTest
     {
         [TestPrototypes]
+        // Mono - add requiredLegs
         private const string Prototypes = @"
 - type: entity
   name: HumanBodyAndAppearanceDummy
@@ -22,6 +23,7 @@ namespace Content.IntegrationTests.Tests.Body
   - type: Appearance
   - type: Body
     prototype: Human
+    requiredLegs: 2
   - type: StandingState
 ";
 

--- a/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
+++ b/Content.IntegrationTests/Tests/Buckle/BuckleTest.cs
@@ -22,6 +22,7 @@ namespace Content.IntegrationTests.Tests.Buckle
         private const string ItemDummyId = "ItemDummy";
 
         [TestPrototypes]
+        // Mono - add requiredLegs
         private const string Prototypes = $@"
 - type: entity
   name: {BuckleDummyId}
@@ -33,6 +34,7 @@ namespace Content.IntegrationTests.Tests.Buckle
   - type: InputMover
   - type: Body
     prototype: Human
+    requiredLegs: 2
   - type: StandingState
 
 - type: entity

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -462,7 +462,7 @@ public partial class SharedBodySystem
 
     private void OnStandAttempt(Entity<BodyComponent> ent, ref StandAttemptEvent args)
     {
-        if (ent.Comp.LegEntities.Count == 0)
+        if (ent.Comp.LegEntities.Count < ent.Comp.RequiredLegs) // Mono - fix
             args.Cancel();
     }
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -30,6 +30,9 @@ using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
 using Robust.Shared.Timing;
 
+// Mono
+using Content.Shared._White.Standing;
+
 namespace Content.Shared.Body.Systems;
 
 public partial class SharedBodySystem
@@ -462,7 +465,7 @@ public partial class SharedBodySystem
 
     private void OnStandAttempt(Entity<BodyComponent> ent, ref StandAttemptEvent args)
     {
-        if (ent.Comp.LegEntities.Count < ent.Comp.RequiredLegs) // Mono - fix
+        if (ent.Comp.LegEntities.Count == 0 && ent.Comp.RequiredLegs > 0) // Mono - fix
             args.Cancel();
     }
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -18,6 +18,9 @@ using Content.Shared._Shitmed.BodyEffects;
 using Content.Shared.Inventory;
 using Content.Shared.Random;
 
+// Mono
+using Content.Shared._White.Standing;
+
 namespace Content.Shared.Body.Systems;
 
 public partial class SharedBodySystem
@@ -370,6 +373,8 @@ public partial class SharedBodySystem
             bodyEnt.Comp.LegEntities.Add(legEnt);
             UpdateMovementSpeed(bodyEnt);
             Dirty(bodyEnt, bodyEnt.Comp);
+            // Mono
+            Standing.Stand(bodyEnt, force: !HasComp<LayingDownComponent>(bodyEnt));
         }
     }
 
@@ -383,7 +388,8 @@ public partial class SharedBodySystem
             bodyEnt.Comp.LegEntities.Remove(legEnt);
             UpdateMovementSpeed(bodyEnt);
             Dirty(bodyEnt, bodyEnt.Comp);
-            Standing.Down(bodyEnt); // Shitmed Change
+            if (bodyEnt.Comp.LegEntities.Count == 0 && bodyEnt.Comp.RequiredLegs > 0) // Mono
+                Standing.Down(bodyEnt); // Shitmed Change
         }
     }
 

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -18,6 +18,9 @@ using Content.Shared.Strip.Components;
 using Content.Shared.Throwing;
 using Robust.Shared.Physics.Components;
 
+// Mono
+using Content.Shared._White.Standing;
+
 namespace Content.Shared.Mobs.Systems;
 
 public partial class MobStateSystem
@@ -100,7 +103,7 @@ public partial class MobStateSystem
         switch (state)
         {
             case MobState.Alive:
-                _standing.Stand(target);
+                _standing.Stand(target, force: !HasComp<LayingDownComponent>(target)); // Mono - force stand up if we can't lay down at will
                 _appearance.SetData(target, MobStateVisuals.State, MobState.Alive);
                 break;
             case MobState.Critical:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
borgs and chims no longer permanently knocked down on leg loss

tested for killing/repairing borg and cutting a chim's legs then rejuvving it

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Borgs and chimeras no longer permanently lie down after being downed once.
