### PR TITLE
Make Combat Related Magboots Slightly Faster than Basic Ones

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -96,7 +96,7 @@
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
   - type: ClothingSpeedModifier
     walkModifier: 0.9
-    sprintModifier: 0.85 # 0.9->0.85 Mono
+    sprintModifier: 0.9
   - type: GasTank
     outputPressure: 42.6
     air:

--- a/Resources/Prototypes/_NF/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Shoes/magboots.yml
@@ -11,6 +11,9 @@
     sprite: _NF/Clothing/Shoes/Boots/magboots-security.rsi
   - type: Magboots
     magbootsAlert: MagbootsSecurity
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9 # Mono
+    sprintModifier: 0.9 # 0.85->0.9 - Mono
   - type: ClothingSlowOnDamageModifier # Mono
     modifier: 0.75 # Mono
 


### PR DESCRIPTION
I found it odd that there's no difference in speed between the combat related and normal magboots, especially with a noticeable 15% slow for the regular ones

## About the PR
made syndicate and combat magboots 5% faster than regular onse

## Why / Balance
combat-specific magboots having the same maneuverability as regular ones seems odd

## How to test
check the combat magboots

**Changelog**
:cl:
- tweak: Combat magboots are slightly more mobile now.
