### PR TITLE
Hydrakin Low Pressure Tweak

### DIFF
--- a/Content.Server/Atmos/Components/BarotraumaComponent.cs
+++ b/Content.Server/Atmos/Components/BarotraumaComponent.cs
@@ -43,6 +43,15 @@ namespace Content.Server.Atmos.Components
         public float LowPressureModifier = 0f;
 
         /// <summary>
+        /// Damage Modifier Values - Mono
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float LowPressureDamageModifier = 1;
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float HighPressureDamageModifier = 1;
+
+
+        /// <summary>
         /// Whether the entity is immuned to pressure (i.e possess the PressureImmunity component)
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -257,8 +257,8 @@ namespace Content.Server.Atmos.EntitySystems
 
                 if (pressure <= Atmospherics.HazardLowPressure)
                 {
-                    // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false, origin: uid, canSever: false);
+                    // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear. - Mono: added damage modifier
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage * barotrauma.LowPressureDamageModifier, true, false, origin: uid, canSever: false);
 
                     if (!barotrauma.TakingDamage)
                     {
@@ -272,8 +272,8 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     var damageScale = MathF.Min(((pressure / Atmospherics.HazardHighPressure) - 1) * Atmospherics.PressureDamageCoefficient, Atmospherics.MaxHighPressureDamage);
 
-                    // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false, origin: uid, canSever: false);
+                    // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear. - Mono: added damage modifier
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale * barotrauma.HighPressureDamageModifier, true, false, origin: uid, canSever: false);
 
                     if (!barotrauma.TakingDamage)
                     {

--- a/Resources/Prototypes/_Obelisk/Entities/Mobs/Species/hydrakin.yml
+++ b/Resources/Prototypes/_Obelisk/Entities/Mobs/Species/hydrakin.yml
@@ -74,6 +74,8 @@
     ignoreHeatResistance: true
   - type: PressureProtection
     lowPressureMultiplier: 1.2
+  - type: Barotrauma # Innate low pressure damage resist TODO: implement it into pressureprotection, maybe, maybe not.
+    LowPressureDamageModifier: 0.5
   - type: Inventory
     speciesId: hydrakin
     templateId: hydrakin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Hydrakin take half damage from low pressure barotrauma

Implements innate barotrauma damage resist

disclaimer: untested atm

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
