### PR TITLE
Make Directions to Purchased Shuttles Point the Right Way

### DIFF
--- a/Content.Server/_Mono/Shipyard/ShipyardDirectionSystem.cs
+++ b/Content.Server/_Mono/Shipyard/ShipyardDirectionSystem.cs
@@ -46,7 +46,7 @@ public sealed class ShipyardDirectionSystem : EntitySystem
 
         // get the angle between the two positions, adjusted for the grid rotation so that
         // we properly preserve north in relation to the grid.
-        var direction = playerPos - shipPos;
+        var direction = shipPos - playerPos;
         var directionAngle = direction.ToWorldAngle();
         var adjustedDir = (directionAngle - gridOffset).GetDir();
         var length = (playerPos - shipPos).LengthSquared();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
the vector pointing from `a` to `b` is `b - a`, not `a - b`. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it pointed the wrong way
## How to test
<!-- Describe the way it can be tested -->
buy a ship

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Shipyard consoles no longer point you in the wrong direction when buying a shuttle.

