### PR TITLE
Significantly Buff Drone Loot

### DIFF
--- a/Content.Server/NameIdentifier/NameIdentifierSystem.cs
+++ b/Content.Server/NameIdentifier/NameIdentifierSystem.cs
@@ -35,7 +35,7 @@ public sealed class NameIdentifierSystem : EntitySystem
 
     private void OnComponentShutdown(EntityUid uid, NameIdentifierComponent component, ComponentShutdown args)
     {
-        if (CurrentIds.TryGetValue(component.Group, out var ids))
+        if (CurrentIds.TryGetValue(component.Group, out var ids) && ids.Count > 0)
         {
             // Avoid inserting the value right back at the end or shuffling in place:
             // just pick a random spot to put it and then move that one to the end.

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -367,6 +367,9 @@
     deconstructable: false # Frontier
   - type: StaticPrice
     price: 95 # Mono
+  - type: Construction # Mono
+    graph: Girder
+    node: wallPlastitaniumDiagonal
 
 - type: entity
   id: WallPlastitaniumDiagonalIndestructible

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -356,7 +356,7 @@
             amount: 2
             doAfter: 1
           - material: Plastitanium
-            amount: 4
+            amount: 2
             doAfter: 1
 
         - to: plastitaniumWall
@@ -372,7 +372,7 @@
             amount: 4
             doAfter: 1
           - material: Plastitanium
-            amount: 8
+            amount: 4
             doAfter: 1
 
         - to: shuttleWall

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -348,7 +348,7 @@
           conditions:
           - !type:EntityAnchored { }
           steps:
-          - tool: Screwing
+          - tool: Prying
             doAfter: 1
           - tool: Welding
             doAfter: 2
@@ -367,7 +367,7 @@
           - !type:EntityAnchored { }
           steps:
           - tool: Welding
-            doAfter: 15
+            doAfter: 5
           - material: Plasteel
             amount: 4
             doAfter: 1

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
@@ -137,7 +137,7 @@
       amount: 6
     - id: SuperMatterBinStockPart
       amount: 2
-    - id: PicoManipulatorStockPar
+    - id: PicoManipulatorStockPart
       amount: 4
     # rare t4 parts
     - id: QuadraticCapacitorStockPart

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Backpacks/drone_loot.yml
@@ -12,23 +12,24 @@
     shape: square
   - type: SpawnItemsOnUse
     items:
-    # Money
+    # Money - 30k
     - id: SpaceCash10000
-      amount: 2
-      prob: 1.0
+      amount: 3
     # Scrap chunks
     - id: ScrapOre100
-      amount: 4
-      prob: 1.0
+      amount: 1
+    # Material
+    - id: SheetPlastitanium10
+      amount: 2
     # Parts
     - id: SuperCapacitorStockPart
-      prob: 0.4
+      prob: 0.8
       amount: 3
     - id: SuperMatterBinStockPart
-      prob: 0.4
-      amount: 1
+      prob: 0.6
+      amount: 2
     - id: PicoManipulatorStockPart
-      prob: 0.4
+      prob: 0.8
       amount: 2
     - id: SpawnDungeonLootPowerCell
       prob: 0.5
@@ -37,10 +38,8 @@
     #   prob: 0.25
     # Circuit boards
     - id: SpawnDungeonLootCircuitBoardEngi
-      amount: 1
       prob: 0.3
     - id: SpawnDungeonLootCircuitBoardScience
-      amount: 1
       prob: 0.3
     - id: SpawnDungeonLootCircuitBoardSalvage
       prob: 0.3
@@ -48,15 +47,15 @@
       prob: 0.3
     # Flatpacks
     - id: SpawnDungeonLootFlatpacks
-      amount: 2
-      prob: 0.3
-    # Research disk, expected value ~12k/drone
-    - id: RogueSiliconResearchDisk5000
       prob: 0.6
+    # rare shard drop even from T1
+    - id: WeaponTurretShardFlatpack
+      prob: 0.5
+    # Research disk, expected value ~30k/drone
+    - id: RogueSiliconResearchDisk5000
     - id: RogueSiliconResearchDisk10000
-      prob: 0.4
     - id: RogueSiliconResearchDisk25000
-      prob: 0.2
+      prob: 0.6
     # Tech disk
     - id: SpawnLootTechDisksT1
       prob: 0.5
@@ -72,62 +71,43 @@
   components:
   - type: SpawnItemsOnUse
     items:
-    # Money
-    - id: SpaceCash10000
-      amount: 4
-      prob: 1.0
+    # Money - 80k
+    - id: SpaceCash25000
+      amount: 3
+    - id: SpaceCash5000
     # Scrap chunks
     - id: ScrapOre100
-      amount: 5
-      prob: 1.0
+      amount: 3
     # Material
     - id: SheetPlastitanium10
-      amount: 2
-      prob: 1
+      amount: 4
     # Parts
     - id: SuperCapacitorStockPart
-      prob: 1
       amount: 3
     - id: SuperMatterBinStockPart
-      prob: 1
       amount: 1
     - id: PicoManipulatorStockPart
-      prob: 1
       amount: 2
     # rare t4 parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.3
+      amount: 2
+      prob: 0.8
     - id: FemtoManipulatorStockPart
-      prob: 0.2
+      prob: 0.8
     - id: BluespaceMatterBinStockPart
-      prob: 0.1
+      prob: 0.6
     - id: SpawnDungeonLootPowerCell
       prob: 0.5
-    # - id: SpawnDungeonLootPartsEngi #Mono: mostly trash and bloat
-    #   amount: 3
-    #   prob: 0.25
-    # Circuit boards
-    - id: SpawnDungeonLootCircuitBoardEngi
-      prob: 0.3
-    - id: SpawnDungeonLootCircuitBoardScience
-      prob: 0.4
-    - id: SpawnDungeonLootCircuitBoardSalvage
-      prob: 0.4
-    - id: SpawnDungeonLootCircuitBoard
-      prob: 0.3
-    # Flatpacks
-    - id: SpawnDungeonLootFlatpacks
-      amount: 3
-      prob: 0.5
-    # Research disk, expected value ~50k/drone
+    - id: PowerCellMicroreactor
+    # free shard
+    - id: WeaponTurretShardFlatpack
+    # no flatpacks or boards, just gamble scrap
+    # Research disk, expected value ~80k/drone
     - id: RogueSiliconResearchDisk5000
-      prob: 1
     - id: RogueSiliconResearchDisk10000
-      prob: 1
     - id: RogueSiliconResearchDisk25000
       prob: 0.6
     - id: RogueSiliconResearchDisk50000
-      prob: 0.4
     # Tech disk
     - id: SpawnLootTechDisksT2Mech
       prob: 0.5
@@ -143,68 +123,50 @@
   components:
   - type: SpawnItemsOnUse
     items:
-    # Money
-    - id: SpaceCash25000
-      amount: 3
-      prob: 1.0
+    # Money - 200k
+    - id: SpaceCash100000
+      amount: 2
     # Scrap chunks
     - id: ScrapOre100
-      amount: 8
-      prob: 1.0
+      amount: 6
     # Material
     - id: SheetPlastitanium10
-      amount: 6
-      prob: 1
+      amount: 8
     # Parts
     - id: SuperCapacitorStockPart
-      prob: 1
       amount: 6
     - id: SuperMatterBinStockPart
-      prob: 1
       amount: 2
-    - id: PicoManipulatorStockPart
-      prob: 1
+    - id: PicoManipulatorStockPar
       amount: 4
     # rare t4 parts
     - id: QuadraticCapacitorStockPart
-      prob: 0.9
-      count: 2
-    - id: FemtoManipulatorStockPart
-      prob: 0.6
-      count: 2
-    - id: BluespaceMatterBinStockPart
-      prob: 0.3
-      count: 2
-    - id: SpawnDungeonLootPowerCell
-      count: 2
-      prob: 0.5
-    # - id: SpawnDungeonLootPartsEngi #Mono: mostly trash and bloat
-    #   amount: 3
-    #   prob: 0.25
-    # Circuit boards
-    - id: SpawnDungeonLootCircuitBoardEngi
-      prob: 0.3
-    - id: SpawnDungeonLootCircuitBoardScience
-      prob: 0.4
-    - id: SpawnDungeonLootCircuitBoardSalvage
-      prob: 0.4
-    - id: SpawnDungeonLootCircuitBoard
-      prob: 0.3
-    # Flatpacks
-    - id: SpawnDungeonLootFlatpacks
       amount: 3
-      prob: 0.5
-    # Research disk, expected value ~50k/drone
-    - id: RogueSiliconResearchDisk5000
-      prob: 1
-    - id: RogueSiliconResearchDisk10000
-      prob: 1
-    - id: RogueSiliconResearchDisk25000
-      prob: 0.6
+      maxAmount: 6
+    - id: FemtoManipulatorStockPart
+      amount: 2
+      maxAmount: 4
+    - id: BluespaceMatterBinStockPart
+      amount: 0
+      maxAmount: 2
+    - id: SpawnDungeonLootPowerCell
+      amount: 1
+      maxAmount: 2
+    - id: PowerCellMicroreactor
+    # free guns
+    - id: WeaponTurretShardFlatpack
+      amount: 1
+      maxAmount: 2
+    - id: WeaponTurretPinholeFlatpack
+    # no flatpacks or boards, just gamble scrap
+    # Research disk, expected value 200k/drone
     - id: RogueSiliconResearchDisk50000
-      prob: 0.4
+      amount: 3
+      maxAmount: 5
     # Tech disk
-    - id: SpawnLootTechDisksT2Mech
-      prob: 0.5
+    - id: SpawnLootTechDisksT3Mech
+      prob: 0.6
+    - id: SpawnLootTechDisksT3Fracture
+      prob: 0.2
     sound:
       path: /Audio/Machines/windoor_open.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
@@ -55,6 +55,28 @@
 
 - type: entity
   parent: BaseFlatpack
+  id: WeaponTurretShardFlatpack
+  name: Shard flatpack
+  description: A flatpack used for constructing an "Shard"-designation ultralight mass driver.
+  components:
+  - type: Flatpack
+    entity: WeaponTurretShard
+  - type: StaticPrice
+    price: 250
+
+- type: entity
+  parent: BaseFlatpack
+  id: WeaponTurretPinholeFlatpack
+  name: Pinhole flatpack
+  description: A flatpack used for constructing an "Pinhole"-designation mass driver.
+  components:
+  - type: Flatpack
+    entity: WeaponTurretPinhole
+  - type: StaticPrice
+    price: 500
+
+- type: entity
+  parent: BaseFlatpack
   id: FTLDriveFlatpack
   name: CTLA-25 bluespace drive flatpack
   description: A flatpack used for constructing a CTLA-25 bluespace drive.

--- a/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
+++ b/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
@@ -146,7 +146,7 @@
     - id: NFWreckDebrisBrassExtraLarge
       prob: 3
       orGroup: wreck
-    - id: MonoRamDroneSpawnerT1
+    - id: MonoDroneSpawnerT1
       prob: 3
       orGroup: wreck
 
@@ -174,8 +174,8 @@
     - id: NFWreckDebrisBrassExtraLarge
       prob: 0.3
       orGroup: wreck
-    - id: MonoRamDroneSpawnerT2Inner
-      prob: 4
+    - id: MonoDroneSpawnerT2Inner
+      prob: 2.5
       orGroup: wreck
 
 - type: spaceBiome
@@ -202,6 +202,6 @@
     - id: NFWreckDebrisBrassExtraLarge
       prob: 0.3
       orGroup: wreck
-    - id: MonoRamDroneSpawnerT2Middle
-      prob: 4
+    - id: MonoDroneSpawnerT2Middle
+      prob: 2.5
       orGroup: wreck

--- a/Resources/Prototypes/_Mono/Entities/World/Debris/drone.yml
+++ b/Resources/Prototypes/_Mono/Entities/World/Debris/drone.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: MonoRamDroneSpawnerT1
+  id: MonoDroneSpawnerT1
   parent: MarkerBase
   components:
   - type: RandomSpawner
@@ -8,7 +8,7 @@
     - SpawnDroneBasicMedium
 
 - type: entity
-  id: MonoRamDroneSpawnerT2Inner
+  id: MonoDroneSpawnerT2Inner
   parent: MarkerBase
   components:
   - type: RandomSpawner
@@ -18,7 +18,7 @@
     - SpawnDroneGust
 
 - type: entity
-  id: MonoRamDroneSpawnerT2Middle
+  id: MonoDroneSpawnerT2Middle
   parent: MarkerBase
   components:
   - type: EntityTableSpawner

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/tools.yml
@@ -30,7 +30,7 @@
     Plasteel: 1600
     Plasma: 2000
     Gold: 2000
-    
+
 - type: latheRecipe
   parent: BaseToolRecipe
   id: ShipRepairDeviceAmmo
@@ -40,10 +40,10 @@
     Plastic: 800
     Glass: 800
     Plasteel: 1600
-    
+
 - type: latheRecipe
   parent: BaseToolRecipe
   id: ScrapShipRepairDeviceAmmo
   result: ShipRepairDeviceAmmo
   materials:
-    RawScrap: 50000
+    RawScrap: 10000

--- a/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_silicons.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Backpacks/npc_loot_silicons.yml
@@ -38,7 +38,7 @@
   - type: SpawnItemsOnUse
     items:
     # Scrap chunks
-    - id: ScrapOre50
+    - id: ScrapOre10
       prob: 1.0
     # Parts
     - id: SuperCapacitorStockPart
@@ -100,10 +100,8 @@
   - type: SpawnItemsOnUse
     items:
     # Scrap chunks
-    - id: ScrapOre50
-      prob: 1.0
     - id: ScrapOre20
-      prob: 0.5
+      prob: 0.6
     # Parts
     - id: QuadraticCapacitorStockPart
       prob: 0.05
@@ -175,8 +173,8 @@
   - type: SpawnItemsOnUse
     items:
     # Scrap chunks
-    - id: ScrapOre100
-      prob: 1.0
+    - id: ScrapOre20
+      prob: 1
     # Parts
     - id: QuadraticCapacitorStockPart
       prob: 0.12
@@ -242,9 +240,7 @@
     items:
     # Scrap chunks
     - id: ScrapOre100
-      prob: 1.0
-    - id: ScrapOre20
-      prob: 0.5
+      prob: 0.4
     # Parts
     - id: QuadraticCapacitorStockPart
       prob: 0.4
@@ -311,9 +307,7 @@
     items:
     # Scrap chunks
     - id: ScrapOre100
-      prob: 1.0
-    - id: ScrapOre50
-      prob: 0.5
+      prob: 0.6
     - id: WeaponLaserTurboNF
       prob: 0.1
     # Parts

--- a/Resources/Prototypes/_NF/Entities/Materials/ore.yml
+++ b/Resources/Prototypes/_NF/Entities/Materials/ore.yml
@@ -20,9 +20,9 @@
 # Ore vein
 - type: ore
   id: NFOreScrap
-  oreEntity: ScrapOre3
-  minOreYield: 1
-  maxOreYield: 5
+  oreEntity: ScrapOre4
+  minOreYield: 0
+  maxOreYield: 1
 
 # Stacks
 - type: stack
@@ -48,7 +48,16 @@
   - type: Stack
     count: 3
 
-#Mono aditions
+#region Mono
+
+- type: entity
+  parent: ScrapOre
+  id: ScrapOre4
+  suffix: 3
+  components:
+  - type: Stack
+    count: 4
+
 - type: entity
   parent: ScrapOre
   id: ScrapOre20
@@ -72,7 +81,8 @@
   components:
   - type: Stack
     count: 100
-#Mono end
+
+#endregion Mono
 
 - type: material
   id: RawScrap
@@ -81,7 +91,7 @@
   unit: materials-unit-chunk
   icon: { sprite: /Textures/_NF/Objects/Materials/ore.rsi, state: scrapore }
   color: "#FFD700"
-  price: 0.02
+  price: 0.1
 
 # Spawner for lathe: yield random mats if processed in ore processor
 - type: entity
@@ -101,7 +111,7 @@
         color: red
   - type: RandomSpawner
     prototypes:
-#    - SpawnDungeonLootMaterialsBasicSingle #Mono out 
+#    - SpawnDungeonLootMaterialsBasicSingle #Mono out
 #    - SpawnDungeonLootMaterialsBasicSingle #wtf use entitytables
 #    - SpawnDungeonLootMaterialsBasicSingle
 #    - SpawnDungeonLootMaterialsBasicSingle

--- a/Resources/Prototypes/_NF/Entities/Materials/ore.yml
+++ b/Resources/Prototypes/_NF/Entities/Materials/ore.yml
@@ -59,8 +59,8 @@
     count: 4
 
 - type: entity
-  parent: ScrapOre10
-  id: ScrapOre4
+  parent: ScrapOre
+  id: ScrapOre10
   suffix: 10
   components:
   - type: Stack

--- a/Resources/Prototypes/_NF/Entities/Materials/ore.yml
+++ b/Resources/Prototypes/_NF/Entities/Materials/ore.yml
@@ -53,10 +53,18 @@
 - type: entity
   parent: ScrapOre
   id: ScrapOre4
-  suffix: 3
+  suffix: 4
   components:
   - type: Stack
     count: 4
+
+- type: entity
+  parent: ScrapOre10
+  id: ScrapOre4
+  suffix: 10
+  components:
+  - type: Stack
+    count: 10
 
 - type: entity
   parent: ScrapOre

--- a/Resources/Prototypes/_NF/Recipes/Lathes/materials.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/materials.yml
@@ -25,4 +25,4 @@
     sprite: _NF/Objects/Materials/ore.rsi
     state: scrapore
   materials:
-    RawScrap: 2000
+    RawScrap: 400 # Mono - 2000 > 400

--- a/Resources/Prototypes/_NF/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/sheet.yml
@@ -8,7 +8,7 @@
   categories:
   - Materials
   materialDiscountScale: 0
-  completetime: 0.06
+  completetime: 0.3
 
 #Mono fun installation
 - type: latheRecipe
@@ -16,7 +16,7 @@
   id: BaseMaterialsYesDiscountRecipe
   categories:
   - Materials
-  completetime: 0.06
+  completetime: 0.3
 
 # Recipes
 
@@ -86,42 +86,42 @@
   result: CableHVStack1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 20 # ~0.3 of steel sheet #Mono - 300 > 20
+    RawScrap: 4 # ~0.3 of steel sheet #Mono - 300 > 4
 
 - type: latheRecipe
   id: ScrapCableMVStack1
   result: CableMVStack1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 20 # ~0.3 of steel sheet #Mono - 300 > 20
+    RawScrap: 4 # ~0.3 of steel sheet #Mono - 300 > 4
 
 - type: latheRecipe
   id: ScrapCableApcStack1
   result: CableApcStack1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 20 # ~0.3 of steel sheet #Mono - 300 > 20
+    RawScrap: 4 # ~0.3 of steel sheet #Mono - 300 > 4
 
 - type: latheRecipe
   id: ScrapPartRodMetal1
   result: PartRodMetal1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 50 # ~0.5 of steel sheet #Mono - 500 > 50
+    RawScrap: 10 # ~0.5 of steel sheet #Mono - 500 > 10
 
 - type: latheRecipe
   id: ScrapSheetSteel1
   result: SheetSteel1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 100 #Mono 900 > 100
+    RawScrap: 20 #Mono 900 > 20
 
 - type: latheRecipe
   id: ScrapSheetGlass1
   result: SheetGlass1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 150 #Mono 1200 > 150
+    RawScrap: 30 #Mono 1200 > 30
 
 #Mono
 - type: latheRecipe
@@ -129,130 +129,130 @@
   result: MaterialWoodPlank1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 150
+    RawScrap: 30
 
 - type: latheRecipe
   id: ScrapSheetBrass1
   result: SheetBrass1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 150 #Mono 1500 > 150
+    RawScrap: 30 #Mono 1500 > 30
 
 - type: latheRecipe
   id: ScrapSheetRGlass1
   result: SheetRGlass1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 200 #Mono 1300 > 200
+    RawScrap: 40 #Mono 1300 > 40
 
 - type: latheRecipe
   id: ScrapSheetPlasteel1
   result: SheetPlasteel1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 600 #Mono 4000 > 600
+    RawScrap: 120 #Mono 4000 > 120
 
 - type: latheRecipe
   id: ScrapSheetPlastic1
   result: SheetPlastic1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 150 #Mono 1500 > 150
+    RawScrap: 30 #Mono 1500 > 30
 
 - type: latheRecipe
   id: ScrapSheetPlasma1
   result: SheetPlasma1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 600 #Mono 3000 > 60
+    RawScrap: 120 #Mono 3000 > 120
 
 - type: latheRecipe
   id: ScrapSheetUranium1
   result: SheetUranium1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 600 #Mono 3000 > 600
+    RawScrap: 120 #Mono 3000 > 120
 
 - type: latheRecipe
   id: ScrapIngotSilver1
   result: IngotSilver1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 500 #Mono 2300 > 500
+    RawScrap: 100 #Mono 2300 > 100
 
 - type: latheRecipe
   id: ScrapIngotGold1
   result: IngotGold1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 500 #Mono 3000 > 500
+    RawScrap: 100 #Mono 3000 > 100
 
 - type: latheRecipe
   id: ScrapMaterialBananium1
   result: MaterialBananium1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 1500 #Mono 6500 > 1500
+    RawScrap: 300 #Mono 6500 > 300
 
 - type: latheRecipe
   id: ScrapMaterialCloth1
   result: MaterialCloth1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 150 #Mono 800 > 150
+    RawScrap: 30 #Mono 800 > 30
 
 - type: latheRecipe
   id: ScrapMaterialDurathread1
   result: MaterialDurathread1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 300 #Mono 2300 > 300
+    RawScrap: 60 #Mono 2300 > 60
 
 - type: latheRecipe
   id: ScrapSheetUGlass1
   result: SheetUGlass1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 850 #Mono 3300 > 850
+    RawScrap: 170 #Mono 3300 > 170
 
 - type: latheRecipe
   id: ScrapSheetPGlass1
   result: SheetPGlass1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 850 #Mono 3300 > 850
+    RawScrap: 170 #Mono 3300 > 170
 
 - type: latheRecipe
   id: ScrapSheetRUGlass1
   result: SheetRUGlass1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 900 #Mono 3700 > 900
+    RawScrap: 180 #Mono 3700 > 180
 
 - type: latheRecipe
   id: ScrapSheetRPGlass1
   result: SheetRPGlass1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 900 #Mono 3700 > 900
+    RawScrap: 180 #Mono 3700 > 180
 
 - type: latheRecipe
   id: ScrapSheetClockworkGlass1
   result: SheetClockworkGlass1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 300 #Mono 1400 > 300
+    RawScrap: 60 #Mono 1400 > 60
 
 - type: latheRecipe
   id: ScrapMaterialBluespace1
   result: MaterialBluespace1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 80000 #Mono 225k >> 80k
+    RawScrap: 16000 #Mono 225k >> 16k
 
 - type: latheRecipe
   id: ScrapMaterialDiamond1
   result: MaterialDiamond1
   parent: BaseMaterialsYesDiscountRecipe
   materials:
-    RawScrap: 80000 #Mono 300k >> 80k
+    RawScrap: 16000 #Mono 300k >> 16k

--- a/Resources/Prototypes/_NF/World/Biomes/basic.yml
+++ b/Resources/Prototypes/_NF/World/Biomes/basic.yml
@@ -362,6 +362,6 @@
     - id: NFWreckDebrisBrassExtraLarge
       prob: 0.1
       orGroup: wreck
-    - id: MonoRamDroneSpawnerT1 # Mono
+    - id: MonoDroneSpawnerT1 # Mono
       prob: 0.15
       orGroup: wreck


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- buffs drone loot a lot (see diff), justified considering you're liable to die and lose everything
- decreases drone spawnrates a bit because right now you just get swarmed and die
- downscales scrap 5x: it's now 5x as rare but 5x as valuable
- halves plasti wall plasti cost seeing we haven't seen anyone abuse them and they're a bit insane to make right now

i'm thinking i haven't even buffed drone loot enough but we'll see

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Significantly buffed outer reach drone loot.
- tweak: T2 outer reach drone spawnrates decreased.
- tweak: Scrap now has 5x less yield but is used 5x less.
- tweak: Plastitanium wall plastitanium cos halved.
