### PR TITLE
Added a OnBoltBoltStateChangedEvent, Guns Now Show Empty Untill Cocked.

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.ChamberMagazine.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.ChamberMagazine.cs
@@ -16,6 +16,7 @@ public sealed partial class GunSystem
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, AmmoCounterControlEvent>(OnChamberMagazineCounter);
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, UpdateAmmoCounterEvent>(OnChamberMagazineAmmoUpdate);
         SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, AppearanceChangeEvent>(OnChamberMagazineAppearance);
+        SubscribeLocalEvent<ChamberMagazineAmmoProviderComponent, BoltStateChangedEvent>(OnBoltStateChanged);
     }
 
     private void OnChamberMagazineAppearance(EntityUid uid, ChamberMagazineAmmoProviderComponent component, ref AppearanceChangeEvent args)
@@ -71,6 +72,11 @@ public sealed partial class GunSystem
         if (magEntity != null)
             RaiseLocalEvent(magEntity.Value, ref ammoCountEv, false);
 
-        control.Update(chambered != null, magEntity != null, ammoCountEv.Count, ammoCountEv.Capacity);
+        var hasRoundChambered = chambered != null && component.BoltClosed == true; // don't show chambered round if bolt is open
+        control.Update(hasRoundChambered, magEntity != null, ammoCountEv.Count, ammoCountEv.Capacity);
+    }
+    private void OnBoltStateChanged(EntityUid uid, ChamberMagazineAmmoProviderComponent comp, BoltStateChangedEvent args)
+    {
+        UpdateAmmoCount(uid); // Update the ammo counter when the bolt state changes
     }
 }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.ChamberMagazine.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.ChamberMagazine.cs
@@ -72,9 +72,10 @@ public sealed partial class GunSystem
         if (magEntity != null)
             RaiseLocalEvent(magEntity.Value, ref ammoCountEv, false);
 
-        var hasRoundChambered = chambered != null && component.BoltClosed == true; // don't show chambered round if bolt is open
+        var hasRoundChambered = chambered != null && component.BoltClosed == true; // Mono: don't show chambered round if bolt is open
         control.Update(hasRoundChambered, magEntity != null, ammoCountEv.Count, ammoCountEv.Capacity);
     }
+    //Mono
     private void OnBoltStateChanged(EntityUid uid, ChamberMagazineAmmoProviderComponent comp, BoltStateChangedEvent args)
     {
         UpdateAmmoCount(uid); // Update the ammo counter when the bolt state changes

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -203,7 +203,7 @@ public abstract partial class SharedGunSystem
         }
 
         component.BoltClosed = value;
-        RaiseLocalEvent(uid, new BoltStateChangedEvent(user ?? EntityUid.Invalid, value));
+        RaiseLocalEvent(uid, new BoltStateChangedEvent(user ?? EntityUid.Invalid, value)); //Mono
         Dirty(uid, component);
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -43,7 +43,7 @@ public abstract partial class SharedGunSystem
         // Appearance data doesn't get serialized and want to make sure this is correct on spawn (regardless of MapInit) so.
         if (component.BoltClosed != null)
         {
-           Appearance.SetData(uid, AmmoVisuals.BoltClosed, component.BoltClosed.Value);
+            Appearance.SetData(uid, AmmoVisuals.BoltClosed, component.BoltClosed.Value);
         }
     }
 
@@ -185,7 +185,7 @@ public abstract partial class SharedGunSystem
                     // The problem is client will dump the cartridge on the ground and the new server state
                     // won't correspond due to randomness so looks weird
                     // but we also need to always take it from the chamber or else ammocount won't be correct.
-                    TransformSystem.DetachParentToNull(chambered.Value, Transform(chambered.Value));
+                    TransformSystem.DetachEntity(chambered.Value, Transform(chambered.Value));
                 }
 
                 UpdateAmmoCount(uid);
@@ -203,6 +203,7 @@ public abstract partial class SharedGunSystem
         }
 
         component.BoltClosed = value;
+        RaiseLocalEvent(uid, new BoltStateChangedEvent(user ?? EntityUid.Invalid, value));
         Dirty(uid, component);
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -808,22 +808,12 @@ public abstract partial class SharedGunSystem : EntitySystem
     {
         public List<(NetCoordinates coordinates, Angle angle, SpriteSpecifier Sprite, float Distance)> Sprites = new();
     }
-
-    /// <summary>
-    /// Raised when a chamber-mag gun's bolt is opened or closed.
-    /// </summary>
-    public sealed class BoltStateChangedEvent : EntityEventArgs
-    {
-        public readonly EntityUid User;
-        public readonly bool Closed;
-
-        public BoltStateChangedEvent(EntityUid user, bool closed)
-        {
-            User = user;
-            Closed = closed;
-        }
-    }
 }
+
+/// <summary>
+/// Raised when a chamber-mag gun's bolt is opened or closed.
+/// </summary>
+public record struct BoltStateChangedEvent(EntityUid User, bool Closed); //Mono
 
 /// <summary>
 ///     Raised directed on the gun before firing to see if the shot should go through.

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -808,6 +808,21 @@ public abstract partial class SharedGunSystem : EntitySystem
     {
         public List<(NetCoordinates coordinates, Angle angle, SpriteSpecifier Sprite, float Distance)> Sprites = new();
     }
+
+    /// <summary>
+    /// Raised when a chamber-mag gun's bolt is opened or closed.
+    /// </summary>
+    public sealed class BoltStateChangedEvent : EntityEventArgs
+    {
+        public readonly EntityUid User;
+        public readonly bool Closed;
+
+        public BoltStateChangedEvent(EntityUid user, bool closed)
+        {
+            User = user;
+            Closed = closed;
+        }
+    }
 }
 
 /// <summary>


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I added an Event for when a gun is bolted. I changed the visual logic so that the guns don't show a bullet in the chamber until AFTER it is bolted, even if there is a bullet in the chamber. I also changed out a deprecated method i found after trying to fix random errors.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I feel like this is a clearer representation of when you can fire and when you cannot. I've had many occasions where i thought a gun was ready to fire, yet it was not. That second usually counts in combat.
## How to test
<!-- Describe the way it can be tested -->
You can vend or print yourself a gun, it will now show it doesn't have a bullet in the chamber until after it is bolted. Before it was shown as full.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Guns now show no bullet in the chamber until cocked.