### PR TITLE
Rammable POIs

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -1,4 +1,5 @@
 using Content.Server.Shuttles.Components;
+using Content.Server._Mono.Shuttles.Components;
 using Content.Server._NF.Shuttles.Components;
 using Content.Shared._Crescent.ShipShields;
 using Content.Shared._Mono;
@@ -155,10 +156,9 @@ public sealed partial class ShuttleSystem
             if (!_enabled)
                 continue;
 
-
             // Check if either grid has GridGodMode or ForceAnchor protection
-            var ourProtected = HasComp<GridGodModeComponent>(args.OurEntity) || HasComp<ForceAnchorComponent>(args.OurEntity);
-            var otherProtected = HasComp<GridGodModeComponent>(args.OtherEntity) || HasComp<ForceAnchorComponent>(args.OtherEntity);
+            var ourProtected = HasComp<GridGodModeComponent>(args.OurEntity) || HasComp<NoGridImpactsComponent>(args.OurEntity);
+            var otherProtected = HasComp<GridGodModeComponent>(args.OtherEntity) || HasComp<NoGridImpactsComponent>(args.OtherEntity);
 
             // Check if the grids are docked together to prevent impact
             var areGridsDocked = _dockSystem.AreGridsDocked(args.OurEntity, args.OtherEntity);
@@ -210,10 +210,10 @@ public sealed partial class ShuttleSystem
                 && TryComp<ShipShieldEmitterComponent>(ShipShieldedComponent.Source, out var ShipShieldEmitterComponent)
             )
                 toUsEnergy *= ShipShieldEmitterComponent.CollisionResistanceMultiplier;
-            
+
             if (TryComp<ShipShieldedComponent>(args.OtherEntity, out var OtherShipShieldedComponent) //Other ship collision resistance
                 && TryComp<ShipShieldEmitterComponent>(OtherShipShieldedComponent.Source, out var OtherShipShieldEmitterComponent)
-            ) 
+            )
                 toOtherEnergy *= OtherShipShieldEmitterComponent.CollisionResistanceMultiplier;
             // Mono Edit end
 

--- a/Content.Server/_Mono/Shuttles/Components/NoGridImpactsComponent.cs
+++ b/Content.Server/_Mono/Shuttles/Components/NoGridImpactsComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._Mono.Shuttles.Components;
+
+/// <summary>
+/// Prevents grids from taking or dealing impact damage.
+/// </summary>
+[RegisterComponent]
+public sealed partial class NoGridImpactsComponent : Component;

--- a/Resources/Maps/_Mono/Outpost/colossus_central.yml
+++ b/Resources/Maps/_Mono/Outpost/colossus_central.yml
@@ -102,6 +102,7 @@ entities:
       protectedEntities: []
     - type: GridRaider
       protectedEntities: []
+    - type: NoGridImpacts
     - type: BecomesStation
       id: Frontier
     - type: InitRepairSnapshot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
eenables ram damage to all POIs that aren't CC

## Why / Balance
with SRD we can afford to make them rammable
also POI wall is ram-resistant anyway
and we have shields resisting impacts so you have to actually shoot at it for quite a bit before being able to ram

## How to test
1. get vulture
2. remove shields on poi and self (else it does nothing)
3. ram poi

## Media
<img width="298" height="321" alt="image" src="https://github.com/user-attachments/assets/564c9fec-6e30-499b-a2c1-2a4634d8fd64" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: POIs are now rammable, except CC.
