### PR TITLE
Increase Maxcap Scaling

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -342,12 +342,16 @@ namespace Content.Server.Atmos.EntitySystems
                 pressure = component.Air.Pressure;
                 var range = MathF.Sqrt((pressure - component.TankFragmentPressure) / component.TankFragmentScale);
 
+                if (TryComp<ExplosiveComponent>(owner, out var explosive)) // Monolith - pressure wave scaling
+                {
+                    explosive.MaxIntensity *= MathF.Sqrt(range); // technically pointless but guarantees it's a full cone instead of an octagonal frustum
+                    explosive.IntensitySlope *= MathF.Sqrt(range);
+                }
+
                 // Let's cap the explosion, yeah?
                 // !1984
                 range = Math.Min(Math.Min(range, GasTankComponent.MaxExplosionRange), _maxExplosionRange);
 
-                if (TryComp<ExplosiveComponent>(owner, out var explosive)) // Monolith - pressure wave scaling
-                    explosive.MaxIntensity *= MathF.sqrt(range);
                 _explosions.TriggerExplosive(owner, radius: range);
 
                 return;

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Actions;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Examine;
+using Content.Shared.Explosion.Components;
 using Content.Shared.Throwing;
 using Content.Shared.Toggleable;
 using Content.Shared.Verbs;
@@ -345,6 +346,8 @@ namespace Content.Server.Atmos.EntitySystems
                 // !1984
                 range = Math.Min(Math.Min(range, GasTankComponent.MaxExplosionRange), _maxExplosionRange);
 
+                if (TryComp<ExplosiveComponent>(owner, out var explosive)) // Monolith - pressure wave scaling
+                    explosive.MaxIntensity *= MathF.sqrt(range);
                 _explosions.TriggerExplosive(owner, radius: range);
 
                 return;

--- a/Content.Shared/Explosion/Components/ExplosiveComponent.cs
+++ b/Content.Shared/Explosion/Components/ExplosiveComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Explosion.Components;
 ///      The total intensity may be overridden by whatever system actually calls TriggerExplosive(), but this
 ///      component still determines the explosion type and other properties.
 /// </remarks>
-[RegisterComponent, Access(typeof(SharedExplosionSystem))]
+[RegisterComponent] // Mono - remove access
 public sealed partial class ExplosiveComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
LICENSE: MIT

## About the PR
currently, maxcaps have intensity calculation that eventually results in the cone being cut off due to slope being literally 1 at higher radii so every maxcap at >20 radius simply becomes a circular plateau of 20 with an extruding slope down  
this PR makes maxcaps strictly deadlier depending on radius

## Why / Balance
meaningful structural and anti-personnel damage due to resist slop

## How to test
spawn a filled air tank and vvedit its volume to be 0.01

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content. (the PR reviewer is ai-generated content)

**Changelog**
:cl: router
- tweak: Gas tank explosion maximum intensity now scales with the square root of its radius. You can now maxcap Jupiter if you really want to.
