### PR TITLE
Further Nerf Uranium

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -161,7 +161,7 @@ public sealed partial class LatheMenu : FancyWindow
             if (!_prototypeManager.TryIndex(id, out var proto))
                 continue;
 
-            var adjustedAmount = SharedLatheSystem.AdjustMaterial(amount, prototype.ApplyMaterialDiscount, multiplier);
+            var adjustedAmount = SharedLatheSystem.AdjustMaterial(amount, prototype.MaterialDiscountScale, multiplier);
             var sheetVolume = _materialStorage.GetSheetVolume(proto);
 
             var unit = Loc.GetString(proto.Unit);

--- a/Content.Client/_Goobstation/Research/UI/MiniRecipeCardControl.xaml.cs
+++ b/Content.Client/_Goobstation/Research/UI/MiniRecipeCardControl.xaml.cs
@@ -21,7 +21,9 @@ public sealed partial class MiniRecipeCardControl : Control
         Background.ModulateSelfOverride = discipline.Color;
         NameLabel.SetMessage(lathe.GetRecipeName(proto));
 
-        if (proto.Result.HasValue)
+        if (proto.Icon is { } icon)
+            Showcase.Texture = sprite.Frame0(icon);
+        else if (proto.Result.HasValue)
             Showcase.Texture = sprite.Frame0(prototypeManager.Index(proto.Result.Value));
 
         if (proto.Description.HasValue)

--- a/Content.IntegrationTests/Tests/Lathe/LatheTest.cs
+++ b/Content.IntegrationTests/Tests/Lathe/LatheTest.cs
@@ -123,8 +123,8 @@ public sealed class LatheTest
         {
             foreach (var recipe in proto.EnumeratePrototypes<LatheRecipePrototype>())
             {
-                if (recipe.Result == null)
-                    Assert.That(recipe.ResultReagents, Is.Not.Null, $"Recipe '{recipe.ID}' has no result or result reagents.");
+                if (recipe.Result == null && recipe.MaterialResult.Count == 0)
+                    Assert.That(recipe.ResultReagents, Is.Not.Null, $"Recipe '{recipe.ID}' has no result or result reagents or result materials.");
             }
         });
 

--- a/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
+++ b/Content.IntegrationTests/Tests/MaterialArbitrageTest.cs
@@ -192,7 +192,7 @@ public sealed class MaterialArbitrageTest
                     {
                         foreach (var (matId, amount) in recipe.Materials)
                         {
-                            var actualAmount = SharedLatheSystem.AdjustMaterial(amount, recipe.ApplyMaterialDiscount, multiplier);
+                            var actualAmount = SharedLatheSystem.AdjustMaterial(amount, recipe.MaterialDiscountScale, multiplier);
                             if (spawnedMats.TryGetValue(matId, out var numSpawned))
                                 Assert.That(numSpawned, Is.LessThanOrEqualTo(actualAmount), $"destroying a {id} spawns more {matId} than required to produce via an (upgraded) lathe.");
                         }
@@ -272,7 +272,7 @@ public sealed class MaterialArbitrageTest
                     {
                         foreach (var (matId, amount) in recipe.Materials)
                         {
-                            var actualAmount = SharedLatheSystem.AdjustMaterial(amount, recipe.ApplyMaterialDiscount, multiplier);
+                            var actualAmount = SharedLatheSystem.AdjustMaterial(amount, recipe.MaterialDiscountScale, multiplier);
                             if (deconstructedMats.TryGetValue(matId, out var numSpawned))
                                 Assert.That(numSpawned, Is.LessThanOrEqualTo(actualAmount), $"deconstructing {id} spawns more {matId} than required to produce via an (upgraded) lathe.");
                         }
@@ -327,7 +327,7 @@ public sealed class MaterialArbitrageTest
                     {
                         foreach (var (matId, amount) in recipe.Materials)
                         {
-                            var actualAmount = SharedLatheSystem.AdjustMaterial(amount, recipe.ApplyMaterialDiscount, multiplier);
+                            var actualAmount = SharedLatheSystem.AdjustMaterial(amount, recipe.MaterialDiscountScale, multiplier);
                             if (compositionComponent.MaterialComposition.TryGetValue(matId, out var numSpawned))
                                 Assert.That(numSpawned, Is.LessThanOrEqualTo(actualAmount), $"The physical composition of {id} has more {matId} than required to produce via an (upgraded) lathe.");
                         }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -283,9 +283,7 @@ namespace Content.Server.Lathe
 
             foreach (var (mat, amount) in recipe.Materials)
             {
-                var adjustedAmount = recipe.ApplyMaterialDiscount
-                    ? (int) (-amount * component.FinalMaterialUseMultiplier) // Frontier: MaterialUseMultiplier<FinalMaterialUseMultiplier
-                    : -amount;
+                var adjustedAmount = -AdjustMaterial(amount, recipe.MaterialDiscountScale, component.FinalMaterialUseMultiplier);
 
                 _materialStorage.TryChangeMaterialAmount(uid, mat, adjustedAmount);
             }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -186,19 +186,17 @@ namespace Content.Server.Lathe
         {
             if (args.Storage != uid)
                 return;
-            var materialWhitelist = new List<ProtoId<MaterialPrototype>>();
+            var materialWhitelist = new HashSet<ProtoId<MaterialPrototype>>();
             var recipes = GetAvailableRecipes(uid, component, true);
             foreach (var id in recipes)
             {
                 if (!_proto.TryIndex(id, out var proto))
                     continue;
                 foreach (var (mat, _) in proto.Materials)
-                {
-                    if (!materialWhitelist.Contains(mat))
-                    {
-                        materialWhitelist.Add(mat);
-                    }
-                }
+                    materialWhitelist.Add(mat);
+                // Mono
+                foreach (var (mat, _) in proto.MaterialResult)
+                    materialWhitelist.Add(mat);
             }
 
             var combined = args.Whitelist.Union(materialWhitelist).ToList();
@@ -337,6 +335,9 @@ namespace Content.Server.Lathe
 
                     _stack.TryMergeToContacts(result);
                 }
+
+                // Mono
+                _materialStorage.TryChangeMaterialAmount(uid, comp.CurrentRecipe.MaterialResult.ToDictionary()); // copy
 
                 if (comp.CurrentRecipe.ResultReagents is { } resultReagents &&
                     comp.ReagentOutputSlotId is { } slotId)

--- a/Content.Shared/Lathe/SharedLatheSystem.cs
+++ b/Content.Shared/Lathe/SharedLatheSystem.cs
@@ -78,7 +78,7 @@ public abstract class SharedLatheSystem : EntitySystem
             var recipe = batch.Recipe;
             foreach (var (material, needed) in recipe.Materials)
             {
-                var adjustedAmount = AdjustMaterial(needed, recipe.ApplyMaterialDiscount, ent.Comp.FinalMaterialUseMultiplier);
+                var adjustedAmount = AdjustMaterial(needed, recipe.MaterialDiscountScale, ent.Comp.FinalMaterialUseMultiplier);
                 currentMaterial[material] -= adjustedAmount * (batch.ItemsRequested - batch.ItemsPrinted);
             }
         }
@@ -100,7 +100,7 @@ public abstract class SharedLatheSystem : EntitySystem
 
         foreach (var (material, needed) in recipe.Materials)
         {
-            var adjustedAmount = AdjustMaterial(needed, recipe.ApplyMaterialDiscount, ent.Comp.FinalMaterialUseMultiplier);
+            var adjustedAmount = AdjustMaterial(needed, recipe.MaterialDiscountScale, ent.Comp.FinalMaterialUseMultiplier);
 
             if (endAmts.GetValueOrDefault(material) < adjustedAmount * amount)
                 return false;
@@ -117,7 +117,7 @@ public abstract class SharedLatheSystem : EntitySystem
 
         foreach (var (material, needed) in recipe.Materials)
         {
-            var adjustedAmount = AdjustMaterial(needed, recipe.ApplyMaterialDiscount, component.FinalMaterialUseMultiplier);
+            var adjustedAmount = AdjustMaterial(needed, recipe.MaterialDiscountScale, component.FinalMaterialUseMultiplier);
 
             if (_materialStorage.GetMaterialAmount(uid, material) < adjustedAmount * amount)
                 return false;
@@ -149,8 +149,8 @@ public abstract class SharedLatheSystem : EntitySystem
     }
     // End Frontier: demag
 
-    public static int AdjustMaterial(int original, bool reduce, float multiplier)
-        => reduce ? (int) MathF.Ceiling(original * multiplier) : original;
+    public static int AdjustMaterial(int original, float multScale, float multiplier)
+        => (int) MathF.Ceiling(original * MathF.Pow(multiplier, multScale));
 
     protected abstract bool HasRecipe(EntityUid uid, LatheRecipePrototype recipe, LatheComponent component);
 

--- a/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
+++ b/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
@@ -43,6 +43,12 @@ namespace Content.Shared.Research.Prototypes
         [DataField]
         public EntProtoId? Result;
 
+        /// <summary>
+        ///     Mono - Materials created by processing this recipe, deposited directly into the lathe.
+        /// </summary>
+        [DataField]
+        public Dictionary<ProtoId<MaterialPrototype>, int> MaterialResult = new();
+
         [DataField]
         public Dictionary<ProtoId<ReagentPrototype>, FixedPoint2>? ResultReagents;
 

--- a/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
+++ b/Content.Shared/Research/Prototypes/LatheRecipePrototype.cs
@@ -63,7 +63,7 @@ namespace Content.Shared.Research.Prototypes
         public Dictionary<ProtoId<MaterialPrototype>, int> Materials = new();
 
         [DataField]
-        public bool ApplyMaterialDiscount = true;
+        public float MaterialDiscountScale = 1f; // Mono - changed from bool to float
 
         /// <summary>
         /// List of categories used for visually sorting lathe recipes in the UI.

--- a/Resources/Locale/en-US/_Mono/recipe/uranium.ftl
+++ b/Resources/Locale/en-US/_Mono/recipe/uranium.ftl
@@ -1,0 +1,8 @@
+recipe-uranium-processing-name = uranium processing
+recipe-uranium-processing-description = Seperate fissile isotopes from uranium ingots. High probability of producing depleted uranium.
+
+recipe-uranium-processing-advanced-name = plasma enriched uranium processing
+recipe-uranium-processing-advanced-description = Use a mixture of uranium and plasma to produce fissile uranium with a higher probability.
+
+recipe-uranium-reprocessing-name = uranium re-processing
+recipe-uranium-reprocessing-description = Use depleted uranium to produce unfiltered uranium.

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/materials.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/materials.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: plasma
   result: SheetPlasma1
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 2
   materials:
     Plasma: 100
@@ -15,7 +15,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: plasteel
   result: SheetPlasteel1
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 2
   materials:
     Steel: 100

--- a/Resources/Prototypes/Recipes/Lathes/bedsheets.yml
+++ b/Resources/Prototypes/Recipes/Lathes/bedsheets.yml
@@ -4,7 +4,7 @@
   categories:
   - Bedsheets
   completetime: 2
-  applyMaterialDiscount: false # Frontier
+  materialDiscountScale: 0 # Frontier
   materials:
     Cloth: 150
 

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -205,7 +205,7 @@
   id: TargetHuman
   result: TargetHuman
   completetime: 5
-  applyMaterialDiscount: false # ingredients dropped when destroyed
+  materialDiscountScale: 0 # ingredients dropped when destroyed
   materials:
     Steel: 500
 

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -219,7 +219,7 @@
 - type: latheRecipe
   id: SheetPlastic
   result: SheetPlastic1
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 0.06 # Frontier: 0<0.06 (~2/30)
   materials:
     Plastic: 100
@@ -243,6 +243,6 @@
   result: SheetPaper1
   categories: [Materials] # Frontier
   completetime: 1
-  applyMaterialDiscount: false # Frontier
+  materialDiscountScale: 0 # Frontier
   materials:
     Wood: 50

--- a/Resources/Prototypes/Recipes/Lathes/tiles.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tiles.yml
@@ -3,7 +3,7 @@
 - type: latheRecipe
   abstract: true
   id: BaseTileRecipe
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 0.5
   materials:
     Steel: 25

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/uranium.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/uranium.yml
@@ -10,6 +10,7 @@
   icon:
     sprite: _Mono/Effects/processing.rsi
     state: processing_2
+  materialDiscountScale: 0.5
 
 - type: entity
   name: uranium processing
@@ -40,12 +41,11 @@
   result: UraniumReprocessingSpawner
   completetime: 20
   materials:
-    UraniumDepleted: 150 # 1.5 ingots
-    UraniumFissile: 10 # 0.1 ingots
+    UraniumDepleted: 300 # 3 ingots
   icon:
     sprite: _Mono/Effects/processing.rsi
     state: processing
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
 
 - type: entity
   name: uranium re-processing
@@ -58,7 +58,7 @@
     - SheetUranium10
     rarePrototypes:
     - SheetUraniumFissile1
-    rareChance: 0.15
+    rareChance: 0.1
     offset: 0.0
     chance: 1
   - type: Sprite
@@ -82,6 +82,7 @@
   icon:
     sprite: _Mono/Effects/processing.rsi
     state: processing_3
+  materialDiscountScale: 0.5
 
 - type: entity
   name: plasma enriched uranium processing

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/uranium.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/uranium.yml
@@ -1,9 +1,13 @@
 
 - type: latheRecipe
   id: UraniumCentrifugeProcessingMini
+  name: uranium processing
+  description: Seperate fissile isotopes from uranium ingots. High probability of producing depleted uranium.
   categories:
   - Explosive
-  result: UraniumProcessingSpawner
+  materialResult:
+    UraniumDepleted: 97 # 0.97 ingots
+    UraniumFissile: 3 # 0.03 ingots
   completetime: 20
   materials:
     Uranium: 1000 # 10 ingots
@@ -12,69 +16,35 @@
     state: processing_2
   materialDiscountScale: 0.5
 
-- type: entity
-  name: uranium processing
-  description: Seperate fissile isotopes from uranium ingots. High probability of producing depleted uranium.
-  id: UraniumProcessingSpawner
-  parent: MarkerBase
-  components:
-  - type: RandomSpawner
-    prototypes:
-    - SheetUraniumDepleted1
-    rarePrototypes:
-    - SheetUraniumFissile1
-    rareChance: 0.03
-    offset: 0.0
-    chance: 1
-  - type: Sprite
-    sprite: _Mono/Effects/processing.rsi
-    state: processing_2
-  - type: Icon
-    sprite: _Mono/Effects/processing.rsi
-    state: processing_2
 # reprocessing
 
 - type: latheRecipe
   id: UraniumCentrifugeReprocessingMini
+  name: uranium re-processing
+  description: Use depleted uranium to produce unfiltered uranium.
   categories:
   - Explosive
-  result: UraniumReprocessingSpawner
+  materialResult:
+    Uranium: 1000 # 10 ingots
   completetime: 20
   materials:
-    UraniumDepleted: 300 # 3 ingots
+    UraniumDepleted: 250 # 2.5 ingots
   icon:
     sprite: _Mono/Effects/processing.rsi
     state: processing
   materialDiscountScale: 0
 
-- type: entity
-  name: uranium re-processing
-  description: Use a mixture of fissile and depleted uranium to produce all three types of uranium.
-  id: UraniumReprocessingSpawner
-  parent: MarkerBase
-  components:
-  - type: RandomSpawner
-    prototypes:
-    - SheetUranium10
-    rarePrototypes:
-    - SheetUraniumFissile1
-    rareChance: 0.1
-    offset: 0.0
-    chance: 1
-  - type: Sprite
-    sprite: _Mono/Effects/processing.rsi
-    state: processing
-  - type: Icon
-    sprite: _Mono/Effects/processing.rsi
-    state: processing
-
 # plasma enriched processing
 
 - type: latheRecipe
   id: UraniumCentrifugeEnrichedProcessingMini
+  name: plasma enriched uranium processing
+  description: Use a mixture of uranium and plasma to produce fissile uranium with a higher probability.
   categories:
   - Explosive
-  result: UraniumEnrichedProcessingSpawner
+  materialResult:
+    UraniumDepleted: 94 # 0.94 ingots
+    UraniumFissile: 6 # 0.06 ingots
   completetime: 20
   materials:
     Uranium: 1000 # 10 ingots
@@ -83,24 +53,3 @@
     sprite: _Mono/Effects/processing.rsi
     state: processing_3
   materialDiscountScale: 0.5
-
-- type: entity
-  name: plasma enriched uranium processing
-  description: Use a mixture of uranium and plasma to produce fissile uranium with a higher probability.
-  id: UraniumEnrichedProcessingSpawner
-  parent: MarkerBase
-  components:
-  - type: RandomSpawner
-    prototypes:
-    - SheetUraniumDepleted1
-    rarePrototypes:
-    - SheetUraniumFissile1
-    rareChance: 0.1
-    offset: 0.0
-    chance: 1
-  - type: Sprite
-    sprite: _Mono/Effects/processing.rsi
-    state: processing_3
-  - type: Icon
-    sprite: _Mono/Effects/processing.rsi
-    state: processing_3

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/uranium.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/uranium.yml
@@ -1,8 +1,8 @@
 
 - type: latheRecipe
   id: UraniumCentrifugeProcessingMini
-  name: uranium processing
-  description: Seperate fissile isotopes from uranium ingots. High probability of producing depleted uranium.
+  name: recipe-uranium-processing-name
+  description: recipe-uranium-processing-description
   categories:
   - Explosive
   materialResult:
@@ -20,8 +20,8 @@
 
 - type: latheRecipe
   id: UraniumCentrifugeReprocessingMini
-  name: uranium re-processing
-  description: Use depleted uranium to produce unfiltered uranium.
+  name: recipe-uranium-reprocessing-name
+  description: recipe-uranium-reprocessing-description
   categories:
   - Explosive
   materialResult:
@@ -38,8 +38,8 @@
 
 - type: latheRecipe
   id: UraniumCentrifugeEnrichedProcessingMini
-  name: plasma enriched uranium processing
-  description: Use a mixture of uranium and plasma to produce fissile uranium with a higher probability.
+  name: recipe-uranium-processing-advanced-name
+  description: recipe-uranium-processing-advanced-description
   categories:
   - Explosive
   materialResult:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/service.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/service.yml
@@ -3,6 +3,6 @@
   result: PaperCup
   categories: [KitchenNF]
   completetime: 0.4
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   materials:
     Paper: 50

--- a/Resources/Prototypes/_Mono/Research/Universal/economy.yml
+++ b/Resources/Prototypes/_Mono/Research/Universal/economy.yml
@@ -2,7 +2,7 @@
 - type: technology
   id: BasicProcessing
   name: research-technology-basic-economy
-  entityIcon: UraniumProcessingSpawner
+  entityIcon: UraniumProcessingIcon
   discipline: FactionUniversal
   tier: 1
   cost: 20000
@@ -12,10 +12,17 @@
   - UniversalMaterialResearchT1
   position: 9, 1
 
+- type: entity
+  id: UraniumProcessingIcon
+  components:
+  - type: Sprite
+    sprite: _Mono/Effects/processing.rsi
+    state: processing_2
+
 - type: technology
   id: UraniumProcessingAdvanced
   name: research-technology-uranium-processing-advanced
-  entityIcon: UraniumEnrichedProcessingSpawner
+  entityIcon: UraniumEnrichedProcessingIcon
   discipline: FactionUniversal
   tier: 2
   cost: 30000
@@ -27,3 +34,9 @@
   - BasicProcessing
   position: 9, 6
 
+- type: entity
+  id: UraniumEnrichedProcessingIcon
+  components:
+  - type: Sprite
+    sprite: _Mono/Effects/processing.rsi
+    state: processing_3

--- a/Resources/Prototypes/_NF/Recipes/Lathes/biogen.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/biogen.yml
@@ -31,7 +31,7 @@
   categories:
   - Tools
   completetime: 20 # Mono
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   materials:
     Biomass: 160 # Mono
 
@@ -60,7 +60,7 @@
   id: NFBioGenFoodMeat
   result: FoodMeat
   parent: BioGenFoodRecipe
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 1 # Mono
   materials:
     Biomass: 5 # Mono

--- a/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/clothing-eva.yml
@@ -6,7 +6,7 @@
   categories:
   - EVASuits
   - ArmorNF # Mono
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 5
   materials:
     Steel: 300

--- a/Resources/Prototypes/_NF/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/clothing.yml
@@ -6,7 +6,7 @@
   parent: BaseJumpsuitRecipe
   categories:
   - ClothesNF
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
 
 - type: latheRecipe
   abstract: true
@@ -14,7 +14,7 @@
   parent: BaseCoatRecipe
   categories:
   - ClothesNF
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
 
 - type: latheRecipe
   abstract: true

--- a/Resources/Prototypes/_NF/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/electronics.yml
@@ -97,7 +97,7 @@
   id: SmallThrusterMachineCircuitboard
   parent: BaseCircuitboardRecipe
   result: SmallThrusterMachineCircuitboard
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   materials:
     Steel: 140
     Glass: 300

--- a/Resources/Prototypes/_NF/Recipes/Lathes/prizecounter.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/prizecounter.yml
@@ -3,7 +3,7 @@
 - type: latheRecipe
   abstract: true
   id: BasePrizeRecipe
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 4
 
 - type: latheRecipe

--- a/Resources/Prototypes/_NF/Recipes/Lathes/service.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/service.yml
@@ -39,14 +39,14 @@
   id: NapkinDrum
   result: NapkinDrum
   parent: BaseServiceItemsRecipe
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
 
 - type: latheRecipe
   id: Napkin
   result: Napkin
   parent: BaseServiceItemsRecipe
   completetime: 0.1
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   materials:
     Paper: 10
 
@@ -63,14 +63,14 @@
   id: CondimentCupDispenser
   result: CondimentCupDispenser
   parent: BaseServiceItemsRecipe
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
 
 - type: latheRecipe
   id: CondimentCup
   result: CondimentCup
   parent: BaseServiceItemsRecipe
   completetime: 0.1
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   materials:
     Steel: 10
 
@@ -78,7 +78,7 @@
   id: FoodCondimentSqueezeBottleClear
   result: FoodCondimentSqueezeBottleClear
   parent: BaseServiceItemsRecipe
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   materials:
     Plastic: 50
 

--- a/Resources/Prototypes/_NF/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/sheet.yml
@@ -7,7 +7,7 @@
   id: BaseMaterialsNoDiscountRecipe
   categories:
   - Materials
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 0.06
 
 #Mono fun installation
@@ -100,7 +100,7 @@
   result: CableApcStack1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 20 # ~0.3 of steel sheet #Mono - 300 > 20 
+    RawScrap: 20 # ~0.3 of steel sheet #Mono - 300 > 20
 
 - type: latheRecipe
   id: ScrapPartRodMetal1

--- a/Resources/Prototypes/_NF/Recipes/Lathes/storage.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/storage.yml
@@ -14,7 +14,7 @@
   id: NFBaseBoxRecipe
   parent: NFBaseToolboxRecipe
   completetime: 1
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   materials:
     Cardboard: 100
 

--- a/Resources/Prototypes/_NF/Recipes/Lathes/tiles.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/tiles.yml
@@ -3,7 +3,7 @@
 - type: latheRecipe
   abstract: true
   id: NFBaseFloorTileRecipe
-  applyMaterialDiscount: false
+  materialDiscountScale: 0
   completetime: 0.5
   materials:
     Steel: 25


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- allows recipes to just directly produce material so we can have fractional-production recipes
- removes gambling from uranium
- nerfs uranium production to non-insane levels
- makes reprocessing not broken (because it's still broken)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Nerfed uranium reprocessing.
- tweak: Uranium processing is no longer RNG and now instead makes fractional amounts of uranium per recipe completion.
