### PR TITLE
Scallywag Shipyard Fix

### DIFF
--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/scallywag.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/scallywag.yml
@@ -2,29 +2,29 @@
 # GitHub: Corrupt142
 # Discord: Corrupt
 
-# Shuttle Notes: To hell with you plunderer! Armament uniformised to ballistics, sorry y'all, a pirate shit bucket doesn't get laser PD.
+# To hell with you plunderer! 
+# Armament uniformised to ballistics, sorry y'all, a pirate shit bucket doesn't get laser PD.
+# Im going to rip you apart peace by peace..
 
 - type: vessel
   id: Scallywag
   parent: BaseVessel
-  name: RSC-Scallywag
+  name: RSC Scallywag
   description: Heavily armoured hit and run ship dedicated for Piracy operations. Armed with 2x Longbow 90mm autocannon,4x L85 20mm PD turret,2x VESPERA swarm missile launchers and a RUBICON for Disabling fleeing ships.
   price: 120000 # 89K base x 1.35 -> 120K (35% markup).
-  category: medium
+  category: Medium
   group: Scrap
-  access: Mercenary
   shuttlePath: /Maps/_Mono/Shuttles/Scrap/scallywag.yml
   guidebookPage: Null
   class:
-  - pursuit
   - Scrapyard
-
+  - Pursuit
   engine:
   - uranium
 
 - type: gameMap
   id: Scallywag
-  mapName: 'RSC-Scallywag'
+  mapName: 'RSC Scallywag'
   mapPath: /Maps/_Mono/Shuttles/Scrap/scallywag.yml
   minPlayers: 0
   stations:

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/scallywag.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/scallywag.yml
@@ -14,6 +14,7 @@
   price: 120000 # 89K base x 1.35 -> 120K (35% markup).
   category: Medium
   group: Scrap
+  access: Mercenary
   shuttlePath: /Maps/_Mono/Shuttles/Scrap/scallywag.yml
   guidebookPage: Null
   class:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? --> Hopefully fixed the issue where you coudnt buy/see the scallywag in scapyard shipyard


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Made this fix after some players reported it not showing up, even though that trough internal testing it worked fine

## How to test
<!-- Describe the way it can be tested --> Boot up dev enviro, test it if it works 


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- fix: Hopefully fixed the issue of scallywag not being aviable for purchase
