### PR TITLE
Autopilot

### DIFF
--- a/Content.Client/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
+++ b/Content.Client/Shuttles/BUI/ShuttleConsoleBoundUserInterface.cs
@@ -6,6 +6,9 @@ using Robust.Client.UserInterface;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 
+// Mono
+using Content.Shared._Mono.Shuttles;
+
 namespace Content.Client.Shuttles.BUI;
 
 [UsedImplicitly]
@@ -25,6 +28,7 @@ public sealed partial class ShuttleConsoleBoundUserInterface : BoundUserInterfac
 
         _window.RequestFTL += OnFTLRequest;
         _window.RequestBeaconFTL += OnFTLBeaconRequest;
+        _window.RequestAutopilot += OnAutopilotRequest; // Mono
         _window.DockRequest += OnDockRequest;
         _window.UndockRequest += OnUndockRequest;
         _window.UndockAllRequest += OnUndockAllRequest;
@@ -72,6 +76,16 @@ public sealed partial class ShuttleConsoleBoundUserInterface : BoundUserInterfac
     private void OnFTLRequest(MapCoordinates obj, Angle angle)
     {
         SendMessage(new ShuttleConsoleFTLPositionMessage()
+        {
+            Coordinates = obj,
+            Angle = angle,
+        });
+    }
+
+    // Mono
+    private void OnAutopilotRequest(MapCoordinates obj, Angle angle)
+    {
+        SendMessage(new ShuttleConsoleAutopilotPositionMessage()
         {
             Coordinates = obj,
             Angle = angle,

--- a/Content.Client/Shuttles/UI/MapScreen.xaml
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml
@@ -82,6 +82,12 @@
                                  Text="{controls:Loc 'shuttle-console-ftl-button'}"
                                  TextAlign="Center"
                                  StyleClasses="ButtonSquare"/>
+                <!-- Mono - Autopilot -->
+                <controls:Button Name="MapAutopilotButton"
+                                 ToggleMode="True"
+                                 Text="{controls:Loc 'shuttle-console-autopilot-button'}"
+                                 TextAlign="Center"
+                                 StyleClasses="ButtonSquare"/>
                 <controls:Button Name="MapRebuildButton"
                         Text="{controls:Loc 'shuttle-console-map-rebuild'}"
                         TextAlign="Center"

--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -51,6 +51,9 @@ public sealed partial class MapScreen : BoxContainer
     private TimeSpan _pingCooldown = TimeSpan.FromSeconds(3);
     private TimeSpan _nextMapDequeue;
 
+    // Mono
+    private bool _autopilotTargeting = false;
+
     private float _minMapDequeue = 0.05f;
     private float _maxMapDequeue = 0.25f;
 
@@ -58,6 +61,9 @@ public sealed partial class MapScreen : BoxContainer
 
     public event Action<MapCoordinates, Angle>? RequestFTL;
     public event Action<NetEntity, Angle>? RequestBeaconFTL;
+
+    // Mono
+    public event Action<MapCoordinates, Angle>? RequestAutopilot;
 
     private readonly Dictionary<MapId, BoxContainer> _mapHeadings = new();
     private readonly Dictionary<MapId, List<IMapObject>> _mapObjects = new();
@@ -86,6 +92,7 @@ public sealed partial class MapScreen : BoxContainer
         OnVisibilityChanged += OnVisChange;
 
         MapFTLButton.OnToggled += FtlPreviewToggled;
+        MapAutopilotButton.OnToggled += AutopilotPreviewToggled; // Mono
 
         _ftlStyle = new StyleBoxFlat(Color.LimeGreen);
         FTLBar.ForegroundStyleBoxOverride = _ftlStyle;
@@ -93,7 +100,15 @@ public sealed partial class MapScreen : BoxContainer
         // Just pass it on up.
         MapRadar.RequestFTL += (coords, angle) =>
         {
-            RequestFTL?.Invoke(coords, angle);
+            if (_autopilotTargeting) // Mono
+            {
+                RequestAutopilot?.Invoke(coords, angle);
+                SetTargeting(false, true);
+            }
+            else
+            {
+                RequestFTL?.Invoke(coords, angle);
+            }
         };
 
         MapRadar.RequestBeaconFTL += (ent, angle) =>
@@ -192,12 +207,30 @@ public sealed partial class MapScreen : BoxContainer
 
     private void FtlPreviewToggled(BaseButton.ButtonToggledEventArgs obj)
     {
-        MapRadar.FtlMode = obj.Pressed;
+        SetTargeting(obj.Pressed, false);
+    }
 
-        // When FTL button is toggled, disable the ShowFTLRangeOnly mode
-        if (obj.Pressed)
+    // Mono
+    private void AutopilotPreviewToggled(BaseButton.ButtonToggledEventArgs obj)
+    {
+        SetTargeting(obj.Pressed, true);
+    }
+
+    // Mono
+    private void SetTargeting(bool pressed, bool isAutopilot)
+    {
+        if (pressed)
         {
+            MapRadar.FtlMode = true;
             MapRadar.ShowFTLRangeOnly = false;
+            MapRadar.ShowFTLRange = !isAutopilot;
+            MapFTLButton.Pressed = !isAutopilot;
+            MapAutopilotButton.Pressed = isAutopilot;
+            _autopilotTargeting = isAutopilot;
+        }
+        else
+        {
+            MapRadar.FtlMode = false;
         }
     }
 

--- a/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleConsoleWindow.xaml.cs
@@ -20,6 +20,9 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
     public event Action<MapCoordinates, Angle>? RequestFTL;
     public event Action<NetEntity, Angle>? RequestBeaconFTL;
 
+    // Mono
+    public event Action<MapCoordinates, Angle>? RequestAutopilot;
+
     public event Action<NetEntity, NetEntity>? DockRequest;
     public event Action<NetEntity>? UndockRequest;
     public event Action<List<NetEntity>>? UndockAllRequest;
@@ -55,6 +58,12 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
             RequestBeaconFTL?.Invoke(ent, angle);
         };
 
+        // Mono
+        MapContainer.RequestAutopilot += (coords, angle) =>
+        {
+            RequestAutopilot?.Invoke(coords, angle);
+        };
+
         DockContainer.DockRequest += (entity, netEntity) =>
         {
             DockRequest?.Invoke(entity, netEntity);
@@ -64,12 +73,12 @@ public sealed partial class ShuttleConsoleWindow : FancyWindow,
         {
             UndockRequest?.Invoke(entity);
         };
-        
+
         DockContainer.UndockAllRequest += dockEntities =>
         {
             UndockAllRequest?.Invoke(dockEntities);
         };
-        
+
         DockContainer.ToggleFTLLockRequest += (dockEntities, enabled) =>
         {
             ToggleFTLLockRequest?.Invoke(dockEntities, enabled);

--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -57,6 +57,11 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
     /// </summary>
     public bool ShowFTLRangeOnly;
 
+    /// <summary>
+    /// Mono - Whether to show FTL range at all.
+    /// </summary>
+    public bool ShowFTLRange = true;
+
     private Angle _ftlAngle;
 
     /// <summary>
@@ -275,7 +280,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
 
         // Draw our FTL range + no FTL zones
         // Do it up here because we want this layered below most things.
-        if (FtlMode || ShowFTLRangeOnly)
+        if ((FtlMode || ShowFTLRangeOnly) && ShowFTLRange) // Mono
         {
             if (EntManager.TryGetComponent<TransformComponent>(_shuttleEntity, out var shuttleXform))
             {

--- a/Content.Server/Physics/Components/PilotedShuttleComponent.cs
+++ b/Content.Server/Physics/Components/PilotedShuttleComponent.cs
@@ -16,4 +16,10 @@ public sealed partial class PilotedShuttleComponent : Component
     /// </summary>
     [DataField]
     public HashSet<EntityUid> InputSources = new();
+
+    /// <summary>
+    ///     Amount of sources currently actively providing input.
+    /// </summary>
+    [DataField]
+    public int ActiveSources = 0;
 }

--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -354,6 +354,7 @@ public sealed class MoverController : SharedMoverController
             shuttle.LastThrust = Vector2.Zero;
 
             var count = inputs.Count;
+            piloted.ActiveSources = count;
             if (count == 0)
             {
                 _thruster.DisableLinearThrusters(shuttle);

--- a/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
@@ -53,6 +53,14 @@ namespace Content.Server.Shuttles.Components
         public InertiaDampeningMode DampeningMode = InertiaDampeningMode.Dampen;
         // End Frontier
 
+        // <Mono>
+        [DataField]
+        public string AutopilotTargetKey = "Target";
+
+        [DataField]
+        public string AutopilotRotationKey = "TargetRotation";
+        // </Mono>
+
         // Network Port Button Source Ports
         [DataField]
         public List<ProtoId<SourcePortPrototype>> SourcePorts = new()

--- a/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleConsoleComponent.cs
@@ -5,6 +5,9 @@ using Content.Shared.Shuttles.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
+// Mono
+using Robust.Shared.Audio;
+
 namespace Content.Server.Shuttles.Components
 {
     [RegisterComponent]
@@ -59,6 +62,9 @@ namespace Content.Server.Shuttles.Components
 
         [DataField]
         public string AutopilotRotationKey = "TargetRotation";
+
+        [DataField]
+        public SoundSpecifier? AutopilotDoneSound = new SoundPathSpecifier("/Audio/Effects/Shuttle/radar_ping.ogg");
         // </Mono>
 
         // Network Port Button Source Ports

--- a/Content.Server/_Mono/NPC/HTN/Operators/ShipMoveToOperator.cs
+++ b/Content.Server/_Mono/NPC/HTN/Operators/ShipMoveToOperator.cs
@@ -1,14 +1,13 @@
 using Content.Server.NPC;
 using Content.Server.NPC.HTN;
 using Content.Server.NPC.HTN.PrimitiveTasks;
+using Content.Server.Physics.Controllers;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Construction.Components;
 using Robust.Shared.Map;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Content.Server.Physics.Controllers; // Mono
 
 namespace Content.Server._Mono.NPC.HTN.Operators;
 
@@ -158,6 +157,9 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
 
     private const string MovementCancelToken = "ShipMovementCancelToken";
 
+    // needed so it doesn't do it twice
+    private bool _raisedEvent = false;
+
     public override void Initialize(IEntitySystemManager sysManager)
     {
         base.Initialize(sysManager);
@@ -182,6 +184,8 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
     public override void Startup(NPCBlackboard blackboard)
     {
         base.Startup(blackboard);
+
+        _raisedEvent = false;
 
         // Need to remove the planning value for execution.
         blackboard.Remove<EntityCoordinates>(NPCBlackboard.OwnerCoordinates);
@@ -270,7 +274,13 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
             blackboard.Remove<Angle>(AngleKey);
         }
 
-        _steering.Stop(blackboard.GetValue<EntityUid>(NPCBlackboard.Owner));
+        var uid = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
+        _steering.Stop(uid);
+        if (!_raisedEvent)
+        {
+            _raisedEvent = true;
+            _entManager.EventBus.RaiseLocalEvent(uid, new SteeringDoneEvent(), false);
+        }
     }
 
     public override void PlanShutdown(NPCBlackboard blackboard)
@@ -280,3 +290,5 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
         ConditionalShutdown(blackboard);
     }
 }
+
+public record struct SteeringDoneEvent();

--- a/Content.Server/_Mono/NPC/HTN/Operators/ShipMoveToOperator.cs
+++ b/Content.Server/_Mono/NPC/HTN/Operators/ShipMoveToOperator.cs
@@ -8,6 +8,8 @@ using Robust.Shared.Map;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Content.Server.Physics.Controllers; // Mono
+
 namespace Content.Server._Mono.NPC.HTN.Operators;
 
 /// <summary>
@@ -36,6 +38,12 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
     /// </summary>
     [DataField]
     public string TargetKey = "ShipTargetCoordinates";
+
+    /// <summary>
+    /// World angle to try to be at after arrival. This gets removed after execution.
+    /// </summary>
+    [DataField]
+    public string AngleKey = "ShipTargetAngle";
 
     /// <summary>
     /// Whether to keep facing target if backing off due to RangeTolerance.
@@ -99,12 +107,6 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
     public float? MaxRotateRate = null;
 
     /// <summary>
-    /// If target goes further than this, drop target.
-    /// </summary>
-    [DataField]
-    public float MaxTargetingRange = 2000f;
-
-    /// <summary>
     /// What movement behavior to use.
     /// </summary>
     [DataField]
@@ -143,6 +145,12 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
     public bool RequirePowered = true;
 
     /// <summary>
+    /// Whether to finish if there's another active pilot on the grid.
+    /// </summary>
+    [DataField]
+    public bool RequireSolo = false;
+
+    /// <summary>
     /// Rotation to move at relative to direction to target.
     /// </summary>
     [DataField]
@@ -179,6 +187,7 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
         blackboard.Remove<EntityCoordinates>(NPCBlackboard.OwnerCoordinates);
         if (!blackboard.TryGetValue<EntityCoordinates>(TargetKey, out var targetCoordinates, _entManager))
             return;
+        blackboard.TryGetValue<Angle>(AngleKey, out var targetAngle, _entManager);
 
         var uid = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
 
@@ -195,6 +204,7 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
         comp.EvasionSectorDepth = EvasionSectorDepth;
         comp.FinishOnCollide = FinishOnCollide;
         comp.InRangeMaxSpeed = InRangeMaxSpeed;
+        comp.InRangeRotation = targetAngle;
         comp.LeadingEnabled = LeadingEnabled;
         comp.MaxRotateRate = MaxRotateRate;
         comp.Mode = Mode;
@@ -225,14 +235,17 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
         if (comp == null)
             return HTNOperatorStatus.Failed;
 
-        if (target.EntityId == EntityUid.Invalid || !xform.Coordinates.TryDistance(_entManager, target, out var distance) || distance > MaxTargetingRange)
-            return HTNOperatorStatus.Finished;
+        blackboard.TryGetValue<Angle>(AngleKey, out var targetAngle, _entManager);
+        comp.InRangeRotation = targetAngle;
 
         // Just keep moving in the background and let the other tasks handle it.
         if (ShutdownState == HTNPlanState.PlanFinished && steerer.Status == ShipSteeringStatus.Moving)
         {
             return HTNOperatorStatus.Finished;
         }
+
+        if (RequireSolo && _entManager.TryGetComponent<PilotedShuttleComponent>(xform.GridUid, out var piloted) && piloted.ActiveSources > 1)
+            return HTNOperatorStatus.Finished;
 
         return steerer.Status switch
         {
@@ -252,7 +265,10 @@ public sealed partial class ShipMoveToOperator : HTNOperator, IHtnConditionalShu
         }
 
         if (RemoveKeyOnFinish)
+        {
             blackboard.Remove<EntityCoordinates>(TargetKey);
+            blackboard.Remove<Angle>(AngleKey);
+        }
 
         _steering.Stop(blackboard.GetValue<EntityUid>(NPCBlackboard.Owner));
     }

--- a/Content.Server/_Mono/NPC/HTN/ShipSteererComponent.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipSteererComponent.cs
@@ -31,10 +31,10 @@ public sealed partial class ShipSteererComponent : Component
     public bool AvoidProjectiles = false;
 
     /// <summary>
-    /// If AlwaysFaceTarget is true, how much of a difference in angle (in radians) to accept.
+    /// If AlwaysFaceTarget is true or InRangeRotation is set, how much of a difference in angle (in radians) to accept.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float AlwaysFaceTargetOffset = 0.01f;
+    public float RotationTolerance = 0.0333f;
 
     /// <summary>
     /// Whether to avoid obstacles.
@@ -95,6 +95,12 @@ public sealed partial class ShipSteererComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public float? InRangeMaxSpeed = null;
+
+    /// <summary>
+    /// Global angle to rotate to while in range.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public Angle? InRangeRotation = null;
 
     /// <summary>
     /// Whether to try to match velocity with target.

--- a/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipSteeringSystem.cs
@@ -90,11 +90,13 @@ public sealed partial class ShipSteeringSystem : EntitySystem
         var relVel = linVel - targetVel;
 
         // get the actual destination we will move to
-        var destMapPos = ResolveDestination(ent.Comp, mapTarget, shipPos, shipNorthAngle, toTargetVec, distance, relVel, angVel);
+        var (destMapPos, inRange) = ResolveDestination(ent.Comp, mapTarget, shipPos, shipNorthAngle, toTargetVec, distance, relVel, angVel);
 
         // ResolveDestination says we're all good
         if (ent.Comp.Status == ShipSteeringStatus.InRange)
             return;
+
+        Angle? targetAngle = inRange ? ent.Comp.InRangeRotation : (ent.Comp.AlwaysFaceTarget ? toTargetVec.ToWorldAngle() : null);
 
         var config = new SteeringConfig
         {
@@ -116,8 +118,7 @@ public sealed partial class ShipSteeringSystem : EntitySystem
 
             RotationCompensationGain = ent.Comp.RotationCompensationGain,
             TargetAngleOffset = Angle.FromDegrees(ent.Comp.TargetRotation),
-            AngleOverride = ent.Comp.AlwaysFaceTarget ? toTargetVec.ToWorldAngle() : null,
-            AlwaysFaceTarget = ent.Comp.AlwaysFaceTarget
+            AngleOverride = targetAngle
         };
         var context = new SteeringContext
         {
@@ -144,7 +145,7 @@ public sealed partial class ShipSteeringSystem : EntitySystem
     /// <summary>
     /// Set our status and destination.
     /// </summary>
-    private MapCoordinates ResolveDestination(
+    private (MapCoordinates, bool) ResolveDestination(
         ShipSteererComponent comp,
         MapCoordinates mapTarget,
         MapCoordinates shipPos,
@@ -172,22 +173,27 @@ public sealed partial class ShipSteeringSystem : EntitySystem
                     && MathF.Abs(angVel) < maxArrivedAngVel)
                 {
                     var good = true;
-                    if (comp.AlwaysFaceTarget)
+                    if (comp.InRangeRotation is { } targetWorldRot)
+                    {
+                        var wishRotateBy = ShortestAngleDistance(shipNorthAngle + new Angle(Math.PI), targetWorldRot);
+                        good = MathF.Abs((float)wishRotateBy.Theta) < comp.RotationTolerance;
+                    }
+                    else if (comp.AlwaysFaceTarget)
                     {
                         var wishRotateBy = ShortestAngleDistance(shipNorthAngle + new Angle(Math.PI) - targetAngleOffset, toTargetVec.ToWorldAngle());
-                        good = MathF.Abs((float)wishRotateBy.Theta) < comp.AlwaysFaceTargetOffset;
+                        good = MathF.Abs((float)wishRotateBy.Theta) < comp.RotationTolerance;
                     }
                     if (good)
                     {
                         comp.Status = ShipSteeringStatus.InRange;
-                        return mapTarget; // will be ignored
+                        return (mapTarget, true); // will be ignored
                     }
                 }
 
                 if (distance < lowRange || distance > highRange)
-                    return mapTarget.Offset(NormalizedOrZero(-toTargetVec) * midRange);
+                    return (mapTarget.Offset(NormalizedOrZero(-toTargetVec) * midRange), false);
 
-                return shipPos;
+                return (shipPos, true);
             }
             case ShipSteeringMode.OrbitCW:
             case ShipSteeringMode.Orbit:
@@ -195,11 +201,11 @@ public sealed partial class ShipSteeringSystem : EntitySystem
                 // take our position, project onto our target radius, rotate by desired orbit offset
                 var invert = comp.Mode == ShipSteeringMode.OrbitCW;
                 var rotateAngle = new Angle(comp.OrbitOffset * (invert ? -1 : 1));
-                return mapTarget.Offset(NormalizedOrZero(rotateAngle.RotateVec(-toTargetVec)) * midRange);
+                return (mapTarget.Offset(NormalizedOrZero(rotateAngle.RotateVec(-toTargetVec)) * midRange), false);
             }
         }
 
-        return mapTarget;
+        return (mapTarget, false);
     }
 
     /// <summary>
@@ -695,7 +701,6 @@ public sealed partial class ShipSteeringSystem : EntitySystem
         // rotation
         public Angle TargetAngleOffset;
         public Angle? AngleOverride;
-        public bool AlwaysFaceTarget;
     }
 
     private readonly record struct BrakeContext(float BrakeAccel, float BrakePath, float LeftoverBrakePath);

--- a/Content.Server/_Mono/Shuttles/Systems/ShuttleConsoleSystem.Autopilot.cs
+++ b/Content.Server/_Mono/Shuttles/Systems/ShuttleConsoleSystem.Autopilot.cs
@@ -1,0 +1,27 @@
+using Content.Server.NPC.HTN;
+using Content.Server.Shuttles.Components;
+using Content.Shared._Mono.Shuttles;
+
+namespace Content.Server._Mono.Shuttles;
+
+public sealed partial class ShuttleConsoleAutopilotSystem : EntitySystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ShuttleConsoleComponent, ShuttleConsoleAutopilotPositionMessage>(OnAutopilotMessage);
+    }
+
+    private void OnAutopilotMessage(Entity<ShuttleConsoleComponent> ent, ref ShuttleConsoleAutopilotPositionMessage args)
+    {
+        if (!TryComp<HTNComponent>(ent, out var htn))
+            return;
+
+        var blackboard = htn.Blackboard;
+        blackboard.SetValue(ent.Comp.AutopilotTargetKey, _transform.ToCoordinates(args.Coordinates));
+        blackboard.SetValue(ent.Comp.AutopilotRotationKey, args.Angle + MathF.PI);
+    }
+}

--- a/Content.Server/_Mono/Shuttles/Systems/ShuttleConsoleSystem.Autopilot.cs
+++ b/Content.Server/_Mono/Shuttles/Systems/ShuttleConsoleSystem.Autopilot.cs
@@ -1,11 +1,17 @@
+using Content.Server._Mono.NPC.HTN.Operators;
 using Content.Server.NPC.HTN;
+using Content.Shared.Popups;
 using Content.Server.Shuttles.Components;
 using Content.Shared._Mono.Shuttles;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
 
 namespace Content.Server._Mono.Shuttles;
 
 public sealed partial class ShuttleConsoleAutopilotSystem : EntitySystem
 {
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
@@ -13,6 +19,7 @@ public sealed partial class ShuttleConsoleAutopilotSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ShuttleConsoleComponent, ShuttleConsoleAutopilotPositionMessage>(OnAutopilotMessage);
+        SubscribeLocalEvent<ShuttleConsoleComponent, SteeringDoneEvent>(OnSteeringDone);
     }
 
     private void OnAutopilotMessage(Entity<ShuttleConsoleComponent> ent, ref ShuttleConsoleAutopilotPositionMessage args)
@@ -23,5 +30,11 @@ public sealed partial class ShuttleConsoleAutopilotSystem : EntitySystem
         var blackboard = htn.Blackboard;
         blackboard.SetValue(ent.Comp.AutopilotTargetKey, _transform.ToCoordinates(args.Coordinates));
         blackboard.SetValue(ent.Comp.AutopilotRotationKey, args.Angle + MathF.PI);
+    }
+
+    private void OnSteeringDone(Entity<ShuttleConsoleComponent> ent, ref SteeringDoneEvent args)
+    {
+        _audio.PlayPvs(ent.Comp.AutopilotDoneSound, ent);
+        _popup.PopupEntity(Loc.GetString("shuttle-console-autopilot-popup-done"), ent, PopupType.Medium);
     }
 }

--- a/Content.Shared/_Mono/Shuttles/ShuttleMessages.cs
+++ b/Content.Shared/_Mono/Shuttles/ShuttleMessages.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Mono.Shuttles;
+
+/// <summary>
+/// Raised on the client when it wishes to travel somewhere via autopilot.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class ShuttleConsoleAutopilotPositionMessage : BoundUserInterfaceMessage
+{
+    public MapCoordinates Coordinates;
+    public Angle Angle;
+}

--- a/Resources/Locale/en-US/_Mono/shuttles/console.ftl
+++ b/Resources/Locale/en-US/_Mono/shuttles/console.ftl
@@ -1,1 +1,2 @@
 shuttle-console-autopilot-button = Autopilot
+shuttle-console-autopilot-popup-done = Autopilot Arrived

--- a/Resources/Locale/en-US/_Mono/shuttles/console.ftl
+++ b/Resources/Locale/en-US/_Mono/shuttles/console.ftl
@@ -1,0 +1,1 @@
+shuttle-console-autopilot-button = Autopilot

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -195,6 +195,9 @@
       respectZoom: true
       rotate: true
       bounds: "-0.5,-0.5,0.5,0.5"
+  - type: HTN
+    rootTask:
+      task: AutopilotShuttleCompound
 
 - type: entity
   parent: [BaseComputerShuttle, BaseShuttleIntercom] # Frontier - BaseShuttleIntercom

--- a/Resources/Prototypes/_Mono/NPCs/Shuttle/shuttle.yml
+++ b/Resources/Prototypes/_Mono/NPCs/Shuttle/shuttle.yml
@@ -1,3 +1,5 @@
+#region Cores
+
 # rams parent ship into the closest shuttle with a powered shuttle console
 - type: htnCompound
   id: RammerShuttleCompound
@@ -344,3 +346,31 @@
         proto: NearbyShuttleTargets
         key: Target
         coordinatesKey: TargetCoordinates
+
+#region Autopilot
+
+- type: htnCompound
+  id: AutopilotShuttleCompound
+  branches:
+  - preconditions:
+    - !type:KeyExistsPrecondition
+      key: Target
+    tasks:
+    - !type:HTNCompoundTask
+      task: AutopilotMoveCompound
+
+- type: htnCompound
+  id: AutopilotMoveCompound
+  branches:
+  - tasks:
+    - !type:HTNPrimitiveTask
+      operator: !type:ShipMoveToOperator
+        shutdownState: TaskFinished
+        removeKeyOnFinish: true
+        inRangeMaxSpeed: 0.1
+        range: 40
+        leadingEnabled: false
+        targetKey: Target
+        angleKey: TargetRotation
+        maxRotateRate: 0.01
+        requireSolo: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
adds autopilot button next to ftl button
works same way ftl does but instead of ftl it makes your ship drive itself to destination
auto-cancel on using any manual controls
popup+sound on finish
uses shipHTN

## Why / Balance
part of planned FTL rework and just nice to have

## How to test
buy ship
autopilot a long distance
watch it dodge asteroids

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Shuttle consoles now come with autopilot in the map tab.
