### PR TITLE
Nuke Cyborg AA

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -330,7 +330,9 @@
   - type: Access
     enabled: false
     groups:
-    - AllAccess
+     - External # Mono
+     - Mercenary # Mono
+#    - AllAccess # Mono
 #  - type: AccessReader
 #    access: [["Command"], ["Research"]]
   - type: ShowJobIcons
@@ -397,7 +399,9 @@
   - type: Access
     enabled: false
     groups:
-    - AllAccess #Randomized access would be fun. AllAccess is the best i can think of right now that does make it too hard for it to enter the station or navigate it..
+     - External # Mono
+     - Mercenary # Mono
+#    - AllAccess # Mono
   # - type: AccessReader # Frontier
   #   access: [["Command"], ["Research"]] # Frontier
   - type: StartIonStormed

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -328,10 +328,11 @@
     factions:
     - NanoTrasen
   - type: Access
-    enabled: false
-    groups:
+    tags:
      - External # Mono
      - Mercenary # Mono
+    enabled: false
+#   groups:
 #    - AllAccess # Mono
 #  - type: AccessReader
 #    access: [["Command"], ["Research"]]
@@ -397,11 +398,12 @@
     factions:
     - NanoTrasen #The seemingly best fit. It was a regular NT cyborg once, after all.
   - type: Access
-    enabled: false
-    groups:
+    tags:
      - External # Mono
      - Mercenary # Mono
-#    - AllAccess # Mono
+    enabled: false
+  # groups:
+  #   - AllAccess # Mono
   # - type: AccessReader # Frontier
   #   access: [["Command"], ["Research"]] # Frontier
   - type: StartIonStormed


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes AA from Cyborg innate access, adds External and Mercenary access.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Cyborg AA has been abused to steal from secure areas they have no business being in. Given their crew affiliations, instead of blanket AA they now instead have NO access except External and Mercenary. With the way Access is handled on Monolith, the only things this impacts are Cyborgs trespassing into CC's Bridge, CSec's department, DoC's Office, and TSF/PDV base areas.

This does not impact TSF/PDV Cyborgs, who already had their own special set of accesses.

Yes you can still break into places manually, but that has its own way of being handled ICly.

## How to test
<!-- Describe the way it can be tested -->
Spawn Borg -> You can no longer open locked doors.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Cyborgs and Derelict Cyborgs no longer have innate All Access.
