### PR TITLE
Ship Shield Ramming Resistance

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -206,19 +206,15 @@ public sealed partial class ShuttleSystem
 
             // Mono Edit - partial credit to https://github.com/Sector-Crescent/Hullrot/pull/692
             //ShipShieldedComp is removed when shields are broken, only reduces energy delivered when shields are active. ShipShieldsSystem ln 256.
-            if (TryComp<ShipShieldedComponent>(args.OurEntity, out var ShipShieldedComponent)) //Our ship collision resistance
-            {
-                TryComp<ShipShieldEmitterComponent>(ShipShieldedComponent.Source, out var ShipShieldEmitterComponent);
-                if(ShipShieldEmitterComponent != null)
-                    toUsEnergy *= ShipShieldEmitterComponent.CollisionResistanceMultiplier;
-            }
-
-            if (TryComp<ShipShieldedComponent>(args.OtherEntity, out var OtherShipShieldedComponent)) //Other ship collision resistance
-            {
-                TryComp<ShipShieldEmitterComponent>(OtherShipShieldedComponent.Source, out var OtherShipShieldEmitterComponent);
-                if (OtherShipShieldEmitterComponent != null)
-                    toOtherEnergy *= OtherShipShieldEmitterComponent.CollisionResistanceMultiplier;
-            }
+            if (TryComp<ShipShieldedComponent>(args.OurEntity, out var ShipShieldedComponent) //Our ship collision resistance
+                && TryComp<ShipShieldEmitterComponent>(ShipShieldedComponent.Source, out var ShipShieldEmitterComponent)
+            )
+                toUsEnergy *= ShipShieldEmitterComponent.CollisionResistanceMultiplier;
+            
+            if (TryComp<ShipShieldedComponent>(args.OtherEntity, out var OtherShipShieldedComponent) //Other ship collision resistance
+                && TryComp<ShipShieldEmitterComponent>(OtherShipShieldedComponent.Source, out var OtherShipShieldEmitterComponent)
+            ) 
+                toOtherEnergy *= OtherShipShieldEmitterComponent.CollisionResistanceMultiplier;
             // Mono Edit end
 
             DoGridImpact((args.OurEntity, ourGrid, ourXform, ourBody), args.OurFixture, inelasticVel, ourVelocity, ourTile, ourTiles, toUsEnergy);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -1,5 +1,6 @@
 using Content.Server.Shuttles.Components;
 using Content.Server._NF.Shuttles.Components;
+using Content.Shared._Crescent.ShipShields;
 using Content.Shared._Mono;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Components;
@@ -93,6 +94,7 @@ public sealed partial class ShuttleSystem
     /// </summary>
     private void OnShuttleCollide(EntityUid uid, ShuttleComponent component, ref StartCollideEvent args)
     {
+
         if (TerminatingOrDeleted(uid) || EntityManager.IsQueuedForDeletion(uid)
             || TerminatingOrDeleted(args.OtherEntity) || EntityManager.IsQueuedForDeletion(args.OtherEntity)
         )
@@ -202,9 +204,27 @@ public sealed partial class ShuttleSystem
             var totalInertia = ourVelocity * ourMass + otherVelocity * otherMass;
             var inelasticVel = totalInertia / (ourMass + otherMass);
 
+            // Mono Edit - partial credit to https://github.com/Sector-Crescent/Hullrot/pull/692
+            //ShipShieldedComp is removed when shields are broken, only reduces energy delivered when shields are active. ShipShieldsSystem ln 256.
+            if (TryComp<ShipShieldedComponent>(args.OurEntity, out var ShipShieldedComponent)) //Our ship collision resistance
+            {
+                TryComp<ShipShieldEmitterComponent>(ShipShieldedComponent.Source, out var ShipShieldEmitterComponent);
+                if(ShipShieldEmitterComponent != null)
+                    toUsEnergy *= ShipShieldEmitterComponent.CollisionResistanceMultiplier;
+            }
+
+            if (TryComp<ShipShieldedComponent>(args.OtherEntity, out var OtherShipShieldedComponent)) //Other ship collision resistance
+            {
+                TryComp<ShipShieldEmitterComponent>(OtherShipShieldedComponent.Source, out var OtherShipShieldEmitterComponent);
+                if (OtherShipShieldEmitterComponent != null)
+                    toOtherEnergy *= OtherShipShieldEmitterComponent.CollisionResistanceMultiplier;
+            }
+            // Mono Edit end
+
             DoGridImpact((args.OurEntity, ourGrid, ourXform, ourBody), args.OurFixture, inelasticVel, ourVelocity, ourTile, ourTiles, toUsEnergy);
             DoGridImpact((args.OtherEntity, otherGrid, otherXform, otherBody), args.OtherFixture, inelasticVel, otherVelocity, otherTile, otherTiles, toOtherEnergy);
         }
+
     }
 
     private void DoGridImpact(Entity<MapGridComponent, TransformComponent, PhysicsComponent> ent,

--- a/Content.Shared/_Crescent/ShipShields/ShipShieldEmitterComponent.cs
+++ b/Content.Shared/_Crescent/ShipShields/ShipShieldEmitterComponent.cs
@@ -80,4 +80,10 @@ public sealed partial class ShipShieldEmitterComponent : Component
 
     [DataField]
     public SoundSpecifier PowerDownSound = new SoundPathSpecifier("/Audio/Effects/teleport_departure.ogg");
+
+    /// <summary>
+    /// While shield is active, reduces impact energy from grid collisions by this much.
+    /// </summary>
+    [DataField]
+    public float CollisionResistanceMultiplier = 1.0f;
 }

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
@@ -129,7 +129,7 @@
     damageLimit: 10000
     damageOverloadTimePunishment: 30
     shieldColor: "#FF9933"
-    CollisionResistanceMultiplier: 0.0
+    collisionResistanceMultiplier: 0.0
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/fobshield.rsi
     snapCardinals: true
@@ -203,7 +203,7 @@
     damageLimit: 8000
     damageOverloadTimePunishment: 35
     shieldColor: "#FF0A70"
-    CollisionResistanceMultiplier: 0.05
+    collisionResistanceMultiplier: 0.05
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/fobshield.rsi
     snapCardinals: true
@@ -270,7 +270,7 @@
   - type: ShipRepairable
     repairTime: 30
     repairCost: 300
-    CollisionResistanceMultiplier: 0.1
+    collisionResistanceMultiplier: 0.1
   - type: ShipRepairableRestrict
     toolWhitelist:
       tags:
@@ -292,7 +292,7 @@
     damageLimit: 40000
     damageOverloadTimePunishment: 100
     shieldColor: "#9933FF"
-    CollisionResistanceMultiplier: 0.6
+    collisionResistanceMultiplier: 0.6
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/shield.rsi
     snapCardinals: true
@@ -378,7 +378,7 @@
     damageLimit: 5000 # Mono
     damageOverloadTimePunishment: 80
     shieldColor: "#3399FF"
-    CollisionResistanceMultiplier: 0.5
+    collisionResistanceMultiplier: 0.5
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/shield.rsi
     snapCardinals: true

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
@@ -90,7 +90,7 @@
     maxDraw: 100000 # Base is 150000
     unpoweredBonus: 7 # Base is 6
     shieldColor: "#FF3333"
-    CollisionResistanceMultiplier: 1.0
+    collisionResistanceMultiplier: 1.0
     powerUpSound: !type:SoundPathSpecifier
         path: "/Audio/Effects/teleport_arrival.ogg"
         params:
@@ -130,7 +130,7 @@
     damageLimit: 10000
     damageOverloadTimePunishment: 30
     shieldColor: "#FF9933"
-    CollisionResistanceMultiplier: 0.0
+    collisionResistanceMultiplier: 0.0
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/fobshield.rsi
     snapCardinals: true
@@ -204,7 +204,7 @@
     damageLimit: 8000
     damageOverloadTimePunishment: 35
     shieldColor: "#FF0A70"
-    CollisionResistanceMultiplier: 0.05
+    collisionResistanceMultiplier: 0.05
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/fobshield.rsi
     snapCardinals: true
@@ -271,7 +271,7 @@
   - type: ShipRepairable
     repairTime: 30
     repairCost: 300
-    CollisionResistanceMultiplier: 0.1
+    collisionResistanceMultiplier: 0.1
   - type: ShipRepairableRestrict
     toolWhitelist:
       tags:
@@ -293,7 +293,7 @@
     damageLimit: 40000
     damageOverloadTimePunishment: 100
     shieldColor: "#9933FF"
-    CollisionResistanceMultiplier: 0.6
+    collisionResistanceMultiplier: 0.6
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/shield.rsi
     snapCardinals: true
@@ -379,7 +379,7 @@
     damageLimit: 5000 # Mono
     damageOverloadTimePunishment: 80
     shieldColor: "#3399FF"
-    CollisionResistanceMultiplier: 0.5
+    collisionResistanceMultiplier: 0.5
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/shield.rsi
     snapCardinals: true

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
@@ -268,10 +268,19 @@
   name: MS-500 "Titan" Shield Generator
   suffix: ADS ONLY
   components:
+  - type: ShipShieldEmitter
+    damageLimit: 8000
+    damageOverloadTimePunishment: 40
+    healPerSecond: 120 # Base is 250
+    damageExp: 1.15 # Base is 1.1
+    baseDraw: 40000 # Base is 50000
+    maxDraw: 100000 # Base is 150000
+    unpoweredBonus: 7 # Base is 6
+    shieldColor: "#FF3333"
+    collisionResistanceMultiplier: 0.05
   - type: ShipRepairable
     repairTime: 30
     repairCost: 300
-    collisionResistanceMultiplier: 0.1
   - type: ShipRepairableRestrict
     toolWhitelist:
       tags:

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
@@ -129,6 +129,7 @@
     damageLimit: 10000
     damageOverloadTimePunishment: 30
     shieldColor: "#FF9933"
+    CollisionResistanceMultiplier: 0.0
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/fobshield.rsi
     snapCardinals: true
@@ -202,6 +203,7 @@
     damageLimit: 8000
     damageOverloadTimePunishment: 35
     shieldColor: "#FF0A70"
+    CollisionResistanceMultiplier: 0.05
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/fobshield.rsi
     snapCardinals: true
@@ -268,6 +270,7 @@
   - type: ShipRepairable
     repairTime: 30
     repairCost: 300
+    CollisionResistanceMultiplier: 0.1
   - type: ShipRepairableRestrict
     toolWhitelist:
       tags:
@@ -289,6 +292,7 @@
     damageLimit: 40000
     damageOverloadTimePunishment: 100
     shieldColor: "#9933FF"
+    CollisionResistanceMultiplier: 0.6
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/shield.rsi
     snapCardinals: true
@@ -374,6 +378,7 @@
     damageLimit: 5000 # Mono
     damageOverloadTimePunishment: 80
     shieldColor: "#3399FF"
+    CollisionResistanceMultiplier: 0.5
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/shield.rsi
     snapCardinals: true

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/shield_generator.yml
@@ -90,6 +90,7 @@
     maxDraw: 100000 # Base is 150000
     unpoweredBonus: 7 # Base is 6
     shieldColor: "#FF3333"
+    CollisionResistanceMultiplier: 1.0
     powerUpSound: !type:SoundPathSpecifier
         path: "/Audio/Effects/teleport_arrival.ogg"
         params:
@@ -129,7 +130,7 @@
     damageLimit: 10000
     damageOverloadTimePunishment: 30
     shieldColor: "#FF9933"
-    collisionResistanceMultiplier: 0.0
+    CollisionResistanceMultiplier: 0.0
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/fobshield.rsi
     snapCardinals: true
@@ -203,7 +204,7 @@
     damageLimit: 8000
     damageOverloadTimePunishment: 35
     shieldColor: "#FF0A70"
-    collisionResistanceMultiplier: 0.05
+    CollisionResistanceMultiplier: 0.05
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/fobshield.rsi
     snapCardinals: true
@@ -270,7 +271,7 @@
   - type: ShipRepairable
     repairTime: 30
     repairCost: 300
-    collisionResistanceMultiplier: 0.1
+    CollisionResistanceMultiplier: 0.1
   - type: ShipRepairableRestrict
     toolWhitelist:
       tags:
@@ -292,7 +293,7 @@
     damageLimit: 40000
     damageOverloadTimePunishment: 100
     shieldColor: "#9933FF"
-    collisionResistanceMultiplier: 0.6
+    CollisionResistanceMultiplier: 0.6
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/shield.rsi
     snapCardinals: true
@@ -378,7 +379,7 @@
     damageLimit: 5000 # Mono
     damageOverloadTimePunishment: 80
     shieldColor: "#3399FF"
-    collisionResistanceMultiplier: 0.5
+    CollisionResistanceMultiplier: 0.5
   - type: Sprite
     sprite: _Mono/Structures/ShuttleComponents/shield.rsi
     snapCardinals: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds code to ShuttleSystem.Impact to reduce energy of impacts by a multiplier.
Adds field to component ShipShieldEmitterComponent to store the modifier.
Adds modifiers to ship shield prototype.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Adds slight depth to ship combat by making ramming less effective against ships that have active shielding. Break the shields, ramming has full effectiveness again.

The effectiveness of this varies based on what shield you're using, with MS-100 shields offering basic protection while Vanguard capital shields offer a massive reduction. The only noteworthy exception is MS-250 shields have slightly worse ramming protection than MS-100s due to their increased recharge rate making it harder to keep the shield disabled.

This may require changes to scale ramming effectiveness as desired, I mostly pulled these values out of my ass.

## How to test
<!-- Describe the way it can be tested -->
Ram a specific shuttle into another shuttle.
Put a shield on the shuttle, ram it into the same model of shuttle with as many other variables being similar.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Ship shielding now offers protection from ramming attacks based on what shield you have. Break the shield before going for a kamikaze strike.
