### PR TITLE
Allows All Moveable Shipguns to Be Rotated.

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/base_launcher.yml
@@ -46,7 +46,7 @@
   - type: Rotatable
     rotateWhilePulling: false
     rotateWhileAnchored: false
-    increment: 45
+    increment: 90
   - type: DeviceLinkSink
     ports:
     - SpaceArtilleryFire
@@ -195,6 +195,10 @@
   components:
   - type: Anchorable
     delay: 10
+  - type: Rotatable
+    rotateWhilePulling: false
+    rotateWhileAnchored: false
+    increment: 90
   - type: Pullable
   - type: PirateBountyItem # not putting this on the other, because like. how do you get a cyrexa for your bounty. thats stupid.
     id: ShipWeapon
@@ -307,6 +311,10 @@
   components:
   - type: Anchorable
     delay: 10
+  - type: Rotatable
+    rotateWhilePulling: false
+    rotateWhileAnchored: false
+    increment: 90
   - type: Pullable
   - type: PirateBountyItem # not putting this on the other, because like. how do you get a cyrexa for your bounty. thats stupid.
     id: ShipWeapon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

* Gives ```BallisticArtilleryCartridge``` and ```BallisticArtilleryMagazine``` the rotateable tag. 

* Also increases the rotation on ```BallisticArtilleryBase``` to 90.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QOL, the moveable energy ship guns can do it and it saves everyone smacking Vanyks or AK570s against the hull 20 times to get a spin going.

Also the guns couldn't be anchored at 45 degree angles, so might as well save clicks.
## How to test
<!-- Describe the way it can be tested -->

1. Spawn in the dev enviroment
2. Unanchor the AK570 (```BallisticArtilleryMagazine```) and the Vanyk (```BallisticArtilleryCartridge```)
3. See that you can rotate it. 

During my testing, I made sure to double check that the GCS and Shuttle Console could still fire them after rotating a bunch and re-anchoring.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="865" height="514" alt="Screenshot_20260304_102537" src="https://github.com/user-attachments/assets/c1b96f2a-d732-4b3e-ae66-388d3a6becda" />
<img width="865" height="514" alt="Screenshot_20260304_102607" src="https://github.com/user-attachments/assets/61d54dfc-7181-4c97-82a8-a7908240544c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Allows more shipguns to be rotated trough the right-click UI.
