### PR TITLE
Optimise Blip Network Usage

### DIFF
--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -95,7 +95,7 @@ public sealed partial class RadarBlipsSystem : EntitySystem
             }
             var maybeGrid = grid != EntityUid.Invalid ? grid : (EntityUid?)null;
 
-            _cachedBlipData.Add(new(blip.Uid, predictedPos, blip.Rotation, maybeGrid, config));
+            _cachedBlipData.Add(new(blip.Uid, predictedPos, rotation, maybeGrid, config));
         }
 
         return _cachedBlipData;

--- a/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
+++ b/Content.Client/_Mono/Radar/RadarBlipsSystem.cs
@@ -13,17 +13,16 @@ public sealed partial class RadarBlipsSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xform = default!;
 
     private const double BlipStaleSeconds = 3.0;
-    private static readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> EmptyHitscanList = new();
     private TimeSpan _lastRequestTime = TimeSpan.Zero;
     private static readonly TimeSpan RequestThrottle = TimeSpan.FromMilliseconds(500);
 
     private TimeSpan _lastUpdatedTime;
     private List<BlipNetData> _blips = new();
-    private List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> _hitscans = new();
+    private List<HitscanNetData> _hitscans = new();
+    private List<BlipConfig> _configPalette = new();
 
     // cached results to avoid allocating on every draw/frame
     private readonly List<BlipData> _cachedBlipData = new();
-    private readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> _cachedHitscanData = new();
 
     public override void Initialize()
     {
@@ -34,24 +33,9 @@ public sealed partial class RadarBlipsSystem : EntitySystem
 
     private void HandleReceiveBlips(GiveBlipsEvent ev, EntitySessionEventArgs args)
     {
-        if (ev?.Blips == null)
-        {
-            _blips.Clear();
-        }
-        else
-        {
-            _blips = ev.Blips;
-        }
-
-        if (ev?.HitscanLines == null)
-        {
-            _hitscans = EmptyHitscanList;
-        }
-        else
-        {
-            _hitscans = ev.HitscanLines;
-        }
-
+        _configPalette = ev.ConfigPalette;
+        _blips = ev.Blips;
+        _hitscans = ev.HitscanLines;
         _lastUpdatedTime = _timing.CurTime;
     }
 
@@ -100,10 +84,15 @@ public sealed partial class RadarBlipsSystem : EntitySystem
 
             var predictedMap = _xform.ToMapCoordinates(predictedPos);
 
-            var config = blip.Config;
+            var config = _configPalette[blip.ConfigIndex];
+            var rotation = blip.Rotation;
             // hijack our shape if we're on a grid and we want to do that
-            if (_map.TryFindGridAt(predictedMap, out var grid, out _) && grid != EntityUid.Invalid && blip.OnGridConfig != null)
-                config = blip.OnGridConfig.Value;
+            if (_map.TryFindGridAt(predictedMap, out var grid, out _) && grid != EntityUid.Invalid)
+            {
+                if (blip.OnGridConfigIndex is { } gridIdx)
+                    config = _configPalette[gridIdx];
+                rotation += Transform(grid).LocalRotation;
+            }
             var maybeGrid = grid != EntityUid.Invalid ? grid : (EntityUid?)null;
 
             _cachedBlipData.Add(new(blip.Uid, predictedPos, blip.Rotation, maybeGrid, config));
@@ -115,18 +104,12 @@ public sealed partial class RadarBlipsSystem : EntitySystem
     /// <summary>
     /// Gets the hitscan lines to be rendered on the radar
     /// </summary>
-    public List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> GetHitscanLines()
+    public List<HitscanNetData> GetHitscanLines()
     {
-        _cachedHitscanData.Clear();
         if (_timing.CurTime.TotalSeconds - _lastUpdatedTime.TotalSeconds > BlipStaleSeconds)
-            return _cachedHitscanData;
+            return new();
 
-        foreach (var hitscan in _hitscans)
-        {
-            _cachedHitscanData.Add((hitscan.Start, hitscan.End, hitscan.Thickness, hitscan.Color));
-        }
-
-        return _cachedHitscanData;
+        return _hitscans;
     }
 }
 

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -296,7 +296,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
     protected override void CreateEffect(EntityUid gunUid, MuzzleFlashEvent message, EntityUid? user = null)
     {
-        var filter = Robust.Shared.Player.Filter.Pvs(gunUid, entityManager: EntityManager);
+        var filter = Robust.Shared.Player.Filter.Pvs(gunUid, 0.6f, EntityManager); // Mono - default -> 0.6f
 
         if (TryComp<ActorComponent>(user, out var actor))
             filter.RemovePlayer(actor.PlayerSession);

--- a/Content.Server/_Mono/Radar/RadarBlipSystem.cs
+++ b/Content.Server/_Mono/Radar/RadarBlipSystem.cs
@@ -15,8 +15,10 @@ public sealed partial class RadarBlipSystem : EntitySystem
 
     // Pooled collections to avoid per-request heap churn
     private readonly List<BlipNetData> _tempBlipsCache = new();
-    private readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> _tempHitscansCache = new();
+    private readonly List<HitscanNetData> _tempHitscansCache = new();
     private readonly List<EntityUid> _tempSourcesCache = new();
+    private readonly List<BlipConfig> _tempPaletteCache = new();
+    private readonly Dictionary<BlipConfig, ushort> _paletteIndex = new();
 
     public override void Initialize()
     {
@@ -27,10 +29,9 @@ public sealed partial class RadarBlipSystem : EntitySystem
 
     private void OnBlipsRequested(RequestBlipsEvent ev, EntitySessionEventArgs args)
     {
-        if (!TryGetEntity(ev.Radar, out var radarUid))
-            return;
-
-        if (!TryComp<RadarConsoleComponent>(radarUid, out var radar))
+        if (!TryGetEntity(ev.Radar, out var radarUid)
+            || !TryComp<RadarConsoleComponent>(radarUid, out var radar)
+        )
             return;
 
         var sourcesEv = new GetRadarSourcesEvent();
@@ -47,12 +48,14 @@ public sealed partial class RadarBlipSystem : EntitySystem
         AssembleHitscanReport((EntityUid)radarUid, _tempSourcesCache, radar);
 
         // Combine the blips and hitscan lines
-        var giveEv = new GiveBlipsEvent(_tempBlipsCache, _tempHitscansCache);
+        var giveEv = new GiveBlipsEvent(_tempPaletteCache, _tempBlipsCache, _tempHitscansCache);
         RaiseNetworkEvent(giveEv, args.SenderSession);
 
         _tempBlipsCache.Clear();
         _tempHitscansCache.Clear();
         _tempSourcesCache.Clear();
+        _tempPaletteCache.Clear();
+        _paletteIndex.Clear();
     }
 
     private void OnBlipShutdown(EntityUid blipUid, RadarBlipComponent component, ComponentShutdown args)
@@ -64,68 +67,86 @@ public sealed partial class RadarBlipSystem : EntitySystem
 
     private void AssembleBlipsReport(EntityUid uid, List<EntityUid> sources, RadarConsoleComponent? component = null)
     {
-        _tempBlipsCache.Clear();
+        if (!Resolve(uid, ref component))
+            return;
 
-        if (Resolve(uid, ref component))
+        var radarXform = Transform(uid);
+        var radarGrid = radarXform.GridUid;
+        var radarMapId = radarXform.MapID;
+
+        var blipQuery = EntityQueryEnumerator<RadarBlipComponent, TransformComponent, PhysicsComponent>();
+
+        while (blipQuery.MoveNext(out var blipUid, out var blip, out var blipXform, out var blipPhysics))
         {
-            var radarXform = Transform(uid);
-            var radarGrid = radarXform.GridUid;
-            var radarMapId = radarXform.MapID;
+            if (!blip.Enabled
+                || blipXform.MapID != radarMapId
+                || !NearAnySources(_xform.GetWorldPosition(blipXform), sources, blip.MaxDistance)
+            )
+                continue;
 
-            var blipQuery = EntityQueryEnumerator<RadarBlipComponent, TransformComponent, PhysicsComponent>();
+            var blipGrid = blipXform.GridUid;
 
-            while (blipQuery.MoveNext(out var blipUid, out var blip, out var blipXform, out var blipPhysics))
+            if (blip.RequireNoGrid && blipGrid != null // if we want no grid but we are on a grid
+                || !blip.VisibleFromOtherGrids && blipGrid != radarGrid // or if we don't want to be visible from other grids but we're on another grid
+            )
+                continue; // don't show this blip
+
+            var netBlipUid = GetNetEntity(blipUid);
+
+            var blipVelocity = _physics.GetMapLinearVelocity(blipUid, blipPhysics, blipXform);
+
+            // due to PVS being a thing, things will break if we try to parent to not the map or a grid
+            var coord = blipXform.Coordinates;
+            if (blipXform.ParentUid != blipXform.MapUid && blipXform.ParentUid != blipGrid)
+                coord = _xform.WithEntityId(coord, blipGrid ?? blipXform.MapUid!.Value);
+
+            var gridCfg = (BlipConfig?)null;
+            var rotation = _xform.GetWorldRotation(blipXform);
+
+            // we're parented to either the map or a grid and this is relative velocity so account for grid movement
+            if (blipGrid != null)
             {
-                if (!blip.Enabled)
-                    continue;
-
-                // This prevents blips from showing on radars that are on different maps
-                if (blipXform.MapID != radarMapId)
-                    continue;
-
-                if (!NearAnySources(_xform.GetWorldPosition(blipXform), sources, blip.MaxDistance))
-                    continue;
-
-                var blipGrid = blipXform.GridUid;
-
-                if (blip.RequireNoGrid && blipGrid != null // if we want no grid but we are on a grid
-                    || !blip.VisibleFromOtherGrids && blipGrid != radarGrid) // or if we don't want to be visible from other grids but we're on another grid
-                    continue; // don't show this blip
-
-                var netBlipUid = GetNetEntity(blipUid);
-
-                var blipVelocity = _physics.GetMapLinearVelocity(blipUid, blipPhysics, blipXform);
-
-                // due to PVS being a thing, things will break if we try to parent to not the map or a grid
-                var coord = blipXform.Coordinates;
-                if (blipXform.ParentUid != blipXform.MapUid && blipXform.ParentUid != blipGrid)
-                    coord = _xform.WithEntityId(coord, blipGrid ?? blipXform.MapUid!.Value);
-
-                var gridCfg = (BlipConfig?)null;
-                var rotation = _xform.GetWorldRotation(blipXform);
-
-                // we're parented to either the map or a grid and this is relative velocity so account for grid movement
-                if (blipGrid != null)
-                {
-                    blipVelocity -= _physics.GetLinearVelocity(blipGrid.Value, coord.Position);
-
-                    var gridXform = Transform(blipGrid.Value);
-                    // it's local-frame velocity so rotate it too
-                    blipVelocity = (-gridXform.LocalRotation).RotateVec(blipVelocity);
-
-                    // and hijack our shape if we want to
-                    gridCfg = blip.GridConfig;
-                }
-
-                // ideally we would handle blips being culled by detection on server but detection grid culling is already clientside so might as well
-                _tempBlipsCache.Add(new(netBlipUid,
-                              GetNetCoordinates(coord),
-                              blipVelocity,
-                              rotation,
-                              blip.Config,
-                              gridCfg));
+                var gridXform = Transform(blipGrid.Value);
+                blipVelocity -= _physics.GetLinearVelocity(blipGrid.Value, coord.Position);
+                // it's local-frame velocity so rotate it too
+                blipVelocity = (-gridXform.LocalRotation).RotateVec(blipVelocity);
+                // and also offset the rotation
+                rotation -= gridXform.LocalRotation;
+                // and hijack our shape if we want to
+                gridCfg = blip.GridConfig;
             }
+
+            var configIdx = GetOrAddConfig(blip.Config);
+            ushort? gridConfigIdx = gridCfg is { } gridCf ? GetOrAddConfig(gridCf) : null;
+
+            // ideally we would handle blips being culled by detection on server but detection grid culling is already clientside so might as well
+            _tempBlipsCache.Add(new(netBlipUid,
+                            GetNetCoordinates(coord),
+                            blipVelocity,
+                            rotation,
+                            configIdx,
+                            gridConfigIdx));
         }
+    }
+
+    /// <summary>
+    /// Gets or create palette index for blip config.
+    /// </summary>
+    private ushort GetOrAddConfig(BlipConfig config)
+    {
+        if (_paletteIndex.TryGetValue(config, out var index))
+            return index;
+
+        if (_tempPaletteCache.Count >= ushort.MaxValue)
+        {
+            Log.Error($"Blip config count overflow! Reached max {ushort.MaxValue}, but trying to add more.");
+            return 0;
+        }
+
+        index = (ushort)_tempPaletteCache.Count;
+        _tempPaletteCache.Add(config);
+        _paletteIndex[config] = index;
+        return index;
     }
 
     /// <summary>
@@ -133,8 +154,6 @@ public sealed partial class RadarBlipSystem : EntitySystem
     /// </summary>
     private void AssembleHitscanReport(EntityUid uid, List<EntityUid> sources, RadarConsoleComponent? component = null)
     {
-        _tempHitscansCache.Clear();
-
         if (!Resolve(uid, ref component))
             return;
 
@@ -150,7 +169,7 @@ public sealed partial class RadarBlipSystem : EntitySystem
             if (!NearAnySources(hitscan.StartPosition, sources, component.MaxRange) && NearAnySources(hitscan.EndPosition, sources, component.MaxRange))
                 continue;
 
-            _tempHitscansCache.Add((hitscan.StartPosition, hitscan.EndPosition, hitscan.LineThickness, hitscan.RadarColor));
+            _tempHitscansCache.Add(new(hitscan.StartPosition, hitscan.EndPosition, hitscan.LineThickness, hitscan.RadarColor));
         }
     }
 

--- a/Content.Shared/_Mono/Radar/RadarMessages.cs
+++ b/Content.Shared/_Mono/Radar/RadarMessages.cs
@@ -23,6 +23,11 @@ public enum RadarBlipShape
 public sealed class GiveBlipsEvent : EntityEventArgs
 {
     /// <summary>
+    /// Palette of blip configs, basically an int->config map.
+    /// </summary>
+    public readonly List<BlipConfig> ConfigPalette;
+
+    /// <summary>
     /// Blips are now (position, velocity, scale, color, shape).
     /// </summary>
     public readonly List<BlipNetData> Blips;
@@ -30,18 +35,14 @@ public sealed class GiveBlipsEvent : EntityEventArgs
     /// <summary>
     /// Hitscan lines to display on the radar as (start position, end position, thickness, color).
     /// </summary>
-    public readonly List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> HitscanLines;
-
-    public GiveBlipsEvent(List<BlipNetData> blips)
-    {
-        Blips = blips;
-        HitscanLines = new List<(Vector2 Start, Vector2 End, float Thickness, Color Color)>();
-    }
+    public readonly List<HitscanNetData> HitscanLines;
 
     public GiveBlipsEvent(
+        List<BlipConfig> configPalette,
         List<BlipNetData> blips,
-        List<(Vector2 Start, Vector2 End, float Thickness, Color Color)> hitscans)
+        List<HitscanNetData> hitscans)
     {
+        ConfigPalette = configPalette;
         Blips = blips;
         HitscanLines = hitscans;
     }
@@ -75,9 +76,12 @@ public record struct BlipNetData
     NetCoordinates Position,
     Vector2 Vel,
     Angle Rotation,
-    BlipConfig Config,
-    BlipConfig? OnGridConfig
+    ushort ConfigIndex,
+    ushort? OnGridConfigIndex
 );
+
+[Serializable, NetSerializable]
+public record struct HitscanNetData(Vector2 Start, Vector2 End, float Thickness, Color Color);
 
 [Serializable, NetSerializable, DataDefinition]
 public partial record struct BlipConfig


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
cuts blip network usage in ~1/2
i could go further but that'd hurt performance for like 30B->24B aka 20% improvement
tested works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Significantly reduced radar blip network usage.
