### PR TITLE
Drone Tweaks

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/World/crown.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/crown.yml
@@ -231,7 +231,7 @@ entities:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-- proto: ClothingBackpackDroneLoot
+- proto: ClothingBackpackDroneLootT21
   entities:
   - uid: 113
     components:

--- a/Resources/Maps/_Mono/Shuttles/World/medusa.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/medusa.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/30/2025 16:14:51
-  entityCount: 186
+  time: 01/04/2026 16:58:11
+  entityCount: 185
 maps: []
 grids:
 - 1
@@ -68,11 +68,11 @@ entities:
           version: 7
         -1,-1:
           ind: -1,-1
-          tiles: BQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAA8AAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAKAAAAAAAABQAAAAAAAAUAAAAAAAAXAAAAAAAABQAAAAAAAA8AAAAAAAAQAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAHQAAAAAAABIAAAAAAAAPAAAAAAAAEAAAAAAAABIAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAASAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAB4AAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: BQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAA8AAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAKAAAAAAAABQAAAAAAAAUAAAAAAAAXAAAAAAAABQAAAAAAAA8AAAAAAAAQAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAHQAAAAAAAAoAAAAAAAAPAAAAAAAAAAAAAAAAABIAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAASAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAB4AAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAA==
           version: 7
         0,-1:
           ind: 0,-1
-          tiles: BQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAEgAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAABAAAAAAAAASAAAAAAAABQAAAAAAABcAAAAAAAAFAAAAAAAABQAAAAAAAAMAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAADwAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAQAAAAAAAAEgAAAAAAAA8AAAAAAAAfAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAB8AAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAA==
+          tiles: BQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAEgAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAABAAAAAAAAASAAAAAAAABQAAAAAAABcAAAAAAAAFAAAAAAAABQAAAAAAAAMAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAADwAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAAAAAAAAAAEgAAAAAAAAMAAAAAAAAfAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAB8AAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAAUAAAAAAAAFAAAAAAAABQAAAAAAAA==
           version: 7
     - type: Broadphase
     - type: Physics
@@ -114,6 +114,11 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
   - uid: 9
     components:
     - type: Transform
@@ -203,11 +208,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,0.5
-      parent: 1
-  - uid: 32
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
       parent: 1
   - uid: 33
     components:
@@ -304,6 +304,21 @@ entities:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
   - uid: 165
     components:
     - type: Transform
@@ -313,6 +328,11 @@ entities:
     components:
     - type: Transform
       pos: -0.5,1.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
       parent: 1
   - uid: 184
     components:
@@ -435,6 +455,11 @@ entities:
       parent: 1
 - proto: ClothingBackpackDroneLoot
   entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 0.5788634,0.47274494
+      parent: 1
   - uid: 164
     components:
     - type: Transform
@@ -491,38 +516,11 @@ entities:
       parent: 1
 - proto: Grille
   entities:
-  - uid: 73
-    components:
-    - type: Transform
-      pos: -5.5,-4.5
-      parent: 1
-  - uid: 78
-    components:
-    - type: Transform
-      pos: -4.5,-3.5
-      parent: 1
   - uid: 83
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
-      parent: 1
-  - uid: 84
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-3.5
-      parent: 1
-  - uid: 86
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 1
-  - uid: 91
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-3.5
       parent: 1
   - uid: 92
     components:
@@ -542,25 +540,25 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 174
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-4.5
-      parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 88
+  - uid: 53
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,-4.5
+      pos: 7.5,-3.5
       parent: 1
-  - uid: 100
+  - uid: 55
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,-4.5
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-3.5
       parent: 1
   - uid: 134
     components:
@@ -586,40 +584,23 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 171
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-4.5
-      parent: 1
-  - uid: 172
+  - uid: 182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -6.5,-4.5
-      parent: 1
-  - uid: 173
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-4.5
-      parent: 1
-  - uid: 176
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-4.5
+      pos: 5.5,-3.5
       parent: 1
 - proto: SmallGyroscope
   entities:
-  - uid: 130
+  - uid: 61
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 0.5,0.5
       parent: 1
-- proto: SpawnMobRammerCoreStraight
+- proto: SpawnMobAttackerCoreShortRange
   entities:
-  - uid: 3
+  - uid: 62
     components:
     - type: Transform
       pos: 0.5,1.5
@@ -662,35 +643,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 7.5,-2.5
       parent: 1
-  - uid: 128
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-3.5
-      parent: 1
-  - uid: 131
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-3.5
-      parent: 1
   - uid: 132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
-      parent: 1
-  - uid: 170
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-3.5
-      parent: 1
-  - uid: 177
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-3.5
       parent: 1
 - proto: ThrusterLarge
   entities:
@@ -718,271 +675,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,-4.5
       parent: 1
-- proto: WallPlastitanium
-  entities:
-  - uid: 53
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
-      parent: 1
-  - uid: 58
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-0.5
-      parent: 1
-  - uid: 59
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,1.5
-      parent: 1
-  - uid: 60
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,3.5
-      parent: 1
-  - uid: 61
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,3.5
-      parent: 1
-  - uid: 62
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,1.5
-      parent: 1
-  - uid: 63
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-0.5
-      parent: 1
-  - uid: 64
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 65
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,3.5
-      parent: 1
-  - uid: 66
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 67
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 68
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 69
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,2.5
-      parent: 1
-  - uid: 70
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 71
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 72
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 1
-  - uid: 74
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,2.5
-      parent: 1
-  - uid: 75
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,1.5
-      parent: 1
-  - uid: 76
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 77
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 1
-  - uid: 116
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 118
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 119
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,1.5
-      parent: 1
-  - uid: 121
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,1.5
-      parent: 1
-  - uid: 123
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 125
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 153
-    components:
-    - type: Transform
-      pos: -0.5,4.5
-      parent: 1
-  - uid: 178
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,2.5
-      parent: 1
-  - uid: 183
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,5.5
-      parent: 1
-- proto: WallPlastitaniumDiagonal
-  entities:
-  - uid: 37
-    components:
-    - type: Transform
-      pos: -6.5,-0.5
-      parent: 1
-  - uid: 54
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 1
-  - uid: 55
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,3.5
-      parent: 1
-  - uid: 57
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-0.5
-      parent: 1
-  - uid: 82
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 1
-  - uid: 85
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-0.5
-      parent: 1
-  - uid: 90
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
-  - uid: 93
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,0.5
-      parent: 1
-  - uid: 154
-    components:
-    - type: Transform
-      pos: -1.5,4.5
-      parent: 1
-  - uid: 155
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 1
-  - uid: 156
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,5.5
-      parent: 1
-  - uid: 157
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,4.5
-      parent: 1
-  - uid: 179
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,1.5
-      parent: 1
-  - uid: 180
-    components:
-    - type: Transform
-      pos: -4.5,2.5
-      parent: 1
-  - uid: 181
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,2.5
-      parent: 1
-  - uid: 182
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,1.5
-      parent: 1
 - proto: WallReinforced
   entities:
   - uid: 6
@@ -990,6 +682,102 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
       parent: 1
   - uid: 94
     components:
@@ -1075,6 +863,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,-1.5
       parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
   - uid: 120
     components:
     - type: Transform
@@ -1087,6 +887,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,-2.5
       parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
   - uid: 126
     components:
     - type: Transform
@@ -1097,6 +903,24 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-0.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
       parent: 1
   - uid: 142
     components:
@@ -1116,6 +940,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-0.5
       parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
   - uid: 160
     components:
     - type: Transform
@@ -1128,18 +964,122 @@ entities:
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
 - proto: WallReinforcedDiagonal
   entities:
+  - uid: 32
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
   - uid: 81
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-1.5
       parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
   - uid: 105
     components:
     - type: Transform
       pos: -2.5,-1.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
       parent: 1
   - uid: 129
     components:
@@ -1147,9 +1087,59 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
   - uid: 167
     components:
     - type: Transform
       pos: -7.5,-1.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+- proto: WeaponTurretShard
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
       parent: 1
 ...

--- a/Resources/Maps/_Mono/Shuttles/World/medusa.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/medusa.yml
@@ -453,17 +453,12 @@ entities:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-- proto: ClothingBackpackDroneLoot
+- proto: ClothingBackpackDroneLootT22
   entities:
   - uid: 60
     components:
     - type: Transform
       pos: 0.5788634,0.47274494
-      parent: 1
-  - uid: 164
-    components:
-    - type: Transform
-      pos: 0.71895885,0.82954866
       parent: 1
 - proto: GeneratorRTG
   entities:

--- a/Resources/Maps/_Mono/Shuttles/World/needle.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/needle.yml
@@ -219,7 +219,7 @@ entities:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-- proto: ClothingBackpackDroneLoot
+- proto: ClothingBackpackDroneLootT1
   entities:
   - uid: 83
     components:

--- a/Resources/Maps/_Mono/Shuttles/World/ramdronemedium.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/ramdronemedium.yml
@@ -731,7 +731,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,5.5
       parent: 1
-- proto: ClothingBackpackDroneLoot
+- proto: ClothingBackpackDroneLootT1
   entities:
   - uid: 94
     components:

--- a/Resources/Maps/_Mono/Shuttles/World/ramdronesmall.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/ramdronesmall.yml
@@ -363,7 +363,7 @@ entities:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-- proto: ClothingBackpackDroneLoot
+- proto: ClothingBackpackDroneLootT1
   entities:
   - uid: 75
     components:

--- a/Resources/Maps/_Mono/Shuttles/World/wasp.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/wasp.yml
@@ -201,7 +201,7 @@ entities:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-- proto: ClothingBackpackDroneLoot
+- proto: ClothingBackpackDroneLootT21
   entities:
   - uid: 87
     components:

--- a/Resources/Maps/_Mono/Shuttles/World/wedge.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/wedge.yml
@@ -265,7 +265,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-- proto: ClothingBackpackDroneLoot
+- proto: ClothingBackpackDroneLootT1
   entities:
   - uid: 87
     components:

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: RogueSiliconGiftBox
-  id: ClothingBackpackDroneLoot
-  name: blackbox data recorder
-  description: Data recorder from a derelict drone. Contains valuable components.
+  id: ClothingBackpackDroneLootT1
+  name: blackbox data recorder (T1)
+  description: Data recorder from a drone. Contains valuable components.
   suffix: Drone Loot
   components:
   - type: RadarBlip
@@ -14,7 +14,7 @@
     items:
     # Money
     - id: SpaceCash10000
-      amount: 3
+      amount: 2
       prob: 1.0
     # Scrap chunks
     - id: ScrapOre100
@@ -22,13 +22,13 @@
       prob: 1.0
     # Parts
     - id: SuperCapacitorStockPart
-      prob: 1
+      prob: 0.4
       amount: 3
     - id: SuperMatterBinStockPart
-      prob: 1
+      prob: 0.4
       amount: 1
     - id: PicoManipulatorStockPart
-      prob: 1
+      prob: 0.4
       amount: 2
     - id: SpawnDungeonLootPowerCell
       prob: 0.5
@@ -48,19 +48,155 @@
       prob: 0.3
     # Flatpacks
     - id: SpawnDungeonLootFlatpacks
-      amount: 3
+      amount: 2
       prob: 0.3
-    # Research disk, expected value ~45k/drone
+    # Research disk, expected value ~12k/drone
     - id: RogueSiliconResearchDisk5000
       prob: 0.6
     - id: RogueSiliconResearchDisk10000
       prob: 0.4
     - id: RogueSiliconResearchDisk25000
-      prob: 0.25
-    - id: RogueSiliconResearchDisk50000
-      prob: 0.15
+      prob: 0.2
     # Tech disk
     - id: SpawnLootTechDisksT1
+      prob: 0.5
+    sound:
+      path: /Audio/Machines/windoor_open.ogg
+
+- type: entity
+  parent: ClothingBackpackDroneLootT1
+  id: ClothingBackpackDroneLootT21
+  name: blackbox data recorder (T2-1)
+  description: Data recorder from a drone. Contains valuable components.
+  suffix: Drone Loot
+  components:
+  - type: SpawnItemsOnUse
+    items:
+    # Money
+    - id: SpaceCash10000
+      amount: 4
+      prob: 1.0
+    # Scrap chunks
+    - id: ScrapOre100
+      amount: 5
+      prob: 1.0
+    # Parts
+    - id: SuperCapacitorStockPart
+      prob: 1
+      amount: 3
+    - id: SuperMatterBinStockPart
+      prob: 1
+      amount: 1
+    - id: PicoManipulatorStockPart
+      prob: 1
+      amount: 2
+    # rare t4 parts
+    - id: QuadraticCapacitorStockPart
+      prob: 0.3
+    - id: FemtoManipulatorStockPart
+      prob: 0.2
+    - id: BluespaceMatterBinStockPart
+      prob: 0.1
+    - id: SpawnDungeonLootPowerCell
+      prob: 0.5
+    # - id: SpawnDungeonLootPartsEngi #Mono: mostly trash and bloat
+    #   amount: 3
+    #   prob: 0.25
+    # Circuit boards
+    - id: SpawnDungeonLootCircuitBoardEngi
+      prob: 0.3
+    - id: SpawnDungeonLootCircuitBoardScience
+      prob: 0.4
+    - id: SpawnDungeonLootCircuitBoardSalvage
+      prob: 0.4
+    - id: SpawnDungeonLootCircuitBoard
+      prob: 0.3
+    # Flatpacks
+    - id: SpawnDungeonLootFlatpacks
+      amount: 3
+      prob: 0.5
+    # Research disk, expected value ~50k/drone
+    - id: RogueSiliconResearchDisk5000
+      prob: 1
+    - id: RogueSiliconResearchDisk10000
+      prob: 1
+    - id: RogueSiliconResearchDisk25000
+      prob: 0.6
+    - id: RogueSiliconResearchDisk50000
+      prob: 0.4
+    # Tech disk
+    - id: SpawnLootTechDisksT2Mech
+      prob: 0.5
+    sound:
+      path: /Audio/Machines/windoor_open.ogg
+
+- type: entity
+  parent: ClothingBackpackDroneLootT1
+  id: ClothingBackpackDroneLootT22
+  name: blackbox data recorder (T2-2)
+  description: Data recorder from a drone. Contains valuable components.
+  suffix: Drone Loot
+  components:
+  - type: SpawnItemsOnUse
+    items:
+    # Money
+    - id: SpaceCash25000
+      amount: 3
+      prob: 1.0
+    # Scrap chunks
+    - id: ScrapOre100
+      amount: 8
+      prob: 1.0
+    # Parts
+    - id: SuperCapacitorStockPart
+      prob: 1
+      amount: 6
+    - id: SuperMatterBinStockPart
+      prob: 1
+      amount: 2
+    - id: PicoManipulatorStockPart
+      prob: 1
+      amount: 4
+    # rare t4 parts
+    - id: QuadraticCapacitorStockPart
+      prob: 0.9
+      count: 2
+    - id: FemtoManipulatorStockPart
+      prob: 0.6
+      count: 2
+    - id: BluespaceMatterBinStockPart
+      prob: 0.3
+      count: 2
+    - id: SpawnDungeonLootPowerCell
+      count: 2
+      prob: 0.5
+    # - id: SpawnDungeonLootPartsEngi #Mono: mostly trash and bloat
+    #   amount: 3
+    #   prob: 0.25
+    # Circuit boards
+    - id: SpawnDungeonLootCircuitBoardEngi
+      prob: 0.3
+    - id: SpawnDungeonLootCircuitBoardScience
+      prob: 0.4
+    - id: SpawnDungeonLootCircuitBoardSalvage
+      prob: 0.4
+    - id: SpawnDungeonLootCircuitBoard
+      prob: 0.3
+    # Flatpacks
+    - id: SpawnDungeonLootFlatpacks
+      amount: 3
+      prob: 0.5
+    # Research disk, expected value ~50k/drone
+    - id: RogueSiliconResearchDisk5000
+      prob: 1
+    - id: RogueSiliconResearchDisk10000
+      prob: 1
+    - id: RogueSiliconResearchDisk25000
+      prob: 0.6
+    - id: RogueSiliconResearchDisk50000
+      prob: 0.4
+    # Tech disk
+    - id: SpawnLootTechDisksT2Mech
       prob: 0.5
     sound:
       path: /Audio/Machines/windoor_open.ogg

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
@@ -80,6 +80,10 @@
     - id: ScrapOre100
       amount: 5
       prob: 1.0
+    # Material
+    - id: SheetPlastitanium10
+      amount: 2
+      prob: 1
     # Parts
     - id: SuperCapacitorStockPart
       prob: 1
@@ -147,6 +151,10 @@
     - id: ScrapOre100
       amount: 8
       prob: 1.0
+    # Material
+    - id: SheetPlastitanium10
+      amount: 6
+      prob: 1
     # Parts
     - id: SuperCapacitorStockPart
       prob: 1

--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
@@ -122,6 +122,22 @@
       task: AttackerShuttleSmartCompound
 
 - type: entity
+  id: NpcStationAiAttackerShortRange
+  name: attacker core
+  parent: [NpcStationAiRammer, BaseFactionGearOtherFactionT2]
+  description: Shoots at you.
+  suffix: AI, Short-Range
+  components:
+  - type: Sprite
+    layers:
+    - state: base
+    - state: green_t1
+      shader: unshaded
+  - type: HTN
+    rootTask:
+      task: AttackerShuttleShortRangeCompound
+
+- type: entity
   name: rammer core spawner
   id: SpawnMobRammerCore
   parent: MarkerBase
@@ -219,6 +235,16 @@
   - type: ConditionalSpawner
     prototypes:
     - NpcStationAiAttacker
+
+- type: entity
+  name: attacker core spawner
+  id: SpawnMobAttackerCoreShortRange
+  parent: SpawnMobAttackerCore
+  suffix: Short-Range
+  components:
+  - type: ConditionalSpawner
+    prototypes:
+    - NpcStationAiAttackerShortRange
 
 - type: entity
   name: smart attacker core spawner

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/projectiles.yml
@@ -278,7 +278,7 @@
   - type: Projectile
     damage:
       types:
-        Structural: 50
+        Structural: 300
         Blunt: 50
         Piercing: 50
   - type: Sprite
@@ -300,6 +300,6 @@
   - type: Explosive
     explosionType: Default
     totalIntensity: 12
-    intensitySlope: 1
+    intensitySlope: 2
     maxIntensity: 2
     maxTileBreak: 1

--- a/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
+++ b/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
@@ -26,7 +26,7 @@
   id: MonoWorldgenVeryFarT1
   parent: NFBiomeBase
   priority: -1
-  distanceRange: 18000, 20000
+  distanceRange: 18000, 22000
   noiseRanges: {}
   chunkComponents:
   - type: DebrisFeaturePlacerController
@@ -155,7 +155,7 @@
   id: MonoWorldgenVeryFarT2Inner
   parent: NFBiomeBase
   priority: -1
-  distanceRange: 20000, 22000
+  distanceRange: 22000, 25000
   noiseRanges: {}
   chunkComponents:
   - type: NoiseDrivenDebrisSelector
@@ -181,7 +181,7 @@
       orGroup: wreck
 
 - type: spaceBiome
-  id: MonoWorldgenVeryFarT2Inner
+  id: MonoWorldgenVeryFarT2Middle
   parent: NFBiomeBase
   priority: -10
   # no distanceRange, accepts all remaining distance

--- a/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
+++ b/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
@@ -23,10 +23,10 @@
 
 # region Far Ring
 - type: spaceBiome
-  id: MonoWorldgenVeryFar
+  id: MonoWorldgenVeryFarT1
   parent: NFBiomeBase
   priority: -1
-  # no distanceRange, accepts all remaining distance
+  distanceRange: 18000, 20000
   noiseRanges: {}
   chunkComponents:
   - type: DebrisFeaturePlacerController
@@ -147,6 +147,64 @@
     - id: NFWreckDebrisBrassExtraLarge
       prob: 0.3
       orGroup: wreck
-    - id: MonoRamDroneSpawner
+    - id: MonoRamDroneSpawnerT1
       prob: 3
+      orGroup: wreck
+
+- type: spaceBiome
+  id: MonoWorldgenVeryFarT2Inner
+  parent: NFBiomeBase
+  priority: -1
+  distanceRange: 20000, 22000
+  noiseRanges: {}
+  chunkComponents:
+  - type: NoiseDrivenDebrisSelector
+    noiseChannel: WreckRare
+    debrisTable:
+    - id: NFWreckDebrisSmall
+      prob: 1
+      orGroup: wreck
+    - id: NFWreckDebrisMedium
+      prob: 2
+      orGroup: wreck
+    - id: NFWreckDebrisLarge
+      prob: 1
+      orGroup: wreck
+    - id: NFWreckDebrisBrassLarge
+      prob: 0.9
+      orGroup: wreck
+    - id: NFWreckDebrisBrassExtraLarge
+      prob: 0.3
+      orGroup: wreck
+    - id: MonoRamDroneSpawnerT2Inner
+      prob: 4
+      orGroup: wreck
+
+- type: spaceBiome
+  id: MonoWorldgenVeryFarT2Inner
+  parent: NFBiomeBase
+  priority: -10
+  # no distanceRange, accepts all remaining distance
+  noiseRanges: {}
+  chunkComponents:
+  - type: NoiseDrivenDebrisSelector
+    noiseChannel: WreckRare
+    debrisTable:
+    - id: NFWreckDebrisSmall
+      prob: 1
+      orGroup: wreck
+    - id: NFWreckDebrisMedium
+      prob: 2
+      orGroup: wreck
+    - id: NFWreckDebrisLarge
+      prob: 1
+      orGroup: wreck
+    - id: NFWreckDebrisBrassLarge
+      prob: 0.9
+      orGroup: wreck
+    - id: NFWreckDebrisBrassExtraLarge
+      prob: 0.3
+      orGroup: wreck
+    - id: MonoRamDroneSpawnerT2Middle
+      prob: 4
       orGroup: wreck

--- a/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
+++ b/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
@@ -27,7 +27,6 @@
   parent: NFBiomeBase
   priority: -1
   distanceRange: 18000, 22000
-  noiseRanges: {}
   chunkComponents:
   - type: DebrisFeaturePlacerController
     densityNoiseChannel: DensityRare
@@ -145,7 +144,7 @@
       prob: 0.9
       orGroup: wreck
     - id: NFWreckDebrisBrassExtraLarge
-      prob: 0.3
+      prob: 3
       orGroup: wreck
     - id: MonoRamDroneSpawnerT1
       prob: 3
@@ -153,10 +152,9 @@
 
 - type: spaceBiome
   id: MonoWorldgenVeryFarT2Inner
-  parent: NFBiomeBase
-  priority: -1
+  parent: MonoWorldgenVeryFarT1
+  priority: -2
   distanceRange: 22000, 25000
-  noiseRanges: {}
   chunkComponents:
   - type: NoiseDrivenDebrisSelector
     noiseChannel: WreckRare
@@ -182,10 +180,9 @@
 
 - type: spaceBiome
   id: MonoWorldgenVeryFarT2Middle
-  parent: NFBiomeBase
-  priority: -10
+  parent: MonoWorldgenVeryFarT1
+  priority: -3
   # no distanceRange, accepts all remaining distance
-  noiseRanges: {}
   chunkComponents:
   - type: NoiseDrivenDebrisSelector
     noiseChannel: WreckRare

--- a/Resources/Prototypes/_Mono/Entities/World/Debris/drone.yml
+++ b/Resources/Prototypes/_Mono/Entities/World/Debris/drone.yml
@@ -1,14 +1,41 @@
 - type: entity
-  id: MonoRamDroneSpawner
+  id: MonoRamDroneSpawnerT1
   parent: MarkerBase
   components:
   - type: RandomSpawner
     prototypes:
-      - SpawnDroneWasp
-      - SpawnDroneMedusa
-      - SpawnDroneCrown
-      - SpawnDroneBasicSmall
-      - SpawnDroneBasicMedium
+    - SpawnDroneBasicSmall
+    - SpawnDroneBasicMedium
+
+- type: entity
+  id: MonoRamDroneSpawnerT2Inner
+  parent: MarkerBase
+  components:
+  - type: RandomSpawner
+    prototypes:
+    - SpawnDroneWasp
+    - SpawnDroneCrown
+
+- type: entity
+  id: MonoRamDroneSpawnerT2Middle
+  parent: MarkerBase
+  components:
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: DroneSpawnTableT2Middle
+
+- type: entityTable
+  id: DroneSpawnTableT2Middle
+  table: !type:GroupSelector
+    children:
+    # T2 small
+    - id: SpawnDroneWasp
+      weight: 20
+    - id: SpawnDroneCrown
+      weight: 20
+    # T2 medium
+    - id: SpawnDroneMedusa
+      weight: 20
 
 - type: entity
   id: SpawnDroneBase
@@ -17,28 +44,28 @@
   components:
   - type: GridSpawner
     addComponents:
-      - type: IFF
-        flags: AlwaysShowColor
-        color: "#9a2020"
-      - type: Tag
-        tags:
-        - ShuttleAIIgnore
-      - type: GridCleanupGrid
-        cleanupAcceleration: 3
-        ignorePowered: true
-        ignoreIFF: true
-        ignorePrice: true
-      - type: RandomMetadata
-        nameSeparator: ""
-        nameSegments:
-        - DroneTitle
-        - " 0x"
-        - DroneHex
-        - DroneHex
-        - DroneHex
-        - DroneHex
-        - DroneHex
-        - DroneHex
+    - type: IFF
+      flags: AlwaysShowColor
+      color: "#9a2020"
+    - type: Tag
+      tags:
+      - ShuttleAIIgnore
+    - type: GridCleanupGrid
+      cleanupAcceleration: 3
+      ignorePowered: true
+      ignoreIFF: true
+      ignorePrice: true
+    - type: RandomMetadata
+      nameSeparator: ""
+      nameSegments:
+      - DroneTitle
+      - " 0x"
+      - DroneHex
+      - DroneHex
+      - DroneHex
+      - DroneHex
+      - DroneHex
+      - DroneHex
     nameGrid: false
 
 - type: entity

--- a/Resources/Prototypes/_Mono/NPCs/Shuttle/specific.yml
+++ b/Resources/Prototypes/_Mono/NPCs/Shuttle/specific.yml
@@ -1,0 +1,38 @@
+- type: htnCompound
+  id: AttackerShuttleShortRangeCompound
+  branches:
+  - tasks:
+    - !type:HTNPrimitiveTask
+      operator: !type:UtilityOperator
+        proto: NearbyShuttleTargets
+    - !type:HTNCompoundTask
+      task: ShuttleAttackShortRangeCompound
+
+- type: htnCompound
+  id: ShuttleAttackShortRangeCompound
+  branches:
+  - preconditions:
+    - !type:KeyExistsPrecondition
+      key: TargetCoordinates
+    tasks:
+    - !type:HTNPrimitiveTask
+      operator: !type:ShipMoveToOperator
+        shutdownState: PlanFinished
+        removeKeyOnFinish: false
+        inRangeMaxSpeed: null
+        range: 250
+        rangeTolerance: 50
+        targetKey: TargetCoordinates
+        mode: Orbit
+    - !type:HTNPrimitiveTask
+      operator: !type:ShipFireGunsOperator
+        shutdownState: TaskFinished
+        removeKeyOnFinish: false
+        leadingAccuracy: 0.2
+        targetKey: TargetCoordinates
+      services:
+      - !type:UtilityService
+        id: TargetsService
+        proto: NearbyShuttleTargets
+        key: Target
+        coordinatesKey: TargetCoordinates

--- a/Resources/Prototypes/_NF/World/Biomes/basic.yml
+++ b/Resources/Prototypes/_NF/World/Biomes/basic.yml
@@ -362,6 +362,6 @@
     - id: NFWreckDebrisBrassExtraLarge
       prob: 0.1
       orGroup: wreck
-    - id: MonoRamDroneSpawner # Mono
-      prob: 0.05
+    - id: MonoRamDroneSpawnerT1 # Mono
+      prob: 0.15
       orGroup: wreck

--- a/Resources/Prototypes/_NF/World/worldgen_default.yml
+++ b/Resources/Prototypes/_NF/World/worldgen_default.yml
@@ -7,4 +7,6 @@
         - NFAsteroidsNear
         - NFAsteroidsMid
         - NFAsteroidsFar
-        - MonoWorldgenVeryFar # Mono
+        - MonoWorldgenVeryFarT1 # Mono
+        - MonoWorldgenVeryFarT2Inner # Mono
+        - MonoWorldgenVeryFarT2Middle # Mono


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- buffs shard
- tweaks medusa, turns it into an attacker drone
- differentiates drone belts, there's now 3 belts
- inner spawns t1 drones
- inner outer spawns small t2 drones
- middle outer (currently farthest) spawns small t2 drones and medusa (medium t2)
- adds different lootboxes for different drone types, assigns them

## Why / Balance
shard currently does basically nothing
medusa is a bit too strong
and the rest was needed

## Media
(image outdated: has 1 t2-2 lootbox in latest)
<img width="954" height="644" alt="image" src="https://github.com/user-attachments/assets/4880f73a-b947-4224-a518-e464a43273ba" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Drone spawning distances are now differentiated. Scarier drones farther out.
- tweak: Drone loot tweaked.
- tweak: Medusa (outer drone) has been changed to an attacker drone and now has 2 blackboxes.
- tweak: Buffed Shard, the drone gun.
