### PR TITLE
Printable Big Ammo Boxes

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/4.6x30mm.yml
@@ -188,7 +188,7 @@
     shape:
     - 0,0,1,1
   - type: BallisticAmmoProvider
-    capacity: 280 # 8 mags per box similar to rifle box
+    capacity: 240 # 3x ammo box
     proto: Cartridge46x30mmFMJ
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/45_ACP.yml
@@ -187,7 +187,7 @@
     shape:
     - 0,0,1,1
   - type: BallisticAmmoProvider
-    capacity: 280 # 8 mags per box similar to rifle box
+    capacity: 240 # 3x ammo box
     proto: Cartridge45_ACPFMJ
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/5.7x28mm.yml
@@ -188,7 +188,7 @@
     shape:
     - 0,0,1,1
   - type: BallisticAmmoProvider
-    capacity: 280 # 8 mags per box similar to rifle box
+    capacity: 240 # 3x ammo box
     proto: Cartridge57x28mmFMJ
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/6.35x40mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/6.35x40mm.yml
@@ -114,7 +114,7 @@
     shape:
     - 0,0,1,1
   - type: BallisticAmmoProvider
-    capacity: 200
+    capacity: 240
     proto: Cartridge635x40mmCaseless
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/Ammunition/Boxes/6.35x40mm_caseless.rsi

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/68x52mm.yml
@@ -91,7 +91,7 @@
     shape:
     - 0,0,1,1
   - type: BallisticAmmoProvider
-    capacity: 200
+    capacity: 240
     proto: Cartridge68x52mmCaseless
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/Ammunition/Boxes/6.35x40mm_caseless.rsi

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/9x19mm.yml
@@ -188,7 +188,7 @@
     shape:
     - 0,0,1,1
   - type: BallisticAmmoProvider
-    capacity: 280 # 8 mags per box similar to rifle box
+    capacity: 240 # 3x standard box
     proto: Cartridge9x19mmFMJ
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/FullyPowered_7.62x51mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/FullyPowered_7.62x51mm.yml
@@ -86,3 +86,9 @@
   parent: BaseAmmoRIPFullyPoweredAmmoBoxRecipe
   id: AmmoBox762x51mmRIP
   result: AmmoBox762x51mmRIP
+
+#big
+- type: latheRecipe
+  parent: BaseAmmoFMJFullyPoweredBigAmmoBoxRecipe
+  id: AmmoBox762x51mmBigFMJ
+  result: AmmoBox762x51mmBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/FullyPowered_7.62x54mmR.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/FullyPowered_7.62x54mmR.yml
@@ -93,3 +93,9 @@
   parent: BaseAmmoRIPFullyPoweredAmmoBoxRecipe
   id: AmmoBox762x54mmRRIP
   result: AmmoBox762x54mmRRIP
+
+#big box
+- type: latheRecipe
+  parent: BaseAmmoFMJFullyPoweredBigAmmoBoxRecipe
+  id: AmmoBox762x54mmRBigFMJ
+  result: AmmoBox762x54mmRBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_45_magnum.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_45_magnum.yml
@@ -138,3 +138,9 @@
   parent: BaseAmmoRIPIntermediateMagazineRecipe
   id: AmmoBox45_magnumRIP
   result: AmmoBox45_magnumRIP
+
+#big box
+- type: latheRecipe
+  parent: BaseAmmoFMJIntermediateBigAmmoBoxRecipe
+  id: AmmoBox45_magnumBigFMJ
+  result: AmmoBox45_magnumBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_5.56x45mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_5.56x45mm.yml
@@ -123,3 +123,9 @@
   parent: BaseAmmoRIPIntermediateAmmoBoxRecipe
   id: AmmoBox556x45mmRIP
   result: AmmoBox556x45mmRIP
+
+#big box
+- type: latheRecipe
+  parent: BaseAmmoFMJIntermediateBigAmmoBoxRecipe
+  id: AmmoBox556x45mmBigFMJ
+  result: AmmoBox556x45mmBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_68x52mm.yml
@@ -36,3 +36,10 @@
   parent: BaseAmmoPracticeIntermediateAmmoBoxRecipe
   id: AmmoBox68x52mmPractice
   result: AmmoBox68x52mmCaselessPractice
+
+#big box
+- type: latheRecipe
+  parent: BaseAmmoFMJIntermediateBigAmmoBoxRecipe
+  id: AmmoBox68x52mmCaselessBig
+  result: AmmoBox68x52mmCaselessBig
+

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_7.62x39mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_7.62x39mm.yml
@@ -113,3 +113,9 @@
   parent: BaseAmmoRIPIntermediateAmmoBoxRecipe
   id: AmmoBox762x39mmRIP
   result: AmmoBox762x39mmRIP
+
+#big box
+- type: latheRecipe
+  parent: BaseAmmoFMJIntermediateBigAmmoBoxRecipe
+  id: AmmoBox762x39mmBigFMJ
+  result: AmmoBox762x39mmBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_4.6x30mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_4.6x30mm.yml
@@ -143,3 +143,9 @@
   parent: BaseAmmoRIPPistolCaliberAmmoBoxRecipe
   id: AmmoBox46x30mmRIP
   result: AmmoBox46x30mmRIP
+
+#big box
+- type: latheRecipe
+  parent: BaseAmmoFMJPistolCaliberBigAmmoBoxRecipe
+  id: AmmoBox46x30mmBigFMJ
+  result: AmmoBox46x30mmBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_45_ACP.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_45_ACP.yml
@@ -143,3 +143,8 @@
   parent: BaseAmmoRIPPistolCaliberAmmoBoxRecipe
   id: AmmoBox45_ACPRIP
   result: AmmoBox45_ACPRIP
+
+- type: latheRecipe
+  parent: BaseAmmoFMJPistolCaliberBigAmmoBoxRecipe
+  id: AmmoBox45_ACPBigFMJ
+  result: AmmoBox45_ACPBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_5.7x28mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_5.7x28mm.yml
@@ -143,3 +143,9 @@
   parent: BaseAmmoRIPPistolCaliberAmmoBoxRecipe
   id: AmmoBox57x28mmRIP
   result: AmmoBox57x28mmRIP
+
+#big box
+- type: latheRecipe
+  parent: BaseAmmoFMJPistolCaliberBigAmmoBoxRecipe
+  id: AmmoBox57x28mmBigFMJ
+  result: AmmoBox57x28mmBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_6.35x40mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_6.35x40mm.yml
@@ -16,3 +16,8 @@
   parent: BaseAmmoFMJPistolCaliberAmmoBoxRecipe
   id: MagazineAsmgtUniversal635x40mm
   result: MagazineAsmgtUniversal635x40mm
+
+- type: latheRecipe
+  parent: BaseAmmoFMJPistolCaliberAmmoBoxRecipe
+  id: AmmoBox635x40mmCaselessBig
+  result: AmmoBox635x40mmCaselessBig

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_9x19mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/PistolCaliber_9x19mm.yml
@@ -180,3 +180,9 @@
   parent: BaseAmmoFMJPistolCaliberAmmoBoxRecipe
   id: MagazineAsmgtUniversal9x19mm
   result: MagazineAsmgtUniversal9x19mm
+
+  #big box
+- type: latheRecipe
+  parent: BaseAmmoFMJPistolCaliberBigAmmoBoxRecipe
+  id: AmmoBox9x19mmBigFMJ
+  result: AmmoBox9x19mmBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/BaseAmmo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/BaseAmmo.yml
@@ -824,3 +824,36 @@
   materials:
     Steel: 560
     Plasteel: 565
+
+#pistol caliber big
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: BaseAmmoFMJPistolCaliberBigAmmoBoxRecipe
+  categories:
+  - FMJAmmo
+  - Ammo
+  abstract: true
+  materials:
+    Steel: 3400
+
+#intermediate big
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: BaseAmmoFMJIntermediateBigAmmoBoxRecipe
+  categories:
+  - FMJAmmo
+  - Ammo
+  abstract: true
+  materials:
+    Steel: 4300
+
+#fully powered big
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: BaseAmmoFMJFullyPoweredBigAmmoBoxRecipe
+  categories:
+  - FMJAmmo
+  - Ammo
+  abstract: true
+  materials:
+    Steel: 5200

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
@@ -919,3 +919,6 @@
   - AmmoBox57x28mmBigFMJ
   - AmmoBox635x40mmCaselessBig #PDV
   - AmmoBox68x52mmCaselessBig #TSF
+
+#8x65 SKR Ammo Box
+  - AmmoBox8x65mmSKR

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
@@ -906,3 +906,16 @@
 
 #DP
   - MagazineDP29
+
+#Big Ammo Boxes
+  - AmmoBox762x39mmBigFMJ
+  - AmmoBox762x51mmBigFMJ
+  - AmmoBox762x54mmRBigFMJ
+  - AmmoBox9x19mmBigFMJ
+  - AmmoBox45_ACPBigFMJ
+  - AmmoBox45_magnumBigFMJ
+  - AmmoBox46x30mmBigFMJ
+  - AmmoBox556x45mmBigFMJ
+  - AmmoBox57x28mmBigFMJ
+  - AmmoBox635x40mmCaselessBig #PDV
+  - AmmoBox68x52mmCaselessBig #TSF

--- a/Resources/Prototypes/_Mono/Research/Rogue/rogue_weapons.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/rogue_weapons.yml
@@ -78,6 +78,7 @@
   recipeUnlocks:
   - WeaponSubMachineGunAtreidesRogue
   - WeaponShotgunBulldogRogue
+  - AmmoBox57x28mmBigFMJ
   technologyPrerequisites:
   - RogueAdvancedGuns
   position: 20, 8
@@ -113,6 +114,7 @@
   - Magazine635x40mmCaseless
   - AmmoBox635x40mmCaseless
   - MagazineAsmgtUniversal635x40mm
+  - AmmoBox635x40mmCaselessBig
   technologyPrerequisites:
   - RogueCQCGuns
   position: 21, 8

--- a/Resources/Prototypes/_Mono/Research/TSF/tsf_weapons.yml
+++ b/Resources/Prototypes/_Mono/Research/TSF/tsf_weapons.yml
@@ -53,6 +53,7 @@
   recipeUnlocks:
   #- WeaponLMGMR8BTSF
   - WeaponRifleMR8CTSF
+  - AmmoBox8x65mmSKR
   #- Magazine8x65mmSKRBox
   #- Magazine8x65mmEmptyBox
   technologyPrerequisites:

--- a/Resources/Prototypes/_Mono/Research/TSF/tsf_weapons.yml
+++ b/Resources/Prototypes/_Mono/Research/TSF/tsf_weapons.yml
@@ -37,6 +37,7 @@
   cost: 40000
   recipeUnlocks:
   - WeaponLMGGrizzlyTSF
+  - AmmoBox68x52mmCaselessBig
   technologyPrerequisites:
   - TsfAnnie
   - UniversalMaterialResearchT2

--- a/Resources/Prototypes/_Mono/Research/Universal/prerequisites.yml
+++ b/Resources/Prototypes/_Mono/Research/Universal/prerequisites.yml
@@ -37,6 +37,15 @@
   technologyPrerequisites:
   - UniversalMaterialResearchT1
   position: 10, 5
+  recipeUnlocks:
+  - AmmoBox762x39mmBigFMJ
+  - AmmoBox762x51mmBigFMJ
+  - AmmoBox762x54mmRBigFMJ
+  - AmmoBox9x19mmBigFMJ
+  - AmmoBox45_ACPBigFMJ
+  - AmmoBox45_magnumBigFMJ
+  - AmmoBox46x30mmBigFMJ
+  - AmmoBox556x45mmBigFMJ
 
 - type: technology
   id: UniversalMaterialResearchT3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
YAMLslaving printable large ammo boxes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With a few exceptions these were already purchasable from a Liberty Vendor for $200 apiece. Rather than add a liberty vendor to Halcyon because i'm clearly bias, I just made them printable with T2 Matsci tech as their research.

This also tweaked some large ammo boxes to have different capacity amounts, this is to standardize their material cost with their contents in case any goofy recycling shit happens in the future. Standard was set at 3x capacity and 3x cost of standard FMJ Ammo Boxes.

The exceptions are;
-6.35x40mm which is only normally found in PDV weapons and not accessible from the Liberty Vend, shows up from the applicable PDV weapon tech.
-5.7x28mm which is only found in the Atreides, also assigned to PDV tech.
-6.8x52mm caseless which is only really found in TSF weapons, assigned to TSF tech.
-8x65 SKR _ammo box_ which is only found in TSF weapons, assigned to TSF tech. 

## How to test
<!-- Describe the way it can be tested -->
Research console -> Research T2 Matsci, Grizzley, MARSOC, PDV CQC Weapons, or PDV Subsonic.
Military Multi-Purpose (or any DynamicAmmo lathe) -> Printable big ammo boxes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Big Ammo Boxes are now printable, gated behind T2 Matsci prerequisite technology or the applicable faction technology.