### PR TITLE
Material Preservation

### DIFF
--- a/Content.Shared/Materials/MaterialStorageComponent.cs
+++ b/Content.Shared/Materials/MaterialStorageComponent.cs
@@ -38,6 +38,12 @@ public sealed partial class MaterialStorageComponent : Component
     public bool DropOnDeconstruct = true;
 
     /// <summary>
+    /// Mono - Whether or not to drop contained materials when destroyed.
+    /// </summary>
+    [DataField]
+    public bool DropOnDestroy = true;
+
+    /// <summary>
     /// Whitelist generated on runtime for what specific materials can be inserted into this entity.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -15,6 +15,20 @@
     tags:
     - Sheet
     - Metal
+  - type: SolutionContainerManager
+    solutions:
+      steel:
+        canReact: false
+  - type: GuideHelp
+    guides:
+    - ExpandingRepairingStation
+
+# Mono - extract from SheetMetalBase
+- type: entity
+  abstract: true
+  parent: SheetMetalBase
+  id: SheetMetalBaseDestructible
+  components:
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
@@ -26,13 +40,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: SolutionContainerManager
-    solutions:
-      steel:
-        canReact: false
-  - type: GuideHelp
-    guides:
-    - ExpandingRepairingStation
 
 - type: entity
   parent: SheetMetalBase

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -12,6 +12,17 @@
   - type: Tag
     tags:
     - Sheet
+  - type: SolutionContainerManager
+    solutions:
+      paper:
+        canReact: false
+
+# Mono - extract from SheetOtherBase
+- type: entity
+  abstract: true
+  parent: SheetOtherBase
+  id: SheetOtherBaseDestructible
+  components:
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -22,10 +33,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: SolutionContainerManager
-    solutions:
-      paper:
-        canReact: false
 
 - type: entity
   parent: SheetOtherBase

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -13,6 +13,13 @@
     tags:
       - DroneUsable
       - RawMaterial
+
+# Mono - extract from MaterialBase
+- type: entity
+  abstract: true
+  parent: MaterialBase
+  id: MaterialBaseDestructible
+  components:
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- materials (that aren't glass) are no longer destructible because why were they
- lathes/silos now drop materials on destruction

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Lathes now drop material on destruction.
- tweak: Materials (except glass) are no longer destructible.
