### PR TITLE
Printable Cleanades, Metal Foam Grenades, Air Alarm Trigger

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/air_alarm.yml
@@ -25,6 +25,7 @@
   - type: WirelessNetworkConnection
     range: 200
   - type: DeviceList
+  - type: NoSignalOnLink # Mono
   - type: DeviceNetworkRequiresPower
   - type: DeviceLinkSource
     ports:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/misc.yml
@@ -35,3 +35,25 @@
     Steel: 600
     Glass: 50
     Plastic: 200
+
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: CleanerGrenade
+  result: CleanerGrenade
+  categories:
+  - Tools
+  completetime: 5
+  materials:
+    Steel: 500
+    Plastic: 1000
+
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: MetalFoamGrenade
+  result: MetalFoamGrenade
+  categories:
+  - Tools
+  completetime: 5
+  materials:
+    Steel: 1500
+    Plastic: 1000

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/engineering_techfab.yml
@@ -55,6 +55,7 @@
     - FireExtinguisher
     - GasDepositLocator
     - RPED # Mono
+    - MetalFoamGrenade #Mono
   ## Parts
     - MicroManipulatorStockPart
     - MatterBinStockPart

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/service_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/service_techfab.yml
@@ -82,6 +82,7 @@
     - Holoprojector
     - Shovel
     - FreezerElectronics
+    - CleanerGrenade #Mono
   ## Kitchen
     - DrinkMug
     - DrinkMugMetal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds Cleanades to Service Techfab and Metal Foam Nades to Engineering Techfab, both as static recipes.
Adds NoSignalOnLink to air alarms to make them functional with foam and nanofoam grenades.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I hate the mess I hate the mess I hate the mess.

Cleanades are hardly gamebreaking and are easily accessible through repeatedly purchasing a certain very cheap janitorial ship. Any issues with "ease of cleaning chemical spills" can be directed towards my normal syringe, normal bucket, and then the comically large anvil strung over your head in that order.

With the advent of the SRD metal foam nades for sealing hull breaches aren't as valuable as they were so i'd like to see them more commonly used.

Both recipes add value to their respective techfabs as recipes exclusive to those techfabs.

Air Alarms previously sent a signal when they were linked which would cause a sealing grenade to immediately trigger, this causes them to only trigger once the signal-out condition is met. Amusingly, the air alarm cannot be paired with most lethal grenades for reasons I haven't checked. That'll probably be part of Saw Traps Pt 2.

## How to test
<!-- Describe the way it can be tested -->
Service Techfab -> Cleanade
Engineering Techfab -> Metal Foam Nade
Link an Air Alarm to a Metal Foam or Nanofoam nade -> it doesn't immediately trigger.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Cleanades and Metal Foam Nades are now available for printing at the Service Techfab and Engineering Techfab respectively.
- tweak: Air Alarms no longer instantly detonate linked grenades.

