### PR TITLE
Repair Tool Availability

### DIFF
--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -210,6 +210,8 @@
   # Mono edit start
   - RCD
   - RCDAmmo
+  - ShipRepairDevice
+  - ShipRepairDeviceAmmo
   - NFBlueprintRCDAmmo
   # Mono edit end 
   technologyPrerequisites:

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/scrap_processor.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/scrap_processor.yml
@@ -123,6 +123,8 @@
      - id: FlashPayload
      - id: ModularGrenade
      - id: RCDAmmo
+     - id: ShipRepairDeviceAmmo
+       weight: 0.75
    - !type:GroupSelector
      weight: 2
      children:
@@ -156,6 +158,7 @@
      - id: JawsOfLife
      - id: WelderExperimental
      - id: RCD
+     - id: ShipRepairDeviceEmpty
 # Scrap
 - type: entityTable
   id: ScrapSalvageTrashBranch

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/tools.yml
@@ -18,3 +18,32 @@
   result: NaniteApplicatorSyndicate
   materials:
     Steel: 500
+
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: ShipRepairDevice
+  result: ShipRepairDevice
+  materials:
+    Steel: 2400
+    Plastic: 1200
+    Glass: 1200
+    Plasteel: 1600
+    Plasma: 2000
+    Gold: 2000
+    
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: ShipRepairDeviceAmmo
+  result: ShipRepairDeviceAmmo
+  materials:
+    Steel: 1600
+    Plastic: 800
+    Glass: 800
+    Plasteel: 1600
+    
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: ScrapShipRepairDeviceAmmo
+  result: ShipRepairDeviceAmmo
+  materials:
+    RawScrap: 50000

--- a/Resources/Prototypes/_NF/Entities/Materials/ore.yml
+++ b/Resources/Prototypes/_NF/Entities/Materials/ore.yml
@@ -86,6 +86,7 @@
 # Spawner for lathe: yield random mats if processed in ore processor
 - type: entity
   name: refined scrap
+  description: Comb through the scrap for intact boards, tools, and native materials. Results vary. #Mono
   id: SpawnRandomRefinedScrap
   parent: MarkerBasePlaceFree
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
@@ -131,8 +131,10 @@
     - RPED
     - MiningDrill
     - MiningDrillDiamond
-    - RCD # Mono
-    - RCDAmmo # Mono
+    - RCD # Mono start
+    - RCDAmmo
+    - ShipRepairDevice
+    - ShipRepairDeviceAmmo #Mono end
     - SignallerAdvanced
     - ClothingOuterHardsuitBasic
     - ClothingOuterHardsuitAtmos

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/engineering.yml
@@ -13,6 +13,8 @@
 #  - ShipyardRCDAmmo
   - RCD
   - RCDAmmo
+  - ShipRepairDevice #Mono
+  - ShipRepairDeviceAmmo #Mono
   - ConstructionBagOfHolding
   - UtilityBeltChiefEngineer
   # - FireExtinguisherBluespace # Delta-V

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/scrap.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/scrap.yml
@@ -2,6 +2,7 @@
   id: NFScrapStatic
   recipes:
   - SmeltScrap
+  - ScrapShipRepairDeviceAmmo
   - ScrapPartRodMetal1
   - ScrapSheetSteel1
   - ScrapSheetGlass1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds SRD and its ammo to research. Print it from protolathe and engifab.
Adds SRD and its ammo to scrap processor gacha. This is unreliable.

Adds SRD ammo production to scrap processor. This requires no science but is extremely inefficient compared to what it would have costed if materials were printed for the research recipe instead. This enables successful drone hunters to spend scrap to prolong their hunt at a minor premium right from roundstart.

Added a description to the scrap gacha recipe on the scrap processor so people had a rough idea of what it does

## Why / Balance

For the longest time, destruction has vastly outstripped the act of construction in this fork. There's plenty of room to put more weight onto the other end.

## How to test
<!-- Describe the way it can be tested -->

Observe Engifab
Observe Protolathe
You should see no SRD tech.
Add debug disks to the server and research
Observe Engifab
Observe Protolathe
You should see SRD tech.
Observe scrap processor. Process thousands of scrap if you want to get a feel for how rare the SRD is.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="548" height="271" alt="Screenshot 2026-01-12 042304" src="https://github.com/user-attachments/assets/c79874ab-aa36-4f1a-8d5f-a28445b55e1e" />
<img width="489" height="233" alt="Screenshot 2026-01-12 042328" src="https://github.com/user-attachments/assets/e3f4596a-05f9-4410-960e-b68791336a90" />
<img width="451" height="214" alt="Screenshot 2026-01-12 042346" src="https://github.com/user-attachments/assets/7b870684-deb6-4998-ba16-f299df76dac3" />
<img width="434" height="321" alt="Screenshot 2026-01-12 042356" src="https://github.com/user-attachments/assets/5cf76049-e7f5-4ca7-96f7-984f9a31788a" />
<img width="518" height="185" alt="Screenshot 2026-01-12 042443" src="https://github.com/user-attachments/assets/a305865a-df84-4df3-80a1-4be7dee0c534" />
<img width="368" height="674" alt="Screenshot 2026-01-12 043437" src="https://github.com/user-attachments/assets/5fa128bd-de90-4d48-911c-62c9010c6329" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

I'm going to bed. If this testfails or if the numbers suck I'll change/fix it once I finish sleeping (ideally)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Adds SRD and its ammo to research, in Advanced Tools. Print it from protolathe and engifab.
- add: Adds SRD and its ammo to scrap processor gacha. Enjoy your gamble.
- add: Adds SRD ammo production to scrap processor. This requires no science but is extremely inefficient compared to what it would have costed if materials were printed for the research recipe instead.