### PR TITLE
Breaching Charge Signal Trigger to Timer (Nerf) (Also Seismic Charges)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -92,8 +92,8 @@
     - state: icon
       map: ["base"]
   - type: OnUseTimerTrigger
-    delay: 5
-    delayOptions: [5, 10, 15, 20]
+    delay: 3
+    delayOptions: [3, 5, 10, 15, 20]
     initialBeepDelay: 0
     beepSound:
       path: /Audio/Effects/Cargo/buzz_two.ogg
@@ -101,10 +101,10 @@
         volume: -6
     startOnStick: false
     canToggleStartOnStick: true
-  - type: TriggerOnSignal
+  - type: TimerStartOnSignal
   - type: DeviceLinkSink
     ports:
-    - Trigger
+    - Timer
   - type: Explosive
     explosionType: Cryo
     totalIntensity: 120


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changes Seismic Charge to trigger off a timer when detonated from a signaler. This changes both Seismic Charges and Breaching Charges to trigger their explosion after their timer reaches 0, instead of instantly detonate after the signal is sent.

Also reduces the minimum timer for the Seismic Charge to 3 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Instant detonation explosives, particularly the Breaching Charge with how damaging it is, are irritating.

Despite never having been killed by this particular mechanic it still causes me to mald enough to make the PR.

Now if you want to instantly kill whoever you want with this specific explosive, you need to actually time the throw.

## How to test
<!-- Describe the way it can be tested -->
Seismic Charge -> Default timer is 3, minimum timer selection option is 3.
Seismic Charge and Breaching Charge have "Timer" in their signal link menu instead of "Trigger".

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://discord.com/channels/1329292619834069034/1349192764637581334/1463094826147774504
(Video too big)
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Breaching Charges and Seismic Charges can no longer be instantly detonated using signal linking.

