### PR TITLE
Mass Scanner Unrestrict

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -32,7 +32,7 @@
   - type: ToggleCellDraw
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
-    inHandsOnly: true
+    inHandsOnly: false # Mono
     singleUser: true
   - type: UserInterface
     interfaces:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
can now use mass scanner anywhere in your inventory

## Why / Balance
why was it restricted to active hand only
checking your mass scanner should be easier

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Mass scanners now may be used outside of your active hand.
