### PR TITLE
Ports #40933 "Fix Shuttle FTL with UI Scale" From Upstream

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -139,7 +139,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
                 else
                 {
                     // We'll send the "adjusted" position and server will adjust it back when relevant.
-                    var mapCoords = new MapCoordinates(InverseMapPosition(args.RelativePosition), ViewingMap);
+                    var mapCoords = new MapCoordinates(InverseMapPosition(args.RelativePixelPosition), ViewingMap);
 
                     RequestFTL?.Invoke(mapCoords, _ftlAngle);
                 }
@@ -196,7 +196,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
         // Remove offset so we can floor.
         var botLeft = new Vector2(0f, 0f);
-        var topRight = botLeft + Size;
+        var topRight = botLeft + PixelSize;
 
         var flooredBL = botLeft - originBL;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
ports https://github.com/space-wizards/space-station-14/pull/40933/changes from upstream

people have been reporting issues with the FTL screen showing up when they have non-100 ui scale. this fixes it and hopefully doesnt fuck anything else

edit: 
ok so the issue is with FTL that it wouldnt do anything unless you were clicking the top left corner
and same with gunnery

this PR seems to fix FTL but gunnery **blips** are only visible in top left corner

they still fire tho

<img width="947" height="520" alt="image" src="https://github.com/user-attachments/assets/be4a5706-b2a1-42d7-96c1-258b35e4a5d4" />


## How to test
<!-- Describe the way it can be tested -->
load in
test 100% ui scale on shuttle console + map screen
test 200% ui scale on shuttle ocnsole + map screen


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1911" height="1030" alt="image" src="https://github.com/user-attachments/assets/180b0b99-d33c-4327-85f6-16bb13d493f3" />

<img width="1840" height="974" alt="image" src="https://github.com/user-attachments/assets/36df4666-ef68-4773-9927-6b379ac0b813" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: FTL/map screen no longer fucks up on non 100% u.i. scale options
-->
