### PR TITLE
Add Chernobyl

### DIFF
--- a/Content.Server/_Mono/Radiation/ChainRadiationComponent.cs
+++ b/Content.Server/_Mono/Radiation/ChainRadiationComponent.cs
@@ -1,0 +1,48 @@
+namespace Content.Server._Mono.Radiation;
+
+[RegisterComponent]
+public sealed partial class ChainRadiationComponent : Component
+{
+    /// <summary>
+    /// Base radiation intensity. Overrides what's specified in RadiationSourceComponent.
+    /// </summary>
+    [DataField]
+    public float BaseIntensity = 0.5f;
+
+    /// <summary>
+    /// How much to increase our emitted radiation per unit of radiation received.
+    /// </summary>
+    [DataField]
+    public float Coefficient = 0.01f;
+
+    /// <summary>
+    /// Explode upon reaching this amount of radiation emitted.
+    /// </summary>
+    [DataField]
+    public float ExplosionThreshold = 2000f;
+
+    /// <summary>
+    /// TotalIntensity of explosion to make when reaching threshold.
+    /// </summary>
+    [DataField]
+    public float TotalIntensity = 100000f; // legalize nuclear bombs
+
+    /// <summary>
+    /// IntensitySlope of explosion to make when reaching threshold.
+    /// </summary>
+    [DataField]
+    public float IntensitySlope = 20f;
+
+    /// <summary>
+    /// MaxIntensity of explosion to make when reaching threshold.
+    /// </summary>
+    [DataField]
+    public float MaxIntensity = 800f;
+
+    /// <summary>
+    /// When exploding due to exceeding threshold, also explode other ChainRadiation entities in this radius.
+    /// If you're reading this and want this to only affect entities of a certain kind, add an EntityWhitelist.
+    /// </summary>
+    [DataField]
+    public float ChainExplosionRadius = 4f;
+}

--- a/Content.Server/_Mono/Radiation/ChainRadiationSystem.cs
+++ b/Content.Server/_Mono/Radiation/ChainRadiationSystem.cs
@@ -1,0 +1,58 @@
+using Content.Server.Explosion.EntitySystems;
+using Content.Server.Radiation.Components;
+using Content.Server.Radiation.Events;
+using Content.Server.Radiation.Systems;
+using Content.Shared.Explosion.Components;
+using Content.Shared.Radiation.Components;
+
+namespace Content.Server._Mono.Radiation;
+
+public sealed class ChainRadiationSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly ExplosionSystem _explosion = default!;
+    [Dependency] private readonly RadiationSystem _radiation = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RadiationSystemUpdatedEvent>(OnUpdate);
+    }
+
+    private void OnUpdate(RadiationSystemUpdatedEvent args)
+    {
+        var query = EntityQueryEnumerator<ChainRadiationComponent, RadiationReceiverComponent, RadiationSourceComponent>();
+        while (query.MoveNext(out var uid, out var chain, out var receiver, out var source))
+        {
+            source.Intensity = chain.BaseIntensity * (1f + receiver.CurrentRadiation * chain.Coefficient);
+
+            // not great not terrible
+            if (source.Intensity > chain.ExplosionThreshold)
+            {
+                var coord = Transform(uid).Coordinates;
+                foreach (var other in _lookup.GetEntitiesInRange<ChainRadiationComponent>(coord, chain.ChainExplosionRadius))
+                {
+                    // teleport them to us for combined explosion
+                    _transform.SetCoordinates(other, coord);
+
+                    Explode(other);
+                }
+
+                Explode((uid, chain));
+            }
+        }
+    }
+
+    private void Explode(Entity<ChainRadiationComponent> ent)
+    {
+        var explosive = EnsureComp<ExplosiveComponent>(ent);
+
+        explosive.TotalIntensity = ent.Comp.TotalIntensity;
+        explosive.IntensitySlope = ent.Comp.IntensitySlope;
+        explosive.MaxIntensity = ent.Comp.MaxIntensity;
+
+        _explosion.TriggerExplosive(ent, explosive);
+    }
+}

--- a/Content.Shared/Explosion/Components/ExplosiveComponent.cs
+++ b/Content.Shared/Explosion/Components/ExplosiveComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Explosion.Components;
 ///      The total intensity may be overridden by whatever system actually calls TriggerExplosive(), but this
 ///      component still determines the explosion type and other properties.
 /// </remarks>
-[RegisterComponent, Access(typeof(SharedExplosionSystem))]
+[RegisterComponent] // Mono - remove access
 public sealed partial class ExplosiveComponent : Component
 {
     /// <summary>

--- a/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
+++ b/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
@@ -264,8 +264,16 @@
     - uranium_2
     - uranium_3
   - type: Material
+  - type: RadiationReceiver
   - type: RadiationSource
-    intensity: 0.5
+    intensity: 0.4
+  - type: ChainRadiation
+    baseIntensity: 0.4
+    coefficient: 0.1 # critical mass at 25
+    explosionThreshold: 10 # let it cook a bit
+    totalIntensity: 100000
+    intensitySlope: 100
+    maxIntensity: 1200
   - type: Appearance
   - type: PhysicalComposition
     materialComposition:
@@ -275,20 +283,6 @@
     totalIntensity: 20.0
     intensitySlope: 5
     maxIntensity: 4
-  - type: ExplodeOnTrigger
-  - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: Metallic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Radiation
-        damage: 25
-      behaviors:
-      - !type:ExplodeBehavior
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
   - type: ThermalSignature
   - type: PassiveThermalSignature
     signature: 1500000


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- explosives that are stacks now respect stack size
- fissile uranium now radiates more depending on received radiation
- upon reaching a threshold it will make a massive explosion
- critical mass right now is 25 fissile uranium

## Why / Balance
more uses for fissile uranium
i think this is balanced despite the explosion size since 25 is a lot

## How to test
1. spawn saturn
2. place 25 or 30 fissile uranium somewhere near its edge

## Media
<img width="223" height="304" alt="image" src="https://github.com/user-attachments/assets/03b6445d-e33c-4d7b-8331-295d4a2e832e" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Fissile uranium now radiates more depending on received radiation.
- add: Fissile uranium now explodes upon crossing a radiation threshold.
