### PR TITLE
Nerf Shipgun Recoil

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -306,6 +306,13 @@ public sealed partial class GunComponent : Component
     /// </summary>
     [DataField]
     public float Recoil = 25f;
+
+    /// <summary>
+    /// Mono
+    /// Multiplier of how much recoil should rotate you.
+    /// </summary>
+    [DataField]
+    public float RecoilRotation = 0.2f;
 }
 
 [Flags]

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlarge_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlarge_kinetic.yml
@@ -35,7 +35,7 @@
     minAngle: 0
     maxAngle: 1
     fireRate: 0.2
-    recoil: 100 # 4x
+    recoil: 50 # 2x
     burstCooldown: 10
     burstFireRate: 2
     shotsPerBurst: 2
@@ -115,7 +115,7 @@
     minAngle: 0
     maxAngle: 1
     fireRate: 0.1
-    recoil: 100 # 4x
+    recoil: 75 # 3x
     shootThermalSignature: 80000000 # ~9km after firing
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/cannon.ogg
@@ -194,7 +194,7 @@
     minAngle: 0
     maxAngle: 0
     fireRate: 0.2
-    recoil: 100 # 4x
+    recoil: 50 # 2x
     burstCooldown: 10
     burstFireRate: 2
     shotsPerBurst: 2
@@ -271,7 +271,7 @@
     minAngle: 0
     maxAngle: 7
     fireRate: 11
-    recoil: 25 # 1x
+    recoil: 10 # 2/5x
     burstCooldown: 8
     burstFireRate: 11
     shotsPerBurst: 15

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
@@ -30,7 +30,7 @@
     - Toggle
   - type: Gun
     fireRate: 5
-    recoil: 15 # 3/5x
+    recoil: 10 # 2/5x
     projectileSpeed: 200
     minAngle: 0
     maxAngle: 5
@@ -174,7 +174,7 @@
         - MachineLayer
   - type: Gun
     projectileSpeed: 325
-    recoil: 100 # 4x
+    recoil: 50 # 2x
     minAngle: 0
     maxAngle: 3
     fireRate: 0.2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- nerfs recoil on big guns
- now recoil rotates you much less

## Why / Balance
it's a bit debilitating right now

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Shipgun recoil now rotates you much less and is smaller on big guns.
