### PR TITLE
Cyborg Health/Resistances Buffs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -35,10 +35,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 2.5
     baseSprintSpeed : 4.5
-  - type: SlowOnDamage
-    speedModifierThresholds:
-      80: 0.7
-      120: 0.5
   - type: Sprite
     sprite: Mobs/Silicon/chassis.rsi
   - type: RotationVisuals

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -35,6 +35,10 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 2.5
     baseSprintSpeed : 4.5
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      80: 0.7
+      120: 0.5
   - type: Sprite
     sprite: Mobs/Silicon/chassis.rsi
   - type: RotationVisuals
@@ -239,7 +243,7 @@
   #  mask: /Textures/Effects/LightMasks/cone.png
   #  autoRot: true
   #  radius: 4
-  #  netsync: false 
+  #  netsync: false
   - type: Pullable
   - type: Puller
     needsHands: false

--- a/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
@@ -23,7 +23,7 @@
     Piercing: 0.7
 
 - type: damageModifierSet # Mono
-  id: MilitaryBorgChassis
+  id: FactionBorgChassis
   coefficients:
     Heat: 0.8
     Cold: 0

--- a/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
@@ -10,6 +10,8 @@
     Slash: 0.9
     Piercing: 0.9
 
+# Cyborgs
+
 - type: damageModifierSet # Mono
   id: BaseBorgChassis
   coefficients:
@@ -19,6 +21,18 @@
     Blunt: 0.6
     Slash: 0.7
     Piercing: 0.7
+
+- type: damageModifierSet # Mono
+  id: MilitaryBorgChassis
+  coefficients:
+    Heat: 0.8
+    Cold: 0
+    Shock: 2.5
+    Blunt: 0.4
+    Slash: 0.5
+    Piercing: 0.5
+
+# Walls
 
 - type: damageModifierSet
   id: StructuralMetallicHeatReinforced

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -125,6 +125,20 @@
   parent: BaseBorgChassis
   abstract: true
   components:
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      450: Critical
+      550: Dead
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 2.5
+    baseSprintSpeed : 4.5
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      250: 0.7
+      350: 0.5
+  - type: Damageable
+    damageModifierSet: MilitaryBorgChassis
   - type: NpcFactionMember
     factions:
     - Syndicate
@@ -604,6 +618,20 @@
   parent: BaseBorgChassis
   abstract: true
   components:
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      300: Critical
+      400: Dead
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 2.5
+    baseSprintSpeed : 4.5
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      180: 0.7
+      250: 0.5
+  - type: Damageable
+    damageModifierSet: MilitaryBorgChassis
   - type: NpcFactionMember
     factions:
     - PirateNF
@@ -719,6 +747,20 @@
   parent: BaseBorgChassis
   abstract: true
   components:
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      300: Critical
+      400: Dead
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 2.5
+    baseSprintSpeed : 4.5
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      180: 0.7
+      250: 0.5
+  - type: Damageable
+    damageModifierSet: MilitaryBorgChassis
   - type: NpcFactionMember
     factions:
     - TSFMC

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -128,15 +128,15 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      450: Critical
-      550: Dead
+      300: Critical
+      400: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed : 2.5
     baseSprintSpeed : 4.5
   - type: SlowOnDamage
     speedModifierThresholds:
-      250: 0.7
-      350: 0.5
+      180: 0.7
+      250: 0.5
   - type: Damageable
     damageModifierSet: MilitaryBorgChassis
   - type: NpcFactionMember

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -78,6 +78,53 @@
   - ADS-Evasion
   - ADS-Apprehension
 
+# base stats for faction borgs
+
+- type: entity
+  parent: BaseBorgChassis
+  id: BaseFactionBorgChassis
+  abstract: true
+  components:
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      250: Critical
+      350: Dead
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 2.5
+    baseSprintSpeed : 4.5
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      125: 0.7
+      200: 0.5
+  - type: Damageable
+    damageModifierSet: FactionBorgChassis
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 125
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Machines/warning_buzzer.ogg
+          params:
+            volume: 5
+    - trigger:
+        !type:DamageTrigger
+         damage: 450
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:EmptyContainersBehaviour
+        containers:
+        - borg_brain
+        - borg_module
+        - cell_slot
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+
 - type: entity
   id: AiHeldMono
   description: Components added / removed from an entity that gets inserted into an AI core.
@@ -122,23 +169,9 @@
 
 - type: entity
   id: BaseBorgChassisRedacted
-  parent: BaseBorgChassis
+  parent: BaseFactionBorgChassis
   abstract: true
   components:
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      300: Critical
-      400: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 4.5
-  - type: SlowOnDamage
-    speedModifierThresholds:
-      180: 0.7
-      250: 0.5
-  - type: Damageable
-    damageModifierSet: MilitaryBorgChassis
   - type: NpcFactionMember
     factions:
     - Syndicate
@@ -615,23 +648,9 @@
 
 - type: entity
   id: BaseBorgChassisPDV
-  parent: BaseBorgChassis
+  parent: BaseFactionBorgChassis
   abstract: true
   components:
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      300: Critical
-      400: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 4.5
-  - type: SlowOnDamage
-    speedModifierThresholds:
-      180: 0.7
-      250: 0.5
-  - type: Damageable
-    damageModifierSet: MilitaryBorgChassis
   - type: NpcFactionMember
     factions:
     - PirateNF
@@ -744,23 +763,9 @@
 
 - type: entity
   id: BaseBorgChassisTSF
-  parent: BaseBorgChassis
+  parent: BaseFactionBorgChassis
   abstract: true
   components:
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      300: Critical
-      400: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 4.5
-  - type: SlowOnDamage
-    speedModifierThresholds:
-      180: 0.7
-      250: 0.5
-  - type: Damageable
-    damageModifierSet: MilitaryBorgChassis
   - type: NpcFactionMember
     factions:
     - TSFMC


### PR DESCRIPTION
## About the PR
Increased the overall health of the faction borgs, gave them better damage modifiers and now have slowdown at certain damage thresholds so the enemy can tell how damaged they are and to balance out the new health change.
Note: alterations to the values will be made if requested.

**Changelog**
:cl:
- add: Added damage slowdown thresholds to faction cyborgs
- tweak: Faction cyborg health/resistance buffs.