### PR TITLE
Make Stations Repairable

### DIFF
--- a/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/hammeroftheunion.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/hammeroftheunion.yml
@@ -9,7 +9,7 @@
 # Notes: upgraded zenith as a ruin w/ tech disks
 - type: pointOfInterest
   id: HammerOfTheUnion
-  parent: BaseMobilePOI
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'Hammer Of The Union'
   minimumDistance: 10000
   maximumDistance: 15000

--- a/Resources/Prototypes/_Mono/PointsOfInterest/derelictdrillsite.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/derelictdrillsite.yml
@@ -9,7 +9,7 @@
 # Notes:
 - type: pointOfInterest
   id: Mining
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: 'Derelict Drillsite'
   minimumDistance: 3500
   maximumDistance: 7500

--- a/Resources/Prototypes/_Mono/PointsOfInterest/jupiter.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/jupiter.yml
@@ -10,7 +10,7 @@
 #
 - type: pointOfInterest
   id: Jupiter
-  parent: BaseMobilePOI
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'PDV Jupiter Class Carrier'
   minimumDistance: 17000
   maximumDistance: 19000

--- a/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
@@ -7,7 +7,7 @@
 # Discord: ???
 - type: pointOfInterest
   id: HeliosFortress
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: 'PDV Helios Fortress'
   minimumDistance: 7500
   maximumDistance: 9500

--- a/Resources/Prototypes/_Mono/PointsOfInterest/tsfmchalcyon.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/tsfmchalcyon.yml
@@ -12,7 +12,7 @@
 #
 - type: pointOfInterest
   id: TSFMCHalcyon
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: 'TSFMC Flagship Halcyon'
   minimumDistance: 2500 # Mono
   maximumDistance: 4000 # Mono

--- a/Resources/Prototypes/_Mono/PointsOfInterest/tsfmcsecondary.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/tsfmcsecondary.yml
@@ -10,7 +10,7 @@
 #
 - type: pointOfInterest
   id: TSFMCOutpost
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: 'TSFMC Secondary Outpost'
   minimumDistance: 11000
   maximumDistance: 14000

--- a/Resources/Prototypes/_Mono/PointsOfInterest/ussp.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/ussp.yml
@@ -10,7 +10,7 @@
 #
 - type: pointOfInterest
   id: USSPCamelot
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: 'Camelot Station'
   minimumDistance: 10650
   maximumDistance: 12400

--- a/Resources/Prototypes/_NF/PointsOfInterest/bahamamamas.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/bahamamamas.yml
@@ -10,7 +10,7 @@
 # I want to lie, shipwrecked and comatose, drinking fresh mango juice.
 - type: pointOfInterest
   id: Bahama
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: "Bahama Mama's"
   minimumDistance: 3400
   maximumDistance: 5800

--- a/Resources/Prototypes/_NF/PointsOfInterest/base.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/base.yml
@@ -18,3 +18,10 @@
   - type: IFF
     color: "#ffa600"
     readOnly: true
+
+- type: pointOfInterest
+  parent: BaseMobilePOI
+  id: BaseRepairablePOI
+  abstract: true
+  addComponents:
+  - type: InitRepairSnapshot

--- a/Resources/Prototypes/_NF/PointsOfInterest/caseys.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/caseys.yml
@@ -10,7 +10,7 @@
 # Down at your local saloon
 - type: pointOfInterest
   id: CaseysCasino
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: "Crazy Casey's Casino"
   minimumDistance: 4250
   maximumDistance: 5600

--- a/Resources/Prototypes/_NF/PointsOfInterest/depots.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/depots.yml
@@ -10,7 +10,7 @@
 # Basic Cargo Depot selling point for economy and great wealth
 - type: pointOfInterest
   id: CargoDepot
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: Cargo Depot
   minimumDistance: 8000
   maximumDistance: 10000
@@ -34,7 +34,7 @@
 
 - type: pointOfInterest
   id: CargoDepotAlt
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: Cargo Depot
   minimumDistance: 8000
   maximumDistance: 10000

--- a/Resources/Prototypes/_NF/PointsOfInterest/edison.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/edison.yml
@@ -10,7 +10,7 @@
 #
 - type: pointOfInterest
   id: Edison
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: 'Edison Power Plant'
   minimumDistance: 5650
   maximumDistance: 7400

--- a/Resources/Prototypes/_NF/PointsOfInterest/grifty.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/grifty.yml
@@ -10,7 +10,7 @@
 # Down at your local saloon
 - type: pointOfInterest
   id: Grifty
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: "Grifty's Gas n Grub"
   minimumDistance: 6250
   maximumDistance: 8600

--- a/Resources/Prototypes/_NF/PointsOfInterest/medical.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/medical.yml
@@ -10,7 +10,7 @@
 # Medical ship garage, medical manager base and medical bounty staging area.
 - type: pointOfInterest
   id: Medical
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: 'Medical Dispatch'
   minimumDistance: 2650
   maximumDistance: 4400

--- a/Resources/Prototypes/_NF/PointsOfInterest/northpole.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/northpole.yml
@@ -10,7 +10,7 @@
 # just a little loot n shoot POI. Pretty much the second POI to even exist
 - type: pointOfInterest
   id: NorthPole
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: "The North Pole"
   minimumDistance: 6150
   maximumDistance: 8850

--- a/Resources/Prototypes/_NF/PointsOfInterest/omnichurch.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/omnichurch.yml
@@ -10,7 +10,7 @@
 #
 - type: pointOfInterest
   id: Omnichurch
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: "Omnichurch Beacon"
   minimumDistance: 4200
   maximumDistance: 6900

--- a/Resources/Prototypes/_NF/PointsOfInterest/thepit.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/thepit.yml
@@ -10,7 +10,7 @@
 # Down at your local saloon
 - type: pointOfInterest
   id: ThePit
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: "The Pit"
   minimumDistance: 5200
   maximumDistance: 6200

--- a/Resources/Prototypes/_NF/PointsOfInterest/tinniasrest.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/tinniasrest.yml
@@ -10,7 +10,7 @@
 # Down at your local saloon
 - type: pointOfInterest
   id: Tinnia
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: "Tinnia's Rest"
   minimumDistance: 3400
   maximumDistance: 5800

--- a/Resources/Prototypes/_NF/PointsOfInterest/trademall.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/trademall.yml
@@ -10,7 +10,7 @@
 # Basic Trade Outpost buying point for economy and great wealth
 - type: pointOfInterest
   id: TradeMall
-  parent: BasePOI
+  parent: [BasePOI, BaseRepairablePOI]
   name: Trade Mall
   minimumDistance: 3500
   maximumDistance: 6500


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
marks non-CC stations repairable
excludes things like sevas/lpb/polaris

## How to test
1. go to halc
2. chip a wall off
3. srd it back on

## Media
<img width="289" height="205" alt="image" src="https://github.com/user-attachments/assets/a0cc4bef-6630-4dd7-bbd4-8349f05bacb3" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can now use the SRD on stations.
