### PR TITLE
Reptilian Claw Popup Fix

### DIFF
--- a/Content.Shared/_Mono/Claws/ClawsSystem.NailClippers.cs
+++ b/Content.Shared/_Mono/Claws/ClawsSystem.NailClippers.cs
@@ -43,9 +43,13 @@ public abstract partial class SharedClawsSystem
     public bool TryClipNails(NailClipperComponent component, EntityUid nailClipper, EntityUid user, EntityUid? target = null)
     {
         target ??= user;
+        
+        if (!TryComp<ClawsComponent>(target, out var claws))
+        {
+            return false;
+        }
 
-        if (!TryComp<ClawsComponent>(target, out var claws)||
-            TryGetStage(claws, out var stage) && !stage.CanBeCut)
+        if (TryGetStage(claws, out var stage) && !stage.CanBeCut)
         {
             _popup.PopupClient(Loc.GetString("has-no-claws-popup"), Transform(user).Coordinates, user);
             return false;

--- a/Content.Shared/_Mono/Claws/Components/NailClipperComponent.cs
+++ b/Content.Shared/_Mono/Claws/Components/NailClipperComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared._Mono.Claws.Components;
 public sealed partial class NailClipperComponent : Component
 {
     [DataField]
-    public TimeSpan ClipDoAfter = TimeSpan.FromSeconds(10);
+    public TimeSpan ClipDoAfter = TimeSpan.FromSeconds(4);
 
     /// <summary>
     /// Amount of stages to skip down. Capped to 0.

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -52,7 +52,6 @@
     soundHit:
       collection: MetalThud
   - type: NailClipper # Mono
-    clipDoAfter: 2
     allowedClawTypes: ["SharpClaw"]
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -52,6 +52,7 @@
     soundHit:
       collection: MetalThud
   - type: NailClipper # Mono
+    clipDoAfter: 2
     allowedClawTypes: ["SharpClaw"]
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixed wirecutters and Jaws of Life showing "They don't have any claws" when they shouldn't. 

Also lowered the default ClipDoAfter from 10->4 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix and Reptilian QOL.

## How to test
<!-- Describe the way it can be tested -->
Load into test server and spawn a wirecutter.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Wirecutters and Jaws of Life no longer cause spurious messages about claws on use.
- tweak: Time to clip claws lowered from 10->4 seconds. 

