### PR TITLE
Curio-8640 Plasma Lance Buff and Apollo Recharge Tweak

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -458,7 +458,7 @@
     startingCharge: 50000
   - type: BatterySelfRecharger
     autoRechargePause: true
-    autoRechargePauseTime: 45
+    autoRechargePauseTime: 30
     autoRecharge: true
     autoRechargeRate: 50000
   - type: FireControlRotate
@@ -479,7 +479,7 @@
     shipClass: Heavy
   - type: HitscanBatteryAmmoProvider
     proto: ApolloLaser
-    fireCost: 250
+    fireCost: 150
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -457,8 +457,10 @@
     maxCharge: 50000
     startingCharge: 50000
   - type: BatterySelfRecharger
+    autoRechargePause: true
+    autoRechargePauseTime: 45
     autoRecharge: true
-    autoRechargeRate: 800
+    autoRechargeRate: 50000
   - type: FireControlRotate
   - type: ExaminableBattery
   - type: WirelessNetworkConnection
@@ -547,7 +549,7 @@
           bounds: "-0.75,-0.75,0.75,0.75"
         density: 1500
   - type: Gun
-    projectileSpeed: 70
+    projectileSpeed: 170
     fireRate: 13
     recoil: 0
     minAngle: 0


### PR DESCRIPTION
apollo recharge and plasma lance projectile speed

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Increases Plasma Lance projectile speed from 70 to 170
Changes Apollo recharge behavior to deplete, enter cooldown, then fully recharge.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Plasma Lance is a monstrously powerful ADS-only supercapital weapon that creates walls of fire easily outmaneuverable by other capital ships. In preparation for the upcoming Wyvern replacements, I think it's fitting that the plasma lance becomes better at engaging the targets its intended to fight against.

This very mildly improves the weapon's range, from 1km to about 1.1km.

The Apollo laser is mildly irritating in its current state and is generally inferior to mining pulsars for actually mining. This change improves its overall recharge rate but does still impose downtime between uses as the Apollo is still a capable ship-to-ship weapon.

## How to test
<!-- Describe the way it can be tested -->
Spawn old Plasma Lance -> change one line and spawn new Plasma Lance -> compare its projectile speed.
Spawn Apollo -> Shoot Apollo -> wait 45 seconds for it to recharge before firing again.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Curio-8640 Plasma Lances have had their magnetic coils re-tuned by the ADS Overmind. They now propel plasma much faster, though not much further.
- tweak: L-20 Apollo Mining Lasers have received a proprietary software patch, forcing it to disperse heat and cool down after continuous firing. This has improved its overall recharge rate to further adapt to its role as a Mining implement.

