### PR TITLE
Allows Armor Plates to Have Their Durability Examined Outside of Armor

### DIFF
--- a/Content.Shared/_Mono/ArmorPlate/SharedArmorPlateSystem.cs
+++ b/Content.Shared/_Mono/ArmorPlate/SharedArmorPlateSystem.cs
@@ -41,6 +41,7 @@ public sealed class SharedArmorPlateSystem : EntitySystem
         SubscribeLocalEvent<ArmorPlateHolderComponent, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRefreshMoveSpeed);
         SubscribeLocalEvent<ArmorPlateItemComponent, GetVerbsEvent<ExamineVerb>>(OnPlateVerbExamine);
         SubscribeLocalEvent<ArmorPlateItemComponent, EntityTerminatingEvent>(OnPlateDestroyed);
+        SubscribeLocalEvent<ArmorPlateItemComponent, ExaminedEvent>(OnPlateExamined);
         SubscribeLocalEvent<ArmorPlateProtectedComponent, BeforeDamageChangedEvent>(OnBeforeDamageChanged);
     }
 
@@ -461,5 +462,29 @@ public sealed class SharedArmorPlateSystem : EntitySystem
             EnsureComp<ArmorPlateProtectedComponent>(wearerUid);
         else
             RemComp<ArmorPlateProtectedComponent>(wearerUid);
+    }
+    private void OnPlateExamined(EntityUid uid, ArmorPlateItemComponent component, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        if (TryComp<DamageableComponent>(uid, out var damageable))
+        {
+            var totalDamage = damageable.TotalDamage.Int();
+            var maxDurability = component.MaxDurability;
+            var durabilityPercent = ((maxDurability - totalDamage) / (float)maxDurability) * 100f;
+            durabilityPercent = Math.Clamp(durabilityPercent, 0f, 100f);
+
+            var durabilityColor = durabilityPercent switch
+            {
+                > 66f => "green",
+                >= 33f => "yellow",
+                _ => "red",
+            };
+
+            args.PushMarkup(Loc.GetString("armor-plate-item-durability",
+                ("percent", (int)durabilityPercent),
+                ("durabilityColor", durabilityColor)));
+        }
     }
 }

--- a/Resources/Locale/en-US/_Mono/armor-plate.ftl
+++ b/Resources/Locale/en-US/_Mono/armor-plate.ftl
@@ -10,6 +10,8 @@ armor-plate-examinable-verb-message = Examine protection and durability characte
 armor-plate-attributes-examine = This armor plate:
 armor-plate-initial-durability = Is rated for [color=yellow]{ $durability }[/color] standard units of damage.
 
+armor-plate-item-durability = Durability: [color={$durabilityColor}]{$percent}%[/color]
+
 armor-plate-gait-speed = speed
 armor-plate-gait-walk = walking speed
 armor-plate-gait-sprint = running speed


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Allows one to check a plate's durability before having it installed in a piece of armor. I'm surprised no one ever mentioned this.

Do tell me if I should move this code elsewhere or use different localization strings, or anything really.

## Why / Balance
Simple, it was a little weird that you couldn't check the durability of a plate in your bag or on the floor, you had to put it in armor.

This makes it so you can check the durability of an armor plate anywhere, no need to keep stuffing it in armor to find out if this is the nearly broken plate you used 10 minutes ago or the one you just printed.

## How to test
Spawn and examine plates.
Put plates in a piece of armor, make some random urist wear that piece of armor, shoot it, remove it and the plates, verify the durability matches.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="390" height="189" alt="image" src="https://github.com/user-attachments/assets/696a1572-aaeb-44e6-99ae-2048dbed753c" />

<img width="423" height="224" alt="image" src="https://github.com/user-attachments/assets/33c3e392-7698-419d-b543-ef5bae70d556" />

<img width="389" height="188" alt="image" src="https://github.com/user-attachments/assets/369c5c81-d3e5-4f50-b785-a4a6c0fc530d" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The durability of armor plates can now be examined directly.
