### PR TITLE
Buff Durand

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -231,8 +231,8 @@
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: MovementSpeedModifier # Mono
-    baseWalkSpeed: 2
-    baseSprintSpeed: 3.25
+    baseWalkSpeed: 3
+    baseSprintSpeed: 4.5
     baseWeightlessModifier: 5
   - type: StaticPrice
     price: 3000

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -231,8 +231,8 @@
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: MovementSpeedModifier # Mono
-    baseWalkSpeed: 3
-    baseSprintSpeed: 4.5
+    baseWalkSpeed: 2
+    baseSprintSpeed: 3.25
     baseWeightlessModifier: 5
   - type: StaticPrice
     price: 3000
@@ -290,7 +290,8 @@
     brokenState: durand-broken
     mechToPilotDamageMultiplier: 0.25
     airtight: true
-    maxIntegrity: 1200
+    maxIntegrity: 1350
+    maxEquipmentAmount: 3
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -300,8 +301,8 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 40
-        Structural: 220
+        Blunt: 60
+        Structural: 250
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
     baseSprintSpeed: 2
@@ -311,8 +312,8 @@
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: Repairable
-    fuelCost: 30
-    doAfterDelay: 15
+    fuelCost: 55
+    doAfterDelay: 20
   - type: StaticPrice
     price: 5000
   - type: Tag
@@ -654,7 +655,7 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 50
+        Blunt: 60
         Structural: 400
   - type: MovementSpeedModifier
     baseWalkSpeed: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Does minor stat changes to Gygax and Durand, nerfing gygax speed slightly and buffing Durand's health and equipment count.

## Why / Balance
The durand wasnt being used at all due to the fact the Gygax was better in every way shape and form, and if you needed more armor an S2 would do better.

## How to test
Spawn in and shoot the fuck out of it ig

## Media
No media due to number change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Mald PR's

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Buffed Durand health and speed
- tweak: Added extra equipment slot to Durand
