### PR TITLE
Torpedo Buffs and Explosion Fixes.

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -83,7 +83,7 @@
     requireNoGrid: true
     shape: triangle
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     totalIntensity: 10
     intensitySlope: 5
     maxIntensity: 25
@@ -297,7 +297,7 @@
     intensitySlope: 4
     maxIntensity: 3
     maxTileBreak: 1
-    
+
 - type: entity
   id: MechMediumPlasmaProjectile
   name: plasma projectile

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -73,7 +73,7 @@
         Structural: 4500 # So it can break shuttles
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     totalIntensity: 50
     intensitySlope: 2
     maxIntensity: 5
@@ -99,7 +99,7 @@
 - type: entity
   id: BulletLaserPellet
   parent: BulletEnergyGunLaser
-  name: energy 
+  name: energy
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/projectiles.yml
@@ -555,7 +555,7 @@
   - type: TriggerOnSpawn
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     totalIntensity: 6000
     intensitySlope: 35
     maxIntensity: 700
@@ -567,7 +567,7 @@
   - type: TriggerOnSpawn
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     totalIntensity: 22
     intensitySlope: 2
     maxIntensity: 5

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/Cartridge/bomb_bay_ammo.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/Cartridge/bomb_bay_ammo.yml
@@ -28,7 +28,7 @@
     lifetime: 30
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     totalIntensity: 2000
     intensitySlope: 30
     maxIntensity: 1500
@@ -141,7 +141,7 @@
     energy: 2
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     totalIntensity: 100
     intensitySlope: 10
     maxIntensity: 150
@@ -260,7 +260,7 @@
     energy: 2
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     maxIntensity: 25
     intensitySlope: 1000
     totalIntensity: 25

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/Cartridge/trident_ammo.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/Cartridge/trident_ammo.yml
@@ -43,14 +43,14 @@
   - type: Projectile
     damage:
       types:
-        Structural: 300
+        Structural: 250
         Blunt: 200
         Heat: 100
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/mini_rocket.rsi
     layers:
     - state: mini-rocket
-    scale: 3, 3
+    scale: 1, 2
   - type: Ammo
     muzzleFlash: null
   - type: ShipWeaponProjectile
@@ -67,7 +67,7 @@
     energy: 2
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     maxIntensity: 150
     intensitySlope: 30
     totalIntensity: 1000
@@ -134,9 +134,9 @@
       - !type:ExplodeBehavior
   - type: Explosive
     explosionType: Default
-    maxIntensity: 100
-    intensitySlope: 3
-    totalIntensity: 75
+    maxIntensity: 50
+    intensitySlope: 30
+    totalIntensity: 50
   - type: ExplodeOnTrigger
   - type: Damageable
     damageContainer: Inorganic
@@ -160,7 +160,7 @@
     sprite: _Mono/Objects/SpaceArtillery/mini_rocket.rsi
     layers:
     - state: mini-rocket
-    scale: 3, 3
+    scale: 1, 2
   - type: Ammo
     muzzleFlash: null
   - type: ShipWeaponProjectile
@@ -185,10 +185,10 @@
     maxSpeed: 250
     trackDelay: 1
   - type: Explosive
-    explosionType: HardBombShipGun
-    maxIntensity: 1000
+    explosionType: Default
+    maxIntensity: 30
     intensitySlope: 100
-    totalIntensity: 200
+    totalIntensity: 100
   # destructible components below
   - type: Fixtures
     fixtures:
@@ -209,12 +209,12 @@
   - type: Meteor
     damageTypes:
       types:
-        Blunt: 50
+        Blunt: 5
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 2400
+        damage: 28800
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -282,7 +282,7 @@
     sprite: _Mono/Objects/SpaceArtillery/mini_rocket.rsi
     layers:
     - state: mini-rocket
-    scale: 3, 3
+    scale: 1, 2
   - type: Ammo
     muzzleFlash: null
   - type: ShipWeaponProjectile
@@ -299,7 +299,7 @@
     energy: 2
   - type: ExplodeOnTrigger
   - type: Explosive
-    explosionType: HardBombShipGun
+    explosionType: Default
     maxIntensity: 50
     intensitySlope: 4
     totalIntensity: 150
@@ -360,7 +360,7 @@
   - type: Appearance
   - type: SpentAmmoVisuals
   - type: EmpDescription
-    range: 7
+    range: 12
     energyConsumption: 2900000
     disableDuration: 10
   - type: Destructible

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/ShipgunAmmo/research.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/ShipgunAmmo/research.yml
@@ -29,8 +29,7 @@
   result: Asm220TorpedoLOSAT
   materials:
     Steel: 1200 # shell/casing
-    Plasteel: 600 # penetrator
-    Synthalloy: 200 # penetrator
+    Plasteel: 1000 # penetrator
     Glass: 400 # opticals
     Gold: 200 # electronics
     Silver: 200 # electronics


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Gives torpedoes a 1, 2 scale.
Fixes losats not working properly - giving them a 2 wall pen for reinforced plast 3 wall pen for plast, 5 wall pen for reinforced - with practically after explosion damage.
Changes all "HardBombShipGun" explosive damage into "Default"
Buffs ECM to a 12 tile radius.
LOSATs no longer need synthalloy to make.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Torpedoes hit eachother and half the time would not be able to make it to an enemy ship - usually exploding outside of it.

Losats were broken in the literal sense, i also nerfed them from their original state however.

Hardbombshipgun was outdated and needed to be changed.

ECM  torpedoes had a smaller range than tarynx, while having a slightly longer shutdown duration. I think they should have a slight edge over tarynx due to the fact that they can be shot down and quite easily at that.

LOSATS shouldn't be TSF / tech disk exclusive if they're a universal faction tech, especially since TSF is more or less focusing on energy weapons rather than ballistics, in return they've gotten a price increase in their plasteel cost.
## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
Not player facing: Missiles and ship bombs use the correct explosion type.
- tweak: All torpedoes and fighter bombs have been improved.
- tweak: LOSATs no longer require synthalloy to make
- fix: LOSATs now work properly.
