### PR TITLE
Self-Defense Loadout for Colonial Staff

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -129,6 +129,8 @@
   - ContractorTrinkets
   - ContractorBureaucracy
   - NFSpeciesSpecific
+  - ContractorFirearm # Mono
+  - ContractorMag # Mono
 
 - type: roleLoadout
   id: JobNFJanitor
@@ -149,6 +151,8 @@
   - ContractorFun
   - ContractorTrinkets
   - NFSpeciesSpecific
+  - ContractorFirearm # Mono
+  - ContractorMag # Mono
 
 - type: roleLoadout
   id: JobMailCarrier
@@ -170,6 +174,8 @@
   - ContractorTrinkets
   - ContractorBureaucracy
   - NFSpeciesSpecific
+  - ContractorFirearm # Mono
+  - ContractorMag # Mono
 
 - type: roleLoadout
   id: JobStationTrafficController
@@ -193,6 +199,8 @@
   - ContractorTrinkets
   - ContractorBureaucracy
   - NFSpeciesSpecific
+  - ContractorFirearm # Mono
+  - ContractorMag # Mono
 
 # Mono edit
 - type: roleLoadout


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the self-defense loadout group for Colonial Staff that is missing a weapon loadout.

## Why / Balance
Things go wrong! Sometimes, things go terribly wrong. Sometimes, the mail you're delivering belongs to someone who is now a chimera, sometimes someone brings something they shouldn't have to CC, or sometimes, someone decided it would be a good idea to shoot the Janitor.

It is reasonable to include the self-defense firearm loadout for Colonial Staff, as it gives them the choice to be able to try (and most likely still fail) to defend themselves with basic weaponry from round start, should the situation demand it.

## How to test
Open the loadouts for Janitors, Service Workers, Mail Carriers and STC, verify the existence of the aforementioned loadouts.

## Media
Ex: Janitor.
<img width="791" height="793" alt="image" src="https://github.com/user-attachments/assets/b7810fed-f0dd-403d-b64f-54a1f1bdb641" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Janitors, Service Workers, Mail Carriers and STC now have access to the self-defense weapon and ammunition loadouts.
