### PR TITLE
Utility Loadout Access for More Roles

### DIFF
--- a/Resources/Prototypes/_Mono/Loadouts/MedicalDispatch/role_loadouts_mdd.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/MedicalDispatch/role_loadouts_mdd.yml
@@ -20,6 +20,7 @@
   - ContractorWallet
   - ContractorCartridge
   - ContractorImplanter
+  - ContractorUtility
   - ContractorEncryptionKey
   - ContractorFun
   - ContractorTrinkets

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -125,6 +125,7 @@
   - ContractorWallet
   - ContractorCartridge
   - ContractorImplanter
+  - ContractorUtility # Mono
   - ContractorFun
   - ContractorTrinkets
   - ContractorBureaucracy
@@ -148,6 +149,7 @@
   - ContractorWallet
   - ContractorCartridge
   - ContractorImplanter
+  - ContractorUtility # Mono
   - ContractorFun
   - ContractorTrinkets
   - NFSpeciesSpecific
@@ -170,6 +172,7 @@
   - MailCarrierWallet
   - ContractorCartridge
   - ContractorImplanter
+  - ContractorUtility # Mono
   - ContractorFun
   - ContractorTrinkets
   - ContractorBureaucracy
@@ -195,6 +198,7 @@
   - ContractorWallet
   - ContractorCartridge
   - ContractorImplanter
+  - ContractorUtility # Mono
   - ContractorFun
   - ContractorTrinkets
   - ContractorBureaucracy
@@ -228,6 +232,7 @@
   - ContractorWallet
   - ContractorCartridge
   - ContractorImplanter
+  - ContractorUtility # Mono
  # - ContractorFun # Mono - no fun allowed
   - StationRepTrinkets
   - ContractorBureaucracy
@@ -256,6 +261,7 @@
   - ContractorWallet
   - ContractorCartridge
   - ContractorImplanter
+  - ContractorUtility # Mono
   - ContractorEncryptionKey
   - ContractorFun
   - ContractorTrinkets
@@ -281,6 +287,7 @@
   - ContractorWallet
   - ContractorCartridge
   - ContractorImplanter
+  - ContractorUtility # Mono
   - ContractorEncryptionKey
   - ContractorFun
   - ContractorTrinkets


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives the utility loadout (Tools) to service workers, janitors, mail carriers, STC, overseers, security guards, DoCs and emergency responders.

## Why / Balance
Currently, only Contractors, Pilots and Mercenaries have access to the utility loadout. With things as useful as a roundstart SRD, an extra bucket for the janitor or even certain animal cubes for a service worker, it really is quite a useful loadout group that should probably be more widely available.

## How to test
Open loadouts for the mentioned roles, verify the existence of the tools loadout.

## Media
Ex: Overseer
<img width="791" height="797" alt="image" src="https://github.com/user-attachments/assets/69fb3c65-d04c-4fda-a54c-8b7d57fbb879" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- add: More roles now have access to the tools roundstart loadout.