### PR TITLE
Fix Charon Range

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Cartridge/charon_ammo.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/Cartridge/charon_ammo.yml
@@ -24,7 +24,7 @@
     scale: 4
     shape: triangle
   - type: TimedDespawn
-    lifetime: 1.7
+    lifetime: 3.1 # ~2.4 km range
   - type: PointLight
     color: "#19AFFF"
   - type: ExplodeOnTrigger

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/charon_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/charon_launcher.yml
@@ -20,7 +20,7 @@
     recoil: 2500 # 100x
     minAngle: 0
     maxAngle: 0
-    projectileSpeed: 1450
+    projectileSpeed: 790 # projectiles cannot go faster than this
     shootThermalSignature: 18000000 # ~8.5km after firing
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/leviathan_fire.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Increases ShipRailgunProjectile lifetime from 1.7->3.1 to compensate for engine limitations preventing projectiles from reaching the intended 1450 m/s. As a result, its effective range has been doubled, from ~1.35km to ~2.4km.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The additional reach makes the Charon significantly more powerful. If 2.4km is considered too much, a few other possibilities are:
- Dial it back to 1.7-2.0km.
- Severely reduce the range of nuclear slugs to prevent risk-free station glassing.
- Keep the old range.
## How to test
<!-- Describe the way it can be tested -->
Load up the dev map and fire the Charon.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: M381 Charon range now at its intended value of 2.5 km (from 1.4km).

