### PR TITLE
Increase Mech Speed

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -142,7 +142,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
     baseSprintSpeed: 4.5
-    baseWeightlessModifier: 5 # Mono
+    baseWeightlessModifier: 10 # Mono
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: StaticPrice
@@ -246,7 +246,7 @@
   - type: MovementSpeedModifier # Mono
     baseWalkSpeed: 3
     baseSprintSpeed: 4.5
-    baseWeightlessModifier: 5
+    baseWeightlessModifier: 7.5
   - type: StaticPrice
     price: 3000
   - type: Tag
@@ -332,7 +332,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
     baseSprintSpeed: 2
-    baseWeightlessModifier: 3 # Mono
+    baseWeightlessModifier: 4.5 # Mono
   - type: Damageable
     damageModifierSet: MechArmorHeavy
   - type: CanMoveInAir
@@ -426,7 +426,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
     baseSprintSpeed: 1.5
-    baseWeightlessModifier: 3 # Mono
+    baseWeightlessModifier: 4.5 # Mono
   - type: Damageable
     damageModifierSet: MechArmorHeavy
   - type: CanMoveInAir
@@ -529,7 +529,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
     baseSprintSpeed: 3.7
-    baseWeightlessModifier: 3 # Mono
+    baseWeightlessModifier: 4.5 # Mono
   - type: Damageable
     damageModifierSet: MechArmorHeavy
   - type: CanMoveInAir
@@ -635,7 +635,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.5 # Mono
     baseSprintSpeed: 5.5 # Mono
-    baseWeightlessModifier: 7 # Mono
+    baseWeightlessModifier: 10.5 # Mono
   - type: Damageable
     damageModifierSet: MechArmorLight
   - type: CanMoveInAir

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -244,7 +244,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.75
     baseSprintSpeed: 1.33
-    baseWeightlessModifier: 40
+    baseWeightlessModifier: 60
   - type: RadarBlip
     radarColor: "#E3E3E3"
     scale: 3
@@ -358,7 +358,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.75
     baseSprintSpeed: 1.33
-    baseWeightlessModifier: 35
+    baseWeightlessModifier: 50
   - type: Damageable
     damageModifierSet: MechArmorLight
   - type: Tag
@@ -565,7 +565,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.5
     baseSprintSpeed: 1
-    baseWeightlessModifier: 35
+    baseWeightlessModifier: 50
   - type: RadarBlip
     radarColor: "#E3E3E3"
     scale: 3
@@ -683,7 +683,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.4
     baseSprintSpeed: 0.8
-    baseWeightlessModifier: 30
+    baseWeightlessModifier: 45
   - type: Tag
     tags:
     - DoorBumpOpener
@@ -758,7 +758,7 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 0.5
     baseSprintSpeed: 1.2
-    baseWeightlessModifier: 50
+    baseWeightlessModifier: 75
   - type: Tag
     tags:
     - DoorBumpOpener


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
+50% mech space speed
doubled for clarke

## Why / Balance
i don't think we ever buffed mechs after ship speedup
also they're currently just too slow to do anything
for clarke it makes sense to give it more of a niche

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: All mechs significantly sped up in space.
