### PR TITLE
Nerfs Platelet Factories/Nanite Repair Drones Healing

### DIFF
--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -364,7 +364,7 @@
   components:
   - type: PlateletFactories
     intervalSeconds: 1
-    healPerSecond: .5
+    healPerSecond: .2
     critMultiplier: .25
 
 - type: trait
@@ -398,4 +398,4 @@
   components:
   - type: PlateletFactories
     intervalSeconds: 1
-    healPerSecond: .5
+    healPerSecond: .2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Platelet Factories and Nanite Repair Drones now heal 0.2 health per second, from 0.5 health per second.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- It's no longer possible to out-heal asphyxiation, meaning you can't skip out on an O2 tank anymore.
- It's no longer possible to out-heal blood loss induced Airloss, meaning you can no longer stay in crit indefinitely.
- You cannot immediately regenerate your entire healthbar by disengaging from combat for 30 seconds.
## How to test
<!-- Describe the way it can be tested -->
Shoot somebody.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/d4048169-28a9-44ff-aabd-03b955904b9d

After ~1 minute of brute-induced crit:
<img width="645" height="378" alt="image" src="https://github.com/user-attachments/assets/92e03fef-38bf-4db3-947a-d70bb1d7f005" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The Platelet Factories and Nanite Repair Drones traits now heal less (0.5 damage/sec -> 0.2 damage/sec).

