### PR TITLE
Add Missile Tracking Targets

### DIFF
--- a/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingSystem.cs
+++ b/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingSystem.cs
@@ -70,7 +70,7 @@ public sealed class TargetSeekingSystem : EntitySystem
 
     /// <summary>
     /// Sets a target-seeking projectile's <see cref="TargetSeekingComponent.CurrentTarget"/>, and raises
-    /// the appropriate events. 
+    /// the appropriate events.
     /// </summary>
     // NOTE: In the future, someone could want to change this to separate whether `CurrentTarget` is null with whether the seeker is actually targeting something.
     //       If so, change this to take in whether the seeker should be targeting something, rather than whether the target exists.
@@ -212,7 +212,7 @@ public sealed class TargetSeekingSystem : EntitySystem
         EntityUid? bestTarget = null;
 
         // Look for shuttles to target
-        var shuttleQuery = EntityQueryEnumerator<ShuttleConsoleComponent>();
+        var shuttleQuery = EntityQueryEnumerator<TargetSeekingTargetComponent>();
 
         while (shuttleQuery.MoveNext(out var targetUid, out _))
         {

--- a/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingTargetComponent.cs
+++ b/Content.Server/_Mono/Projectiles/TargetSeeking/TargetSeekingTargetComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Server._Mono.Projectiles.TargetSeeking;
+
+[RegisterComponent]
+public sealed partial class TargetSeekingTargetComponent : Component;

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -130,6 +130,7 @@
   abstract: true
   components:
   - type: ShuttleConsole
+  - type: TargetSeekingTarget # Mono
   - type: ShipNpcTarget # Mono
     needPower: true
   - type: ShuttleConsoleLock

--- a/Resources/Prototypes/_Crescent/NPCs/Shuttle/control.yml
+++ b/Resources/Prototypes/_Crescent/NPCs/Shuttle/control.yml
@@ -54,6 +54,7 @@
   - type: Pullable
   - type: DroneControl
   - type: ShipNpcTarget
+  - type: TargetSeekingTarget # Mono
   - type: HTN
     sleepPlayerCheckRangeOverride: 100000 # 100k aka basically never sleep
     rootTask:

--- a/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/NPCs/ai.yml
@@ -54,6 +54,7 @@
   - type: ApcPowerReceiver
     powerLoad: 1000 # suspiciously low power-using AI
   - type: ExtensionCableReceiver
+  - type: TargetSeekingTarget
 
 - type: entity
   id: NpcStationAiApproacher

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -255,6 +255,7 @@
   - type: FireControlConsole
   - type: ShipNpcTarget
     needPower: true
+  - type: TargetSeekingTarget
   - type: ActivatableUI
     key: enum.FireControlConsoleUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/_Mono/Entities/World/Debris/drone.yml
+++ b/Resources/Prototypes/_Mono/Entities/World/Debris/drone.yml
@@ -62,6 +62,7 @@
       ignorePowered: true
       ignoreIFF: true
       ignorePrice: true
+      distanceOverride: 1024 # so it doesn't despawn while in view
     - type: RandomMetadata
       nameSeparator: ""
       nameSegments:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
see CL
also adjusts drone cleanup despawn range to 1024m so they don't despawn while fighting you

## Why / Balance
why didn't they

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Missiles now home into drones and gunnery consoles.
