### PR TITLE
Massive Stealth-Suit Buff

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -63,6 +63,6 @@
       minVisibility: 0.15 # Mono: Changed to be not fully invisible
       maxVisibility: 0.6 # Mono: Changed to be partially invisible
     - type: StealthOnMove
-      passiveVisibilityRate: 0
-      movementVisibilityRate: 0.4
+      passiveVisibilityRate: -0.4
+      movementVisibilityRate: 0
 

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -63,6 +63,6 @@
       minVisibility: 0.15 # Mono: Changed to be not fully invisible
       maxVisibility: 0.6 # Mono: Changed to be partially invisible
     - type: StealthOnMove
-      passiveVisibilityRate: -0.4
+      passiveVisibilityRate: 0
       movementVisibilityRate: 0.4
 


### PR DESCRIPTION
## About the PR
Cybersun Stealth suit no longer loose stealth on movement. 

## Why / Balance
Stealth suit does not see any use because it, honestly is not very good. This buffs their bottom baseline by a lot.

## How to test
spawn the suit-move-it don't go down.

**Changelog**

- tweak: sets the movementVisibilityRate of the Cybersun Stealth suit to 0.
