### PR TITLE
Restores Scream Action, Sets It to Not Auto-Populate on Spawn

### DIFF
--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class VocalComponent : Component
 
     [DataField("screamAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
     [AutoNetworkedField]
-    public string? ScreamAction; // Mono edit - kill hotbar scream action.
+    public string? ScreamAction = "ActionScream";
 
     [DataField("screamActionEntity")]
     [AutoNetworkedField]

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -19,6 +19,7 @@
     icon: Interface/Actions/scream.png
     event: !type:ScreamActionEvent
     checkCanInteract: false
+    autoPopulate: false
 
 - type: entity
   id: ActionTurnUndead
@@ -363,7 +364,7 @@
   components:
   - type: InstantAction
     useDelay: 8
-    icon: 
+    icon:
       sprite: Interface/Actions/jump.rsi
       state: icon
     event: !type:GravityJumpEvent {}

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -19,7 +19,7 @@
     icon: Interface/Actions/scream.png
     event: !type:ScreamActionEvent
     checkCanInteract: false
-    autoPopulate: false
+    autoPopulate: false # Mono
 
 - type: entity
   id: ActionTurnUndead

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -15,7 +15,7 @@
   description: AAAAAAAAAAAAAAAAAAAAAAAAA
   components:
   - type: InstantAction
-    useDelay: 1 # 10->1
+    useDelay: 3 # 10->3
     icon: Interface/Actions/scream.png
     event: !type:ScreamActionEvent
     checkCanInteract: false

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -15,7 +15,7 @@
   description: AAAAAAAAAAAAAAAAAAAAAAAAA
   components:
   - type: InstantAction
-    useDelay: 3 # 10->3
+    useDelay: 3 # Mono: 10->3
     icon: Interface/Actions/scream.png
     event: !type:ScreamActionEvent
     checkCanInteract: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Scream action is restored. It just is in the actions menu instead of the hotbar by default.

Also raises the cooldown from 1 to 3 (its been a while).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

While its stated its useless, being able to quickly scream in response to something like chimeras boarding your ship is generally good RP. By having the action hidden away slightly, this pleases the people who don't care about it at all, hides it away gently from the emote spammers, and allows those interested to equip it at will.

I lowered the scream delay in the past, but I'll raise a bit as well to compensate. 1 second was kinda nuts and me just being silly.

## How to test
<!-- Describe the way it can be tested -->

Boot in, no scream action in hotbar, scream action in action menu that can be dragged to hotbar to be used.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="2553" height="1368" alt="Screamrestored" src="https://github.com/user-attachments/assets/2a772682-4257-4ef4-a7d1-d726960a1c51" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Scream action re-added. Does not populate the hotbar by default, but can be equipped from the actions menu as usual.
- tweak: Scream cooldown set to 3 seconds from 1.
