### PR TITLE
Fixes Diamond Exo-Drills Being Unable to Drill Dense Deposits.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -51,3 +51,4 @@
         Brute: 18
       types:
         Structural: 90 # ~3 seconds for solid wall / 9 seconds for reinforced wall - 60->90 - Mono
+  - type: MiningGatheringHard

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -24,6 +24,7 @@
         Brute: 9
       types:
         Structural: 60 # ~10 seconds for solid wall / ~21 secods for reinforced wall - 40->60 - Mono
+  - type: MiningGatheringSoft
 
 - type: entity
   id: WeaponMechMeleeDrillDiamond
@@ -51,4 +52,5 @@
         Brute: 18
       types:
         Structural: 90 # ~3 seconds for solid wall / 9 seconds for reinforced wall - 60->90 - Mono
+  - type: MiningGatheringSoft
   - type: MiningGatheringHard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Added the appropriate property from the handheld Diamond Drill to the Exosuit Diamond Drill, allowing it to drill hardened deposits.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Seems silly for the hand diamond drill to dig hard rock and not the bigger diamond drill for the exosuit.

## How to test
<!-- Describe the way it can be tested -->
Spawn exosuit, apply regular drill, apply diamond drill, compare against dense mineral deposits.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None expected

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed diamond exo-drills not drilling hard rocks.