### PR TITLE
Shuttle Event Minimum Spawn Timer Decrease

### DIFF
--- a/Resources/Prototypes/_Mono/GameRules/base.yml
+++ b/Resources/Prototypes/_Mono/GameRules/base.yml
@@ -42,9 +42,9 @@
     scheduledGameRules: !type:NestedSelector
       tableId: ChimeraShipsTable
     minimumTimeUntilFirstEvent: 10800 # 3 hours
-    minMaxEventTiming:
-      min: 3600 # 60 minutes between events
-      max: 7200 # 120 minutes between events
+    minMaxEventTiming: #2-4
+      min: 2400 # 40 minutes between events
+      max: 4800 # 80 minutes between events
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_Mono/GameRules/base.yml
+++ b/Resources/Prototypes/_Mono/GameRules/base.yml
@@ -17,7 +17,7 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: DamagedAIShipsTableT2
-    minimumTimeUntilFirstEvent: 18000 # 5 hours
+    minimumTimeUntilFirstEvent: 14400 # 4 hours
     minMaxEventTiming:
       min: 3600 # 60 minutes between events
       max: 3600 # 60 minutes between events
@@ -29,7 +29,7 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: AsakimShipsTable
-    minimumTimeUntilFirstEvent: 10800 # 180 minutes
+    minimumTimeUntilFirstEvent: 7200 # 2 hours
     minMaxEventTiming:
       min: 3600 # 60 minutes between events
       max: 7200 # 120 minutes between events
@@ -41,10 +41,10 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: ChimeraShipsTable
-    minimumTimeUntilFirstEvent: 14400 # 240 minutes
+    minimumTimeUntilFirstEvent: 10800 # 3 hours
     minMaxEventTiming:
       min: 3600 # 60 minutes between events
-      max: 3600 # 60 minutes between events
+      max: 7200 # 120 minutes between events
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changes minimum time til event spawns for 6 hour rounds instead of 8 hour rounds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The swap to 6 hour rounds has caused some antagonists to show up relatively much later into the round.

This PR causes;
-Wyvern to potentially spawn at the 4 hour mark, which allows its scheduler to trigger more than once.
-Asakim to spawn from the 2 hour mark, because they're being separated from ADS.
-Chimera to spawn from the 3 hour mark. Their ships will have a globally _longer_ time between sightings, but the timer will be randomized so they don't only appear once per hour on a regular schedule.

## How to test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Shuttle event spawns (ADS, Asakim, Chimera) have had their spawn timers tweaked. You will now see the Wyvern, Asakim, and Chimera earlier into each round. Prepare carefully, for the horde is coming.