### PR TITLE
Fix Radar Markers Offset

### DIFF
--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
@@ -43,8 +43,6 @@ public partial class BaseShuttleControl : MapGridControl
     private readonly List<(Vector2 Start, Vector2 End)> _edges = new();
     private readonly HashSet<Entity<GridEdgeMarkerComponent>> _edgeMarkers = new();
 
-    private Vector2 CenterVec = new Vector2(0.5f, 0.5f); // Mono
-
     private EntityQuery<TransformComponent> _xformQuery; // Mono
 
     private Vector2[] _allVertices = Array.Empty<Vector2>();
@@ -253,8 +251,8 @@ public partial class BaseShuttleControl : MapGridControl
 
                 var coord = xform.Coordinates.Position;
                 var rotation = xform.LocalRotation;
-                var begin = rotation.RotateVec(edge.Comp.Begin - CenterVec) + CenterVec;
-                var end = rotation.RotateVec(edge.Comp.End - CenterVec) + CenterVec;
+                var begin = rotation.RotateVec(edge.Comp.Begin);
+                var end = rotation.RotateVec(edge.Comp.End);
                 _edges.Add((coord + begin * tileSize, coord + end * tileSize));
             }
 

--- a/Resources/Prototypes/_Mono/Entities/Markers/GridEdge/grid_edge.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/GridEdge/grid_edge.yml
@@ -10,8 +10,8 @@
       - state: label
       - state: edge
   - type: GridEdgeMarker
-    begin: 1, 1
-    end: 1, 0
+    begin: 0.5, 0.5
+    end: 0.5, -0.5
   - type: GlobalPvs
   - type: RequiresGrid
 
@@ -33,8 +33,8 @@
         offset: -0.3535533905932738, -0.3535533905932738
         rotation: 45
   - type: GridEdgeMarker
-    begin: 1, 0
-    end: 0, 1
+    begin: 0.5, -0.5
+    end: -0.5, 0.5
 
 - type: entity
   parent: RadarEdgeMarkerBase
@@ -49,8 +49,8 @@
         offset: -0.223606797749979, -0.19721359549995787
         rotation: 63.43494882292201
   - type: GridEdgeMarker
-    begin: 0, 1
-    end: 1, 0.5
+    begin: -0.5, 0.5
+    end: 0.5, 0
 
 - type: entity
   parent: RadarEdgeMarkerBase
@@ -65,6 +65,19 @@
         offset: 0.2236067977499789, -0.19721359549995793
         rotation: 116.5650511770780
   - type: GridEdgeMarker
-    begin: 0, 0.5
-    end: 1, 1
+    begin: -0.5, 0
+    end: 0.5, 0.5
 
+- type: entity
+  parent: RadarEdgeMarkerBase
+  id: RadarEdgeMarkerCenter
+  name: central radar edge marker
+  components:
+  - type: Sprite
+    layers:
+      - state: label
+      - state: edge
+        offset: -0.5, 0
+  - type: GridEdgeMarker
+    begin: 0, -0.5
+    end: 0, 0.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
no longer offset by half a tile

## Media
<img width="54" height="50" alt="image" src="https://github.com/user-attachments/assets/be95d518-329b-4db3-a32b-4b9c4a2fea3d" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Radar edge markers are no longer offset by half a tile.
