### PR TITLE
Nanite Repair Drones Trait.

### DIFF
--- a/Resources/Locale/en-US/_Mono/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Mono/traits/traits.ftl
@@ -82,3 +82,6 @@ trait-alcohol-tolerance-desc = Your body shrugs off the visual effects of booze.
 
 trait-platelet-factories-name = Platelet Factories
 trait-platelet-factories-desc = Your body has been augmented with a series of bio-tailored organs that enhance long-term survivability. These organs attempt to keep you alive even in the face of advanced trauma, all the way up until—but not including—death. Your natural healing slowly repairs any damage type, including exotic injuries like radiation exposure or cellular damage.
+
+trait-nanite-repair-drones-name = Nanite Repair Drones
+trait-nanite-repair-drones-desc = Your Chassis has Nanite Repair Drones coursing through it that respond to physical trauma. While not as quick as manual repair, these will cut down significantly on day to day maintainance.

--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -373,8 +373,25 @@
   description: trait-nanite-repair-drones-desc
   category: Physical
   cost: 8
-  speciesWhitelist:
-  - IPC
+  speciesBlacklist:
+  - Human
+  - Chitinid
+  - Oni
+  - Vulpkanin
+  - Vox
+  - Diona
+  - Moth Person
+  - Goblin
+  - Arachnid
+  - Resomi
+  - Harpy
+  - Reptilian
+  - Hydrakin
+  - Rodentia
+  - Tarjaran
+  - Dwarf
+  - Slime Person
+  - Felinid
   blacklist:
     components:
     - BorgChassis

--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -366,3 +366,19 @@
     intervalSeconds: 1
     healPerSecond: .5
     critMultiplier: .25
+
+- type: trait
+  id: NaniteRepairDrones
+  name: trait-nanite-repair-drones-name
+  description: trait-nanite-repair-drones-desc
+  category: Physical
+  cost: 8
+  speciesWhitelist:
+  - IPC
+  blacklist:
+    components:
+    - BorgChassis
+  components:
+  - type: PlateletFactories
+    intervalSeconds: 1
+    healPerSecond: .5

--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -389,7 +389,7 @@
   - Hydrakin
   - Rodentia
   - Dwarf
-  - Slime
+  - SlimePerson
   - Felinid
   - Tajaran
   blacklist:

--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -380,7 +380,7 @@
   - Vulpkanin
   - Vox
   - Diona
-  - Moth Person
+  - Moth
   - Goblin
   - Arachnid
   - Resomi
@@ -388,10 +388,10 @@
   - Reptilian
   - Hydrakin
   - Rodentia
-  - Tarjaran
   - Dwarf
-  - Slime Person
+  - Slime
   - Felinid
+  - Tajaran
   blacklist:
     components:
     - BorgChassis


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds Nanite Repair Drones Trait option for IPCs. Functions identically to the Platelet factories however since IPCs have no crit state it can't revive them, and once they're dead the nanites cease functioning. If this is found to be a little underwhelming i could possibly find a way to make it work like goob's nanites work where it'll heal dead ipcs, but never reboot them.

## Why / Balance
IPCs have few traits as it is, and one of their major downsides is constantly having to heal with welders n wires which have long doafters, which is a nuisance since they have no natural healiing to deal with the odd chip damage they take. Given its inability to heal while dead in its current state, and lack of flaw traits for IPCs in general, i reduced the value of the trait to 8 so its still expensive, but still accessible for those who want to take it.

## How to test
load up an ipc with the trait, shoot them a few times, watch the healing, shoot them more till they die, watch them not heal

## Media
<img width="1527" height="698" alt="image" src="https://github.com/user-attachments/assets/028f060a-6d91-4351-b258-23e0227b97da" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Nanite Repair Drone trait for IPCs
