### PR TITLE
Fix Scaf Contraband

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT2 ]
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherPDVT2 ]
   id: ClothingOuterHardsuitPirateScaf
   name: PDV SCAF hardsuit
   description: An old SCAF suit painted in an PDV tan color scheme. The armor feels degraded, but lighter.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/scaf_pirate.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherPDVT2 ]
+  parent: [ ClothingOuterHardsuitBase, BaseFactionGearPDVT2 ]
   id: ClothingOuterHardsuitPirateScaf
   name: PDV SCAF hardsuit
   description: An old SCAF suit painted in an PDV tan color scheme. The armor feels degraded, but lighter.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
now actually pdv and not other-faction

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed PDV SCAF hardsuit being marked as other-faction and not PDV for contraband purposes.
