### PR TITLE
Vendor Hack Freebie Touchup

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -470,7 +470,7 @@ namespace Content.Server.VendingMachines
             if (vendComponent.Ejecting)
                 return;
 
-            if (vendComponent.EjectRandomCounter <= 0)
+            if (vendComponent.EjectRandomCounter < 1)
             {
                 _audioSystem.PlayPvs(_audioSystem.GetSound(vendComponent.SoundDeny), uid);
                 _popupSystem.PopupEntity(Loc.GetString("vending-machine-component-try-eject-access-abused"), uid, PopupType.MediumCaution);
@@ -493,6 +493,15 @@ namespace Content.Server.VendingMachines
             }
             else
                 TryEjectVendorItem(uid, item.Type, item.ID, throwItem, vendComponent);
+
+            //Mono: allow max vends below 2, add probability for extra freebies
+            if (_random.Prob(vendComponent.EjectNoCountChance))
+                return;
+
+            if (vendComponent.EjectRandomCounter == vendComponent.EjectRandomMax)
+                vendComponent.EjectNextChargeTime = _timing.CurTime + vendComponent.EjectRechargeDuration;
+            //Mono end
+
             vendComponent.EjectRandomCounter -= 1;
         }
 

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -494,7 +494,7 @@ namespace Content.Server.VendingMachines
             else
                 TryEjectVendorItem(uid, item.Type, item.ID, throwItem, vendComponent);
 
-            //Mono: allow max vends below 2, add probability for extra freebies
+            //Mono: revise frontier vend protection, allow max vends below 2, add probability for extra freebies
             if (_random.Prob(vendComponent.EjectNoCountChance))
                 return;
 

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -36,28 +36,33 @@ namespace Content.Shared.VendingMachines
 
         // Frontier: random ejection
         /// <summary>
-        /// Used by the server to determine how many items the machine allowed to eject from random triggers.
+        /// Used by the server to determine how many items the machine allowed to eject from random triggers. (Default 2)
         /// </summary>
         [DataField]
-        public int EjectRandomMax = 2;
+        public int EjectRandomMax = 1;
 
         /// <summary>
-        /// Used by the server to determine how many items the machine ejected from random triggers.
+        /// Used by the server to determine how many items the machine ejected from random triggers. (Default 2)
         /// </summary>
         [DataField]
-        public int EjectRandomCounter = 2;
+        public int EjectRandomCounter = 1;
 
         /// <summary>
-        /// The time it takes to regain a single charge
+        /// The time it takes to regain a single charge (Default 1800)
         /// </summary>
         [DataField]
-        public TimeSpan EjectRechargeDuration = TimeSpan.FromSeconds(1800);
+        public TimeSpan EjectRechargeDuration = TimeSpan.FromSeconds(720);
 
         /// <summary>
         /// The time when the next charge will be added
         /// </summary>
         [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
         public TimeSpan EjectNextChargeTime;
+		
+        /// <summary>
+        /// Mono: Chance you can hit that vend wire again (Default 0)
+        /// </summary>
+		[DataField] public float EjectNoCountChance = 0.3f;
         // End Frontier: random ejection
 
         [DataField, AutoNetworkedField]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a check that prevents vendor protection from instantly refreshing, which caused an bug that prevented maximum freebies from being set to 1

Adds a probability value for skipping decrementing the freebie allowance of hacked vendors, which introduces variance in the number of items you can pulse out of a vending machine. I set it to 30% but this can be adjusted

Reduces hack allowance replenishment delay down from 30 minutes to 12 minutes

Overall: fewer items on average in one hacking session but over the long term even with a worst-case of 1 item per session always, you're able to eke out 2.5x more items from a vendor just pulsing it with a multitool

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Options that take a quarter of the shift to (fully) replenish aren't options at all
The RNG serves as a means to incentivize doing it without greatly overinflating the amount of items acquired

## How to test
<!-- Describe the way it can be tested -->

Hack the vend

Tamper with Monolith\content.shared\VendingMachines\VendingMachineComponent.cs

Mess with the fields
public TimeSpan EjectRechargeDuration = TimeSpan.FromSeconds(720);
[DataField] public float EjectNoCountChance = 0.3f;

To see how it behaves

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2f149225-10d8-44d0-b5ea-df454e65133c


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Small C# alterations
If the numbers are coal just fax better ones (no i will not make EjectNoCountChance 1.0f)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Vendors now lock up randomly (70% of the time) when hacked instead of on the third item and now unlock in 12 minutes instead of replenishing one freebie per 30 minutes.
