### PR TITLE
Unchain Nanite Applicator

### DIFF
--- a/Content.Server/_EinsteinEngines/Silicon/WeldingHealable/WeldingHealableSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/WeldingHealable/WeldingHealableSystem.cs
@@ -36,7 +36,7 @@ public sealed class WeldingHealableSystem : SharedWeldingHealableSystem
             || !HasDamage((args.Target.Value, damageable), component, args.User)
             || !TryComp<WelderComponent>(args.Used, out var welder)
             || !TryComp<SolutionContainerManagerComponent>(args.Used, out var solutionContainer)
-            || !_solutionContainer.TryGetSolution(((EntityUid)args.Used, solutionContainer), welder.FuelSolutionName, out var solution))
+            || !_solutionContainer.TryGetSolution(((EntityUid) args.Used, solutionContainer), welder.FuelSolutionName, out var solution))
             return;
 
         _damageableSystem.TryChangeDamage(uid, component.Damage, true, false, origin: args.User);

--- a/Content.Server/_EinsteinEngines/Silicon/WeldingHealable/WeldingHealableSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/WeldingHealable/WeldingHealableSystem.cs
@@ -36,7 +36,7 @@ public sealed class WeldingHealableSystem : SharedWeldingHealableSystem
             || !HasDamage((args.Target.Value, damageable), component, args.User)
             || !TryComp<WelderComponent>(args.Used, out var welder)
             || !TryComp<SolutionContainerManagerComponent>(args.Used, out var solutionContainer)
-            || !_solutionContainer.TryGetSolution(((EntityUid) args.Used, solutionContainer), welder.FuelSolutionName, out var solution))
+            || !_solutionContainer.TryGetSolution(((EntityUid)args.Used, solutionContainer), welder.FuelSolutionName, out var solution))
             return;
 
         _damageableSystem.TryChangeDamage(uid, component.Damage, true, false, origin: args.User);
@@ -48,7 +48,8 @@ public sealed class WeldingHealableSystem : SharedWeldingHealableSystem
             ("tool", args.Used!));
         _popup.PopupEntity(str, uid, args.User);
 
-        if (!args.Used.HasValue)
+        if (!args.Used.HasValue
+            || _toolSystem.GetWelderFuelAndCapacity(args.Used.Value).fuel < component.FuelCost) //Mono: Nanite applicator
             return;
 
         args.Handled = _toolSystem.UseTool
@@ -71,7 +72,8 @@ public sealed class WeldingHealableSystem : SharedWeldingHealableSystem
             || !component.DamageContainers.Contains(damageable.DamageContainerID)
             || !HasDamage((args.Target, damageable), component, args.User)
             || !_toolSystem.HasQuality(args.Used, component.QualityNeeded)
-            || args.User == args.Target && !component.AllowSelfHeal)
+            || args.User == args.Target && !component.AllowSelfHeal
+            || _toolSystem.GetWelderFuelAndCapacity(args.Used).fuel < component.FuelCost) //Mono: Nanite applicator again
             return;
 
         float delay = args.User == args.Target

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -117,6 +117,20 @@ public abstract partial class SharedToolSystem
             && SolutionContainerSystem.TryGetDrainableSolution(target, out var targetSoln, out var targetSolution)
             && SolutionContainerSystem.TryGetSolution(entity.Owner, entity.Comp.FuelSolutionName, out var solutionComp, out var welderSolution))
         {
+            // MONO: Exit refill attempt if the tank contains incompatible reagents
+            // mitigates borgs self-btfoing from welder/applicator refill mixup
+            foreach (var reagent in targetSolution.Contents)
+            {
+                if (reagent.Reagent.Prototype != entity.Comp.FuelReagent.Id)
+                {
+                    _popup.PopupClient(
+                        Loc.GetString("welder-component-incompatible-fuel", ("owner", args.Target)), entity, args.User);
+
+                    return;
+                }
+            }
+            //Mono end
+
             var trans = FixedPoint2.Min(welderSolution.AvailableVolume, targetSolution.Volume);
             if (trans > 0)
             {

--- a/Resources/Locale/en-US/tools/components/welder-component.ftl
+++ b/Resources/Locale/en-US/tools/components/welder-component.ftl
@@ -13,3 +13,4 @@ welder-component-suicide-unlit-others-message = {$victim} bashes themselves with
 welder-component-suicide-unlit-message = You bash yourself with the unlit welding torch!
 welder-component-after-interact-refueled-message = Refueled!
 welder-component-already-full = The welder is already full.
+welder-component-incompatible-fuel = { $owner } contains incorrect or contaminated fuel!

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -7,7 +7,7 @@
     Multitool: 10 # Frontier: 4<10
     ClothingEyesGlassesMeson: 10
     ClothingHeadHatWelding: 6
-    HolofanProjector: 10
+    HolofanProjector: 10 # Mono
     BoxInflatable: 2
     GeigerCounter: 10       # Frontier
     PowerCellMedium: 15 # Frontier: 5<15

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -52,9 +52,6 @@
     resistance: 2
   - type: BlockWeather
   - type: SunShadowCast
-  - type: Repairable
-    qualities:
-    - Applicating
   - type: ArmorThickness
     thickness: 3
 

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -41,7 +41,7 @@
   - type: ExaminableDamage
     messages: WindowMessages
   - type: Repairable
-  qualities:
+      qualities:
       - Welding #Mono
       - Applicating #Mono
   - type: RCDDeconstructable

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -41,7 +41,7 @@
   - type: ExaminableDamage
     messages: WindowMessages
   - type: Repairable
-    qualities:
+      qualities:
       - Welding #Mono
       - Applicating #Mono
   - type: RCDDeconstructable

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -41,6 +41,9 @@
   - type: ExaminableDamage
     messages: WindowMessages
   - type: Repairable
+    qualities:
+      - Welding #Mono
+      - Applicating #Mono
   - type: RCDDeconstructable
     cost: 6
     delay: 4

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -41,7 +41,7 @@
   - type: ExaminableDamage
     messages: WindowMessages
   - type: Repairable
-      qualities:
+  qualities:
       - Welding #Mono
       - Applicating #Mono
   - type: RCDDeconstructable

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -41,7 +41,7 @@
   - type: ExaminableDamage
     messages: WindowMessages
   - type: Repairable
-      qualities:
+    qualities:
       - Welding #Mono
       - Applicating #Mono
   - type: RCDDeconstructable

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -42,8 +42,8 @@
     messages: WindowMessages
   - type: Repairable
     qualities:
-      - Welding #Mono
-      - Applicating #Mono
+    - Welding #Mono
+    - Applicating #Mono
   - type: RCDDeconstructable
     cost: 6
     delay: 4

--- a/Resources/Prototypes/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/Entities/Structures/base_structure.yml
@@ -28,8 +28,8 @@
     tags:
       - Structure
   - type: Repairable #Mono: Nanite applicator
-  qualities:
-  - Applicating
+    qualities:
+    - Applicating
 
 - type: entity
   # This means that it's not anchored on spawn.

--- a/Resources/Prototypes/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/Entities/Structures/base_structure.yml
@@ -27,6 +27,9 @@
   - type: Tag
     tags:
       - Structure
+  - type: Repairable #Mono: Nanite applicator
+  qualities:
+  - Applicating
 
 - type: entity
   # This means that it's not anchored on spawn.

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/salvmaint_locker.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/salvmaint_locker.yml
@@ -406,6 +406,7 @@
     - !type:GroupSelector
       weight: 28
       children:
+      - id: NaniteApplicator
       - id: ClothingHeadHatCone
       - id: Bucket
       - id: MopItem
@@ -415,7 +416,11 @@
       - id: GeigerCounter
       - id: AppraisalTool
       - id: RadioHandheldNF
+      - id: Spoon
+      - id: DrinkShaker
       - id: DrinkGlass
+      - id: JerryCanWeldingFuel
+      - id: JerryCanNaniteFuel
       - id: AmeJar
         weight: 0.5
       #Survival box
@@ -450,7 +455,6 @@
         - id: HandHeldMassScannerEmpty
         - id: PinpointerUniversal
           weight: 0.5
-      - id: JerryCanWeldingFuel
       - id: ResearchDisk35000
         weight: 0.5
       #Medkits

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/chemical-containers.yml
@@ -8,9 +8,9 @@
     currentLabel: reagent-name-nanite-fuel
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      tank:
         reagents:
         - ReagentId: NaniteFuel
-          Quantity: 200
+          Quantity: 250
   - type: StaticPrice # Frontier
     vendPrice: 500 # Frontier

--- a/Resources/Prototypes/_Mono/Entities/Objects/Tools/nanite_applicator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Tools/nanite_applicator.yml
@@ -40,7 +40,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 25
+    price: 20
   - type: GuideHelp
     guides:
     - Construction

--- a/Resources/Prototypes/_Mono/Entities/Objects/Tools/nanite_applicator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Tools/nanite_applicator.yml
@@ -40,7 +40,7 @@
     materialComposition:
       Steel: 100
   - type: StaticPrice
-    price: 11
+    price: 25
   - type: GuideHelp
     guides:
     - Construction

--- a/Resources/Prototypes/_Mono/Entities/Objects/Tools/nanite_applicator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Tools/nanite_applicator.yml
@@ -44,6 +44,18 @@
   - type: GuideHelp
     guides:
     - Construction
+  - type: WeldingHealing #For IPCs
+    qualityNeeded: Applicating
+    damageContainers:
+      - Silicon
+    fuelCost: 5
+    damage:
+      types:
+        Blunt: -12.5
+        Piercing: -12.5
+        Slash: -12.5
+        Heat: -6
+        Shock: -6
 
 - type: entity
   name: experimental nanite applicator

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/engivend.yml
@@ -7,15 +7,17 @@
     Multitool: 4294967295 # Infinite
     ClothingEyesGlassesMeson: 4294967295 # Infinite
     ClothingHeadHatWelding: 4294967295 # Infinite
-    HolofanProjector: 4294967295 # Mono: 10 >> Infinite
+    HolofanProjector: 4294967295 # Mono
     InflatableWallStack1: 4294967295 # Infinite
     InflatableDoorStack1: 4294967295 # Infinite
     GeigerCounter: 4294967295 # Infinite
     PowerCellMedium: 4294967295 # Infinite
 #    NetworkConfigurator: 5
-    ShipRepairDevice: 4294967295 # Infinite
-    ShipRepairDeviceAmmo: 4294967295 # Infinite
+    ShipRepairDevice: 4294967295 # Mono
+    ShipRepairDeviceAmmo: 4294967295 # Mono
     ClothingHeadHatCone: 10 # 4<10
+    JerryCanNaniteFuel: 4294967295 # Mono
+    NaniteApplicator: 4294967295 # Mono
   contrabandInventory: # For consistency
     CowToolboxFilled: 1
     DrinkBeerCan: 3

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/chemical-containers.yml
@@ -62,7 +62,7 @@
     - type: SolutionContainerManager
       solutions:
         beaker:
-          maxVol: 1000
+          maxVol: 2000 #Mono 1000 >> 2000
     - type: Sprite
       sprite: _NF/Objects/Specific/Chemistry/jug_bluespace.rsi
       layers:
@@ -95,16 +95,18 @@
       thresholds: []
 
 # Frontier: an unspillable jug for welding fuel.
+# Mono: all jerry cans, solution: beaker >> solution: tank (ReagentTank support)
 - type: entity
   name: jerry can
   parent: BaseItem
   id: JerryCan
-  description: A plastic jerry can with a spill-proof nozzle.
+  #description: A plastic jerry can with a spill-proof nozzle. #Mono out
+  description: A plastic jerry can fitted with a specialized hot-refill outlet allowing risk-free refueling. #Mono in
   components:
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 200
+        maxVol: 250 #Mono 200 >> 250
   - type: Sprite
     sprite: _NF/Objects/Specific/Chemistry/jerrycan.rsi
     layers:
@@ -116,27 +118,29 @@
     size: Normal
     sprite: _NF/Objects/Specific/Chemistry/jerrycan.rsi
   - type: MixableSolution
-    solution: beaker
+    solution: tank
   - type: RefillableSolution
-    solution: beaker
+    solution: tank
   - type: DrainableSolution
-    solution: beaker
+    solution: tank
   - type: ExaminableSolution
-    solution: beaker
+    solution: tank
   - type: DrawableSolution
-    solution: beaker
+    solution: tank
   - type: InjectableSolution
-    solution: beaker
+    solution: tank
   - type: SolutionTransfer
     canChangeTransferAmount: true
   - type: SolutionItemStatus
-    solution: beaker
+    solution: tank
+  - type: ReagentTank #Mono: Enable borg tool draw
+    tankType: Fuel
   - type: UserInterface
     interfaces:
       enum.TransferAmountUiKey.Key:
         type: TransferAmountBoundUserInterface
   - type: Drink
-    solution: beaker
+    solution: tank
     delay: 1.5
     forceFeedDelay: 5
   - type: Appearance
@@ -159,14 +163,15 @@
           acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 20
+        damage: 100 #Mono: 20 >> 100
       behaviors:
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
           params:
             volume: -4
-      - !type:SpillBehavior { }
+      - !type:SpillBehavior
+        solution: tank #Mono: Bugfix
       - !type:SpawnEntitiesBehavior
         spawn:
           SheetPlastic1:
@@ -177,7 +182,7 @@
         acts: [ "Destruction" ]
   - type: Label
   - type: TrashOnSolutionEmpty # Frontier
-    solution: beaker # Frontier
+    solution: tank # Frontier
 
 - type: entity
   parent: JerryCan
@@ -189,10 +194,10 @@
     currentLabel: reagent-name-welding-fuel
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      tank:
         reagents:
         - ReagentId: WeldingFuel
-          Quantity: 200
+          Quantity: 250 #Mono 200 >> 250
   - type: StaticPrice # Frontier
     vendPrice: 500 # Frontier
 

--- a/Resources/Prototypes/_NF/Entities/Structures/Walls/diagonal_walls.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Walls/diagonal_walls.yml
@@ -44,9 +44,6 @@
         - FullTileMask
         layer:
         - WallLayer
-  - type: Repairable
-    qualities:
-    - Applicating
 
 - type: entity
   parent: [ WallWood, BaseWallDiagonal ]

--- a/Resources/Prototypes/_NF/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/chemistry.yml
@@ -9,6 +9,12 @@
   id: JugBluespace
   result: JugBluespace
   parent: BluespaceBeaker # same size, 1:1 recipe
+  materials: #Mono: The above statement is FALSE. Corrections involve material changes.
+    Steel: 400
+    Plastic: 400
+    Plasma: 100
+    Silver: 100
+    Bluespace: 175 #small discount, less flexible than a beaker
 
 - type: latheRecipe
   id: VialBluespace


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Turns out nanite applicators were less accessible than intended because the POI Engi-vend couldn't dispense them and their fuel. That's been corrected now.

Removes repairable type from walls and diagonals and files it under BaseStructure. This has wacky side effects like being able to repair spaceshrooms and houseplants, but also useful things like thrusters, RD servers, airlocks, and firelocks - things previously not repairable.

Also adds nanite applicator and fuel to salvmaint uncommon pool

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Scyron put effort making this thing so why not give it the opportunities to be acquired and perform work

In regards to repairing unintended shit.. Like, feel free to do that instead of repairing your walls while having your ship glassed, I'm sure it'll save you.

## How to test
<!-- Describe the way it can be tested -->

Buy nanite applicator
Vandalize shit in a non protected station
Try repairing everything

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


https://github.com/user-attachments/assets/b100a33d-16ed-4f82-a66c-f71a393665ff


<img width="604" height="461" alt="image" src="https://github.com/user-attachments/assets/83652c8a-a1fb-4c0c-97c0-a8e783479ad3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Nanite applicator is now more versatile: enjoy repairing houseplants and useless shit. You can also repair useful things like thrusters, RD servers, airlocks, and firelocks too if you're boring
- tweak: Nanite applicator and fuel added to salvmaint locker uncommon pool.
- tweak: IPCs can now use nanite applicators to repair themselves of all damage. This is half as effective as using traditional welder/cable.
- tweak: Jerry cans were changed to act like fuel tanks (meaning you can tap them to refuel from them), and had their durability (20 >> 100) and capacity (200 >> 250) increased.
- tweak: Bluespace jug liquid capacity now proportional to bluespace beaker. Bluespace cost raised proportionally but slightly cheaper since 2 beakers is way more versatile.
- fix: Jerry cans now spew their fuel when destroyed instead of disappearing the liquid entirely
- fix: Borgs can no longer brick their nanite applicator by tapping it on a fuel tank. This also prevents contaminated jerry cans from degrading your tool liquid storage too
- fix: Nanite applicator couldn't be acquired at POI Engi-vends.. not anymore!!