### PR TITLE
Remove Self Recharge From TSF And Normal Energy Shield

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -454,9 +454,6 @@
     - type: Battery
       maxCharge: 60
       startingCharge: 60
-    - type: BatterySelfRecharger
-      autoRecharge: true
-      autoRechargeRate: 5
     - type: RechargeableBlocking
       # WD EDIT END
 


### PR DESCRIPTION
## About the PR
removes the passive recharge comp from energy shields, which also counts TSF ones

## Why / Balance
If you are using an energy shield, you should not be able to consistently switch back between energy shields over and over again in a bag because they self recharge. You can hold two in your pocket. EMP'ing someone whos got an energy shield will only do something for 2 minutes, until their shield instantly recharges and can be used again. Besides this, being able to self recharge as a thing so cheap, providing 50% protection, is not something it should do. Carry a portable recharger to actually recharge your shields. Raising the price of the eshield wouldn't do anything and lowering its protection values would make it entirely useless.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl:
- tweak: The base energy shield (TSF included) no longer self recharge. 