### PR TITLE
Adds Hunger and Thirst Processing Components to Hydrakin.

### DIFF
--- a/Resources/Prototypes/_Obelisk/Entities/Mobs/Player/hydrakin.yml
+++ b/Resources/Prototypes/_Obelisk/Entities/Mobs/Player/hydrakin.yml
@@ -3,11 +3,3 @@
   name: Urist McHydra
   parent: BaseMobHydrakin
   id: MobHydrakin
-  components:
-  - type: LanguageKnowledge
-    speaks:
-    - TauCetiBasic
-    - Hydraspeak
-    understands:
-    - TauCetiBasic
-    - Hydraspeak

--- a/Resources/Prototypes/_Obelisk/Entities/Mobs/Species/hydrakin.yml
+++ b/Resources/Prototypes/_Obelisk/Entities/Mobs/Species/hydrakin.yml
@@ -22,6 +22,8 @@
     state: full
   - type: BodyEmotes
     soundsId: ReptilianBodyEmotes
+  - type: Hunger
+  - type: Thirst
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Hydrakin
@@ -75,6 +77,13 @@
     ignoreHeatResistance: true
   - type: PressureProtection
     lowPressureMultiplier: 1.2
+  - type: LanguageKnowledge
+    speaks:
+    - TauCetiBasic
+    - Hydraspeak
+    understands:
+    - TauCetiBasic
+    - Hydraspeak
   - type: Inventory
     speciesId: hydrakin
     templateId: hydrakin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Enables hunger and thirst in Hydrakin definitions.
Moves species-specific languages for Hydrakin to the species mob definitions instead of the player mob definitions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Language definitions for other species are in their species mob definitions, feels cleaner and consistent and avoids potential issues down the road even if it works fine now. Most players will not notice this change.
#3243 did not add the Hunger or Thirst components to the species mob definitions as other species have: without this, Hydrakin still get neither hungry nor thirsty. Doesn't fix lore dietary discrepancy: Testing shows Hydrakin can eat both (nontoxic) raw meats and normal foods, including raw onion and chocolate, without issue.

## How to test
<!-- Describe the way it can be tested -->
Play as hydrakin, experience hunger and thirst (or take drugs that make you hungry/thirsty)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Added hunger and thirst to hydrakin for real.
- fix: Hydrakin species language definitions attached to species mob instead of player mob for consistency.