### PR TITLE
Bring Back Scream Action (with an Actually Sane Cooldown)

### DIFF
--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class VocalComponent : Component
 
     [DataField("screamAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     [AutoNetworkedField]
-    public string? ScreamAction; // Mono edit - kill hotbar scream action.
+    public string? ScreamAction = "ActionScream";
 
     [DataField("screamActionEntity")]
     [AutoNetworkedField]

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -15,7 +15,7 @@
   description: AAAAAAAAAAAAAAAAAAAAAAAAA
   components:
   - type: InstantAction
-    useDelay: 1 # 10->1
+    useDelay: 10
     icon: Interface/Actions/scream.png
     event: !type:ScreamActionEvent
     checkCanInteract: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Hotbar scream has returned, delay increased from 1 second to 10 seconds (same as upstream)

## Why / Balance
'Twas an unfortunate casualty in the Lizard Wars. It's a vital part of Space Station 14 (and all forks I know of) and finely ingrained muscle memory for anybody with more then 10 hours on any server. The issue with screams here was that https://github.com/Monolith-Station/Monolith/pull/682 had reduced the cooldown to 1 second for some god forsaken reason, so just brought that back to the default.

Emote wheel is mid, manually going in to set a bind for screaming is weird and lame, hot bar scream is a good feature and it's actually HRP to immediately hit the scream action the moment something goes wrong

## How to test
\>load in
\>AAAAAAAAAAAAAAAAAAAAAAAAA

## Media
<img width="1104" height="561" alt="image" src="https://github.com/user-attachments/assets/2c003843-638f-4cd0-ac3b-1a8d6ee9e22b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Scream hotbar action has returned, albeit with a much higher cooldown.
