### PR TITLE
Extra Maint Command Perms

### DIFF
--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -68,7 +68,11 @@
   - print_pvs_ack
   - pvs_override_info
   - merge_grids
-
+  # Mono
+  - tp
+  - tpto
+  - tpgrid
+  - aghost
 
 - Flags: MAPPING
   Commands:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
gives debug perm:
- tp
- tpto
- tpgrid
- aghost

## Why / Balance
basically already possible with VV and otherwise needed for sane debugging/TPing to bug reporters

**Changelog**
i eated it