### PR TITLE
1000 Baegs Must Vaporize

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -230,14 +230,14 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactDamageMultiplier =
-        CVarDef.Create("shuttle.impact.damage_multiplier", 0.00005f, CVar.SERVERONLY); // Previously: 0.00005f
+        CVarDef.Create("shuttle.impact.damage_multiplier", 0.00005f, CVar.SERVERONLY);
 
     /// <summary>
     /// Multiplier of additional structural damage to do
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactStructuralDamage =
-        CVarDef.Create("shuttle.impact.structural_damage", 5f, CVar.SERVERONLY); // Previously: 5f
+        CVarDef.Create("shuttle.impact.structural_damage", 5f, CVar.SERVERONLY);
 
     /// <summary>
     /// Kinetic energy required to spawn sparks
@@ -251,7 +251,7 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactRadius =
-        CVarDef.Create("shuttle.impact.radius", 4f, CVar.SERVERONLY); //Previously: 4f
+        CVarDef.Create("shuttle.impact.radius", 4f, CVar.SERVERONLY);
 
     /// <summary>
     /// Affects slowdown on impact

--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -209,14 +209,14 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> MinimumImpactInertia =
-        CVarDef.Create("shuttle.impact.minimum_inertia", 5f * 50f, CVar.SERVERONLY); // 100tile grid (cargo shuttle) going at 5 m/s
+        CVarDef.Create("shuttle.impact.minimum_inertia", 300f, CVar.SERVERONLY); //baeg vaporization threshold of >35m/s (2 seconds of acceleration) Previously 5f * 50f: "100tile grid (cargo shuttle) going at 5 m/s". (>14m/s baeg vaporization threshold)
 
     /// <summary>
     /// Minimum velocity difference between 2 bodies for a shuttle impact to be guaranteed to trigger any special behaviors like damage.
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> MinimumImpactVelocity =
-        CVarDef.Create("shuttle.impact.minimum_velocity", 15f, CVar.SERVERONLY); // needed so that random space debris can be rammed
+        CVarDef.Create("shuttle.impact.minimum_velocity", 35f, CVar.SERVERONLY); // needed so that random space debris can be rammed // Also important for baeg vaporization threshold increase. Previously 15f
 
     /// <summary>
     /// Multiplier of Kinetic energy required to dismantle a single tile in relation to its mass
@@ -230,14 +230,14 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactDamageMultiplier =
-        CVarDef.Create("shuttle.impact.damage_multiplier", 0.00005f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.impact.damage_multiplier", 0.00005f, CVar.SERVERONLY); // Previously: 0.00005f
 
     /// <summary>
     /// Multiplier of additional structural damage to do
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactStructuralDamage =
-        CVarDef.Create("shuttle.impact.structural_damage", 5f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.impact.structural_damage", 5f, CVar.SERVERONLY); // Previously: 5f
 
     /// <summary>
     /// Kinetic energy required to spawn sparks
@@ -251,14 +251,14 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactRadius =
-        CVarDef.Create("shuttle.impact.radius", 4f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.impact.radius", 4f, CVar.SERVERONLY); //Previously: 4f
 
     /// <summary>
     /// Affects slowdown on impact
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactSlowdown =
-        CVarDef.Create("shuttle.impact.slowdown", 1.6f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.impact.slowdown", 3.2f, CVar.SERVERONLY); //Previously: 1.6f
 
     /// <summary>
     /// Minimum velocity change from impact for special throw effects (e.g. stuns, beakers breaking) to occur


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

I fucked with collision and repeatedly rammed 10000 baegs and 10000 europas into into 10000 wyverns and then tweaking cvars until things felt better.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

We got a massive full-proportion increase to shuttle kinetic energy without scaling our collision behaviors accordingly. End result: Baeg vaporizing at a lukewarm 14m/s (I exhaustively tested and determined this)

The Baeg now vaporizes at above 35m/s instead which is about 2 seconds of acceleration.

It's not a huge reduction on the top end of destruction. But low end should feel less punishing for smaller ships. Refer to screenshots below.

## How to test
<!-- Describe the way it can be tested -->

ram shit with a baeg at progressively faster speeds
ram europas into wyverns

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Historical collision behavior pre-speed change (thanks to Articular for the screenshot):
<img width="229" height="440" alt="image" src="https://github.com/user-attachments/assets/5bb44fc5-2a03-4ee5-b1bc-4571739b5877" />

After speed change and cvar tweaks:
<img width="391" height="508" alt="Screenshot 2026-01-09 045534" src="https://github.com/user-attachments/assets/1fbc709c-4a50-4cf0-8fbb-851f8181fabd" />

Note that the Europa is much more intact because past a certain threshold, its AME caves in and explodes, contributing additional indirect damage to itself.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Obviously I fucked with something that fundamentally alters a major part of the game. Test the feel yourself.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Velocity threshold for collisions was increased such that Baegs vaporize at above 35m/s instead of 14m/s. This is about 2 seconds worth of acceleration.
- tweak: Collision kinetic energy consumption increased to compensate for our overall increased speeds. Ramming should still be lethal as fuck and only slightly nerfed.