### PR TITLE
Shipgun Recoil

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -299,6 +299,13 @@ public sealed partial class GunComponent : Component
     /// </summary>
     [DataField]
     public Angle MuzzleFlashRotationOffset;
+
+    /// <summary>
+    /// Mono
+    /// Recoil to incur per ammo shot, kg*m/s.
+    /// </summary>
+    [DataField]
+    public float Recoil = 25f;
 }
 
 [Flags]

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -513,14 +513,10 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         // Shoot confirmed - sounds also played here in case it's invalid (e.g. cartridge already spent).
         Shoot(gunUid, gun, ev.Ammo, fromCoordinates, toCoordinates.Value, out var userImpulse, user, throwItems: attemptEv.ThrowItems);
-        var shotEv = new GunShotEvent(user, ev.Ammo);
+        var shotEv = new GunShotEvent(user, ev.Ammo, toCoordinates.Value); // Mono - pass coordinates
         RaiseLocalEvent(gunUid, ref shotEv);
 
-        if (userImpulse && _physQuery.TryComp(user, out var userPhysics))
-        {
-            if (_gravity.IsWeightless(user, userPhysics))
-                CauseImpulse(fromCoordinates, toCoordinates.Value, user, userPhysics);
-        }
+        CauseImpulse(toCoordinates.Value, (gunUid, gun), ev.Ammo.Count);
     }
 
     public void Shoot(
@@ -661,27 +657,26 @@ public abstract partial class SharedGunSystem : EntitySystem
         CreateEffect(gun, ev, user);
     }
 
-    public void CauseImpulse(EntityCoordinates fromCoordinates, EntityCoordinates toCoordinates, EntityUid user, PhysicsComponent userPhysics)
+    // Mono - rewritten
+    public void CauseImpulse(EntityCoordinates toCoordinates, Entity<GunComponent> ent, float scale)
     {
-        var fromMap = fromCoordinates.ToMapPos(EntityManager, TransformSystem);
-        var toMap = toCoordinates.ToMapPos(EntityManager, TransformSystem);
-        var shotDirection = (toMap - fromMap).Normalized();
+        var totalImpulse = ent.Comp.Recoil * scale;
+        var selfXform = Transform(ent);
 
-        const float impulseStrength = 25.0f;
-        var impulseVector =  shotDirection * impulseStrength;
+        var impulseCoord = new EntityCoordinates(ent, Vector2.Zero);
 
-        // Frontier: apply impulse to buckled object if buckled
-        if (TryComp<BuckleComponent>(user, out var buckle) && buckle.BuckledTo is not null)
-        {
-            TryComp<PhysicsComponent>(buckle.BuckledTo, out var buckledPhys);
-            Physics.ApplyLinearImpulse(buckle.BuckledTo.Value, -impulseVector, body: buckledPhys);
-        }
-        else
-        {
-            Physics.ApplyLinearImpulse(user, -impulseVector, body: userPhysics);
-        }
-        // End Frontier
-        // Physics.ApplyLinearImpulse(user, -impulseVector, body: userPhysics); // Frontier: old implementation
+        if (Containers.TryGetContainingContainer(ent.Owner, out var container))
+            impulseCoord = TransformSystem.WithEntityId(impulseCoord, container.Owner);
+        else if (selfXform.Anchored && selfXform.ParentUid != selfXform.MapUid)
+            impulseCoord = TransformSystem.WithEntityId(impulseCoord, selfXform.ParentUid);
+
+        // velocity is in world-aligned coordinates so get vec based off that
+        var worldSource = TransformSystem.GetWorldPosition(impulseCoord.EntityId);
+        var worldTarget = TransformSystem.ToWorldPosition(toCoordinates);
+        var dirVec = worldTarget - worldSource;
+        dirVec.Normalize();
+
+        Physics.ApplyLinearImpulse(impulseCoord.EntityId, -dirVec * totalImpulse, impulseCoord.Position);
     }
 
     public void RefreshModifiers(Entity<GunComponent?> gun, EntityUid? User = null) // GoobStation change - User for NoWieldNeeded
@@ -802,7 +797,7 @@ public record struct AttemptShootEvent(EntityUid User, string? Message, bool Can
 /// </summary>
 /// <param name="User">The user that fired this gun.</param>
 [ByRefEvent]
-public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo);
+public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo, EntityCoordinates ToCoordinates); // Mono - pass coordinates
 
 public enum EffectLayers : byte
 {

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -23,6 +23,7 @@
     range: 500
   - type: Gun
     fireRate: 0.5
+    recoil: 5 # 1/5x
     minAngle: 0
     maxAngle: 0
     projectileSpeed: 65
@@ -93,6 +94,7 @@
     range: 500
   - type: Gun
     fireRate: 20
+    recoil: 5 # 1/5x
     minAngle: 0
     maxAngle: 5
     projectileSpeed: 185
@@ -164,6 +166,7 @@
   - type: FireControlRotate
   - type: Gun
     fireRate: 5
+    recoil: 2 # 2/25x
     projectileSpeed: 20
     minAngle: 0
     maxAngle: 5
@@ -310,6 +313,7 @@
   - type: Gun
     projectileSpeed: 250
     fireRate: 0.75
+    recoil: 500 # 20x - station weapon
     shootThermalSignature: 12000000 # ~6km after firing
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/laserfire.ogg
@@ -376,6 +380,7 @@
     range: 500
   - type: Gun
     fireRate: 20
+    recoil: 0
     minAngle: 0
     maxAngle: 0
     shootThermalSignature: 2000000
@@ -442,6 +447,7 @@
     range: 500
   - type: Gun
     fireRate: 20
+    recoil: 0
     minAngle: 0
     maxAngle: 0
     shootThermalSignature: 5000000
@@ -522,6 +528,7 @@
   - type: Gun
     projectileSpeed: 70
     fireRate: 13
+    recoil: 0
     minAngle: 0
     maxAngle: 0
     burstCooldown: 60
@@ -593,6 +600,7 @@
     range: 500
   - type: Gun
     fireRate: 0.04 # 25s
+    recoil: 0
     minAngle: 0
     maxAngle: 0
     shootThermalSignature: 18000000 # ~8.5km after firing
@@ -667,6 +675,7 @@
     range: 500
   - type: Gun
     fireRate: 0.025 # 40s
+    recoil: 50 # 2x
     minAngle: 0
     maxAngle: 0
     projectileSpeed: 750
@@ -741,6 +750,7 @@
     range: 500
   - type: Gun
     fireRate: 1.2
+    recoil: 0
     minAngle: 0
     maxAngle: 4
     shootThermalSignature: 4000000 # ~2.8km with continuous fire
@@ -810,6 +820,7 @@
     range: 500
   - type: Gun
     fireRate: 1
+    recoil: 10 # 2/5x
     projectileSpeed: 150
     minAngle: 0
     maxAngle: 6
@@ -883,6 +894,7 @@
     range: 500
   - type: Gun
     fireRate: 25
+    recoil: 2 # 2/25x
     minAngle: 0
     maxAngle: 4
     shootThermalSignature: 2000000

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/charon_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/charon_launcher.yml
@@ -1,11 +1,7 @@
-# Station one w/ infinite ammo
-
 - type: entity
-  id: WeaponTurretCharon
+  id: WeaponTurretCharonBase
   name: M381 CHARON mass driver
-  parent: BallisticArtilleryUnanchorable
-  suffix: Station, Recharging Ammo
-  description: A capital-class railgun that fires a massive slug at extreme velocity, capable of catastrophic damage to enemy ships. Heavy linear accelerator, can be remotely activated or linked up to a GCS. This one feeds from an autoloader somewhere, and doesn't need manual reloads.
+  abstract: true
   components:
   - type: StaticPrice
     price: 30000
@@ -16,14 +12,11 @@
   - type: Appearance
   - type: FireControlRotate
   - type: AmmoCounter
-  - type: Battery
-    maxCharge: 40000
-    startingCharge: 40000
-  - type: ExaminableBattery
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
     fireRate: 0.05
+    recoil: 2500 # 100x
     minAngle: 0
     maxAngle: 0
     projectileSpeed: 1450
@@ -32,17 +25,11 @@
       path: /Audio/_Mono/Weapons/Guns/Gunshots/leviathan_fire.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 350
   - type: SpaceArtillery
     powerChargeRate: 350
     powerUsePassive: 1000
     powerUseActive: 7500
   - type: Actions
-  - type: ProjectileBatteryAmmoProvider
-    proto: ShipRailgunProjectile
-    fireCost: 1500
   - type: Fixtures
     fixtures:
       fix1:
@@ -73,40 +60,35 @@
   - type: ShipGunClass
     shipClass: Superheavy
 
+# Station one w/ infinite ammo
+
+- type: entity
+  id: WeaponTurretCharon
+  name: M381 CHARON mass driver
+  parent: [WeaponTurretCharonBase, BallisticArtilleryUnanchorable]
+  suffix: Station, Recharging Ammo
+  description: A capital-class railgun that fires a massive slug at extreme velocity, capable of catastrophic damage to enemy ships. Heavy linear accelerator, can be remotely activated or linked up to a GCS. This one feeds from an autoloader somewhere, and doesn't need manual reloads.
+  components:
+  - type: Battery
+    maxCharge: 40000
+    startingCharge: 40000
+  - type: ExaminableBattery
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 350
+  - type: ProjectileBatteryAmmoProvider
+    proto: ShipRailgunProjectile
+    fireCost: 1500
+
 # Ship one w/ limited ammo
 
 - type: entity
   id: WeaponTurretCharonReload
   name: M381 CHARON mass driver
-  parent: BallisticArtilleryUnanchorableCartridge
+  parent: [WeaponTurretCharonBase, BallisticArtilleryUnanchorableCartridge]
   suffix: Ship, Manual Reload, No Rotate
   description: A capital-class railgun that fires a massive slug at extreme velocity, capable of catastrophic damage to enemy ships. Heavy linear accelerator, can be remotely activated or linked up to a GCS.
   components:
-  - type: StaticPrice
-    price: 30000
-  - type: Sprite
-    sprite: _Mono/Objects/ShuttleWeapons/charon.rsi
-    layers:
-    - state: space_artillery
-  - type: Appearance
-  - type: AmmoCounter
-  - type: WirelessNetworkConnection
-    range: 500
-  - type: Gun
-    fireRate: 0.05
-    minAngle: 0
-    maxAngle: 0
-    projectileSpeed: 1450
-    shootThermalSignature: 18000000 # ~8.5m after firing
-    soundGunshot:
-      path: /Audio/_Mono/Weapons/Guns/Gunshots/leviathan_fire.ogg
-    soundEmpty:
-      path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
-  - type: SpaceArtillery
-    powerChargeRate: 350
-    powerUsePassive: 1000
-    powerUseActive: 7500
-  - type: Actions
   - type: BallisticAmmoProvider
     whitelist:
       tags:
@@ -115,32 +97,3 @@
     proto: CharonSlugAmmo
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.5,-0.5,0.5,0.5"
-        density: 1500
-        mask:
-        - MachineMask
-        layer:
-        - MachineLayer
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 35000
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
-  - type: RadarBlip
-    radarColor: "#CF0E0E"
-    scale: 3
-  - type: ShipGunType
-    shipType: Ballistic
-  - type: ShipGunClass
-    shipClass: Superheavy

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/drone_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/drone_kinetic.yml
@@ -18,6 +18,7 @@
     range: 500
   - type: Gun
     fireRate: 0.4
+    recoil: 25 # 1x
     projectileSpeed: 350
     minAngle: 0
     maxAngle: 0

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlarge_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlarge_kinetic.yml
@@ -35,6 +35,7 @@
     minAngle: 0
     maxAngle: 1
     fireRate: 0.2
+    recoil: 100 # 4x
     burstCooldown: 10
     burstFireRate: 2
     shotsPerBurst: 2
@@ -114,6 +115,7 @@
     minAngle: 0
     maxAngle: 1
     fireRate: 0.1
+    recoil: 100 # 4x
     shootThermalSignature: 80000000 # ~9km after firing
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/cannon.ogg
@@ -192,6 +194,7 @@
     minAngle: 0
     maxAngle: 0
     fireRate: 0.2
+    recoil: 100 # 4x
     burstCooldown: 10
     burstFireRate: 2
     shotsPerBurst: 2
@@ -268,6 +271,7 @@
     minAngle: 0
     maxAngle: 7
     fireRate: 11
+    recoil: 25 # 1x
     burstCooldown: 8
     burstFireRate: 11
     shotsPerBurst: 15

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlight_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlight_kinetic.yml
@@ -23,6 +23,7 @@
     - Toggle
   - type: Gun
     fireRate: 12
+    recoil: 5 # 1/5x
     projectileSpeed: 160
     minAngle: 0
     maxAngle: 5
@@ -96,6 +97,7 @@
     - Toggle
   - type: Gun
     fireRate: 10
+    recoil: 5 # 1/5x
     projectileSpeed: 180
     minAngle: 0
     maxAngle: 8

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardmedium_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardmedium_kinetic.yml
@@ -19,6 +19,7 @@
     range: 500
   - type: Gun
     fireRate: 3
+    recoil: 10 # 2/5x
     projectileSpeed: 170
     minAngle: 0
     maxAngle: 3
@@ -92,6 +93,7 @@
     range: 500
   - type: Gun
     fireRate: 1.5
+    recoil: 10 # 2/5x
     projectileSpeed: 250
     minAngle: 0
     maxAngle: 2

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
@@ -30,6 +30,7 @@
     - Toggle
   - type: Gun
     fireRate: 5
+    recoil: 15 # 3/5x
     projectileSpeed: 200
     minAngle: 0
     maxAngle: 5
@@ -95,6 +96,7 @@
     range: 500
   - type: Gun
     fireRate: 2
+    recoil: 10 # 2/5x
     projectileSpeed: 170
     minAngle: 0
     maxAngle: 6
@@ -172,6 +174,7 @@
         - MachineLayer
   - type: Gun
     projectileSpeed: 325
+    recoil: 100 # 4x
     minAngle: 0
     maxAngle: 3
     fireRate: 0.2

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/thantos_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/thantos_launcher.yml
@@ -24,6 +24,7 @@
     range: 500
   - type: Gun
     fireRate: 0.1
+    recoil: 2500 # 100x
     minAngle: 0
     maxAngle: 0
     burstCooldown: 20

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/launcher.yml
@@ -23,6 +23,7 @@
     range: 500
   - type: Gun
     fireRate: 0.5
+    recoil: 10
     shootThermalSignature: 32000000 # ~5.6km
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/light_bomb_bay.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/light_bomb_bay.yml
@@ -18,6 +18,7 @@
   - type: Gun
     projectileSpeed: 10
     fireRate: 0.8
+    recoil: 5
     shootThermalSignature: 8000000 # ~2.8km
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/tovek_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/tovek_launcher.yml
@@ -17,6 +17,7 @@
     range: 500
   - type: Gun
     fireRate: 0.2
+    recoil: 5
     shootThermalSignature: 8000000 # ~2828m
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/trident_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/trident_launcher.yml
@@ -16,6 +16,7 @@
     range: 500
   - type: Gun
     fireRate: 0.1
+    recoil: 10
     shootThermalSignature: 16000000 # 4000m after firing
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rocket_launcher.ogg

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/vanyk_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/vanyk_launcher.yml
@@ -17,6 +17,7 @@
     range: 500
   - type: Gun
     fireRate: 0.8
+    recoil: 5
     minAngle: 0
     maxAngle: 0
     shootThermalSignature: 8000000 # ~5km if firing continuously

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/vespera_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/vespera_launcher.yml
@@ -17,6 +17,7 @@
     range: 500
   - type: Gun
     fireRate: 16
+    recoil: 1
     minAngle: 4
     maxAngle: 35
     burstCooldown: 20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
firing shipguns now knocks your ship around a bit
test ingame before merging

## Why / Balance
allows you to move via firing your shipguns
partially as a counter for people cutting off station pieces with station guns

## How to test
1. load in different ships
2. drive around while firing shipguns

also try firing thanatos on small ship or charon on normal charon ship

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Shipguns now have recoil.
