### PR TITLE
Adjusts the Zephyr, Swaps Thrusters for TSF Variants, Lowers the Gunnery Server to Low.

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/Carrier/zephyr.yml
+++ b/Resources/Maps/_Mono/Shuttles/Carrier/zephyr.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/18/2026 08:42:36
+  time: 03/02/2026 19:39:00
   entityCount: 174
 maps: []
 grids:
@@ -109,10 +109,10 @@ entities:
             6: 0,-4
     - type: SpreaderGrid
       spreadQueues:
-        Puddle: []
-        Kudzu: []
-        Smoke: []
         MetalFoam: []
+        Kudzu: []
+        Puddle: []
+        Smoke: []
     - type: GridAtmosphere
       version: 2
       data:
@@ -686,7 +686,7 @@ entities:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-- proto: GunneryServerMedium
+- proto: GunneryServerLow
   entities:
   - uid: 85
     components:
@@ -696,7 +696,7 @@ entities:
     - type: Battery
       startingCharge: 0
     - type: ApcPowerReceiver
-      powerLoad: 10
+      powerLoad: 5
 - proto: PlasmaReinforcedWindowDirectional
   entities:
   - uid: 86
@@ -933,24 +933,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-- proto: SmallGyroscope
-  entities:
-  - uid: 98
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 1
-- proto: SmallThruster
+- proto: SmallGyroscopeNfsd
   entities:
   - uid: 99
     components:
     - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 100
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
+      pos: -1.5,-3.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
@@ -968,13 +956,23 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-- proto: Thruster
+- proto: ThrusterNfsd
   entities:
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
   - uid: 103
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-4.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
       parent: 1
   - uid: 104
     components:
@@ -985,14 +983,14 @@ entities:
   - uid: 105
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-5.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
       parent: 1
   - uid: 106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,-5.5
+      pos: -1.5,-5.5
       parent: 1
 - proto: WallReinforced
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Swaps the small and normal thrusters to TSF variants
- Swaps the small gyroscope to a small TSF gyroscope
- Lowers the gunnery server from Medium to Low.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Well, it's odd that the Zephyr is the only TSF ship with normal unarmored thrusters. This does, however, mean that the Zephyr has equal forwards and backwards thrust as there is no longer any small thrusters.

As for the gunnery server, the current loadout gives it 6 points to spare on a Low gunnery, which still allows it to upgrade to all 6 pointers.
## How to test
<!-- Describe the way it can be tested -->
* Enter game, spawn 2 CBURN IDs.
* Buy Tumour, buy Zephyr from the Tumour.
* Observe new thrusters.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="352" height="320" alt="zephyr-0" src="https://github.com/user-attachments/assets/c2b9537c-6af4-4136-9f0c-73218259f38f" />
<img width="352" height="320" alt="zephyr-0" src="https://github.com/user-attachments/assets/3b44ed81-d539-4391-bb76-1696ef89d096" />

(I'm aware that the ''before'' picture is the pre-diagonal version of the Zephyr. I forgot to rerun the renders. My bad.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Tumour's Zephyr class fighter now has TSF thrusters and gyroscopes.
- tweak: The Zephyr's gunnery server has been changed from Medium to Low.
