### PR TITLE
Tweaks and Balancing to Big Mecha and Power Cages/Cells

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -322,9 +322,9 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 2800
+    maxCharge: 2800 # Mono: 1400 >> 2800
     startingCharge: 2800
-  - type: EmpResistance
+  - type: EmpResistance # Mono also
     coefficient: 0.000112
 
 - type: entity
@@ -342,7 +342,7 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 4600
+    maxCharge: 4600 # Mono: 2700 >> 4600
     startingCharge: 4600
 
 - type: entity
@@ -383,7 +383,7 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 6400
+    maxCharge: 6400 # Mono: 6100 >> 6400
     startingCharge: 6400
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -311,7 +311,7 @@
   id: PowerCageSmall
   parent: BasePowerCage
   name: small-capacity power cage
-  description: A rechargeable power cage for big devices. This is the cheapest kind you can find.
+  description: A rechargeable power cage for big devices. This is the cheapest kind you can find, but it comes with some moderate EMP shielding.
   components:
   - type: Sprite
     sprite: Objects/Power/power_cages.rsi
@@ -324,6 +324,8 @@
   - type: Battery
     maxCharge: 2800
     startingCharge: 2800
+  - type: EmpResistance
+    coefficient: 0.25
 
 - type: entity
   id: PowerCageMedium
@@ -358,11 +360,13 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 9001 # memes
-    startingCharge: 9001
+    maxCharge: 7200
+    startingCharge: 7200
   - type: BatterySelfRecharger
+    autoRechargePause: true
+    autoRechargePauseTime: 12 # Prevent continuous fire, but not a huge delay
     autoRecharge: true
-    autoRechargeRate: 30 # 5 minutes to fully recharge, 2.5x recharge rate of micro-reactor
+    autoRechargeRate: 30 # 4 minutes to fully recharge, 2.5x recharge rate of micro-reactor
 
 - type: entity
   id: PowerCageHigh

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -364,7 +364,7 @@
     startingCharge: 7200
   - type: BatterySelfRecharger
     autoRechargePause: true
-    autoRechargePauseTime: 12 # Prevent continuous fire, but not a huge delay
+    autoRechargePauseTime: 30 # Prevent continuous fire, but not a huge delay
     autoRecharge: true
     autoRechargeRate: 30 # 4 minutes to fully recharge, 2.5x recharge rate of micro-reactor
 

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -322,8 +322,8 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 1400
-    startingCharge: 1400
+    maxCharge: 2800
+    startingCharge: 2800
 
 - type: entity
   id: PowerCageMedium
@@ -340,14 +340,14 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 2700
-    startingCharge: 2700
+    maxCharge: 4600
+    startingCharge: 4600
 
 - type: entity
   id: PowerCageMech
   parent: BasePowerCage
   name: mech fuel cell
-  description: A rechargeable fuel cell for mechs.
+  description: An auto-recharging fuel cell for mechs.
   components:
   - type: Sprite
     sprite: Objects/Power/power_cages.rsi
@@ -358,8 +358,11 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 6000
-    startingCharge: 6000
+    maxCharge: 9001 # memes
+    startingCharge: 9001
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 30 # 5 minutes to fully recharge, 2.5x recharge rate of micro-reactor
 
 - type: entity
   id: PowerCageHigh
@@ -376,8 +379,8 @@
       state: o2
       shader: unshaded
   - type: Battery
-    maxCharge: 6200
-    startingCharge: 6200
+    maxCharge: 6400
+    startingCharge: 6400
 
 - type: entity
   id: PowerCageSmallEmpty
@@ -394,7 +397,6 @@
       shader: unshaded
       visible: false
   - type: Battery
-    maxCharge: 1400
     startingCharge: 0
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -325,7 +325,7 @@
     maxCharge: 2800
     startingCharge: 2800
   - type: EmpResistance
-    coefficient: 0.25
+    coefficient: 0.000112
 
 - type: entity
   id: PowerCageMedium

--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -95,6 +95,9 @@
     - MechEquipmentGrabber
     - MechEquipmentHorn
     - MechEquipmentGrabberSmall
+    - PowerCageSmall
+    - PowerCageMedium
+    - PowerCageHigh
 
 - type: latheRecipePack
   id: Modsuits

--- a/Resources/Prototypes/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/Recipes/Lathes/powercells.yml
@@ -48,31 +48,35 @@
   id: PowerCageSmall
   result: PowerCageSmall
   completetime: 10
-  materials:
+  materials: # Mono
     Steel: 500
+    Plasteel: 200
     Glass: 200
     Plastic: 200
+    Uranium: 200
+    Gold: 200
+    Diamond: 50
 
 - type: latheRecipe
   id: PowerCageMedium
   result: PowerCageMedium
   completetime: 15
-  materials:
-    Steel: 800
-    Glass: 400
-    Plastic: 400
-    Silver: 200
-    Gold: 200
+  materials: # Mono
+    Steel: 1000
+    Glass: 500
+    Plastic: 500
+    Silver: 250
+    Gold: 500
 
 - type: latheRecipe
   id: PowerCageHigh
   result: PowerCageHigh
   completetime: 20
-  materials:
-    Steel: 400
-    Plasteel: 800
-    Glass: 400
-    Plasma: 400
-    Plastic: 400
-    Silver: 400
-    Gold: 400
+  materials: # Mono
+    Steel: 500
+    Plasteel: 1000
+    Glass: 500
+    Plasma: 500
+    Plastic: 500
+    Silver: 500
+    Gold: 500

--- a/Resources/Prototypes/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/Recipes/Lathes/powercells.yml
@@ -47,27 +47,32 @@
 - type: latheRecipe
   id: PowerCageSmall
   result: PowerCageSmall
-  completetime: 3
+  completetime: 10
   materials:
     Steel: 200
+    Glass: 100
     Plastic: 100
 
 - type: latheRecipe
   id: PowerCageMedium
   result: PowerCageMedium
-  completetime: 6
+  completetime: 15
   materials:
-    Steel: 500
-    Glass: 500
-    Plastic: 250
+    Steel: 400
+    Glass: 200
+    Plastic: 200
+    Silver: 20
     Gold: 40
 
 - type: latheRecipe
   id: PowerCageHigh
   result: PowerCageHigh
-  completetime: 10
+  completetime: 20
   materials:
-    Steel: 600
-    Glass: 800
-    Plastic: 400
+    Steel: 200
+    Plasteel: 200
+    Glass: 400
+    Uranium: 40
+    Plastic: 200
+    Silver: 80
     Gold: 100

--- a/Resources/Prototypes/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/Recipes/Lathes/powercells.yml
@@ -49,30 +49,30 @@
   result: PowerCageSmall
   completetime: 10
   materials:
-    Steel: 200
-    Glass: 100
-    Plastic: 100
+    Steel: 500
+    Glass: 200
+    Plastic: 200
 
 - type: latheRecipe
   id: PowerCageMedium
   result: PowerCageMedium
   completetime: 15
   materials:
-    Steel: 400
-    Glass: 200
-    Plastic: 200
-    Silver: 20
-    Gold: 40
+    Steel: 800
+    Glass: 400
+    Plastic: 400
+    Silver: 200
+    Gold: 200
 
 - type: latheRecipe
   id: PowerCageHigh
   result: PowerCageHigh
   completetime: 20
   materials:
-    Steel: 200
-    Plasteel: 200
+    Steel: 400
+    Plasteel: 800
     Glass: 400
-    Uranium: 40
-    Plastic: 200
-    Silver: 80
-    Gold: 100
+    Plasma: 400
+    Plastic: 400
+    Silver: 400
+    Gold: 400

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -13,9 +13,9 @@
     projectileSpeed: 110
     fireRate: 5
     minAngle: 0
-    maxAngle: 20
-    angleIncrease: 4
-    angleDecay: 20
+    maxAngle: 15
+    angleIncrease: 1
+    angleDecay: 15
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -25,7 +25,7 @@
     maxCharge: 180
   - type: ProjectileBatteryAmmoProvider
     proto: 20mmBullet
-    fireCost: 60
+    fireCost: 45
   - type: Appearance
   - type: AmmoCounter
 
@@ -44,7 +44,7 @@
     fireRate: 14
     minAngle: 0
     maxAngle: 20
-    angleIncrease: 2
+    angleIncrease: 0.5
     angleDecay: 20
     selectedMode: FullAuto
     availableModes:
@@ -109,7 +109,7 @@
     fireRate: 2
     minAngle: 0
     maxAngle: 10
-    angleIncrease: 2
+    angleIncrease: 1.5
     angleDecay: 10
     selectedMode: FullAuto
     availableModes:
@@ -120,7 +120,7 @@
     maxCharge: 200
   - type: ProjectileBatteryAmmoProvider
     proto: Mech90mmBullet
-    fireCost: 200
+    fireCost: 120
   - type: Appearance
   - type: AmmoCounter
 
@@ -176,7 +176,7 @@
     maxCharge: 500
   - type: ProjectileBatteryAmmoProvider
     proto: ShipMissileASM302
-    fireCost: 500
+    fireCost: 300
   - type: Appearance
   - type: AmmoCounter
 
@@ -227,8 +227,8 @@
     shotsPerBurst: 3
     burstCooldown: 5
     minAngle: 0
-    maxAngle: 15
-    angleIncrease: 10
+    maxAngle: 12
+    angleIncrease: 1
     angleDecay: 20
     selectedMode: Burst
     availableModes:
@@ -271,7 +271,7 @@
     maxCharge: 300
   - type: ProjectileBatteryAmmoProvider
     proto: MechMediumPlasmaProjectile
-    fireCost: 70
+    fireCost: 100
   - type: Appearance
   - type: AmmoCounter
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -97,7 +97,7 @@
       types:
         Piercing: 60
         Blunt: 50
-        Structural: 200
+        Structural: 250
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
@@ -148,18 +148,18 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 100
-    intensitySlope: 20
-    maxIntensity: 30
+    totalIntensity: 200
+    intensitySlope: 4
+    maxIntensity: 100
   - type: GatheringProjectile
   - type: MiningGatheringSoft
   - type: MiningGatheringHard
   - type: TargetSeeking
     acceleration: 20
-    detectionRange: 1
-    scanArc: 1
+    detectionRange: 100
+    scanArc: 5
     launchSpeed: 10
-    maxSpeed: 50
+    maxSpeed: 64
 
 - type: entity
   id: BlanketFlare

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -242,8 +242,8 @@
   - type: GenericVisualizer
   # EXTREMELY slow in gravity. Only really good to taxi, and that's about it.
   - type: MovementSpeedModifier
-    baseWalkSpeed: 0.2
-    baseSprintSpeed: 1
+    baseWalkSpeed: 0.75
+    baseSprintSpeed: 1.33
     baseWeightlessModifier: 40
   - type: RadarBlip
     radarColor: "#E3E3E3"
@@ -356,8 +356,8 @@
         acts: ["Destruction"]
   # EXTREMELY slow in gravity. Only really good to taxi, and that's about it.
   - type: MovementSpeedModifier
-    baseWalkSpeed: 0.2
-    baseSprintSpeed: 1
+    baseWalkSpeed: 0.75
+    baseSprintSpeed: 1.33
     baseWeightlessModifier: 35
   - type: Damageable
     damageModifierSet: MechArmorLight
@@ -446,7 +446,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 6
-    baseWeightlessModifier: 0.3 # Barely usable in space.
+    baseWeightlessModifier: 0.66 # Barely usable in space.
   - type: Tag
     tags:
     - DoorBumpOpener
@@ -563,7 +563,7 @@
   - type: MovementAlwaysTouching
   # EXTREMELY slow in gravity. Only really good to taxi, and that's about it. Even worse than S2s
   - type: MovementSpeedModifier
-    baseWalkSpeed: 0.1
+    baseWalkSpeed: 0.5
     baseSprintSpeed: 1
     baseWeightlessModifier: 35
   - type: RadarBlip
@@ -681,8 +681,8 @@
     visualMultiplier: 2
   # EXTREMELY slow in gravity. Only really good to taxi, and that's about it. Even worse than S2s
   - type: MovementSpeedModifier
-    baseWalkSpeed: 0.25
-    baseSprintSpeed: 0.5
+    baseWalkSpeed: 0.4
+    baseSprintSpeed: 0.8
     baseWeightlessModifier: 30
   - type: Tag
     tags:
@@ -756,8 +756,8 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: MovementSpeedModifier
-    baseWalkSpeed: 0.1
-    baseSprintSpeed: 1
+    baseWalkSpeed: 0.5
+    baseSprintSpeed: 1.2
     baseWeightlessModifier: 50
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/mech_parts.yml
@@ -194,14 +194,15 @@
   - MonoMechGear
   completetime: 25
   materials:
-    Plasteel: 400
-    Glass: 400
-    Plastic: 200
-    Silver: 100
-    Plasma: 200
-    Gold: 100
-    UraniumFissile: 50
-    Bluespace: 5
+    Plasteel: 1000
+    Glass: 500
+    Steel: 500
+    Uranium: 500
+    Plastic: 500
+    Silver: 400
+    Gold: 400
+    UraniumFissile: 200
+    Bluespace: 100
 
 #IFFs
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/mech_parts.yml
@@ -194,10 +194,14 @@
   - MonoMechGear
   completetime: 25
   materials:
-    Steel: 600
-    Glass: 800
-    Plastic: 400
+    Plasteel: 400
+    Glass: 400
+    Plastic: 200
+    Silver: 100
+    Plasma: 200
     Gold: 100
+    UraniumFissile: 50
+    Bluespace: 5
 
 #IFFs
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/mech_parts.yml
@@ -199,10 +199,10 @@
     Steel: 500
     Uranium: 500
     Plastic: 500
-    Silver: 400
-    Gold: 400
-    UraniumFissile: 200
-    Bluespace: 100
+    Silver: 500
+    Gold: 500
+    UraniumFissile: 100
+    Diamond: 100
 
 #IFFs
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Slightly increases Sprint speed for S2 and S4 mecha to something more manageable for their large, girthy size. Still slower than a Marauder or Durand.
- Slightly increases Sabre weightless speed to something not entirely useless while still being useless for longer distances
- Rebalances mech power cages to have a more meaningful variety and adjusted costs, with even the smallest cage outclassing a hyper-capacity cell (since it's BIG and expensive).
- Rebalances Mech Fuel Cell to be very expensive but auto-charging (slowly) with a higher power ceiling, designed for the more power-hungry S2 and S4 mech weapons since it unlocks with the research for them.
- Tweaks the energy economy and stats of Frame weapons to reduce the dominance of the Ravager and improve the attractiveness of other Medium and Light Frame weapons.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
You didn't ask for this, but it is something that bugged me, how the S2 mecha were effectively out-classed in practically every way by the S4s in everything but size, and how high-end mech teams would have a fairly hard upper limit on combat effectiveness.
The cheap Small Cage is basically doubled in capacity and gains a total of 25 MJ of EMP resistance, the Medium Cage increases its capacity by 70%, and the High-capacity Cage isn't changed too much while its costs go up substantially.
Mech Fuel Cell is made very high capacity (7200) and auto-charges slowly (30/sec, four minutes from empty to full, 12-second usage delay on recharging) at the cost of being very expensive (2 fissile uranium and 1 bluespace crystal among other costs, 'shielding' to keep it from being super radioactive). This extends the utility of peak-equipped mechs indefinitely as long as they don't need repairs, but still keeps a fairly tight budget on the use of very powerful anti-ship weapons in any given engagement. Probably very powerful on S1 mechs, but offset by the low durability and weaker weapons of S1 mechs.
Made the S2 mecha slightly-less-useless outside of their focus area while still keeping them less-than-optimal in terms of mobility. The Sabre is now fairly good at close-range EVA operations while still remaining vastly inferior to the Broadsword and Halberd in long-range space ops, and those two suffer slightly less if they need to enter a grid: I want to push it higher to 1.5 and be equivalent to the Marauder, but I don't think that's what the server wants.
During this PR, I discovered that the Ravager is pretty much the meta choice for Flails - it does amazing damage and is ridiculously economical compared to all other Frame weapons. It probably isn't enough, but this PR also tries to reduce some of its energy economy while improving the economy of the other Medium, Heavy, and Light Frame weapons though various means.

## How to test
<!-- Describe the way it can be tested -->
Build/Spawn Broadswords, Flails, and their variants and run/fly around, load weapons with new cages/fuel cell and blam away.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a: Refactor

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Walk speed of all S2 and S4 mecha increased to roughly half their Sprint speeds.
- tweak: Broadsword and Halberd Sprint speed increased from 1 to 1.33
- tweak: Sabre space speed doubled from 0.3 to 0.66
- tweak: Spyglass Sprint speed increased from 0.5 to 0.8
- tweak: Mace Sprint speed increased from 1.0 to 1.2
- tweak: Increased capacity of all Power Cages
- tweak: Increased Lathe costs of all Power Cages
- add: Various Power Cages can be printed directly in the Exofab instead of needing a merc/military fab.
- tweak: Mech Fuel Cell now costs Fissile Uranium (1) and Diamond (1) among other cost changes, but auto-regens to full within 4 minutes. 
- tweak: Balance pass on Armored Frame (S2/S4 mech) weapons - RAC-6 spreads slower, LAC-29 spreads slower and firing is cheaper, DMR-90 spreads slower and fires cheaper, ASM-55 fires cheaper, R3 has bigger boom and has actual but limited tracking, Metronome structure damage increased slightly and accuracy greatly increased, Ravager firing costs increased