### PR TITLE
Cartridge Autocleanup but Based

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/AmmoComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/AmmoComponent.cs
@@ -38,4 +38,12 @@ public sealed partial class CartridgeAmmoComponent : AmmoComponent
 
     [DataField("soundEject")]
     public SoundSpecifier? EjectSound = new SoundCollectionSpecifier("CasingEject");
+
+    // Mono start
+    /// <summary>
+    /// Whether to addcomp timeddespawn, and dictates the lifetime of spent boolets. Set to 0 to ignore.
+    /// </summary>
+    [DataField]
+    public float AutoTimedDespawn = 30f;
+    // Mono end
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -615,10 +615,8 @@ public abstract partial class SharedGunSystem : EntitySystem
         if (cartridge.DeleteOnSpawn) // Mono - No need to update appearance if cartridge is getting deleted anyways
             return;
 
-        if (cartridge.AutoTimedDespawn != 0 && !TryComp(uid, out TimedDespawnComponent? timedDespawnComponent)) // Mono - Used for lag reduction (lowered number of entities during gunfights)
-        {
-            AddComp<TimedDespawnComponent>(uid).Lifetime = cartridge.AutoTimedDespawn;
-        }
+        if (cartridge.AutoTimedDespawn != 0)
+            EnsureComp<TimedDespawnComponent>(uid).Lifetime = cartridge.AutoTimedDespawn
         // End mono
 
         Appearance.SetData(uid, AmmoVisuals.Spent, spent);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -616,7 +616,7 @@ public abstract partial class SharedGunSystem : EntitySystem
             return;
 
         if (cartridge.AutoTimedDespawn != 0)
-            EnsureComp<TimedDespawnComponent>(uid).Lifetime = cartridge.AutoTimedDespawn
+            EnsureComp<TimedDespawnComponent>(uid).Lifetime = cartridge.AutoTimedDespawn;
         // End mono
 
         Appearance.SetData(uid, AmmoVisuals.Spent, spent);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -40,6 +40,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Robust.Shared.Spawners; // Mono
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
@@ -613,6 +614,12 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         if (cartridge.DeleteOnSpawn) // Mono - No need to update appearance if cartridge is getting deleted anyways
             return;
+
+        if (cartridge.AutoTimedDespawn != 0 && !TryComp(uid, out TimedDespawnComponent? timedDespawnComponent)) // Mono - Used for lag reduction (lowered number of entities during gunfights)
+        {
+            AddComp<TimedDespawnComponent>(uid).Lifetime = cartridge.AutoTimedDespawn;
+        }
+        // End mono
 
         Appearance.SetData(uid, AmmoVisuals.Spent, spent);
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds code to automatically give spent bullets TimedDespawn comp for a value adjustable in ammo comp. By default it is 30 seconds, to preserve evidence of combat somewhat.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Lag reduction. Now bullets clean themselves up with patented SpaceWind:tm: magic, rather than through trash cleanup systems.
## How to test
<!-- Describe the way it can be tested -->
Shoot bullets with starter pistol, watch them last for the time defined in comp
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/5466f301-3bbd-4a5f-9002-fbf792a30f5f


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- fix: Bullets clean themselves up over time now. (maybe less lag?)

