### PR TITLE
[FIX] Empty Welder Frontier Holdover

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Tools/welders.yml
@@ -29,7 +29,7 @@
     solutions:
       Welder:
         reagents: []
-        maxVol: 250
+        maxVol: 350
 
 - type: entity
   parent: WelderExperimental
@@ -40,4 +40,4 @@
     solutions:
       Welder:
         reagents: []
-        maxVol: 1000
+        maxVol: 2500


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
bugfix pr because frontier had empty welders that you printed from lathes, because of container shitcode they had to specify container volume, which wasnt updated in the very old original pr (#853)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Printed welding tools should now have the proper capacities.
