### PR TITLE
Let Shuttle Console Open Attempts Be Predicted on the Client

### DIFF
--- a/Content.Client/Shuttles/Systems/ShuttleConsoleLockSystem.cs
+++ b/Content.Client/Shuttles/Systems/ShuttleConsoleLockSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Shuttles.Systems;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Access.Components;
+using Content.Shared.UserInterface;
 
 namespace Content.Client.Shuttles.Systems;
 
@@ -17,4 +18,17 @@ public sealed class ShuttleConsoleLockSystem : SharedShuttleConsoleLockSystem
         // Prediction only
         return false;
     }
-} 
+
+    /// <summary>
+    /// Client extension of OnUIOpenAttempt. Prevents UI flashing open on client.
+    /// </summary>
+    protected override void OnUIOpenAttempt(EntityUid uid,
+        ShuttleConsoleLockComponent component,
+        ActivatableUIOpenAttemptEvent args)
+    {
+        base.OnUIOpenAttempt(uid, component, args);
+
+        if(Timing.IsFirstTimePredicted && args.Cancelled)
+            Popup.PopupEntity(Loc.GetString("shuttle-console-locked"), uid, args.User);
+    }
+}

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleLockSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleLockSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Access.Components;
 using Content.Shared._NF.Shipyard.Components;
 using Content.Server.Shuttles.Components;
 using Content.Server.Hands.Systems;
-using Content.Shared.UserInterface;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
@@ -36,7 +35,6 @@ public sealed class ShuttleConsoleLockSystem : SharedShuttleConsoleLockSystem
         base.Initialize();
         SubscribeLocalEvent<ShuttleConsoleLockComponent, ComponentInit>(OnShuttleConsoleLockInit);
         SubscribeLocalEvent<ShuttleConsoleLockComponent, GetVerbsEvent<AlternativeVerb>>(AddUnlockVerb);
-        SubscribeLocalEvent<ShuttleConsoleLockComponent, ActivatableUIOpenAttemptEvent>(OnUIOpenAttempt);
         SubscribeLocalEvent<PdaComponent, AfterInteractEvent>(OnPdaAfterInteract);
         SubscribeLocalEvent<ShuttleConsoleLockComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
         SubscribeLocalEvent<ShuttleDeedComponent, ComponentInit>(OnShuttleDeedInit);
@@ -533,20 +531,6 @@ public sealed class ShuttleConsoleLockSystem : SharedShuttleConsoleLockSystem
             _consoleSystem.RemovePilot(pilot);
 
         return true;
-    }
-
-    /// <summary>
-    /// Prevents using the console UI if it's locked
-    /// </summary>
-    private void OnUIOpenAttempt(EntityUid uid,
-        ShuttleConsoleLockComponent component,
-        ActivatableUIOpenAttemptEvent args)
-    {
-        if (GetEffectiveLockState(uid, component))
-        {
-            Popup.PopupEntity(Loc.GetString("shuttle-console-locked"), uid, args.User);
-            args.Cancel();
-        }
     }
 
     /// <summary>

--- a/Content.Shared/Shuttles/Systems/SharedShuttleConsoleLockSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleConsoleLockSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Access.Components;
 using Content.Shared.Shuttles.Components;
 using Content.Shared._NF.Shipyard.Components;
+using Content.Shared.UserInterface;
 using Content.Shared.Popups;
 using Robust.Shared.Timing;
 using Content.Shared.Examine;
@@ -22,6 +23,7 @@ public abstract class SharedShuttleConsoleLockSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<ShuttleConsoleLockComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<ShuttleConsoleLockComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<ShuttleConsoleLockComponent, ActivatableUIOpenAttemptEvent>(OnUIOpenAttempt);
     }
 
     private void OnStartup(EntityUid uid, ShuttleConsoleLockComponent component, ComponentStartup args)
@@ -56,6 +58,17 @@ public abstract class SharedShuttleConsoleLockSystem : EntitySystem
 
         // No grid lock, use individual console lock state (fallback for legacy consoles)
         return component.Locked;
+    }
+
+    /// <summary>
+    /// Prevents using the console UI if it's locked
+    /// </summary>
+    protected virtual void OnUIOpenAttempt(EntityUid uid,
+        ShuttleConsoleLockComponent component,
+        ActivatableUIOpenAttemptEvent args)
+    {
+        if (GetEffectiveLockState(uid, component))
+            args.Cancel();
     }
 
     protected void UpdateAppearance(EntityUid uid, ShuttleConsoleLockComponent? component = null)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
`OnUIOpenAttempt` was moved from the server `ShuttleConsoleLockSystem` into the shared one. The client system extends that function with the popup.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Prior to this, if you clicked on a locked console, it'd flash a window and then immediately close it after the server says no.
## How to test
<!-- Describe the way it can be tested -->
Acquire a ship. Try to open the shuttle console. Unlock it and try to open it again.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Locked shuttle consoles won't open a window.
-->
