### PR TITLE
[Testmerge] Mobile POIs

### DIFF
--- a/Resources/Maps/_NF/POI/medical.yml
+++ b/Resources/Maps/_NF/POI/medical.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 264.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/05/2026 11:33:26
-  entityCount: 4336
+  time: 03/21/2026 08:26:43
+  entityCount: 4338
 maps: []
 grids:
 - 1
@@ -142,10 +142,10 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
       spreadQueues:
-        Smoke: []
+        Puddle: []
         MetalFoam: []
         Kudzu: []
-        Puddle: []
+        Smoke: []
     - type: Shuttle
       dampingModifier: 0.25
     - type: GridPathfinding
@@ -3437,27 +3437,27 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1677
-      - 2641
-      - 1678
-      - 1679
-      - 2712
-      - 2677
-      - 2681
+      - 1687
+      - 2651
+      - 1688
+      - 1689
+      - 2722
+      - 2687
+      - 2691
+      - 2736
+      - 2724
+      - 2679
+      - 2680
+      - 2725
+      - 2727
+      - 2682
+      - 2728
+      - 2683
       - 2726
-      - 2714
-      - 2669
-      - 2670
-      - 2715
-      - 2717
-      - 2672
-      - 2718
-      - 2673
-      - 2716
-      - 2671
-      - 2711
-      - 2647
-      - 2710
+      - 2681
+      - 2721
+      - 2657
+      - 2720
   - uid: 13
     components:
     - type: Transform
@@ -3465,17 +3465,17 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
+      - 2688
+      - 2717
       - 2678
-      - 2707
-      - 2668
-      - 2721
-      - 2667
-      - 2722
-      - 2666
-      - 2723
-      - 1676
-      - 1675
-      - 1674
+      - 2731
+      - 2677
+      - 2732
+      - 2676
+      - 2733
+      - 1686
+      - 1685
+      - 1684
   - uid: 14
     components:
     - type: Transform
@@ -3483,30 +3483,30 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2710
-      - 2647
-      - 1676
-      - 1675
-      - 1674
+      - 2720
+      - 2657
+      - 1686
       - 1685
-      - 1677
-      - 1678
-      - 1679
-      - 1680
-      - 1681
-      - 1682
       - 1684
-      - 1683
-      - 2711
-      - 2641
-      - 2708
-      - 2648
-      - 2677
-      - 2712
-      - 2681
-      - 2726
-      - 2678
-      - 2707
+      - 1695
+      - 1687
+      - 1688
+      - 1689
+      - 1690
+      - 1691
+      - 1692
+      - 1694
+      - 1693
+      - 2721
+      - 2651
+      - 2718
+      - 2658
+      - 2687
+      - 2722
+      - 2691
+      - 2736
+      - 2688
+      - 2717
   - uid: 15
     components:
     - type: Transform
@@ -3515,31 +3515,31 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2645
-      - 2706
-      - 1669
-      - 1668
-      - 1667
-      - 1689
-      - 1690
-      - 1655
-      - 2713
+      - 2655
+      - 2716
+      - 1679
+      - 1678
+      - 1677
+      - 1699
+      - 1700
+      - 1665
+      - 2723
+      - 2660
+      - 1693
+      - 1694
+      - 1695
+      - 1696
+      - 1697
+      - 1698
+      - 2737
       - 2650
-      - 1683
-      - 1684
-      - 1685
-      - 1686
-      - 1687
-      - 1688
-      - 2727
-      - 2640
-      - 1714
-      - 2679
-      - 2729
-      - 2647
-      - 2710
-      - 2711
-      - 2641
+      - 1724
+      - 2689
+      - 2739
+      - 2657
+      - 2720
+      - 2721
+      - 2651
   - uid: 16
     components:
     - type: Transform
@@ -3548,18 +3548,18 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2676
-      - 2739
-      - 1662
-      - 1663
-      - 2682
-      - 2738
-      - 2740
-      - 2657
-      - 2705
-      - 2683
       - 2686
-      - 2746
+      - 2749
+      - 1672
+      - 1673
+      - 2692
+      - 2748
+      - 2750
+      - 2667
+      - 2715
+      - 2693
+      - 2696
+      - 2756
   - uid: 17
     components:
     - type: Transform
@@ -3567,13 +3567,13 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2737
-      - 2652
-      - 1673
-      - 2748
-      - 2688
-      - 2687
       - 2747
+      - 2662
+      - 1683
+      - 2758
+      - 2698
+      - 2697
+      - 2757
   - uid: 18
     components:
     - type: Transform
@@ -3582,36 +3582,36 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2743
-      - 2644
-      - 1659
-      - 2655
-      - 2744
-      - 2664
-      - 2741
-      - 2658
-      - 2742
-      - 1660
+      - 2753
+      - 2654
       - 1669
-      - 1668
-      - 1667
-      - 1713
-      - 2687
-      - 2747
-      - 2748
-      - 2688
-      - 1692
-      - 1691
-      - 1672
-      - 1671
+      - 2665
+      - 2754
+      - 2674
+      - 2751
+      - 2668
+      - 2752
       - 1670
-      - 1673
-      - 1715
-      - 1716
-      - 1717
-      - 1718
-      - 1719
-      - 1720
+      - 1679
+      - 1678
+      - 1677
+      - 1723
+      - 2697
+      - 2757
+      - 2758
+      - 2698
+      - 1702
+      - 1701
+      - 1682
+      - 1681
+      - 1680
+      - 1683
+      - 1725
+      - 1726
+      - 1727
+      - 1728
+      - 1729
+      - 1730
   - uid: 19
     components:
     - type: Transform
@@ -3620,28 +3620,28 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2731
-      - 2642
-      - 2654
-      - 2684
-      - 2730
-      - 1658
-      - 2733
-      - 2661
-      - 2734
-      - 2662
-      - 2735
-      - 2751
-      - 2663
-      - 2732
-      - 2688
-      - 2748
-      - 2746
-      - 2686
-      - 2683
-      - 2705
-      - 2687
-      - 2747
+      - 2741
+      - 2652
+      - 2664
+      - 2694
+      - 2740
+      - 1668
+      - 2743
+      - 2671
+      - 2744
+      - 2672
+      - 2745
+      - 2761
+      - 2673
+      - 2742
+      - 2698
+      - 2758
+      - 2756
+      - 2696
+      - 2693
+      - 2715
+      - 2697
+      - 2757
   - uid: 20
     components:
     - type: Transform
@@ -3650,18 +3650,18 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2649
-      - 2702
-      - 1689
-      - 1690
+      - 2659
+      - 2712
+      - 1699
+      - 1700
+      - 2666
+      - 2713
+      - 2738
       - 2656
-      - 2703
-      - 2728
-      - 2646
-      - 2651
-      - 2725
-      - 2645
-      - 2706
+      - 2661
+      - 2735
+      - 2655
+      - 2716
   - uid: 21
     components:
     - type: Transform
@@ -3669,11 +3669,11 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2713
-      - 2650
-      - 1655
-      - 2645
-      - 2706
+      - 2723
+      - 2660
+      - 1665
+      - 2655
+      - 2716
   - uid: 22
     components:
     - type: Transform
@@ -3682,18 +3682,18 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2643
-      - 1661
-      - 2745
-      - 2687
-      - 2747
-      - 2746
-      - 2686
-      - 2705
-      - 2683
-      - 2688
-      - 2748
-      - 1660
+      - 2653
+      - 1671
+      - 2755
+      - 2697
+      - 2757
+      - 2756
+      - 2696
+      - 2715
+      - 2693
+      - 2698
+      - 2758
+      - 1670
   - uid: 23
     components:
     - type: Transform
@@ -3707,21 +3707,21 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2709
-      - 2665
-      - 2724
-      - 2639
-      - 2704
-      - 2653
-      - 2685
-      - 2736
-      - 1672
-      - 1671
-      - 1670
-      - 2688
-      - 2748
-      - 2687
-      - 2747
+      - 2719
+      - 2675
+      - 2734
+      - 2649
+      - 2714
+      - 2663
+      - 2695
+      - 2746
+      - 1682
+      - 1681
+      - 1680
+      - 2698
+      - 2758
+      - 2697
+      - 2757
   - uid: 25
     components:
     - type: Transform
@@ -3730,22 +3730,22 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2663
-      - 2751
-      - 1658
-      - 1693
-      - 2735
-      - 2662
-      - 2661
-      - 2734
-      - 2733
-      - 2684
-      - 2659
-      - 2732
-      - 2731
-      - 2654
-      - 2730
-      - 2642
+      - 2673
+      - 2761
+      - 1668
+      - 1703
+      - 2745
+      - 2672
+      - 2671
+      - 2744
+      - 2743
+      - 2694
+      - 2669
+      - 2742
+      - 2741
+      - 2664
+      - 2740
+      - 2652
   - uid: 26
     components:
     - type: Transform
@@ -3754,34 +3754,34 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1716
-      - 2746
-      - 2645
-      - 2706
-      - 1669
-      - 2686
-      - 2729
-      - 2679
-      - 2705
-      - 1691
-      - 1692
-      - 2683
-      - 1713
-      - 1673
-      - 1667
-      - 1668
-      - 1715
-      - 1717
-      - 2687
-      - 2747
-      - 1720
-      - 1719
-      - 1718
-      - 2688
-      - 2748
-      - 1672
-      - 1671
-      - 1670
+      - 1726
+      - 2756
+      - 2655
+      - 2716
+      - 1679
+      - 2696
+      - 2739
+      - 2689
+      - 2715
+      - 1701
+      - 1702
+      - 2693
+      - 1723
+      - 1683
+      - 1677
+      - 1678
+      - 1725
+      - 1727
+      - 2697
+      - 2757
+      - 1730
+      - 1729
+      - 1728
+      - 2698
+      - 2758
+      - 1682
+      - 1681
+      - 1680
   - uid: 27
     components:
     - type: Transform
@@ -3789,24 +3789,24 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2729
-      - 2679
-      - 1713
-      - 1714
-      - 2706
-      - 2645
-      - 2683
-      - 2705
-      - 2686
-      - 2746
-      - 2747
-      - 2687
-      - 2688
-      - 2748
-      - 1715
-      - 1716
-      - 1717
-      - 1664
+      - 2739
+      - 2689
+      - 1723
+      - 1724
+      - 2716
+      - 2655
+      - 2693
+      - 2715
+      - 2696
+      - 2756
+      - 2757
+      - 2697
+      - 2698
+      - 2758
+      - 1725
+      - 1726
+      - 1727
+      - 1674
   - uid: 28
     components:
     - type: Transform
@@ -3815,16 +3815,16 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2680
-      - 2750
-      - 1709
-      - 2749
-      - 2660
-      - 1651
-      - 1657
-      - 1656
-      - 1653
-      - 1654
+      - 2690
+      - 2760
+      - 1719
+      - 2759
+      - 2670
+      - 1661
+      - 1667
+      - 1666
+      - 1663
+      - 1664
   - uid: 29
     components:
     - type: Transform
@@ -3839,14 +3839,14 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1701
-      - 1700
-      - 1653
-      - 1654
-      - 1651
-      - 1652
-      - 2692
-      - 2757
+      - 1711
+      - 1710
+      - 1663
+      - 1664
+      - 1661
+      - 1662
+      - 2702
+      - 2767
   - uid: 31
     components:
     - type: Transform
@@ -3855,15 +3855,15 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1652
-      - 1702
-      - 1708
+      - 1662
       - 1712
+      - 1718
+      - 1722
+      - 1721
+      - 1717
       - 1711
-      - 1707
-      - 1701
-      - 2758
-      - 2638
+      - 2768
+      - 2648
   - uid: 32
     components:
     - type: Transform
@@ -3872,10 +3872,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1697
-      - 2695
-      - 2760
-      - 1696
+      - 1707
+      - 2705
+      - 2770
+      - 1706
   - uid: 33
     components:
     - type: Transform
@@ -3884,14 +3884,14 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 2693
-      - 2754
-      - 2752
-      - 2694
-      - 1706
-      - 1705
-      - 1704
-      - 1703
+      - 2703
+      - 2764
+      - 2762
+      - 2704
+      - 1716
+      - 1715
+      - 1714
+      - 1713
   - uid: 34
     components:
     - type: Transform
@@ -3899,25 +3899,25 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
+      - 2718
+      - 2658
+      - 1692
+      - 1691
+      - 1690
+      - 2685
+      - 2730
+      - 2729
+      - 2684
+      - 2774
+      - 2707
+      - 2775
+      - 2706
+      - 2710
+      - 2771
+      - 2709
+      - 2772
       - 2708
-      - 2648
-      - 1682
-      - 1681
-      - 1680
-      - 2675
-      - 2720
-      - 2719
-      - 2674
-      - 2764
-      - 2697
-      - 2765
-      - 2696
-      - 2700
-      - 2761
-      - 2699
-      - 2762
-      - 2698
-      - 2763
+      - 2773
 - proto: AirCanister
   entities:
   - uid: 35
@@ -4803,7 +4803,7 @@ entities:
       pos: -6.5,5.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -60646.074
+      secondsUntilStateChange: -60829.574
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -4865,14 +4865,14 @@ entities:
     - type: Transform
       pos: 1.5,31.5
       parent: 1
-  - uid: 2913
+  - uid: 182
     components:
     - type: Transform
       pos: 0.5,37.5
       parent: 1
 - proto: AirlockMedicalLocked
   entities:
-  - uid: 182
+  - uid: 183
     components:
     - type: Transform
       pos: -21.5,36.5
@@ -4921,12 +4921,12 @@ entities:
       - - Wizard
     missingComponents:
     - Destructible
-  - uid: 183
+  - uid: 184
     components:
     - type: Transform
       pos: 1.5,35.5
       parent: 1
-  - uid: 2908
+  - uid: 185
     components:
     - type: Transform
       pos: 6.5,35.5
@@ -4935,10 +4935,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2909:
+        186:
         - - DoorStatus
           - DoorBolt
-  - uid: 2909
+  - uid: 186
     components:
     - type: Transform
       pos: 8.5,35.5
@@ -4947,15 +4947,15 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2908:
+        185:
         - - DoorStatus
           - DoorBolt
-  - uid: 2910
+  - uid: 187
     components:
     - type: Transform
       pos: -1.5,32.5
       parent: 1
-  - uid: 2911
+  - uid: 188
     components:
     - type: Transform
       pos: -0.5,28.5
@@ -4964,20 +4964,20 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2915:
+        191:
         - - DoorStatus
           - DoorBolt
-  - uid: 2912
+  - uid: 189
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 1
-  - uid: 2914
+  - uid: 190
     components:
     - type: Transform
       pos: -1.5,35.5
       parent: 1
-  - uid: 2915
+  - uid: 191
     components:
     - type: Transform
       pos: -0.5,30.5
@@ -4986,66 +4986,66 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        2911:
+        188:
         - - DoorStatus
           - DoorBolt
 - proto: AirlockMedicalScienceGlassLocked
   entities:
-  - uid: 184
+  - uid: 192
     components:
     - type: Transform
       pos: 3.5,18.5
       parent: 1
 - proto: AirlockMedicalScienceLocked
   entities:
-  - uid: 185
+  - uid: 193
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -38353.62
+      secondsUntilStateChange: -38537.12
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
 - proto: AirlockScienceGlass
   entities:
-  - uid: 186
+  - uid: 194
     components:
     - type: Transform
       pos: 10.5,21.5
       parent: 1
-  - uid: 187
+  - uid: 195
     components:
     - type: Transform
       pos: 8.5,21.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 188
+  - uid: 196
     components:
     - type: Transform
       pos: -11.5,5.5
       parent: 1
-  - uid: 189
+  - uid: 197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,20.5
       parent: 1
-  - uid: 190
+  - uid: 198
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,30.5
       parent: 1
-  - uid: 191
+  - uid: 199
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 192
+  - uid: 200
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5053,324 +5053,324 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 193
+  - uid: 201
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,36.5
       parent: 1
-  - uid: 194
+  - uid: 202
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,35.5
       parent: 1
-  - uid: 195
+  - uid: 203
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,34.5
       parent: 1
-  - uid: 196
+  - uid: 204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-12.5
       parent: 1
-  - uid: 197
+  - uid: 205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,26.5
       parent: 1
-  - uid: 198
+  - uid: 206
     components:
     - type: Transform
       pos: 12.5,19.5
       parent: 1
-  - uid: 199
+  - uid: 207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,21.5
       parent: 1
-  - uid: 200
+  - uid: 208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,23.5
       parent: 1
-  - uid: 201
+  - uid: 209
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-13.5
       parent: 1
-  - uid: 202
+  - uid: 210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-14.5
       parent: 1
-  - uid: 203
+  - uid: 211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-14.5
       parent: 1
-  - uid: 204
+  - uid: 212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-13.5
       parent: 1
-  - uid: 205
+  - uid: 213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-12.5
       parent: 1
-  - uid: 206
+  - uid: 214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-26.5
       parent: 1
-  - uid: 207
+  - uid: 215
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-27.5
       parent: 1
-  - uid: 208
+  - uid: 216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-28.5
       parent: 1
-  - uid: 209
+  - uid: 217
     components:
     - type: Transform
       pos: -33.5,0.5
       parent: 1
-  - uid: 210
+  - uid: 218
     components:
     - type: Transform
       pos: -32.5,0.5
       parent: 1
-  - uid: 211
+  - uid: 219
     components:
     - type: Transform
       pos: -31.5,0.5
       parent: 1
-  - uid: 212
+  - uid: 220
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-26.5
       parent: 1
-  - uid: 213
+  - uid: 221
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-27.5
       parent: 1
-  - uid: 214
+  - uid: 222
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-28.5
       parent: 1
-  - uid: 215
+  - uid: 223
     components:
     - type: Transform
       pos: -9.5,-31.5
       parent: 1
-  - uid: 216
+  - uid: 224
     components:
     - type: Transform
       pos: -10.5,-31.5
       parent: 1
-  - uid: 217
+  - uid: 225
     components:
     - type: Transform
       pos: -11.5,-31.5
       parent: 1
-  - uid: 218
+  - uid: 226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,8.5
       parent: 1
-  - uid: 219
+  - uid: 227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,8.5
       parent: 1
-  - uid: 220
+  - uid: 228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,8.5
       parent: 1
-  - uid: 221
+  - uid: 229
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,8.5
       parent: 1
-  - uid: 222
+  - uid: 230
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,8.5
       parent: 1
-  - uid: 223
+  - uid: 231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,8.5
       parent: 1
-  - uid: 224
+  - uid: 232
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 1
-  - uid: 225
+  - uid: 233
     components:
     - type: Transform
       pos: 11.5,0.5
       parent: 1
-  - uid: 226
+  - uid: 234
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
-  - uid: 227
+  - uid: 235
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,3.5
       parent: 1
-  - uid: 228
+  - uid: 236
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,4.5
       parent: 1
-  - uid: 229
+  - uid: 237
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,5.5
       parent: 1
-  - uid: 230
+  - uid: 238
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,21.5
       parent: 1
-  - uid: 231
+  - uid: 239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,52.5
       parent: 1
-  - uid: 232
+  - uid: 240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,53.5
       parent: 1
-  - uid: 233
+  - uid: 241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,54.5
       parent: 1
-  - uid: 234
+  - uid: 242
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,57.5
       parent: 1
-  - uid: 235
+  - uid: 243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,57.5
       parent: 1
-  - uid: 236
+  - uid: 244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,57.5
       parent: 1
-  - uid: 237
+  - uid: 245
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,54.5
       parent: 1
-  - uid: 238
+  - uid: 246
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,53.5
       parent: 1
-  - uid: 239
+  - uid: 247
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,52.5
       parent: 1
-  - uid: 240
+  - uid: 248
     components:
     - type: Transform
       pos: -45.5,0.5
       parent: 1
-  - uid: 241
+  - uid: 249
     components:
     - type: Transform
       pos: -46.5,0.5
       parent: 1
-  - uid: 242
+  - uid: 250
     components:
     - type: Transform
       pos: -47.5,0.5
       parent: 1
-  - uid: 243
+  - uid: 251
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,3.5
       parent: 1
-  - uid: 244
+  - uid: 252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,4.5
       parent: 1
-  - uid: 245
+  - uid: 253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,5.5
       parent: 1
-  - uid: 246
+  - uid: 254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -47.5,8.5
       parent: 1
-  - uid: 247
+  - uid: 255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,8.5
       parent: 1
-  - uid: 248
+  - uid: 256
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5378,673 +5378,673 @@ entities:
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 249
+  - uid: 257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-30.5
       parent: 1
-  - uid: 250
+  - uid: 258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-30.5
       parent: 1
-  - uid: 251
+  - uid: 259
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-1.5
       parent: 1
-  - uid: 252
+  - uid: 260
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-31.5
       parent: 1
-  - uid: 253
+  - uid: 261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-31.5
       parent: 1
-  - uid: 254
+  - uid: 262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-30.5
       parent: 1
-  - uid: 255
+  - uid: 263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-30.5
       parent: 1
-  - uid: 256
+  - uid: 264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-24.5
       parent: 1
-  - uid: 257
+  - uid: 265
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-22.5
       parent: 1
-  - uid: 258
+  - uid: 266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-22.5
       parent: 1
-  - uid: 259
+  - uid: 267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-24.5
       parent: 1
-  - uid: 260
+  - uid: 268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-18.5
       parent: 1
-  - uid: 261
+  - uid: 269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-18.5
       parent: 1
-  - uid: 262
+  - uid: 270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-16.5
       parent: 1
-  - uid: 263
+  - uid: 271
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-16.5
       parent: 1
-  - uid: 264
+  - uid: 272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-10.5
       parent: 1
-  - uid: 265
+  - uid: 273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-10.5
       parent: 1
-  - uid: 266
+  - uid: 274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-8.5
       parent: 1
-  - uid: 267
+  - uid: 275
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-8.5
       parent: 1
-  - uid: 268
+  - uid: 276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-4.5
       parent: 1
-  - uid: 269
+  - uid: 277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-4.5
       parent: 1
-  - uid: 270
+  - uid: 278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-0.5
       parent: 1
-  - uid: 271
+  - uid: 279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,0.5
       parent: 1
-  - uid: 272
+  - uid: 280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,1.5
       parent: 1
-  - uid: 273
+  - uid: 281
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,1.5
       parent: 1
-  - uid: 274
+  - uid: 282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,1.5
       parent: 1
-  - uid: 275
+  - uid: 283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,0.5
       parent: 1
-  - uid: 276
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -29.5,8.5
-      parent: 1
-  - uid: 277
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -29.5,8.5
-      parent: 1
-  - uid: 278
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -29.5,7.5
-      parent: 1
-  - uid: 279
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -28.5,7.5
-      parent: 1
-  - uid: 280
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,13.5
-      parent: 1
-  - uid: 281
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,15.5
-      parent: 1
-  - uid: 282
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,16.5
-      parent: 1
-  - uid: 283
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,17.5
-      parent: 1
   - uid: 284
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -22.5,18.5
+      pos: -29.5,8.5
       parent: 1
   - uid: 285
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -21.5,18.5
+      pos: -29.5,8.5
       parent: 1
   - uid: 286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -21.5,19.5
+      pos: -29.5,7.5
       parent: 1
   - uid: 287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,16.5
+      pos: -28.5,7.5
       parent: 1
   - uid: 288
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,27.5
+      rot: 3.141592653589793 rad
+      pos: -27.5,13.5
       parent: 1
   - uid: 289
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,27.5
+      pos: -26.5,15.5
       parent: 1
   - uid: 290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,26.5
+      pos: -25.5,16.5
       parent: 1
   - uid: 291
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 8.5,26.5
+      pos: -23.5,17.5
       parent: 1
   - uid: 292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,26.5
+      pos: -22.5,18.5
       parent: 1
   - uid: 293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,26.5
+      pos: -21.5,18.5
       parent: 1
   - uid: 294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 11.5,26.5
+      pos: -21.5,19.5
       parent: 1
   - uid: 295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 12.5,26.5
+      pos: 6.5,16.5
       parent: 1
   - uid: 296
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,25.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,27.5
       parent: 1
   - uid: 297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 12.5,24.5
+      pos: 7.5,27.5
       parent: 1
   - uid: 298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,24.5
+      pos: 7.5,26.5
       parent: 1
   - uid: 299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,22.5
+      pos: 8.5,26.5
       parent: 1
   - uid: 300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,21.5
+      pos: 9.5,26.5
       parent: 1
   - uid: 301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,20.5
+      pos: 10.5,26.5
       parent: 1
   - uid: 302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 13.5,18.5
+      pos: 11.5,26.5
       parent: 1
   - uid: 303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 12.5,18.5
+      pos: 12.5,26.5
       parent: 1
   - uid: 304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,17.5
+      pos: 10.5,25.5
       parent: 1
   - uid: 305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,8.5
+      pos: 12.5,24.5
       parent: 1
   - uid: 306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,7.5
+      pos: 13.5,24.5
       parent: 1
   - uid: 307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,7.5
+      pos: 15.5,22.5
       parent: 1
   - uid: 308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -0.5,0.5
+      pos: 15.5,21.5
       parent: 1
   - uid: 309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,1.5
+      pos: 15.5,20.5
       parent: 1
   - uid: 310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,1.5
+      pos: 13.5,18.5
       parent: 1
   - uid: 311
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,0.5
+      pos: 12.5,18.5
       parent: 1
   - uid: 312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 8.5,0.5
+      pos: 10.5,17.5
       parent: 1
   - uid: 313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,1.5
+      pos: 14.5,8.5
       parent: 1
   - uid: 314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,1.5
+      pos: 14.5,7.5
       parent: 1
   - uid: 315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,1.5
+      pos: 15.5,7.5
       parent: 1
   - uid: 316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,-0.5
+      pos: -0.5,0.5
       parent: 1
   - uid: 317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-1.5
+      pos: 15.5,1.5
       parent: 1
   - uid: 318
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,30.5
+      rot: 3.141592653589793 rad
+      pos: 14.5,1.5
       parent: 1
   - uid: 319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -23.5,27.5
+      pos: 14.5,0.5
       parent: 1
   - uid: 320
     components:
     - type: Transform
-      pos: -23.5,41.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,0.5
       parent: 1
   - uid: 321
     components:
     - type: Transform
-      pos: -24.5,40.5
+      rot: 3.141592653589793 rad
+      pos: 7.5,1.5
       parent: 1
   - uid: 322
     components:
     - type: Transform
-      pos: -18.5,42.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,1.5
       parent: 1
   - uid: 323
     components:
     - type: Transform
-      pos: -13.5,45.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
       parent: 1
   - uid: 324
     components:
     - type: Transform
-      pos: -7.5,45.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
       parent: 1
   - uid: 325
     components:
     - type: Transform
-      pos: -7.5,49.5
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
       parent: 1
   - uid: 326
     components:
     - type: Transform
-      pos: -6.5,50.5
+      rot: 1.5707963267948966 rad
+      pos: -24.5,30.5
       parent: 1
   - uid: 327
     components:
     - type: Transform
-      pos: -14.5,50.5
+      rot: 3.141592653589793 rad
+      pos: -23.5,27.5
       parent: 1
   - uid: 328
     components:
     - type: Transform
-      pos: -13.5,49.5
+      pos: -23.5,41.5
       parent: 1
   - uid: 329
     components:
     - type: Transform
-      pos: -14.5,56.5
+      pos: -24.5,40.5
       parent: 1
   - uid: 330
     components:
     - type: Transform
-      pos: -13.5,56.5
+      pos: -18.5,42.5
       parent: 1
   - uid: 331
     components:
     - type: Transform
-      pos: -13.5,57.5
+      pos: -13.5,45.5
       parent: 1
   - uid: 332
     components:
     - type: Transform
-      pos: -7.5,57.5
+      pos: -7.5,45.5
       parent: 1
   - uid: 333
     components:
     - type: Transform
-      pos: -7.5,56.5
+      pos: -7.5,49.5
       parent: 1
   - uid: 334
     components:
     - type: Transform
-      pos: -6.5,56.5
+      pos: -6.5,50.5
       parent: 1
   - uid: 335
     components:
     - type: Transform
-      pos: -0.5,42.5
+      pos: -14.5,50.5
       parent: 1
   - uid: 336
     components:
     - type: Transform
-      pos: 9.5,42.5
+      pos: -13.5,49.5
       parent: 1
   - uid: 337
     components:
     - type: Transform
-      pos: 11.5,32.5
+      pos: -14.5,56.5
       parent: 1
   - uid: 338
     components:
     - type: Transform
-      pos: -1.5,42.5
+      pos: -13.5,56.5
       parent: 1
   - uid: 339
     components:
     - type: Transform
-      pos: 13.5,41.5
+      pos: -13.5,57.5
       parent: 1
   - uid: 340
     components:
     - type: Transform
-      pos: 16.5,38.5
+      pos: -7.5,57.5
       parent: 1
   - uid: 341
     components:
     - type: Transform
-      pos: 14.5,40.5
+      pos: -7.5,56.5
       parent: 1
   - uid: 342
     components:
     - type: Transform
-      pos: -3.5,43.5
+      pos: -6.5,56.5
       parent: 1
   - uid: 343
     components:
     - type: Transform
-      pos: 3.5,42.5
+      pos: -0.5,42.5
       parent: 1
   - uid: 344
     components:
     - type: Transform
-      pos: 4.5,42.5
+      pos: 9.5,42.5
       parent: 1
   - uid: 345
     components:
     - type: Transform
-      pos: 6.5,28.5
+      pos: 11.5,32.5
       parent: 1
   - uid: 346
     components:
     - type: Transform
-      pos: 5.5,42.5
+      pos: -1.5,42.5
       parent: 1
   - uid: 347
     components:
     - type: Transform
-      pos: 2.5,42.5
+      pos: 13.5,41.5
       parent: 1
   - uid: 348
     components:
     - type: Transform
-      pos: 1.5,42.5
+      pos: 16.5,38.5
       parent: 1
   - uid: 349
     components:
     - type: Transform
-      pos: 0.5,42.5
+      pos: 14.5,40.5
       parent: 1
   - uid: 350
     components:
     - type: Transform
+      pos: -3.5,43.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 3.5,42.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 4.5,42.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      pos: 6.5,28.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 5.5,42.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      pos: 2.5,42.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: 1.5,42.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      pos: 0.5,42.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
       pos: 16.5,32.5
       parent: 1
-  - uid: 3815
+  - uid: 359
     components:
     - type: Transform
       pos: -17.5,43.5
       parent: 1
 - proto: AtmosFixNitrogenMarker
   entities:
-  - uid: 351
+  - uid: 360
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 352
+  - uid: 361
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 353
+  - uid: 362
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 354
+  - uid: 363
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
 - proto: Autolathe
   entities:
-  - uid: 355
+  - uid: 364
     components:
     - type: Transform
       pos: -14.5,41.5
       parent: 1
 - proto: BannerMedical
   entities:
-  - uid: 356
+  - uid: 365
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 1
-  - uid: 357
+  - uid: 366
     components:
     - type: Transform
       pos: -14.5,22.5
       parent: 1
-  - uid: 358
+  - uid: 367
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 1
-  - uid: 359
+  - uid: 368
     components:
     - type: Transform
       pos: 2.5,40.5
       parent: 1
 - proto: BarricadeBlock
   entities:
-  - uid: 360
+  - uid: 369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,18.5
       parent: 1
-  - uid: 361
+  - uid: 370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,21.5
       parent: 1
-  - uid: 362
+  - uid: 371
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 1
 - proto: BarricadeDirectional
   entities:
-  - uid: 363
+  - uid: 372
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,21.5
       parent: 1
-  - uid: 364
+  - uid: 373
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6052,7 +6052,7 @@ entities:
       parent: 1
 - proto: BarSign
   entities:
-  - uid: 365
+  - uid: 374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6060,107 +6060,107 @@ entities:
       parent: 1
 - proto: BaseGasCondenser
   entities:
-  - uid: 366
+  - uid: 375
     components:
     - type: Transform
       pos: -12.5,9.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 367
+  - uid: 376
     components:
     - type: Transform
       pos: -23.5,7.5
       parent: 1
-  - uid: 368
+  - uid: 377
     components:
     - type: Transform
       pos: 1.5,40.5
       parent: 1
-  - uid: 369
+  - uid: 378
     components:
     - type: Transform
       pos: 12.5,38.5
       parent: 1
-  - uid: 370
+  - uid: 379
     components:
     - type: Transform
       pos: -0.5,40.5
       parent: 1
-  - uid: 371
+  - uid: 380
     components:
     - type: Transform
       pos: 0.5,40.5
       parent: 1
 - proto: BedsheetCMO
   entities:
-  - uid: 372
+  - uid: 381
     components:
     - type: Transform
       pos: -14.5,24.5
       parent: 1
-  - uid: 373
+  - uid: 382
     components:
     - type: Transform
       pos: 12.5,38.5
       parent: 1
 - proto: BedsheetMedical
   entities:
-  - uid: 374
+  - uid: 383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,30.5
       parent: 1
-  - uid: 375
+  - uid: 384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,29.5
       parent: 1
-  - uid: 376
+  - uid: 385
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,30.5
       parent: 1
-  - uid: 377
+  - uid: 386
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,29.5
       parent: 1
-  - uid: 378
+  - uid: 387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,40.5
       parent: 1
-  - uid: 379
+  - uid: 388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,40.5
       parent: 1
-  - uid: 380
+  - uid: 389
     components:
     - type: Transform
       pos: 5.5,29.5
       parent: 1
-  - uid: 381
+  - uid: 390
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,40.5
       parent: 1
-  - uid: 382
+  - uid: 391
     components:
     - type: Transform
       pos: 5.5,30.5
       parent: 1
 - proto: BedsheetUSA
   entities:
-  - uid: 383
+  - uid: 392
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6168,243 +6168,243 @@ entities:
       parent: 1
 - proto: BenchColorfulComfy
   entities:
-  - uid: 384
+  - uid: 393
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-5.5
       parent: 1
-  - uid: 385
+  - uid: 394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,2.5
       parent: 1
-  - uid: 386
+  - uid: 395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,2.5
       parent: 1
-  - uid: 387
+  - uid: 396
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-7.5
       parent: 1
-  - uid: 388
+  - uid: 397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-7.5
       parent: 1
-  - uid: 389
+  - uid: 398
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-5.5
       parent: 1
-  - uid: 390
+  - uid: 399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-19.5
       parent: 1
-  - uid: 391
+  - uid: 400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-21.5
       parent: 1
-  - uid: 392
+  - uid: 401
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-21.5
       parent: 1
-  - uid: 393
+  - uid: 402
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-19.5
       parent: 1
-  - uid: 394
+  - uid: 403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 395
+  - uid: 404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,2.5
       parent: 1
-  - uid: 396
+  - uid: 405
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,48.5
       parent: 1
-  - uid: 397
+  - uid: 406
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,46.5
       parent: 1
-  - uid: 398
+  - uid: 407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,46.5
       parent: 1
-  - uid: 399
+  - uid: 408
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,48.5
       parent: 1
-  - uid: 400
+  - uid: 409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,2.5
       parent: 1
-  - uid: 401
+  - uid: 410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,2.5
       parent: 1
-  - uid: 402
+  - uid: 411
     components:
     - type: Transform
       pos: -40.5,6.5
       parent: 1
-  - uid: 403
+  - uid: 412
     components:
     - type: Transform
       pos: -38.5,6.5
       parent: 1
 - proto: BenchComfy
   entities:
-  - uid: 404
+  - uid: 413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-0.5
       parent: 1
-  - uid: 405
+  - uid: 414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-0.5
       parent: 1
-  - uid: 406
+  - uid: 415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-0.5
       parent: 1
-  - uid: 407
+  - uid: 416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-0.5
       parent: 1
-  - uid: 408
+  - uid: 417
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,1.5
       parent: 1
-  - uid: 409
+  - uid: 418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,1.5
       parent: 1
-  - uid: 410
+  - uid: 419
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,0.5
       parent: 1
-  - uid: 411
+  - uid: 420
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-0.5
       parent: 1
-  - uid: 412
+  - uid: 421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,0.5
       parent: 1
-  - uid: 413
+  - uid: 422
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 414
+  - uid: 423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 415
+  - uid: 424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 416
+  - uid: 425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 417
+  - uid: 426
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 1
-  - uid: 418
+  - uid: 427
     components:
     - type: Transform
       pos: -13.5,13.5
       parent: 1
-  - uid: 419
+  - uid: 428
     components:
     - type: Transform
       pos: -8.5,13.5
       parent: 1
-  - uid: 420
+  - uid: 429
     components:
     - type: Transform
       pos: -12.5,13.5
       parent: 1
-  - uid: 421
+  - uid: 430
     components:
     - type: Transform
       pos: -7.5,13.5
       parent: 1
-  - uid: 422
+  - uid: 431
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
-  - uid: 423
+  - uid: 432
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
 - proto: BenchSofaCorner
   entities:
-  - uid: 424
+  - uid: 433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6412,30 +6412,30 @@ entities:
       parent: 1
 - proto: BenchSofaCorpCorner
   entities:
-  - uid: 425
+  - uid: 434
     components:
     - type: Transform
       pos: -21.5,16.5
       parent: 1
-  - uid: 426
+  - uid: 435
     components:
     - type: Transform
       pos: -18.5,16.5
       parent: 1
 - proto: BenchSofaCorpLeft
   entities:
-  - uid: 427
+  - uid: 436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,15.5
       parent: 1
-  - uid: 428
+  - uid: 437
     components:
     - type: Transform
       pos: -20.5,40.5
       parent: 1
-  - uid: 429
+  - uid: 438
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6443,24 +6443,24 @@ entities:
       parent: 1
 - proto: BenchSofaCorpRight
   entities:
-  - uid: 430
+  - uid: 439
     components:
     - type: Transform
       pos: -22.5,16.5
       parent: 1
-  - uid: 431
+  - uid: 440
     components:
     - type: Transform
       pos: -21.5,40.5
       parent: 1
-  - uid: 432
+  - uid: 441
     components:
     - type: Transform
       pos: -19.5,16.5
       parent: 1
 - proto: BenchSofaLeft
   entities:
-  - uid: 433
+  - uid: 442
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6468,7 +6468,7 @@ entities:
       parent: 1
 - proto: BenchSofaMiddle
   entities:
-  - uid: 434
+  - uid: 443
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6476,7 +6476,7 @@ entities:
       parent: 1
 - proto: BenchSofaRight
   entities:
-  - uid: 435
+  - uid: 444
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6484,103 +6484,103 @@ entities:
       parent: 1
 - proto: BiomassReclaimer
   entities:
-  - uid: 436
+  - uid: 445
     components:
     - type: Transform
       pos: -6.5,38.5
       parent: 1
 - proto: BlastDoorOpen
   entities:
-  - uid: 437
+  - uid: 446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,19.5
       parent: 1
-  - uid: 438
+  - uid: 447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,21.5
       parent: 1
-  - uid: 439
+  - uid: 448
     components:
     - type: Transform
       pos: 12.5,23.5
       parent: 1
-  - uid: 440
+  - uid: 449
     components:
     - type: Transform
       pos: -5.5,33.5
       parent: 1
-  - uid: 441
+  - uid: 450
     components:
     - type: Transform
       pos: -4.5,33.5
       parent: 1
-  - uid: 442
+  - uid: 451
     components:
     - type: Transform
       pos: -3.5,33.5
       parent: 1
-  - uid: 443
+  - uid: 452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,38.5
       parent: 1
-  - uid: 444
+  - uid: 453
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,31.5
       parent: 1
-  - uid: 445
+  - uid: 454
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,39.5
       parent: 1
-  - uid: 446
+  - uid: 455
     components:
     - type: Transform
       pos: 0.5,41.5
       parent: 1
-  - uid: 447
+  - uid: 456
     components:
     - type: Transform
       pos: 3.5,41.5
       parent: 1
-  - uid: 448
+  - uid: 457
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,29.5
       parent: 1
-  - uid: 449
+  - uid: 458
     components:
     - type: Transform
       pos: 11.5,41.5
       parent: 1
-  - uid: 450
+  - uid: 459
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,30.5
       parent: 1
-  - uid: 451
+  - uid: 460
     components:
     - type: Transform
       pos: 13.5,40.5
       parent: 1
-  - uid: 452
+  - uid: 461
     components:
     - type: Transform
       pos: 12.5,41.5
       parent: 1
 - proto: BookMedicalOfficer
   entities:
-  - uid: 453
+  - uid: 462
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6588,7 +6588,7 @@ entities:
       parent: 1
 - proto: BoozeDispenser
   entities:
-  - uid: 454
+  - uid: 463
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6596,7 +6596,7 @@ entities:
       parent: 1
 - proto: BorgCharger
   entities:
-  - uid: 455
+  - uid: 464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6604,96 +6604,96 @@ entities:
       parent: 1
 - proto: BoxBodyBag
   entities:
-  - uid: 456
+  - uid: 465
     components:
     - type: Transform
       pos: -7.4532957,38.696983
       parent: 1
-  - uid: 457
+  - uid: 466
     components:
     - type: Transform
       pos: 0.5222826,33.670086
       parent: 1
 - proto: BoxExteriorLightTube
   entities:
-  - uid: 458
+  - uid: 467
     components:
     - type: Transform
       pos: -8.384234,6.551012
       parent: 1
 - proto: BoxFolderMedicalDoctor
   entities:
-  - uid: 459
+  - uid: 468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.605691,20.811378
       parent: 1
-  - uid: 460
+  - uid: 469
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.422231,20.603458
       parent: 1
-  - uid: 461
+  - uid: 470
     components:
     - type: Transform
       pos: -19.741837,26.566772
       parent: 1
-  - uid: 462
+  - uid: 471
     components:
     - type: Transform
       pos: -19.491837,26.681358
       parent: 1
-  - uid: 463
+  - uid: 472
     components:
     - type: Transform
       pos: -19.606945,39.878635
       parent: 1
-  - uid: 464
+  - uid: 473
     components:
     - type: Transform
       pos: -19.388195,39.64426
       parent: 1
 - proto: BoxHugHealing
   entities:
-  - uid: 465
+  - uid: 474
     components:
     - type: Transform
       pos: 3.5088294,40.696644
       parent: 1
 - proto: BoxLighttube
   entities:
-  - uid: 466
+  - uid: 475
     components:
     - type: Transform
       pos: -8.579925,6.783394
       parent: 1
 - proto: BoxMagazine12_gaugeBeanbag
   entities:
-  - uid: 468
+  - uid: 477
     components:
     - type: Transform
-      parent: 467
+      parent: 476
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ButtonFrameCaution
   entities:
-  - uid: 472
+  - uid: 481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,18.5
       parent: 1
-  - uid: 473
+  - uid: 482
     components:
     - type: Transform
       pos: 12.5,37.5
       parent: 1
 - proto: ButtonFrameCautionSecurity
   entities:
-  - uid: 474
+  - uid: 483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6701,109 +6701,109 @@ entities:
       parent: 1
 - proto: ButtonFrameGrey
   entities:
-  - uid: 475
+  - uid: 484
     components:
     - type: Transform
       pos: -10.5,5.5
       parent: 1
-  - uid: 476
+  - uid: 485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-22.5
       parent: 1
-  - uid: 477
+  - uid: 486
     components:
     - type: Transform
       pos: -8.5,-18.5
       parent: 1
-  - uid: 478
+  - uid: 487
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 1
-  - uid: 479
+  - uid: 488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-8.5
       parent: 1
-  - uid: 480
+  - uid: 489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,18.5
       parent: 1
-  - uid: 481
+  - uid: 490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 1
-  - uid: 482
+  - uid: 491
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 483
+  - uid: 492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,23.5
       parent: 1
-  - uid: 484
+  - uid: 493
     components:
     - type: Transform
       pos: -20.5,36.5
       parent: 1
-  - uid: 485
+  - uid: 494
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,37.5
       parent: 1
-  - uid: 486
+  - uid: 495
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,14.5
       parent: 1
-  - uid: 487
+  - uid: 496
     components:
     - type: Transform
       pos: -12.5,49.5
       parent: 1
-  - uid: 488
+  - uid: 497
     components:
     - type: Transform
       pos: -8.5,49.5
       parent: 1
-  - uid: 489
+  - uid: 498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,39.5
       parent: 1
-  - uid: 490
+  - uid: 499
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,37.5
       parent: 1
-  - uid: 491
+  - uid: 500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,30.5
       parent: 1
-  - uid: 492
+  - uid: 501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,2.5
       parent: 1
-  - uid: 493
+  - uid: 502
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6811,7 +6811,7 @@ entities:
       parent: 1
 - proto: ButtonFrameJanitor
   entities:
-  - uid: 494
+  - uid: 503
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6819,3921 +6819,3926 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 495
+  - uid: 504
     components:
     - type: Transform
       pos: 0.5,37.5
       parent: 1
-  - uid: 496
+  - uid: 505
     components:
     - type: Transform
       pos: 0.5,39.5
       parent: 1
-  - uid: 497
+  - uid: 506
     components:
     - type: Transform
       pos: 11.5,36.5
       parent: 1
-  - uid: 498
+  - uid: 507
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 499
+  - uid: 508
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 500
+  - uid: 509
     components:
     - type: Transform
       pos: -10.5,47.5
       parent: 1
-  - uid: 501
+  - uid: 510
     components:
     - type: Transform
       pos: -10.5,45.5
       parent: 1
-  - uid: 502
+  - uid: 511
     components:
     - type: Transform
       pos: -10.5,46.5
       parent: 1
-  - uid: 503
+  - uid: 512
     components:
     - type: Transform
       pos: -13.5,53.5
       parent: 1
-  - uid: 504
+  - uid: 513
     components:
     - type: Transform
       pos: -10.5,52.5
       parent: 1
-  - uid: 505
+  - uid: 514
     components:
     - type: Transform
       pos: -11.5,56.5
       parent: 1
-  - uid: 506
+  - uid: 515
     components:
     - type: Transform
       pos: -9.5,56.5
       parent: 1
-  - uid: 507
+  - uid: 516
     components:
     - type: Transform
       pos: -17.5,31.5
       parent: 1
-  - uid: 508
+  - uid: 517
     components:
     - type: Transform
       pos: -16.5,31.5
       parent: 1
-  - uid: 509
+  - uid: 518
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 510
+  - uid: 519
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 1
-  - uid: 511
+  - uid: 520
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 512
+  - uid: 521
     components:
     - type: Transform
       pos: -16.5,21.5
       parent: 1
-  - uid: 513
+  - uid: 522
     components:
     - type: Transform
       pos: -19.5,21.5
       parent: 1
-  - uid: 514
+  - uid: 523
     components:
     - type: Transform
       pos: 1.5,22.5
       parent: 1
-  - uid: 515
+  - uid: 524
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 516
+  - uid: 525
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 517
+  - uid: 526
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 518
+  - uid: 527
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 519
+  - uid: 528
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 520
+  - uid: 529
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 521
+  - uid: 530
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 522
+  - uid: 531
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 523
+  - uid: 532
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 524
+  - uid: 533
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 525
+  - uid: 534
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 526
+  - uid: 535
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 527
+  - uid: 536
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 528
+  - uid: 537
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
-  - uid: 529
+  - uid: 538
     components:
     - type: Transform
       pos: 14.5,4.5
       parent: 1
-  - uid: 530
+  - uid: 539
     components:
     - type: Transform
       pos: 14.5,5.5
       parent: 1
-  - uid: 531
+  - uid: 540
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 1
-  - uid: 532
+  - uid: 541
     components:
     - type: Transform
       pos: 11.5,5.5
       parent: 1
-  - uid: 533
+  - uid: 542
     components:
     - type: Transform
       pos: 11.5,7.5
       parent: 1
-  - uid: 534
+  - uid: 543
     components:
     - type: Transform
       pos: 11.5,6.5
       parent: 1
-  - uid: 535
+  - uid: 544
     components:
     - type: Transform
       pos: 10.5,7.5
       parent: 1
-  - uid: 536
+  - uid: 545
     components:
     - type: Transform
       pos: 12.5,7.5
       parent: 1
-  - uid: 537
+  - uid: 546
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 1
-  - uid: 538
+  - uid: 547
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 1
-  - uid: 539
+  - uid: 548
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 1
-  - uid: 540
+  - uid: 549
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 541
+  - uid: 550
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 1
-  - uid: 542
+  - uid: 551
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 543
+  - uid: 552
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 544
+  - uid: 553
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 545
+  - uid: 554
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 546
-    components:
-    - type: Transform
-      pos: -9.5,5.5
-      parent: 1
-  - uid: 547
-    components:
-    - type: Transform
-      pos: -10.5,0.5
-      parent: 1
-  - uid: 548
-    components:
-    - type: Transform
-      pos: -10.5,4.5
-      parent: 1
-  - uid: 549
-    components:
-    - type: Transform
-      pos: -11.5,4.5
-      parent: 1
-  - uid: 550
-    components:
-    - type: Transform
-      pos: -11.5,5.5
-      parent: 1
-  - uid: 551
-    components:
-    - type: Transform
-      pos: -10.5,1.5
-      parent: 1
-  - uid: 552
-    components:
-    - type: Transform
-      pos: -9.5,5.5
-      parent: 1
-  - uid: 553
-    components:
-    - type: Transform
-      pos: -10.5,2.5
-      parent: 1
-  - uid: 554
-    components:
-    - type: Transform
-      pos: -10.5,3.5
-      parent: 1
   - uid: 555
     components:
     - type: Transform
-      pos: -9.5,4.5
+      pos: -9.5,5.5
       parent: 1
   - uid: 556
     components:
     - type: Transform
-      pos: -10.5,-0.5
+      pos: -10.5,0.5
       parent: 1
   - uid: 557
     components:
     - type: Transform
-      pos: -10.5,-1.5
+      pos: -10.5,4.5
       parent: 1
   - uid: 558
     components:
     - type: Transform
-      pos: -10.5,-2.5
+      pos: -11.5,4.5
       parent: 1
   - uid: 559
     components:
     - type: Transform
-      pos: -10.5,-3.5
+      pos: -11.5,5.5
       parent: 1
   - uid: 560
     components:
     - type: Transform
-      pos: -10.5,-4.5
+      pos: -10.5,1.5
       parent: 1
   - uid: 561
     components:
     - type: Transform
-      pos: -10.5,-5.5
+      pos: -9.5,5.5
       parent: 1
   - uid: 562
     components:
     - type: Transform
-      pos: -10.5,-6.5
+      pos: -10.5,2.5
       parent: 1
   - uid: 563
     components:
     - type: Transform
-      pos: -10.5,-7.5
+      pos: -10.5,3.5
       parent: 1
   - uid: 564
     components:
     - type: Transform
-      pos: -10.5,-8.5
+      pos: -9.5,4.5
       parent: 1
   - uid: 565
     components:
     - type: Transform
-      pos: -10.5,-9.5
+      pos: -10.5,-0.5
       parent: 1
   - uid: 566
     components:
     - type: Transform
-      pos: -10.5,-10.5
+      pos: -10.5,-1.5
       parent: 1
   - uid: 567
     components:
     - type: Transform
-      pos: -10.5,-11.5
+      pos: -10.5,-2.5
       parent: 1
   - uid: 568
     components:
     - type: Transform
-      pos: -10.5,-12.5
+      pos: -10.5,-3.5
       parent: 1
   - uid: 569
     components:
     - type: Transform
-      pos: -10.5,-13.5
+      pos: -10.5,-4.5
       parent: 1
   - uid: 570
     components:
     - type: Transform
-      pos: -10.5,-15.5
+      pos: -10.5,-5.5
       parent: 1
   - uid: 571
     components:
     - type: Transform
-      pos: -10.5,-14.5
+      pos: -10.5,-6.5
       parent: 1
   - uid: 572
     components:
     - type: Transform
-      pos: -10.5,-16.5
+      pos: -10.5,-7.5
       parent: 1
   - uid: 573
     components:
     - type: Transform
-      pos: -10.5,-17.5
+      pos: -10.5,-8.5
       parent: 1
   - uid: 574
     components:
     - type: Transform
-      pos: -10.5,-18.5
+      pos: -10.5,-9.5
       parent: 1
   - uid: 575
     components:
     - type: Transform
-      pos: -10.5,-19.5
+      pos: -10.5,-10.5
       parent: 1
   - uid: 576
     components:
     - type: Transform
-      pos: -10.5,-20.5
+      pos: -10.5,-11.5
       parent: 1
   - uid: 577
     components:
     - type: Transform
-      pos: -10.5,-21.5
+      pos: -10.5,-12.5
       parent: 1
   - uid: 578
     components:
     - type: Transform
-      pos: -10.5,-22.5
+      pos: -10.5,-13.5
       parent: 1
   - uid: 579
     components:
     - type: Transform
-      pos: -10.5,-23.5
+      pos: -10.5,-15.5
       parent: 1
   - uid: 580
     components:
     - type: Transform
-      pos: -10.5,-24.5
+      pos: -10.5,-14.5
       parent: 1
   - uid: 581
     components:
     - type: Transform
-      pos: -10.5,-25.5
+      pos: -10.5,-16.5
       parent: 1
   - uid: 582
     components:
     - type: Transform
-      pos: -10.5,-26.5
+      pos: -10.5,-17.5
       parent: 1
   - uid: 583
     components:
     - type: Transform
-      pos: -10.5,-27.5
+      pos: -10.5,-18.5
       parent: 1
   - uid: 584
     components:
     - type: Transform
-      pos: -10.5,-28.5
+      pos: -10.5,-19.5
       parent: 1
   - uid: 585
     components:
     - type: Transform
-      pos: -10.5,-29.5
+      pos: -10.5,-20.5
       parent: 1
   - uid: 586
     components:
     - type: Transform
-      pos: -10.5,-30.5
+      pos: -10.5,-21.5
       parent: 1
   - uid: 587
     components:
     - type: Transform
-      pos: -11.5,-30.5
+      pos: -10.5,-22.5
       parent: 1
   - uid: 588
     components:
     - type: Transform
-      pos: -9.5,-30.5
+      pos: -10.5,-23.5
       parent: 1
   - uid: 589
     components:
     - type: Transform
-      pos: -7.5,-28.5
+      pos: -10.5,-24.5
       parent: 1
   - uid: 590
     components:
     - type: Transform
-      pos: -7.5,-27.5
+      pos: -10.5,-25.5
       parent: 1
   - uid: 591
     components:
     - type: Transform
-      pos: -7.5,-26.5
+      pos: -10.5,-26.5
       parent: 1
   - uid: 592
     components:
     - type: Transform
-      pos: -8.5,-27.5
+      pos: -10.5,-27.5
       parent: 1
   - uid: 593
     components:
     - type: Transform
-      pos: -9.5,-27.5
+      pos: -10.5,-28.5
       parent: 1
   - uid: 594
     components:
     - type: Transform
-      pos: -11.5,-27.5
+      pos: -10.5,-29.5
       parent: 1
   - uid: 595
     components:
     - type: Transform
-      pos: -12.5,-27.5
+      pos: -10.5,-30.5
       parent: 1
   - uid: 596
     components:
     - type: Transform
-      pos: -13.5,-27.5
+      pos: -11.5,-30.5
       parent: 1
   - uid: 597
     components:
     - type: Transform
-      pos: -13.5,-26.5
+      pos: -9.5,-30.5
       parent: 1
   - uid: 598
     components:
     - type: Transform
-      pos: -13.5,-28.5
+      pos: -7.5,-28.5
       parent: 1
   - uid: 599
     components:
     - type: Transform
-      pos: -12.5,-19.5
+      pos: -7.5,-27.5
       parent: 1
   - uid: 600
     components:
     - type: Transform
-      pos: -12.5,-20.5
+      pos: -7.5,-26.5
       parent: 1
   - uid: 601
     components:
     - type: Transform
-      pos: -12.5,-21.5
+      pos: -8.5,-27.5
       parent: 1
   - uid: 602
     components:
     - type: Transform
-      pos: -11.5,-20.5
+      pos: -9.5,-27.5
       parent: 1
   - uid: 603
     components:
     - type: Transform
-      pos: -9.5,-13.5
+      pos: -11.5,-27.5
       parent: 1
   - uid: 604
     components:
     - type: Transform
-      pos: -8.5,-13.5
+      pos: -12.5,-27.5
       parent: 1
   - uid: 605
     components:
     - type: Transform
-      pos: -7.5,-13.5
+      pos: -13.5,-27.5
       parent: 1
   - uid: 606
     components:
     - type: Transform
-      pos: -7.5,-12.5
+      pos: -13.5,-26.5
       parent: 1
   - uid: 607
     components:
     - type: Transform
-      pos: -7.5,-14.5
+      pos: -13.5,-28.5
       parent: 1
   - uid: 608
     components:
     - type: Transform
-      pos: -11.5,-13.5
+      pos: -12.5,-19.5
       parent: 1
   - uid: 609
     components:
     - type: Transform
-      pos: -12.5,-13.5
+      pos: -12.5,-20.5
       parent: 1
   - uid: 610
     components:
     - type: Transform
-      pos: -13.5,-13.5
+      pos: -12.5,-21.5
       parent: 1
   - uid: 611
     components:
     - type: Transform
-      pos: -13.5,-12.5
+      pos: -11.5,-20.5
       parent: 1
   - uid: 612
     components:
     - type: Transform
-      pos: -13.5,-14.5
+      pos: -9.5,-13.5
       parent: 1
   - uid: 613
     components:
     - type: Transform
-      pos: -9.5,-6.5
+      pos: -8.5,-13.5
       parent: 1
   - uid: 614
     components:
     - type: Transform
-      pos: -8.5,-5.5
+      pos: -7.5,-13.5
       parent: 1
   - uid: 615
     components:
     - type: Transform
-      pos: -8.5,-6.5
+      pos: -7.5,-12.5
       parent: 1
   - uid: 616
     components:
     - type: Transform
-      pos: -8.5,-7.5
+      pos: -7.5,-14.5
       parent: 1
   - uid: 617
     components:
     - type: Transform
-      pos: -9.5,3.5
+      pos: -11.5,-13.5
       parent: 1
   - uid: 618
     components:
     - type: Transform
-      pos: -8.5,3.5
+      pos: -12.5,-13.5
       parent: 1
   - uid: 619
     components:
     - type: Transform
-      pos: -7.5,3.5
+      pos: -13.5,-13.5
       parent: 1
   - uid: 620
     components:
     - type: Transform
-      pos: -6.5,3.5
+      pos: -13.5,-12.5
       parent: 1
   - uid: 621
     components:
     - type: Transform
-      pos: -5.5,3.5
+      pos: -13.5,-14.5
       parent: 1
   - uid: 622
     components:
     - type: Transform
-      pos: -3.5,3.5
+      pos: -9.5,-6.5
       parent: 1
   - uid: 623
     components:
     - type: Transform
-      pos: -2.5,3.5
+      pos: -8.5,-5.5
       parent: 1
   - uid: 624
     components:
     - type: Transform
-      pos: -1.5,3.5
+      pos: -8.5,-6.5
       parent: 1
   - uid: 625
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: -8.5,-7.5
       parent: 1
   - uid: 626
     components:
     - type: Transform
-      pos: -0.5,4.5
+      pos: -9.5,3.5
       parent: 1
   - uid: 627
     components:
     - type: Transform
-      pos: 0.5,4.5
+      pos: -8.5,3.5
       parent: 1
   - uid: 628
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: -7.5,3.5
       parent: 1
   - uid: 629
     components:
     - type: Transform
-      pos: -11.5,3.5
+      pos: -6.5,3.5
       parent: 1
   - uid: 630
     components:
     - type: Transform
-      pos: -12.5,3.5
+      pos: -5.5,3.5
       parent: 1
   - uid: 631
     components:
     - type: Transform
-      pos: -13.5,3.5
+      pos: -3.5,3.5
       parent: 1
   - uid: 632
     components:
     - type: Transform
-      pos: -14.5,3.5
+      pos: -2.5,3.5
       parent: 1
   - uid: 633
     components:
     - type: Transform
-      pos: -15.5,3.5
+      pos: -1.5,3.5
       parent: 1
   - uid: 634
     components:
     - type: Transform
-      pos: -16.5,3.5
+      pos: -0.5,3.5
       parent: 1
   - uid: 635
     components:
     - type: Transform
-      pos: -17.5,3.5
+      pos: -0.5,4.5
       parent: 1
   - uid: 636
     components:
     - type: Transform
-      pos: -18.5,3.5
+      pos: 0.5,4.5
       parent: 1
   - uid: 637
     components:
     - type: Transform
-      pos: -19.5,3.5
+      pos: 1.5,4.5
       parent: 1
   - uid: 638
     components:
     - type: Transform
-      pos: -20.5,3.5
+      pos: -11.5,3.5
       parent: 1
   - uid: 639
     components:
     - type: Transform
-      pos: -21.5,3.5
+      pos: -12.5,3.5
       parent: 1
   - uid: 640
     components:
     - type: Transform
-      pos: -21.5,4.5
+      pos: -13.5,3.5
       parent: 1
   - uid: 641
     components:
     - type: Transform
-      pos: -22.5,4.5
+      pos: -14.5,3.5
       parent: 1
   - uid: 642
     components:
     - type: Transform
-      pos: -23.5,4.5
+      pos: -15.5,3.5
       parent: 1
   - uid: 643
     components:
     - type: Transform
-      pos: -24.5,4.5
+      pos: -16.5,3.5
       parent: 1
   - uid: 644
     components:
     - type: Transform
-      pos: -25.5,4.5
+      pos: -17.5,3.5
       parent: 1
   - uid: 645
     components:
     - type: Transform
-      pos: -26.5,4.5
+      pos: -18.5,3.5
       parent: 1
   - uid: 646
     components:
     - type: Transform
-      pos: -27.5,4.5
+      pos: -19.5,3.5
       parent: 1
   - uid: 647
     components:
     - type: Transform
-      pos: -28.5,4.5
+      pos: -20.5,3.5
       parent: 1
   - uid: 648
     components:
     - type: Transform
-      pos: -29.5,4.5
+      pos: -21.5,3.5
       parent: 1
   - uid: 649
     components:
     - type: Transform
-      pos: -30.5,4.5
+      pos: -21.5,4.5
       parent: 1
   - uid: 650
     components:
     - type: Transform
-      pos: -31.5,4.5
+      pos: -22.5,4.5
       parent: 1
   - uid: 651
     components:
     - type: Transform
-      pos: -32.5,4.5
+      pos: -23.5,4.5
       parent: 1
   - uid: 652
     components:
     - type: Transform
-      pos: -33.5,4.5
+      pos: -24.5,4.5
       parent: 1
   - uid: 653
     components:
     - type: Transform
-      pos: -34.5,4.5
+      pos: -25.5,4.5
       parent: 1
   - uid: 654
     components:
     - type: Transform
-      pos: -32.5,3.5
+      pos: -26.5,4.5
       parent: 1
   - uid: 655
     components:
     - type: Transform
-      pos: -32.5,2.5
+      pos: -27.5,4.5
       parent: 1
   - uid: 656
     components:
     - type: Transform
-      pos: -32.5,1.5
+      pos: -28.5,4.5
       parent: 1
   - uid: 657
     components:
     - type: Transform
-      pos: -33.5,1.5
+      pos: -29.5,4.5
       parent: 1
   - uid: 658
     components:
     - type: Transform
-      pos: -31.5,1.5
+      pos: -30.5,4.5
       parent: 1
   - uid: 659
     components:
     - type: Transform
-      pos: -32.5,5.5
+      pos: -31.5,4.5
       parent: 1
   - uid: 660
     components:
     - type: Transform
-      pos: -32.5,6.5
+      pos: -32.5,4.5
       parent: 1
   - uid: 661
     components:
     - type: Transform
-      pos: -32.5,7.5
+      pos: -33.5,4.5
       parent: 1
   - uid: 662
     components:
     - type: Transform
-      pos: -33.5,7.5
+      pos: -34.5,4.5
       parent: 1
   - uid: 663
     components:
     - type: Transform
-      pos: -31.5,7.5
+      pos: -32.5,3.5
       parent: 1
   - uid: 664
     components:
     - type: Transform
-      pos: -14.5,4.5
+      pos: -32.5,2.5
       parent: 1
   - uid: 665
     components:
     - type: Transform
-      pos: -14.5,5.5
+      pos: -32.5,1.5
       parent: 1
   - uid: 666
     components:
     - type: Transform
-      pos: -9.5,10.5
+      pos: -33.5,1.5
       parent: 1
   - uid: 667
     components:
     - type: Transform
-      pos: -10.5,10.5
+      pos: -31.5,1.5
       parent: 1
   - uid: 668
     components:
     - type: Transform
-      pos: -11.5,10.5
+      pos: -32.5,5.5
       parent: 1
   - uid: 669
     components:
     - type: Transform
-      pos: -12.5,10.5
+      pos: -32.5,6.5
       parent: 1
   - uid: 670
     components:
     - type: Transform
-      pos: -13.5,10.5
+      pos: -32.5,7.5
       parent: 1
   - uid: 671
     components:
     - type: Transform
-      pos: -14.5,10.5
+      pos: -33.5,7.5
       parent: 1
   - uid: 672
     components:
     - type: Transform
-      pos: -15.5,10.5
+      pos: -31.5,7.5
       parent: 1
   - uid: 673
     components:
     - type: Transform
-      pos: -16.5,10.5
+      pos: -14.5,4.5
       parent: 1
   - uid: 674
     components:
     - type: Transform
-      pos: -17.5,10.5
+      pos: -14.5,5.5
       parent: 1
   - uid: 675
     components:
     - type: Transform
-      pos: -18.5,10.5
+      pos: -9.5,10.5
       parent: 1
   - uid: 676
     components:
     - type: Transform
-      pos: -8.5,10.5
+      pos: -10.5,10.5
       parent: 1
   - uid: 677
     components:
     - type: Transform
-      pos: -7.5,10.5
+      pos: -11.5,10.5
       parent: 1
   - uid: 678
     components:
     - type: Transform
-      pos: -6.5,10.5
+      pos: -12.5,10.5
       parent: 1
   - uid: 679
     components:
     - type: Transform
-      pos: -5.5,10.5
+      pos: -13.5,10.5
       parent: 1
   - uid: 680
     components:
     - type: Transform
-      pos: -19.5,10.5
+      pos: -14.5,10.5
       parent: 1
   - uid: 681
     components:
     - type: Transform
-      pos: -20.5,10.5
+      pos: -15.5,10.5
       parent: 1
   - uid: 682
     components:
     - type: Transform
-      pos: -21.5,10.5
+      pos: -16.5,10.5
       parent: 1
   - uid: 683
     components:
     - type: Transform
-      pos: -22.5,10.5
+      pos: -17.5,10.5
       parent: 1
   - uid: 684
     components:
     - type: Transform
-      pos: -23.5,10.5
+      pos: -18.5,10.5
       parent: 1
   - uid: 685
     components:
     - type: Transform
-      pos: -24.5,10.5
+      pos: -8.5,10.5
       parent: 1
   - uid: 686
     components:
     - type: Transform
-      pos: -25.5,9.5
+      pos: -7.5,10.5
       parent: 1
   - uid: 687
     components:
     - type: Transform
-      pos: -25.5,8.5
+      pos: -6.5,10.5
       parent: 1
   - uid: 688
     components:
     - type: Transform
-      pos: -25.5,7.5
+      pos: -5.5,10.5
       parent: 1
   - uid: 689
     components:
     - type: Transform
-      pos: -24.5,7.5
+      pos: -19.5,10.5
       parent: 1
   - uid: 690
     components:
     - type: Transform
-      pos: -23.5,7.5
+      pos: -20.5,10.5
       parent: 1
   - uid: 691
     components:
     - type: Transform
-      pos: -22.5,7.5
+      pos: -21.5,10.5
       parent: 1
   - uid: 692
     components:
     - type: Transform
-      pos: -21.5,7.5
+      pos: -22.5,10.5
       parent: 1
   - uid: 693
     components:
     - type: Transform
-      pos: -20.5,7.5
+      pos: -23.5,10.5
       parent: 1
   - uid: 694
     components:
     - type: Transform
-      pos: -19.5,7.5
+      pos: -24.5,10.5
       parent: 1
   - uid: 695
     components:
     - type: Transform
-      pos: -20.5,11.5
+      pos: -25.5,9.5
       parent: 1
   - uid: 696
     components:
     - type: Transform
-      pos: -20.5,12.5
+      pos: -25.5,8.5
       parent: 1
   - uid: 697
     components:
     - type: Transform
-      pos: -20.5,13.5
+      pos: -25.5,7.5
       parent: 1
   - uid: 698
     components:
     - type: Transform
-      pos: -20.5,14.5
+      pos: -24.5,7.5
       parent: 1
   - uid: 699
     components:
     - type: Transform
-      pos: -21.5,14.5
+      pos: -23.5,7.5
       parent: 1
   - uid: 700
     components:
     - type: Transform
-      pos: -22.5,14.5
+      pos: -22.5,7.5
       parent: 1
   - uid: 701
     components:
     - type: Transform
-      pos: -23.5,14.5
+      pos: -21.5,7.5
       parent: 1
   - uid: 702
     components:
     - type: Transform
-      pos: -24.5,14.5
+      pos: -20.5,7.5
       parent: 1
   - uid: 703
     components:
     - type: Transform
-      pos: -25.5,14.5
+      pos: -19.5,7.5
       parent: 1
   - uid: 704
     components:
     - type: Transform
-      pos: -19.5,14.5
+      pos: -20.5,11.5
       parent: 1
   - uid: 705
     components:
     - type: Transform
-      pos: -18.5,14.5
+      pos: -20.5,12.5
       parent: 1
   - uid: 706
     components:
     - type: Transform
-      pos: -25.5,13.5
+      pos: -20.5,13.5
       parent: 1
   - uid: 707
     components:
     - type: Transform
-      pos: -25.5,12.5
+      pos: -20.5,14.5
       parent: 1
   - uid: 708
     components:
     - type: Transform
-      pos: -25.5,11.5
+      pos: -21.5,14.5
       parent: 1
   - uid: 709
     components:
     - type: Transform
-      pos: -10.5,13.5
+      pos: -22.5,14.5
       parent: 1
   - uid: 710
     components:
     - type: Transform
-      pos: -10.5,12.5
+      pos: -23.5,14.5
       parent: 1
   - uid: 711
     components:
     - type: Transform
-      pos: -10.5,11.5
+      pos: -24.5,14.5
       parent: 1
   - uid: 712
     components:
     - type: Transform
-      pos: -11.5,13.5
+      pos: -25.5,14.5
       parent: 1
   - uid: 713
     components:
     - type: Transform
-      pos: -12.5,13.5
+      pos: -19.5,14.5
       parent: 1
   - uid: 714
     components:
     - type: Transform
-      pos: -13.5,13.5
+      pos: -18.5,14.5
       parent: 1
   - uid: 715
     components:
     - type: Transform
-      pos: -14.5,13.5
+      pos: -25.5,13.5
       parent: 1
   - uid: 716
     components:
     - type: Transform
-      pos: -15.5,13.5
+      pos: -25.5,12.5
       parent: 1
   - uid: 717
     components:
     - type: Transform
-      pos: -9.5,13.5
+      pos: -25.5,11.5
       parent: 1
   - uid: 718
     components:
     - type: Transform
-      pos: -8.5,13.5
+      pos: -10.5,13.5
       parent: 1
   - uid: 719
     components:
     - type: Transform
-      pos: -7.5,13.5
+      pos: -10.5,12.5
       parent: 1
   - uid: 720
     components:
     - type: Transform
-      pos: -6.5,13.5
+      pos: -10.5,11.5
       parent: 1
   - uid: 721
     components:
     - type: Transform
-      pos: -5.5,13.5
+      pos: -11.5,13.5
       parent: 1
   - uid: 722
     components:
     - type: Transform
-      pos: -14.5,6.5
+      pos: -12.5,13.5
       parent: 1
   - uid: 723
     components:
     - type: Transform
-      pos: -14.5,7.5
+      pos: -13.5,13.5
       parent: 1
   - uid: 724
     components:
     - type: Transform
-      pos: -14.5,8.5
+      pos: -14.5,13.5
       parent: 1
   - uid: 725
     components:
     - type: Transform
-      pos: -14.5,9.5
+      pos: -15.5,13.5
       parent: 1
   - uid: 726
     components:
     - type: Transform
-      pos: -6.5,9.5
+      pos: -9.5,13.5
       parent: 1
   - uid: 727
     components:
     - type: Transform
-      pos: -6.5,8.5
+      pos: -8.5,13.5
       parent: 1
   - uid: 728
     components:
     - type: Transform
-      pos: -6.5,7.5
+      pos: -7.5,13.5
       parent: 1
   - uid: 729
     components:
     - type: Transform
-      pos: -6.5,6.5
+      pos: -6.5,13.5
       parent: 1
   - uid: 730
     components:
     - type: Transform
-      pos: -4.5,10.5
+      pos: -5.5,13.5
       parent: 1
   - uid: 731
     components:
     - type: Transform
-      pos: 3.5,16.5
+      pos: -14.5,6.5
       parent: 1
   - uid: 732
     components:
     - type: Transform
-      pos: 2.5,16.5
+      pos: -14.5,7.5
       parent: 1
   - uid: 733
     components:
     - type: Transform
-      pos: 1.5,16.5
+      pos: -14.5,8.5
       parent: 1
   - uid: 734
     components:
     - type: Transform
-      pos: 0.5,16.5
+      pos: -14.5,9.5
       parent: 1
   - uid: 735
     components:
     - type: Transform
-      pos: -0.5,16.5
+      pos: -6.5,9.5
       parent: 1
   - uid: 736
     components:
     - type: Transform
-      pos: -1.5,16.5
+      pos: -6.5,8.5
       parent: 1
   - uid: 737
     components:
     - type: Transform
-      pos: -2.5,16.5
+      pos: -6.5,7.5
       parent: 1
   - uid: 738
     components:
     - type: Transform
-      pos: -3.5,16.5
+      pos: -6.5,6.5
       parent: 1
   - uid: 739
     components:
     - type: Transform
-      pos: -4.5,16.5
+      pos: -4.5,10.5
       parent: 1
   - uid: 740
     components:
     - type: Transform
-      pos: -5.5,16.5
+      pos: 3.5,16.5
       parent: 1
   - uid: 741
     components:
     - type: Transform
-      pos: -6.5,16.5
+      pos: 2.5,16.5
       parent: 1
   - uid: 742
     components:
     - type: Transform
-      pos: -7.5,16.5
+      pos: 1.5,16.5
       parent: 1
   - uid: 743
     components:
     - type: Transform
-      pos: -8.5,16.5
+      pos: 0.5,16.5
       parent: 1
   - uid: 744
     components:
     - type: Transform
-      pos: -9.5,16.5
+      pos: -0.5,16.5
       parent: 1
   - uid: 745
     components:
     - type: Transform
-      pos: -10.5,16.5
+      pos: -1.5,16.5
       parent: 1
   - uid: 746
     components:
     - type: Transform
-      pos: -11.5,16.5
+      pos: -2.5,16.5
       parent: 1
   - uid: 747
     components:
     - type: Transform
-      pos: -12.5,16.5
+      pos: -3.5,16.5
       parent: 1
   - uid: 748
     components:
     - type: Transform
-      pos: -14.5,16.5
+      pos: -4.5,16.5
       parent: 1
   - uid: 749
     components:
     - type: Transform
-      pos: -10.5,18.5
+      pos: -5.5,16.5
       parent: 1
   - uid: 750
     components:
     - type: Transform
-      pos: -10.5,17.5
+      pos: -6.5,16.5
       parent: 1
   - uid: 751
     components:
     - type: Transform
-      pos: -10.5,19.5
+      pos: -7.5,16.5
       parent: 1
   - uid: 752
     components:
     - type: Transform
-      pos: -10.5,20.5
+      pos: -8.5,16.5
       parent: 1
   - uid: 753
     components:
     - type: Transform
-      pos: -10.5,21.5
+      pos: -9.5,16.5
       parent: 1
   - uid: 754
     components:
     - type: Transform
-      pos: -10.5,22.5
+      pos: -10.5,16.5
       parent: 1
   - uid: 755
     components:
     - type: Transform
-      pos: -10.5,23.5
+      pos: -11.5,16.5
       parent: 1
   - uid: 756
     components:
     - type: Transform
-      pos: -10.5,24.5
+      pos: -12.5,16.5
       parent: 1
   - uid: 757
     components:
     - type: Transform
-      pos: -10.5,25.5
+      pos: -14.5,16.5
       parent: 1
   - uid: 758
     components:
     - type: Transform
-      pos: -10.5,26.5
+      pos: -10.5,18.5
       parent: 1
   - uid: 759
     components:
     - type: Transform
-      pos: -10.5,27.5
+      pos: -10.5,17.5
       parent: 1
   - uid: 760
     components:
     - type: Transform
-      pos: -10.5,28.5
+      pos: -10.5,19.5
       parent: 1
   - uid: 761
     components:
     - type: Transform
-      pos: -10.5,29.5
+      pos: -10.5,20.5
       parent: 1
   - uid: 762
     components:
     - type: Transform
-      pos: -10.5,30.5
+      pos: -10.5,21.5
       parent: 1
   - uid: 763
     components:
     - type: Transform
-      pos: -10.5,31.5
+      pos: -10.5,22.5
       parent: 1
   - uid: 764
     components:
     - type: Transform
-      pos: -10.5,32.5
+      pos: -10.5,23.5
       parent: 1
   - uid: 765
     components:
     - type: Transform
-      pos: -10.5,33.5
+      pos: -10.5,24.5
       parent: 1
   - uid: 766
     components:
     - type: Transform
-      pos: -10.5,34.5
+      pos: -10.5,25.5
       parent: 1
   - uid: 767
     components:
     - type: Transform
-      pos: -10.5,35.5
+      pos: -10.5,26.5
       parent: 1
   - uid: 768
     components:
     - type: Transform
-      pos: -10.5,36.5
+      pos: -10.5,27.5
       parent: 1
   - uid: 769
     components:
     - type: Transform
-      pos: -10.5,37.5
+      pos: -10.5,28.5
       parent: 1
   - uid: 770
     components:
     - type: Transform
-      pos: -10.5,38.5
+      pos: -10.5,29.5
       parent: 1
   - uid: 771
     components:
     - type: Transform
-      pos: -10.5,39.5
+      pos: -10.5,30.5
       parent: 1
   - uid: 772
     components:
     - type: Transform
-      pos: -10.5,40.5
+      pos: -10.5,31.5
       parent: 1
   - uid: 773
     components:
     - type: Transform
-      pos: -10.5,41.5
+      pos: -10.5,32.5
       parent: 1
   - uid: 774
     components:
     - type: Transform
-      pos: -10.5,42.5
+      pos: -10.5,33.5
       parent: 1
   - uid: 775
     components:
     - type: Transform
-      pos: -9.5,40.5
+      pos: -10.5,34.5
       parent: 1
   - uid: 776
     components:
     - type: Transform
-      pos: -8.5,40.5
+      pos: -10.5,35.5
       parent: 1
   - uid: 777
     components:
     - type: Transform
-      pos: -7.5,40.5
+      pos: -10.5,36.5
       parent: 1
   - uid: 778
     components:
     - type: Transform
-      pos: -6.5,40.5
+      pos: -10.5,37.5
       parent: 1
   - uid: 779
     components:
     - type: Transform
-      pos: -5.5,40.5
+      pos: -10.5,38.5
       parent: 1
   - uid: 780
     components:
     - type: Transform
-      pos: -4.5,40.5
+      pos: -10.5,39.5
       parent: 1
   - uid: 781
     components:
     - type: Transform
-      pos: -3.5,40.5
+      pos: -10.5,40.5
       parent: 1
   - uid: 782
     components:
     - type: Transform
-      pos: -2.5,40.5
+      pos: -10.5,41.5
       parent: 1
   - uid: 783
     components:
     - type: Transform
-      pos: -6.5,39.5
+      pos: -10.5,42.5
       parent: 1
   - uid: 784
     components:
     - type: Transform
-      pos: -2.5,39.5
+      pos: -9.5,40.5
       parent: 1
   - uid: 785
     components:
     - type: Transform
-      pos: -11.5,38.5
+      pos: -8.5,40.5
       parent: 1
   - uid: 786
     components:
     - type: Transform
-      pos: -12.5,38.5
+      pos: -7.5,40.5
       parent: 1
   - uid: 787
     components:
     - type: Transform
-      pos: -13.5,38.5
+      pos: -6.5,40.5
       parent: 1
   - uid: 788
     components:
     - type: Transform
-      pos: -14.5,38.5
+      pos: -5.5,40.5
       parent: 1
   - uid: 789
     components:
     - type: Transform
-      pos: -15.5,38.5
+      pos: -4.5,40.5
       parent: 1
   - uid: 790
     components:
     - type: Transform
-      pos: -16.5,38.5
+      pos: -3.5,40.5
       parent: 1
   - uid: 791
     components:
     - type: Transform
-      pos: -17.5,38.5
+      pos: -2.5,40.5
       parent: 1
   - uid: 792
     components:
     - type: Transform
-      pos: -18.5,38.5
+      pos: -6.5,39.5
       parent: 1
   - uid: 793
     components:
     - type: Transform
-      pos: -19.5,38.5
+      pos: -2.5,39.5
       parent: 1
   - uid: 794
     components:
     - type: Transform
-      pos: -20.5,38.5
+      pos: -11.5,38.5
       parent: 1
   - uid: 795
     components:
     - type: Transform
-      pos: -21.5,38.5
+      pos: -12.5,38.5
       parent: 1
   - uid: 796
     components:
     - type: Transform
-      pos: -21.5,37.5
+      pos: -13.5,38.5
       parent: 1
   - uid: 797
     components:
     - type: Transform
-      pos: -21.5,36.5
+      pos: -14.5,38.5
       parent: 1
   - uid: 798
     components:
     - type: Transform
-      pos: -21.5,35.5
+      pos: -15.5,38.5
       parent: 1
   - uid: 799
     components:
     - type: Transform
-      pos: -21.5,34.5
+      pos: -16.5,38.5
       parent: 1
   - uid: 800
     components:
     - type: Transform
-      pos: -21.5,33.5
+      pos: -17.5,38.5
       parent: 1
   - uid: 801
     components:
     - type: Transform
-      pos: -15.5,31.5
+      pos: -18.5,38.5
       parent: 1
   - uid: 802
     components:
     - type: Transform
-      pos: -20.5,32.5
+      pos: -19.5,38.5
       parent: 1
   - uid: 803
     components:
     - type: Transform
-      pos: -20.5,31.5
+      pos: -20.5,38.5
       parent: 1
   - uid: 804
     components:
     - type: Transform
-      pos: -19.5,31.5
+      pos: -21.5,38.5
       parent: 1
   - uid: 805
     components:
     - type: Transform
-      pos: -16.5,30.5
+      pos: -21.5,37.5
       parent: 1
   - uid: 806
     components:
     - type: Transform
-      pos: -11.5,19.5
+      pos: -21.5,36.5
       parent: 1
   - uid: 807
     components:
     - type: Transform
-      pos: -12.5,19.5
+      pos: -21.5,35.5
       parent: 1
   - uid: 808
     components:
     - type: Transform
-      pos: -13.5,19.5
+      pos: -21.5,34.5
       parent: 1
   - uid: 809
     components:
     - type: Transform
-      pos: -14.5,19.5
+      pos: -21.5,33.5
       parent: 1
   - uid: 810
     components:
     - type: Transform
-      pos: -15.5,19.5
+      pos: -15.5,31.5
       parent: 1
   - uid: 811
     components:
     - type: Transform
-      pos: -16.5,19.5
+      pos: -20.5,32.5
       parent: 1
   - uid: 812
     components:
     - type: Transform
-      pos: -16.5,20.5
+      pos: -20.5,31.5
       parent: 1
   - uid: 813
     components:
     - type: Transform
-      pos: -17.5,19.5
+      pos: -19.5,31.5
       parent: 1
   - uid: 814
     components:
     - type: Transform
-      pos: -17.5,21.5
+      pos: -16.5,30.5
       parent: 1
   - uid: 815
     components:
     - type: Transform
-      pos: -18.5,21.5
+      pos: -11.5,19.5
       parent: 1
   - uid: 816
     components:
     - type: Transform
-      pos: -18.5,22.5
+      pos: -12.5,19.5
       parent: 1
   - uid: 817
     components:
     - type: Transform
-      pos: -18.5,23.5
+      pos: -13.5,19.5
       parent: 1
   - uid: 818
     components:
     - type: Transform
-      pos: -18.5,24.5
+      pos: -14.5,19.5
       parent: 1
   - uid: 819
     components:
     - type: Transform
-      pos: -18.5,25.5
+      pos: -15.5,19.5
       parent: 1
   - uid: 820
     components:
     - type: Transform
-      pos: -17.5,25.5
+      pos: -16.5,19.5
       parent: 1
   - uid: 821
     components:
     - type: Transform
-      pos: -16.5,25.5
+      pos: -16.5,20.5
       parent: 1
   - uid: 822
     components:
     - type: Transform
-      pos: -15.5,25.5
+      pos: -17.5,19.5
       parent: 1
   - uid: 823
     components:
     - type: Transform
-      pos: 3.5,17.5
+      pos: -17.5,21.5
       parent: 1
   - uid: 824
     components:
     - type: Transform
-      pos: 3.5,18.5
+      pos: -18.5,21.5
       parent: 1
   - uid: 825
     components:
     - type: Transform
-      pos: 3.5,19.5
+      pos: -18.5,22.5
       parent: 1
   - uid: 826
     components:
     - type: Transform
-      pos: 3.5,20.5
+      pos: -18.5,23.5
       parent: 1
   - uid: 827
     components:
     - type: Transform
-      pos: 3.5,21.5
+      pos: -18.5,24.5
       parent: 1
   - uid: 828
     components:
     - type: Transform
-      pos: 4.5,21.5
+      pos: -18.5,25.5
       parent: 1
   - uid: 829
     components:
     - type: Transform
-      pos: 5.5,21.5
+      pos: -17.5,25.5
       parent: 1
   - uid: 830
     components:
     - type: Transform
-      pos: 6.5,21.5
+      pos: -16.5,25.5
       parent: 1
   - uid: 831
     components:
     - type: Transform
-      pos: 7.5,21.5
+      pos: -15.5,25.5
       parent: 1
   - uid: 832
     components:
     - type: Transform
-      pos: 8.5,21.5
+      pos: 3.5,17.5
       parent: 1
   - uid: 833
     components:
     - type: Transform
-      pos: 9.5,21.5
+      pos: 3.5,18.5
       parent: 1
   - uid: 834
     components:
     - type: Transform
-      pos: 10.5,21.5
+      pos: 3.5,19.5
       parent: 1
   - uid: 835
     components:
     - type: Transform
-      pos: 11.5,21.5
+      pos: 3.5,20.5
       parent: 1
   - uid: 836
     components:
     - type: Transform
-      pos: 12.5,21.5
+      pos: 3.5,21.5
       parent: 1
   - uid: 837
     components:
     - type: Transform
-      pos: 2.5,21.5
+      pos: 4.5,21.5
       parent: 1
   - uid: 838
     components:
     - type: Transform
-      pos: 1.5,21.5
+      pos: 5.5,21.5
       parent: 1
   - uid: 839
     components:
     - type: Transform
-      pos: 0.5,21.5
+      pos: 6.5,21.5
       parent: 1
   - uid: 840
     components:
     - type: Transform
-      pos: -0.5,21.5
+      pos: 7.5,21.5
       parent: 1
   - uid: 841
     components:
     - type: Transform
-      pos: -0.5,22.5
+      pos: 8.5,21.5
       parent: 1
   - uid: 842
     components:
     - type: Transform
-      pos: -0.5,23.5
+      pos: 9.5,21.5
       parent: 1
   - uid: 843
     components:
     - type: Transform
-      pos: -0.5,24.5
+      pos: 10.5,21.5
       parent: 1
   - uid: 844
     components:
     - type: Transform
-      pos: -0.5,25.5
+      pos: 11.5,21.5
       parent: 1
   - uid: 845
     components:
     - type: Transform
-      pos: -0.5,26.5
+      pos: 12.5,21.5
       parent: 1
   - uid: 846
     components:
     - type: Transform
-      pos: -0.5,20.5
+      pos: 2.5,21.5
       parent: 1
   - uid: 847
     components:
     - type: Transform
-      pos: -9.5,19.5
+      pos: 1.5,21.5
       parent: 1
   - uid: 848
     components:
     - type: Transform
-      pos: -8.5,19.5
+      pos: 0.5,21.5
       parent: 1
   - uid: 849
     components:
     - type: Transform
-      pos: -7.5,19.5
+      pos: -0.5,21.5
       parent: 1
   - uid: 850
     components:
     - type: Transform
-      pos: -6.5,19.5
+      pos: -0.5,22.5
       parent: 1
   - uid: 851
     components:
     - type: Transform
-      pos: -5.5,19.5
+      pos: -0.5,23.5
       parent: 1
   - uid: 852
     components:
     - type: Transform
-      pos: -5.5,20.5
+      pos: -0.5,24.5
       parent: 1
   - uid: 853
     components:
     - type: Transform
-      pos: -5.5,21.5
+      pos: -0.5,25.5
       parent: 1
   - uid: 854
     components:
     - type: Transform
-      pos: -5.5,22.5
+      pos: -0.5,26.5
       parent: 1
   - uid: 855
     components:
     - type: Transform
-      pos: -4.5,22.5
+      pos: -0.5,20.5
       parent: 1
   - uid: 856
     components:
     - type: Transform
-      pos: -1.5,26.5
+      pos: -9.5,19.5
       parent: 1
   - uid: 857
     components:
     - type: Transform
-      pos: -2.5,26.5
+      pos: -8.5,19.5
       parent: 1
   - uid: 858
     components:
     - type: Transform
-      pos: -3.5,26.5
+      pos: -7.5,19.5
       parent: 1
   - uid: 859
     components:
     - type: Transform
-      pos: -4.5,26.5
+      pos: -6.5,19.5
       parent: 1
   - uid: 860
     components:
     - type: Transform
-      pos: -5.5,26.5
+      pos: -5.5,19.5
       parent: 1
   - uid: 861
     components:
     - type: Transform
-      pos: -6.5,26.5
+      pos: -5.5,20.5
       parent: 1
   - uid: 862
     components:
     - type: Transform
-      pos: -6.5,25.5
+      pos: -5.5,21.5
       parent: 1
   - uid: 863
     components:
     - type: Transform
-      pos: -6.5,24.5
+      pos: -5.5,22.5
       parent: 1
   - uid: 864
     components:
     - type: Transform
-      pos: -6.5,23.5
+      pos: -4.5,22.5
       parent: 1
   - uid: 865
     components:
     - type: Transform
-      pos: 0.5,26.5
+      pos: -1.5,26.5
       parent: 1
   - uid: 866
     components:
     - type: Transform
-      pos: 1.5,26.5
+      pos: -2.5,26.5
       parent: 1
   - uid: 867
     components:
     - type: Transform
-      pos: 2.5,26.5
+      pos: -3.5,26.5
       parent: 1
   - uid: 868
     components:
     - type: Transform
-      pos: 3.5,26.5
+      pos: -4.5,26.5
       parent: 1
   - uid: 869
     components:
     - type: Transform
-      pos: 4.5,26.5
+      pos: -5.5,26.5
       parent: 1
   - uid: 870
     components:
     - type: Transform
-      pos: 5.5,26.5
+      pos: -6.5,26.5
       parent: 1
   - uid: 871
     components:
     - type: Transform
-      pos: 6.5,26.5
+      pos: -6.5,25.5
       parent: 1
   - uid: 872
     components:
     - type: Transform
-      pos: 7.5,26.5
+      pos: -6.5,24.5
       parent: 1
   - uid: 873
     components:
     - type: Transform
-      pos: 8.5,26.5
+      pos: -6.5,23.5
       parent: 1
   - uid: 874
     components:
     - type: Transform
-      pos: 9.5,26.5
+      pos: 0.5,26.5
       parent: 1
   - uid: 875
     components:
     - type: Transform
-      pos: 10.5,26.5
+      pos: 1.5,26.5
       parent: 1
   - uid: 876
     components:
     - type: Transform
-      pos: 5.5,20.5
+      pos: 2.5,26.5
       parent: 1
   - uid: 877
     components:
     - type: Transform
-      pos: 5.5,22.5
+      pos: 3.5,26.5
       parent: 1
   - uid: 878
     components:
     - type: Transform
-      pos: -5.5,15.5
+      pos: 4.5,26.5
       parent: 1
   - uid: 879
     components:
     - type: Transform
-      pos: -6.5,15.5
+      pos: 5.5,26.5
       parent: 1
   - uid: 880
     components:
     - type: Transform
-      pos: -13.5,16.5
+      pos: 6.5,26.5
       parent: 1
   - uid: 881
     components:
     - type: Transform
-      pos: -14.5,15.5
+      pos: 7.5,26.5
       parent: 1
   - uid: 882
     components:
     - type: Transform
-      pos: -15.5,15.5
+      pos: 8.5,26.5
       parent: 1
   - uid: 883
     components:
     - type: Transform
-      pos: -6.5,5.5
+      pos: 9.5,26.5
       parent: 1
   - uid: 884
     components:
     - type: Transform
-      pos: -6.5,4.5
+      pos: 10.5,26.5
       parent: 1
   - uid: 885
     components:
     - type: Transform
-      pos: -18.5,19.5
+      pos: 5.5,20.5
       parent: 1
   - uid: 886
     components:
     - type: Transform
-      pos: -19.5,19.5
+      pos: 5.5,22.5
       parent: 1
   - uid: 887
     components:
     - type: Transform
-      pos: -15.5,21.5
+      pos: -5.5,15.5
       parent: 1
   - uid: 888
     components:
     - type: Transform
-      pos: -14.5,21.5
+      pos: -6.5,15.5
       parent: 1
   - uid: 889
     components:
     - type: Transform
-      pos: -13.5,21.5
+      pos: -13.5,16.5
       parent: 1
   - uid: 890
     components:
     - type: Transform
-      pos: -14.5,25.5
+      pos: -14.5,15.5
       parent: 1
   - uid: 891
     components:
     - type: Transform
-      pos: -13.5,25.5
+      pos: -15.5,15.5
       parent: 1
   - uid: 892
     components:
     - type: Transform
-      pos: -18.5,26.5
+      pos: -6.5,5.5
       parent: 1
   - uid: 893
     components:
     - type: Transform
-      pos: -18.5,27.5
+      pos: -6.5,4.5
       parent: 1
   - uid: 894
     components:
     - type: Transform
-      pos: -18.5,31.5
+      pos: -18.5,19.5
       parent: 1
   - uid: 895
     components:
     - type: Transform
-      pos: -2.5,35.5
+      pos: -19.5,19.5
       parent: 1
   - uid: 896
     components:
     - type: Transform
-      pos: -3.5,35.5
+      pos: -15.5,21.5
       parent: 1
   - uid: 897
     components:
     - type: Transform
-      pos: -4.5,35.5
+      pos: -14.5,21.5
       parent: 1
   - uid: 898
     components:
     - type: Transform
-      pos: -5.5,35.5
+      pos: -13.5,21.5
       parent: 1
   - uid: 899
     components:
     - type: Transform
-      pos: -5.5,31.5
+      pos: -14.5,25.5
       parent: 1
   - uid: 900
     components:
     - type: Transform
-      pos: -4.5,31.5
+      pos: -13.5,25.5
       parent: 1
   - uid: 901
     components:
     - type: Transform
-      pos: -2.5,31.5
+      pos: -18.5,26.5
       parent: 1
   - uid: 902
     components:
     - type: Transform
-      pos: -5.5,30.5
+      pos: -18.5,27.5
       parent: 1
   - uid: 903
     components:
     - type: Transform
-      pos: -5.5,29.5
+      pos: -18.5,31.5
       parent: 1
   - uid: 904
     components:
     - type: Transform
-      pos: -5.5,32.5
+      pos: -2.5,35.5
       parent: 1
   - uid: 905
     components:
     - type: Transform
-      pos: -5.5,33.5
+      pos: -3.5,35.5
       parent: 1
   - uid: 906
     components:
     - type: Transform
-      pos: -5.5,34.5
+      pos: -4.5,35.5
       parent: 1
   - uid: 907
     components:
     - type: Transform
-      pos: -16.5,29.5
+      pos: -5.5,35.5
       parent: 1
   - uid: 908
     components:
     - type: Transform
-      pos: -16.5,28.5
+      pos: -5.5,31.5
       parent: 1
   - uid: 909
     components:
     - type: Transform
-      pos: -16.5,27.5
+      pos: -4.5,31.5
       parent: 1
   - uid: 910
     components:
     - type: Transform
-      pos: -15.5,8.5
+      pos: -2.5,31.5
       parent: 1
   - uid: 911
     components:
     - type: Transform
-      pos: -16.5,8.5
+      pos: -5.5,30.5
       parent: 1
   - uid: 912
     components:
     - type: Transform
-      pos: -17.5,8.5
+      pos: -5.5,29.5
       parent: 1
   - uid: 913
     components:
     - type: Transform
-      pos: -18.5,8.5
+      pos: -5.5,32.5
       parent: 1
   - uid: 914
     components:
     - type: Transform
-      pos: -19.5,8.5
+      pos: -5.5,33.5
       parent: 1
   - uid: 915
     components:
     - type: Transform
-      pos: -5.5,2.5
+      pos: -5.5,34.5
       parent: 1
   - uid: 916
     components:
     - type: Transform
-      pos: -5.5,1.5
+      pos: -16.5,29.5
       parent: 1
   - uid: 917
     components:
     - type: Transform
-      pos: -5.5,0.5
+      pos: -16.5,28.5
       parent: 1
   - uid: 918
     components:
     - type: Transform
-      pos: -15.5,2.5
+      pos: -16.5,27.5
       parent: 1
   - uid: 919
     components:
     - type: Transform
-      pos: -15.5,1.5
+      pos: -15.5,8.5
       parent: 1
   - uid: 920
     components:
     - type: Transform
-      pos: -15.5,0.5
+      pos: -16.5,8.5
       parent: 1
   - uid: 921
     components:
     - type: Transform
-      pos: -14.5,0.5
+      pos: -17.5,8.5
       parent: 1
   - uid: 922
     components:
     - type: Transform
-      pos: -13.5,0.5
+      pos: -18.5,8.5
       parent: 1
   - uid: 923
     components:
     - type: Transform
-      pos: -12.5,0.5
+      pos: -19.5,8.5
       parent: 1
   - uid: 924
     components:
     - type: Transform
-      pos: -11.5,0.5
+      pos: -5.5,2.5
       parent: 1
   - uid: 925
     components:
     - type: Transform
-      pos: -9.5,0.5
+      pos: -5.5,1.5
       parent: 1
   - uid: 926
     components:
     - type: Transform
-      pos: -8.5,0.5
+      pos: -5.5,0.5
       parent: 1
   - uid: 927
     components:
     - type: Transform
-      pos: -7.5,0.5
+      pos: -15.5,2.5
       parent: 1
   - uid: 928
     components:
     - type: Transform
-      pos: -6.5,0.5
+      pos: -15.5,1.5
       parent: 1
   - uid: 929
     components:
     - type: Transform
-      pos: 1.5,20.5
+      pos: -15.5,0.5
       parent: 1
   - uid: 930
     components:
     - type: Transform
-      pos: -4.5,3.5
+      pos: -14.5,0.5
       parent: 1
   - uid: 931
     components:
     - type: Transform
-      pos: -6.5,41.5
+      pos: -13.5,0.5
       parent: 1
   - uid: 932
     components:
     - type: Transform
-      pos: -6.5,42.5
+      pos: -12.5,0.5
       parent: 1
   - uid: 933
     components:
     - type: Transform
-      pos: -11.5,34.5
+      pos: -11.5,0.5
       parent: 1
   - uid: 934
     components:
     - type: Transform
-      pos: -12.5,34.5
+      pos: -9.5,0.5
       parent: 1
   - uid: 935
     components:
     - type: Transform
-      pos: -13.5,34.5
+      pos: -8.5,0.5
       parent: 1
   - uid: 936
     components:
     - type: Transform
-      pos: -14.5,34.5
+      pos: -7.5,0.5
       parent: 1
   - uid: 937
     components:
     - type: Transform
-      pos: -15.5,34.5
+      pos: -6.5,0.5
       parent: 1
   - uid: 938
     components:
     - type: Transform
-      pos: -16.5,34.5
+      pos: 1.5,20.5
       parent: 1
   - uid: 939
     components:
     - type: Transform
-      pos: -17.5,34.5
+      pos: -4.5,3.5
       parent: 1
   - uid: 940
     components:
     - type: Transform
-      pos: -18.5,34.5
+      pos: -6.5,41.5
       parent: 1
   - uid: 941
     components:
     - type: Transform
-      pos: -18.5,33.5
+      pos: -6.5,42.5
       parent: 1
   - uid: 942
     components:
     - type: Transform
-      pos: -18.5,32.5
+      pos: -11.5,34.5
       parent: 1
   - uid: 943
     components:
     - type: Transform
-      pos: -20.5,28.5
+      pos: -12.5,34.5
       parent: 1
   - uid: 944
     components:
     - type: Transform
-      pos: -20.5,29.5
+      pos: -13.5,34.5
       parent: 1
   - uid: 945
     components:
     - type: Transform
-      pos: -20.5,30.5
+      pos: -14.5,34.5
       parent: 1
   - uid: 946
     components:
     - type: Transform
-      pos: -15.5,30.5
+      pos: -15.5,34.5
       parent: 1
   - uid: 947
     components:
     - type: Transform
-      pos: -14.5,30.5
+      pos: -16.5,34.5
       parent: 1
   - uid: 948
     components:
     - type: Transform
-      pos: -7.5,7.5
+      pos: -17.5,34.5
       parent: 1
   - uid: 949
     components:
     - type: Transform
-      pos: -4.5,20.5
+      pos: -18.5,34.5
       parent: 1
   - uid: 950
     components:
     - type: Transform
-      pos: -3.5,20.5
+      pos: -18.5,33.5
       parent: 1
   - uid: 951
     components:
     - type: Transform
-      pos: -3.5,22.5
+      pos: -18.5,32.5
       parent: 1
   - uid: 952
     components:
     - type: Transform
-      pos: -0.5,19.5
+      pos: -20.5,28.5
       parent: 1
   - uid: 953
     components:
     - type: Transform
-      pos: -8.5,7.5
+      pos: -20.5,29.5
       parent: 1
   - uid: 954
     components:
     - type: Transform
-      pos: -9.5,7.5
+      pos: -20.5,30.5
       parent: 1
   - uid: 955
     components:
     - type: Transform
-      pos: -10.5,7.5
+      pos: -15.5,30.5
       parent: 1
   - uid: 956
     components:
     - type: Transform
-      pos: -11.5,7.5
+      pos: -14.5,30.5
       parent: 1
   - uid: 957
     components:
     - type: Transform
-      pos: -12.5,7.5
+      pos: -7.5,7.5
       parent: 1
   - uid: 958
     components:
     - type: Transform
-      pos: -13.5,7.5
+      pos: -4.5,20.5
       parent: 1
   - uid: 959
     components:
     - type: Transform
-      pos: -21.5,32.5
+      pos: -3.5,20.5
       parent: 1
   - uid: 960
     components:
     - type: Transform
-      pos: -22.5,32.5
+      pos: -3.5,22.5
       parent: 1
   - uid: 961
     components:
     - type: Transform
-      pos: -23.5,32.5
+      pos: -0.5,19.5
       parent: 1
   - uid: 962
     components:
     - type: Transform
-      pos: -14.5,31.5
+      pos: -8.5,7.5
       parent: 1
   - uid: 963
     components:
     - type: Transform
-      pos: -12.5,31.5
+      pos: -9.5,7.5
       parent: 1
   - uid: 964
     components:
     - type: Transform
-      pos: -11.5,31.5
+      pos: -10.5,7.5
       parent: 1
   - uid: 965
     components:
     - type: Transform
-      pos: -13.5,31.5
+      pos: -11.5,7.5
       parent: 1
   - uid: 966
     components:
     - type: Transform
-      pos: -25.5,10.5
+      pos: -12.5,7.5
       parent: 1
   - uid: 967
     components:
     - type: Transform
-      pos: -3.5,31.5
+      pos: -13.5,7.5
       parent: 1
   - uid: 968
     components:
     - type: Transform
-      pos: -7.5,54.5
+      pos: -21.5,32.5
       parent: 1
   - uid: 969
     components:
     - type: Transform
-      pos: -13.5,54.5
+      pos: -22.5,32.5
       parent: 1
   - uid: 970
     components:
     - type: Transform
-      pos: -7.5,53.5
+      pos: -23.5,32.5
       parent: 1
   - uid: 971
     components:
     - type: Transform
-      pos: -10.5,53.5
+      pos: -14.5,31.5
       parent: 1
   - uid: 972
     components:
     - type: Transform
-      pos: -10.5,55.5
+      pos: -12.5,31.5
       parent: 1
   - uid: 973
     components:
     - type: Transform
-      pos: -12.5,53.5
+      pos: -11.5,31.5
       parent: 1
   - uid: 974
     components:
     - type: Transform
-      pos: -10.5,49.5
+      pos: -13.5,31.5
       parent: 1
   - uid: 975
     components:
     - type: Transform
-      pos: -11.5,53.5
+      pos: -25.5,10.5
       parent: 1
   - uid: 976
     components:
     - type: Transform
-      pos: -7.5,52.5
+      pos: -3.5,31.5
       parent: 1
   - uid: 977
     components:
     - type: Transform
-      pos: -10.5,54.5
+      pos: -7.5,54.5
       parent: 1
   - uid: 978
     components:
     - type: Transform
-      pos: -10.5,56.5
+      pos: -13.5,54.5
       parent: 1
   - uid: 979
     components:
     - type: Transform
-      pos: -9.5,50.5
+      pos: -7.5,53.5
       parent: 1
   - uid: 980
     components:
     - type: Transform
-      pos: -13.5,52.5
+      pos: -10.5,53.5
       parent: 1
   - uid: 981
     components:
     - type: Transform
-      pos: -9.5,53.5
+      pos: -10.5,55.5
       parent: 1
   - uid: 982
     components:
     - type: Transform
-      pos: -10.5,51.5
+      pos: -12.5,53.5
       parent: 1
   - uid: 983
     components:
     - type: Transform
-      pos: -10.5,50.5
+      pos: -10.5,49.5
       parent: 1
   - uid: 984
     components:
     - type: Transform
-      pos: -8.5,53.5
+      pos: -11.5,53.5
       parent: 1
   - uid: 985
     components:
     - type: Transform
-      pos: -10.5,48.5
+      pos: -7.5,52.5
       parent: 1
   - uid: 986
     components:
     - type: Transform
-      pos: -10.5,44.5
+      pos: -10.5,54.5
       parent: 1
   - uid: 987
     components:
     - type: Transform
-      pos: -10.5,43.5
+      pos: -10.5,56.5
       parent: 1
   - uid: 988
     components:
     - type: Transform
-      pos: 7.5,6.5
+      pos: -9.5,50.5
       parent: 1
   - uid: 989
     components:
     - type: Transform
-      pos: -8.5,50.5
+      pos: -13.5,52.5
       parent: 1
   - uid: 990
     components:
     - type: Transform
-      pos: 6.5,6.5
+      pos: -9.5,53.5
       parent: 1
   - uid: 991
     components:
     - type: Transform
-      pos: 1.5,14.5
+      pos: -10.5,51.5
       parent: 1
   - uid: 992
     components:
     - type: Transform
-      pos: 1.5,13.5
+      pos: -10.5,50.5
       parent: 1
   - uid: 993
     components:
     - type: Transform
-      pos: 1.5,12.5
+      pos: -8.5,53.5
       parent: 1
   - uid: 994
     components:
     - type: Transform
-      pos: 1.5,11.5
+      pos: -10.5,48.5
       parent: 1
   - uid: 995
     components:
     - type: Transform
-      pos: 1.5,10.5
+      pos: -10.5,44.5
       parent: 1
   - uid: 996
     components:
     - type: Transform
-      pos: 1.5,9.5
+      pos: -10.5,43.5
       parent: 1
   - uid: 997
     components:
     - type: Transform
-      pos: 1.5,8.5
+      pos: 7.5,6.5
       parent: 1
   - uid: 998
     components:
     - type: Transform
-      pos: 1.5,7.5
+      pos: -8.5,50.5
       parent: 1
   - uid: 999
     components:
     - type: Transform
-      pos: 0.5,7.5
+      pos: 6.5,6.5
       parent: 1
   - uid: 1000
     components:
     - type: Transform
-      pos: 0.5,8.5
+      pos: 1.5,14.5
       parent: 1
   - uid: 1001
     components:
     - type: Transform
-      pos: -0.5,7.5
+      pos: 1.5,13.5
       parent: 1
   - uid: 1002
     components:
     - type: Transform
-      pos: -0.5,8.5
+      pos: 1.5,12.5
       parent: 1
   - uid: 1003
     components:
     - type: Transform
-      pos: -1.5,7.5
+      pos: 1.5,11.5
       parent: 1
   - uid: 1004
     components:
     - type: Transform
-      pos: -1.5,8.5
+      pos: 1.5,10.5
       parent: 1
   - uid: 1005
     components:
     - type: Transform
-      pos: -2.5,7.5
+      pos: 1.5,9.5
       parent: 1
   - uid: 1006
     components:
     - type: Transform
-      pos: -2.5,8.5
+      pos: 1.5,8.5
       parent: 1
   - uid: 1007
     components:
     - type: Transform
-      pos: 1.5,8.5
+      pos: 1.5,7.5
       parent: 1
   - uid: 1008
     components:
     - type: Transform
-      pos: 1.5,7.5
+      pos: 0.5,7.5
       parent: 1
   - uid: 1009
     components:
     - type: Transform
-      pos: 2.5,8.5
+      pos: 0.5,8.5
       parent: 1
   - uid: 1010
     components:
     - type: Transform
-      pos: 4.5,31.5
+      pos: -0.5,7.5
       parent: 1
   - uid: 1011
     components:
     - type: Transform
-      pos: 0.5,35.5
+      pos: -0.5,8.5
       parent: 1
   - uid: 1012
     components:
     - type: Transform
-      pos: 4.5,35.5
+      pos: -1.5,7.5
       parent: 1
   - uid: 1013
     components:
     - type: Transform
-      pos: 1.5,35.5
+      pos: -1.5,8.5
       parent: 1
   - uid: 1014
     components:
     - type: Transform
-      pos: 9.5,39.5
+      pos: -2.5,7.5
       parent: 1
   - uid: 1015
     components:
     - type: Transform
-      pos: 12.5,40.5
+      pos: -2.5,8.5
       parent: 1
   - uid: 1016
     components:
     - type: Transform
-      pos: 5.5,35.5
+      pos: 1.5,8.5
       parent: 1
   - uid: 1017
     components:
     - type: Transform
-      pos: 2.5,39.5
+      pos: 1.5,7.5
       parent: 1
   - uid: 1018
     components:
     - type: Transform
-      pos: 11.5,39.5
+      pos: 2.5,8.5
       parent: 1
   - uid: 1019
     components:
     - type: Transform
-      pos: 2.5,40.5
+      pos: 4.5,31.5
       parent: 1
   - uid: 1020
     components:
     - type: Transform
-      pos: 5.5,39.5
+      pos: 0.5,35.5
       parent: 1
   - uid: 1021
     components:
     - type: Transform
-      pos: 12.5,38.5
+      pos: 4.5,35.5
       parent: 1
   - uid: 1022
     components:
     - type: Transform
-      pos: 6.5,35.5
+      pos: 1.5,35.5
       parent: 1
   - uid: 1023
     components:
     - type: Transform
-      pos: 4.5,39.5
+      pos: 9.5,39.5
       parent: 1
   - uid: 1024
     components:
     - type: Transform
-      pos: 6.5,38.5
+      pos: 12.5,40.5
       parent: 1
   - uid: 1025
     components:
     - type: Transform
-      pos: 10.5,35.5
+      pos: 5.5,35.5
       parent: 1
   - uid: 1026
     components:
     - type: Transform
-      pos: 3.5,39.5
+      pos: 2.5,39.5
       parent: 1
   - uid: 1027
     components:
     - type: Transform
-      pos: 12.5,39.5
+      pos: 11.5,39.5
       parent: 1
   - uid: 1028
     components:
     - type: Transform
-      pos: 11.5,35.5
+      pos: 2.5,40.5
       parent: 1
   - uid: 1029
     components:
     - type: Transform
-      pos: 4.5,28.5
+      pos: 5.5,39.5
       parent: 1
   - uid: 1030
     components:
     - type: Transform
-      pos: 2.5,28.5
+      pos: 12.5,38.5
       parent: 1
   - uid: 1031
     components:
     - type: Transform
-      pos: 3.5,30.5
+      pos: 6.5,35.5
       parent: 1
   - uid: 1032
     components:
     - type: Transform
-      pos: 3.5,31.5
+      pos: 4.5,39.5
       parent: 1
   - uid: 1033
     components:
     - type: Transform
-      pos: -1.5,31.5
+      pos: 6.5,38.5
       parent: 1
   - uid: 1034
     components:
     - type: Transform
-      pos: -0.5,31.5
+      pos: 10.5,35.5
       parent: 1
   - uid: 1035
     components:
     - type: Transform
-      pos: 5.5,29.5
+      pos: 3.5,39.5
       parent: 1
   - uid: 1036
     components:
     - type: Transform
-      pos: 7.5,35.5
+      pos: 12.5,39.5
       parent: 1
   - uid: 1037
     components:
     - type: Transform
-      pos: 6.5,39.5
+      pos: 11.5,35.5
       parent: 1
   - uid: 1038
     components:
     - type: Transform
-      pos: 8.5,38.5
+      pos: 4.5,28.5
       parent: 1
   - uid: 1039
     components:
     - type: Transform
-      pos: 7.5,39.5
+      pos: 2.5,28.5
       parent: 1
   - uid: 1040
     components:
     - type: Transform
-      pos: 8.5,40.5
+      pos: 3.5,30.5
       parent: 1
   - uid: 1041
     components:
     - type: Transform
-      pos: 8.5,35.5
+      pos: 3.5,31.5
       parent: 1
   - uid: 1042
     components:
     - type: Transform
-      pos: 3.5,29.5
+      pos: -1.5,31.5
       parent: 1
   - uid: 1043
     components:
     - type: Transform
-      pos: 11.5,26.5
+      pos: -0.5,31.5
       parent: 1
   - uid: 1044
     components:
     - type: Transform
-      pos: 9.5,35.5
+      pos: 5.5,29.5
       parent: 1
   - uid: 1045
     components:
     - type: Transform
-      pos: 6.5,40.5
+      pos: 7.5,35.5
       parent: 1
   - uid: 1046
     components:
     - type: Transform
-      pos: 8.5,39.5
+      pos: 6.5,39.5
       parent: 1
   - uid: 1047
     components:
     - type: Transform
-      pos: 4.5,33.5
+      pos: 8.5,38.5
       parent: 1
   - uid: 1048
     components:
     - type: Transform
-      pos: 3.5,28.5
+      pos: 7.5,39.5
       parent: 1
   - uid: 1049
     components:
     - type: Transform
-      pos: -0.5,29.5
+      pos: 8.5,40.5
       parent: 1
   - uid: 1050
     components:
     - type: Transform
-      pos: -0.5,27.5
+      pos: 8.5,35.5
       parent: 1
   - uid: 1051
     components:
     - type: Transform
-      pos: -0.5,28.5
+      pos: 3.5,29.5
       parent: 1
   - uid: 1052
     components:
     - type: Transform
-      pos: 2.5,35.5
+      pos: 11.5,26.5
       parent: 1
   - uid: 1053
     components:
     - type: Transform
-      pos: 0.5,38.5
+      pos: 9.5,35.5
       parent: 1
   - uid: 1054
     components:
     - type: Transform
-      pos: 0.5,36.5
+      pos: 6.5,40.5
       parent: 1
   - uid: 1055
     components:
     - type: Transform
-      pos: 12.5,35.5
+      pos: 8.5,39.5
       parent: 1
   - uid: 1056
     components:
     - type: Transform
-      pos: 15.5,34.5
+      pos: 4.5,33.5
       parent: 1
   - uid: 1057
     components:
     - type: Transform
-      pos: 13.5,35.5
+      pos: 3.5,28.5
       parent: 1
   - uid: 1058
     components:
     - type: Transform
-      pos: 12.5,26.5
+      pos: -0.5,29.5
       parent: 1
   - uid: 1059
     components:
     - type: Transform
-      pos: 2.5,31.5
+      pos: -0.5,27.5
       parent: 1
   - uid: 1060
     components:
     - type: Transform
-      pos: 1.5,31.5
+      pos: -0.5,28.5
       parent: 1
   - uid: 1061
     components:
     - type: Transform
-      pos: -1.5,35.5
+      pos: 2.5,35.5
       parent: 1
   - uid: 1062
     components:
     - type: Transform
-      pos: 11.5,34.5
+      pos: 0.5,38.5
       parent: 1
   - uid: 1063
     components:
     - type: Transform
-      pos: 3.5,34.5
+      pos: 0.5,36.5
       parent: 1
   - uid: 1064
     components:
     - type: Transform
-      pos: 0.5,31.5
+      pos: 12.5,35.5
       parent: 1
   - uid: 1065
     components:
     - type: Transform
-      pos: 1.5,39.5
+      pos: 15.5,34.5
       parent: 1
   - uid: 1066
     components:
     - type: Transform
-      pos: 10.5,39.5
+      pos: 13.5,35.5
       parent: 1
   - uid: 1067
     components:
     - type: Transform
-      pos: 2.5,38.5
+      pos: 12.5,26.5
       parent: 1
   - uid: 1068
     components:
     - type: Transform
-      pos: 5.5,34.5
+      pos: 2.5,31.5
       parent: 1
   - uid: 1069
     components:
     - type: Transform
-      pos: 5.5,30.5
+      pos: 1.5,31.5
       parent: 1
   - uid: 1070
     components:
     - type: Transform
-      pos: 4.5,34.5
+      pos: -1.5,35.5
       parent: 1
   - uid: 1071
     components:
     - type: Transform
-      pos: 4.5,32.5
+      pos: 11.5,34.5
       parent: 1
   - uid: 1072
     components:
     - type: Transform
-      pos: 3.5,35.5
+      pos: 3.5,34.5
       parent: 1
   - uid: 1073
     components:
     - type: Transform
-      pos: -0.5,35.5
+      pos: 0.5,31.5
       parent: 1
   - uid: 1074
     components:
     - type: Transform
-      pos: 5.5,31.5
+      pos: 1.5,39.5
       parent: 1
   - uid: 1075
     components:
     - type: Transform
-      pos: 1.5,34.5
+      pos: 10.5,39.5
       parent: 1
   - uid: 1076
     components:
     - type: Transform
-      pos: 14.5,35.5
+      pos: 2.5,38.5
       parent: 1
   - uid: 1077
     components:
     - type: Transform
-      pos: 15.5,36.5
+      pos: 5.5,34.5
       parent: 1
   - uid: 1078
     components:
     - type: Transform
-      pos: 15.5,35.5
+      pos: 5.5,30.5
       parent: 1
   - uid: 1079
     components:
     - type: Transform
-      pos: -0.5,32.5
+      pos: 4.5,34.5
       parent: 1
   - uid: 1080
     components:
     - type: Transform
-      pos: -0.5,33.5
+      pos: 4.5,32.5
       parent: 1
   - uid: 1081
     components:
     - type: Transform
-      pos: -0.5,34.5
+      pos: 3.5,35.5
       parent: 1
   - uid: 1082
     components:
     - type: Transform
-      pos: -35.5,4.5
+      pos: -0.5,35.5
       parent: 1
   - uid: 1083
     components:
     - type: Transform
-      pos: -36.5,4.5
+      pos: 5.5,31.5
       parent: 1
   - uid: 1084
     components:
     - type: Transform
-      pos: -37.5,4.5
+      pos: 1.5,34.5
       parent: 1
   - uid: 1085
     components:
     - type: Transform
-      pos: -38.5,4.5
+      pos: 14.5,35.5
       parent: 1
   - uid: 1086
     components:
     - type: Transform
-      pos: -39.5,4.5
+      pos: 15.5,36.5
       parent: 1
   - uid: 1087
     components:
     - type: Transform
-      pos: -40.5,4.5
+      pos: 15.5,35.5
       parent: 1
   - uid: 1088
     components:
     - type: Transform
-      pos: -41.5,4.5
+      pos: -0.5,32.5
       parent: 1
   - uid: 1089
     components:
     - type: Transform
-      pos: -42.5,4.5
+      pos: -0.5,33.5
       parent: 1
   - uid: 1090
     components:
     - type: Transform
-      pos: -43.5,4.5
+      pos: -0.5,34.5
       parent: 1
   - uid: 1091
     components:
     - type: Transform
-      pos: -44.5,4.5
+      pos: -35.5,4.5
       parent: 1
   - uid: 1092
     components:
     - type: Transform
-      pos: -45.5,4.5
+      pos: -36.5,4.5
       parent: 1
   - uid: 1093
     components:
     - type: Transform
-      pos: -46.5,4.5
+      pos: -37.5,4.5
       parent: 1
   - uid: 1094
     components:
     - type: Transform
-      pos: -47.5,4.5
+      pos: -38.5,4.5
       parent: 1
   - uid: 1095
     components:
     - type: Transform
-      pos: -48.5,4.5
+      pos: -39.5,4.5
       parent: 1
   - uid: 1096
     components:
     - type: Transform
-      pos: -49.5,4.5
+      pos: -40.5,4.5
       parent: 1
   - uid: 1097
     components:
     - type: Transform
-      pos: -49.5,5.5
+      pos: -41.5,4.5
       parent: 1
   - uid: 1098
     components:
     - type: Transform
-      pos: -49.5,3.5
+      pos: -42.5,4.5
       parent: 1
   - uid: 1099
     components:
     - type: Transform
-      pos: -46.5,7.5
+      pos: -43.5,4.5
       parent: 1
   - uid: 1100
     components:
     - type: Transform
-      pos: -47.5,7.5
+      pos: -44.5,4.5
       parent: 1
   - uid: 1101
     components:
     - type: Transform
-      pos: -45.5,7.5
+      pos: -45.5,4.5
       parent: 1
   - uid: 1102
     components:
     - type: Transform
-      pos: -47.5,1.5
+      pos: -46.5,4.5
       parent: 1
   - uid: 1103
     components:
     - type: Transform
-      pos: -46.5,1.5
+      pos: -47.5,4.5
       parent: 1
   - uid: 1104
     components:
     - type: Transform
-      pos: -45.5,1.5
+      pos: -48.5,4.5
       parent: 1
   - uid: 1105
     components:
     - type: Transform
-      pos: -46.5,3.5
+      pos: -49.5,4.5
       parent: 1
   - uid: 1106
     components:
     - type: Transform
-      pos: -46.5,2.5
+      pos: -49.5,5.5
       parent: 1
   - uid: 1107
     components:
     - type: Transform
-      pos: -46.5,5.5
+      pos: -49.5,3.5
       parent: 1
   - uid: 1108
     components:
     - type: Transform
-      pos: -46.5,6.5
+      pos: -46.5,7.5
       parent: 1
   - uid: 1109
     components:
     - type: Transform
-      pos: -40.5,6.5
+      pos: -47.5,7.5
       parent: 1
   - uid: 1110
     components:
     - type: Transform
-      pos: -39.5,6.5
+      pos: -45.5,7.5
       parent: 1
   - uid: 1111
     components:
     - type: Transform
-      pos: -38.5,6.5
+      pos: -47.5,1.5
       parent: 1
   - uid: 1112
     components:
     - type: Transform
-      pos: -40.5,2.5
+      pos: -46.5,1.5
       parent: 1
   - uid: 1113
     components:
     - type: Transform
-      pos: -39.5,2.5
+      pos: -45.5,1.5
       parent: 1
   - uid: 1114
     components:
     - type: Transform
-      pos: -38.5,2.5
+      pos: -46.5,3.5
       parent: 1
   - uid: 1115
     components:
     - type: Transform
-      pos: -39.5,3.5
+      pos: -46.5,2.5
       parent: 1
   - uid: 1116
     components:
     - type: Transform
+      pos: -46.5,5.5
+      parent: 1
+  - uid: 1117
+    components:
+    - type: Transform
+      pos: -46.5,6.5
+      parent: 1
+  - uid: 1118
+    components:
+    - type: Transform
+      pos: -40.5,6.5
+      parent: 1
+  - uid: 1119
+    components:
+    - type: Transform
+      pos: -39.5,6.5
+      parent: 1
+  - uid: 1120
+    components:
+    - type: Transform
+      pos: -38.5,6.5
+      parent: 1
+  - uid: 1121
+    components:
+    - type: Transform
+      pos: -40.5,2.5
+      parent: 1
+  - uid: 1122
+    components:
+    - type: Transform
+      pos: -39.5,2.5
+      parent: 1
+  - uid: 1123
+    components:
+    - type: Transform
+      pos: -38.5,2.5
+      parent: 1
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: -39.5,3.5
+      parent: 1
+  - uid: 1125
+    components:
+    - type: Transform
       pos: -39.5,5.5
+      parent: 1
+  - uid: 3252
+    components:
+    - type: Transform
+      pos: -2.5,6.5
       parent: 1
 - proto: CableApcStack10
   entities:
-  - uid: 1117
+  - uid: 1126
     components:
     - type: Transform
       pos: -15.652112,37.58818
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 1118
+  - uid: 1127
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 1119
+  - uid: 1128
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 1120
+  - uid: 1129
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 1121
+  - uid: 1130
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 1122
+  - uid: 1131
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 1123
+  - uid: 1132
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 1124
+  - uid: 1133
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 1125
+  - uid: 1134
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 1126
+  - uid: 1135
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 1127
+  - uid: 1136
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 1128
+  - uid: 1137
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 1129
+  - uid: 1138
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
-  - uid: 1130
+  - uid: 1139
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 1131
+  - uid: 1140
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 1132
+  - uid: 1141
     components:
     - type: Transform
       pos: 3.5,33.5
       parent: 1
-  - uid: 1133
+  - uid: 1142
     components:
     - type: Transform
       pos: 0.5,32.5
       parent: 1
-  - uid: 1134
+  - uid: 1143
     components:
     - type: Transform
       pos: -1.5,32.5
       parent: 1
-  - uid: 1135
+  - uid: 1144
     components:
     - type: Transform
       pos: 1.5,32.5
       parent: 1
-  - uid: 1136
+  - uid: 1145
     components:
     - type: Transform
       pos: 2.5,32.5
       parent: 1
-  - uid: 1137
+  - uid: 1146
     components:
     - type: Transform
       pos: 1.5,35.5
       parent: 1
-  - uid: 1138
+  - uid: 1147
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 1
-  - uid: 1139
+  - uid: 1148
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 1140
+  - uid: 1149
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 1141
+  - uid: 1150
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 1142
+  - uid: 1151
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
-  - uid: 1143
+  - uid: 1152
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 1144
+  - uid: 1153
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 1
-  - uid: 1145
+  - uid: 1154
     components:
     - type: Transform
       pos: -21.5,37.5
       parent: 1
-  - uid: 1146
+  - uid: 1155
     components:
     - type: Transform
       pos: -5.5,21.5
       parent: 1
-  - uid: 1147
+  - uid: 1156
     components:
     - type: Transform
       pos: -11.5,31.5
       parent: 1
-  - uid: 1148
+  - uid: 1157
     components:
     - type: Transform
       pos: -13.5,31.5
       parent: 1
-  - uid: 1149
+  - uid: 1158
     components:
     - type: Transform
       pos: -12.5,31.5
       parent: 1
-  - uid: 1150
+  - uid: 1159
     components:
     - type: Transform
       pos: -14.5,31.5
       parent: 1
-  - uid: 1151
+  - uid: 1160
     components:
     - type: Transform
       pos: -14.5,30.5
       parent: 1
-  - uid: 1152
+  - uid: 1161
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 1
-  - uid: 1153
+  - uid: 1162
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 1
-  - uid: 1154
+  - uid: 1163
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
-  - uid: 1155
+  - uid: 1164
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 1156
+  - uid: 1165
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
-  - uid: 1157
+  - uid: 1166
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 1
-  - uid: 1158
+  - uid: 1167
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 1
-  - uid: 1159
+  - uid: 1168
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 1
-  - uid: 1160
+  - uid: 1169
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 1
-  - uid: 1161
+  - uid: 1170
     components:
     - type: Transform
       pos: -11.5,5.5
       parent: 1
-  - uid: 1162
+  - uid: 1171
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 1
-  - uid: 1163
+  - uid: 1172
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 1164
+  - uid: 1173
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 1165
+  - uid: 1174
     components:
     - type: Transform
       pos: -0.5,26.5
       parent: 1
-  - uid: 1166
+  - uid: 1175
     components:
     - type: Transform
       pos: -1.5,26.5
       parent: 1
-  - uid: 1167
+  - uid: 1176
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 1
-  - uid: 1168
+  - uid: 1177
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-  - uid: 1169
+  - uid: 1178
     components:
     - type: Transform
       pos: -4.5,26.5
       parent: 1
-  - uid: 1170
+  - uid: 1179
     components:
     - type: Transform
       pos: -5.5,26.5
       parent: 1
-  - uid: 1171
+  - uid: 1180
     components:
     - type: Transform
       pos: -6.5,26.5
       parent: 1
-  - uid: 1172
+  - uid: 1181
     components:
     - type: Transform
       pos: -6.5,25.5
       parent: 1
-  - uid: 1173
+  - uid: 1182
     components:
     - type: Transform
       pos: -6.5,24.5
       parent: 1
-  - uid: 1174
+  - uid: 1183
     components:
     - type: Transform
       pos: -6.5,23.5
       parent: 1
-  - uid: 1175
+  - uid: 1184
     components:
     - type: Transform
       pos: -6.5,22.5
       parent: 1
-  - uid: 1176
+  - uid: 1185
     components:
     - type: Transform
       pos: -6.5,21.5
       parent: 1
-  - uid: 1177
+  - uid: 1186
     components:
     - type: Transform
       pos: -6.5,20.5
       parent: 1
-  - uid: 1178
+  - uid: 1187
     components:
     - type: Transform
       pos: -6.5,19.5
       parent: 1
-  - uid: 1179
+  - uid: 1188
     components:
     - type: Transform
       pos: -7.5,19.5
       parent: 1
-  - uid: 1180
+  - uid: 1189
     components:
     - type: Transform
       pos: -8.5,19.5
       parent: 1
-  - uid: 1181
+  - uid: 1190
     components:
     - type: Transform
       pos: -9.5,19.5
       parent: 1
-  - uid: 1182
+  - uid: 1191
     components:
     - type: Transform
       pos: -10.5,19.5
       parent: 1
-  - uid: 1183
+  - uid: 1192
     components:
     - type: Transform
       pos: -10.5,18.5
       parent: 1
-  - uid: 1184
+  - uid: 1193
     components:
     - type: Transform
       pos: -10.5,17.5
       parent: 1
-  - uid: 1185
+  - uid: 1194
     components:
     - type: Transform
       pos: -10.5,16.5
       parent: 1
-  - uid: 1186
+  - uid: 1195
     components:
     - type: Transform
       pos: -9.5,16.5
       parent: 1
-  - uid: 1187
+  - uid: 1196
     components:
     - type: Transform
       pos: -8.5,16.5
       parent: 1
-  - uid: 1188
+  - uid: 1197
     components:
     - type: Transform
       pos: -7.5,16.5
       parent: 1
-  - uid: 1189
+  - uid: 1198
     components:
     - type: Transform
       pos: -6.5,16.5
       parent: 1
-  - uid: 1190
+  - uid: 1199
     components:
     - type: Transform
       pos: -5.5,16.5
       parent: 1
-  - uid: 1191
+  - uid: 1200
     components:
     - type: Transform
       pos: -4.5,16.5
       parent: 1
-  - uid: 1192
+  - uid: 1201
     components:
     - type: Transform
       pos: -2.5,16.5
       parent: 1
-  - uid: 1193
+  - uid: 1202
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 1194
+  - uid: 1203
     components:
     - type: Transform
       pos: -2.5,32.5
       parent: 1
-  - uid: 1195
+  - uid: 1204
     components:
     - type: Transform
       pos: -3.5,32.5
       parent: 1
-  - uid: 1196
+  - uid: 1205
     components:
     - type: Transform
       pos: -4.5,32.5
       parent: 1
-  - uid: 1197
+  - uid: 1206
     components:
     - type: Transform
       pos: -6.5,32.5
       parent: 1
-  - uid: 1198
+  - uid: 1207
     components:
     - type: Transform
       pos: -6.5,31.5
       parent: 1
-  - uid: 1199
+  - uid: 1208
     components:
     - type: Transform
       pos: -6.5,30.5
       parent: 1
-  - uid: 1200
+  - uid: 1209
     components:
     - type: Transform
       pos: -6.5,29.5
       parent: 1
-  - uid: 1201
+  - uid: 1210
     components:
     - type: Transform
       pos: -6.5,28.5
       parent: 1
-  - uid: 1202
+  - uid: 1211
     components:
     - type: Transform
       pos: -6.5,27.5
       parent: 1
-  - uid: 1203
+  - uid: 1212
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 1
-  - uid: 1204
+  - uid: 1213
     components:
     - type: Transform
       pos: -10.5,31.5
       parent: 1
-  - uid: 1205
+  - uid: 1214
     components:
     - type: Transform
       pos: -10.5,30.5
       parent: 1
-  - uid: 1206
+  - uid: 1215
     components:
     - type: Transform
       pos: -10.5,29.5
       parent: 1
-  - uid: 1207
+  - uid: 1216
     components:
     - type: Transform
       pos: -10.5,28.5
       parent: 1
-  - uid: 1208
+  - uid: 1217
     components:
     - type: Transform
       pos: -10.5,27.5
       parent: 1
-  - uid: 1209
+  - uid: 1218
     components:
     - type: Transform
       pos: -10.5,26.5
       parent: 1
-  - uid: 1210
+  - uid: 1219
     components:
     - type: Transform
       pos: -10.5,25.5
       parent: 1
-  - uid: 1211
+  - uid: 1220
     components:
     - type: Transform
       pos: -10.5,24.5
       parent: 1
-  - uid: 1212
+  - uid: 1221
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
-  - uid: 1213
+  - uid: 1222
     components:
     - type: Transform
       pos: -10.5,22.5
       parent: 1
-  - uid: 1214
+  - uid: 1223
     components:
     - type: Transform
       pos: -10.5,21.5
       parent: 1
-  - uid: 1215
+  - uid: 1224
     components:
     - type: Transform
       pos: -10.5,20.5
       parent: 1
-  - uid: 1216
+  - uid: 1225
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 1
-  - uid: 1217
+  - uid: 1226
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 1
-  - uid: 1218
+  - uid: 1227
     components:
     - type: Transform
       pos: 1.5,18.5
       parent: 1
-  - uid: 1219
+  - uid: 1228
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1
-  - uid: 1220
+  - uid: 1229
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 1
-  - uid: 1221
+  - uid: 1230
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 1222
+  - uid: 1231
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 1223
+  - uid: 1232
     components:
     - type: Transform
       pos: -4.5,21.5
       parent: 1
-  - uid: 1224
+  - uid: 1233
     components:
     - type: Transform
       pos: -3.5,21.5
       parent: 1
-  - uid: 1225
+  - uid: 1234
     components:
     - type: Transform
       pos: -2.5,21.5
       parent: 1
-  - uid: 1226
+  - uid: 1235
     components:
     - type: Transform
       pos: -1.5,21.5
       parent: 1
-  - uid: 1227
+  - uid: 1236
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 1
-  - uid: 1228
+  - uid: 1237
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 1229
+  - uid: 1238
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 1
-  - uid: 1230
+  - uid: 1239
     components:
     - type: Transform
       pos: -11.5,7.5
       parent: 1
-  - uid: 1231
+  - uid: 1240
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 1
-  - uid: 1232
+  - uid: 1241
     components:
     - type: Transform
       pos: -9.5,7.5
       parent: 1
-  - uid: 1233
+  - uid: 1242
     components:
     - type: Transform
       pos: -8.5,7.5
       parent: 1
-  - uid: 1234
+  - uid: 1243
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 1
-  - uid: 1235
+  - uid: 1244
     components:
     - type: Transform
       pos: -19.5,38.5
       parent: 1
-  - uid: 1236
+  - uid: 1245
     components:
     - type: Transform
       pos: -18.5,38.5
       parent: 1
-  - uid: 1237
+  - uid: 1246
     components:
     - type: Transform
       pos: -17.5,38.5
       parent: 1
-  - uid: 1238
+  - uid: 1247
     components:
     - type: Transform
       pos: -16.5,38.5
       parent: 1
-  - uid: 1239
+  - uid: 1248
     components:
     - type: Transform
       pos: -14.5,38.5
       parent: 1
-  - uid: 1240
+  - uid: 1249
     components:
     - type: Transform
       pos: -15.5,40.5
       parent: 1
-  - uid: 1241
+  - uid: 1250
     components:
     - type: Transform
       pos: -21.5,35.5
       parent: 1
-  - uid: 1242
+  - uid: 1251
     components:
     - type: Transform
       pos: -21.5,31.5
       parent: 1
-  - uid: 1243
+  - uid: 1252
     components:
     - type: Transform
       pos: -21.5,38.5
       parent: 1
-  - uid: 1244
+  - uid: 1253
     components:
     - type: Transform
       pos: -15.5,38.5
       parent: 1
-  - uid: 1245
+  - uid: 1254
     components:
     - type: Transform
       pos: -21.5,34.5
       parent: 1
-  - uid: 1246
+  - uid: 1255
     components:
     - type: Transform
       pos: -17.5,31.5
       parent: 1
-  - uid: 1247
+  - uid: 1256
     components:
     - type: Transform
       pos: -21.5,33.5
       parent: 1
-  - uid: 1248
+  - uid: 1257
     components:
     - type: Transform
       pos: -21.5,32.5
       parent: 1
-  - uid: 1249
+  - uid: 1258
     components:
     - type: Transform
       pos: -16.5,31.5
       parent: 1
-  - uid: 1250
+  - uid: 1259
     components:
     - type: Transform
       pos: -15.5,31.5
       parent: 1
-  - uid: 1251
+  - uid: 1260
     components:
     - type: Transform
       pos: -15.5,39.5
       parent: 1
-  - uid: 1252
+  - uid: 1261
     components:
     - type: Transform
       pos: -21.5,36.5
       parent: 1
-  - uid: 1253
+  - uid: 1262
     components:
     - type: Transform
       pos: -18.5,31.5
       parent: 1
-  - uid: 1254
+  - uid: 1263
     components:
     - type: Transform
       pos: -20.5,31.5
       parent: 1
-  - uid: 1255
+  - uid: 1264
     components:
     - type: Transform
       pos: -19.5,31.5
       parent: 1
-  - uid: 1256
+  - uid: 1265
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 1257
+  - uid: 1266
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 1258
+  - uid: 1267
     components:
     - type: Transform
       pos: -6.5,4.5
       parent: 1
-  - uid: 1259
+  - uid: 1268
     components:
     - type: Transform
       pos: -5.5,32.5
       parent: 1
-  - uid: 1260
+  - uid: 1269
     components:
     - type: Transform
       pos: -20.5,38.5
       parent: 1
-  - uid: 1261
+  - uid: 1270
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
-  - uid: 1262
+  - uid: 1271
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 1263
+  - uid: 1272
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 1264
+  - uid: 1273
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 1265
+  - uid: 1274
     components:
     - type: Transform
       pos: -0.5,32.5
       parent: 1
-  - uid: 1266
+  - uid: 1275
     components:
     - type: Transform
       pos: 3.5,32.5
       parent: 1
-  - uid: 1267
+  - uid: 1276
     components:
     - type: Transform
       pos: 3.5,34.5
       parent: 1
-  - uid: 1268
+  - uid: 1277
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 1
-  - uid: 1269
+  - uid: 1278
     components:
     - type: Transform
       pos: 3.5,35.5
       parent: 1
-  - uid: 1270
+  - uid: 1279
     components:
     - type: Transform
       pos: 1.5,34.5
       parent: 1
-  - uid: 1271
+  - uid: 1280
     components:
     - type: Transform
       pos: -0.5,33.5
       parent: 1
-  - uid: 1272
+  - uid: 1281
     components:
     - type: Transform
       pos: -0.5,34.5
       parent: 1
-  - uid: 1273
+  - uid: 1282
     components:
     - type: Transform
       pos: -0.5,35.5
       parent: 1
-  - uid: 1274
+  - uid: 1283
     components:
     - type: Transform
       pos: 0.5,35.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 1275
+  - uid: 1284
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 1
-  - uid: 1276
+  - uid: 1285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10741,65 +10746,65 @@ entities:
       parent: 1
 - proto: CarpetBlue
   entities:
-  - uid: 1277
+  - uid: 1286
     components:
     - type: Transform
       pos: -21.5,10.5
       parent: 1
-  - uid: 1278
+  - uid: 1287
     components:
     - type: Transform
       pos: -21.5,11.5
       parent: 1
-  - uid: 1279
+  - uid: 1288
     components:
     - type: Transform
       pos: -21.5,12.5
       parent: 1
-  - uid: 1280
+  - uid: 1289
     components:
     - type: Transform
       pos: -22.5,13.5
       parent: 1
-  - uid: 1281
+  - uid: 1290
     components:
     - type: Transform
       pos: -23.5,13.5
       parent: 1
-  - uid: 1282
+  - uid: 1291
     components:
     - type: Transform
       pos: -24.5,13.5
       parent: 1
-  - uid: 1283
+  - uid: 1292
     components:
     - type: Transform
       pos: -19.5,13.5
       parent: 1
-  - uid: 1284
+  - uid: 1293
     components:
     - type: Transform
       pos: -19.5,12.5
       parent: 1
-  - uid: 1285
+  - uid: 1294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,40.5
       parent: 1
-  - uid: 1286
+  - uid: 1295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,39.5
       parent: 1
-  - uid: 1287
+  - uid: 1296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,40.5
       parent: 1
-  - uid: 1288
+  - uid: 1297
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10807,488 +10812,493 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 1289
+  - uid: 1298
     components:
     - type: Transform
       pos: 0.5,35.5
       parent: 1
-  - uid: 1290
+  - uid: 1299
     components:
     - type: Transform
       pos: 0.5,42.5
       parent: 1
-  - uid: 1291
+  - uid: 1300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,29.5
       parent: 1
-  - uid: 1292
+  - uid: 1301
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 1293
+  - uid: 1302
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 1294
+  - uid: 1303
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 1295
+  - uid: 1304
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 1296
+  - uid: 1305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,41.5
       parent: 1
-  - uid: 1297
+  - uid: 1306
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,21.5
       parent: 1
-  - uid: 1298
+  - uid: 1307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,22.5
       parent: 1
-  - uid: 1299
+  - uid: 1308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,20.5
       parent: 1
-  - uid: 1300
+  - uid: 1309
     components:
     - type: Transform
       pos: -6.5,25.5
       parent: 1
-  - uid: 1301
+  - uid: 1310
     components:
     - type: Transform
       pos: 0.5,26.5
       parent: 1
-  - uid: 1302
+  - uid: 1311
     components:
     - type: Transform
       pos: 1.5,26.5
       parent: 1
-  - uid: 1303
+  - uid: 1312
     components:
     - type: Transform
       pos: 11.5,26.5
       parent: 1
-  - uid: 1304
+  - uid: 1313
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,21.5
       parent: 1
-  - uid: 1305
+  - uid: 1314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,22.5
       parent: 1
-  - uid: 1306
+  - uid: 1315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,20.5
       parent: 1
-  - uid: 1307
+  - uid: 1316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,22.5
       parent: 1
-  - uid: 1308
+  - uid: 1317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,20.5
       parent: 1
-  - uid: 1309
+  - uid: 1318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,22.5
       parent: 1
-  - uid: 1310
+  - uid: 1319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,30.5
       parent: 1
-  - uid: 1311
+  - uid: 1320
     components:
     - type: Transform
       pos: 8.5,26.5
       parent: 1
-  - uid: 1312
+  - uid: 1321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,26.5
       parent: 1
-  - uid: 1313
+  - uid: 1322
     components:
     - type: Transform
       pos: -1.5,26.5
       parent: 1
-  - uid: 1314
+  - uid: 1323
     components:
     - type: Transform
       pos: -6.5,25.5
       parent: 1
-  - uid: 1315
-    components:
-    - type: Transform
-      pos: -2.5,26.5
-      parent: 1
-  - uid: 1316
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,26.5
-      parent: 1
-  - uid: 1317
-    components:
-    - type: Transform
-      pos: -3.5,26.5
-      parent: 1
-  - uid: 1318
-    components:
-    - type: Transform
-      pos: -6.5,26.5
-      parent: 1
-  - uid: 1319
-    components:
-    - type: Transform
-      pos: -4.5,26.5
-      parent: 1
-  - uid: 1320
-    components:
-    - type: Transform
-      pos: -0.5,25.5
-      parent: 1
-  - uid: 1321
-    components:
-    - type: Transform
-      pos: 2.5,26.5
-      parent: 1
-  - uid: 1322
-    components:
-    - type: Transform
-      pos: 3.5,26.5
-      parent: 1
-  - uid: 1323
-    components:
-    - type: Transform
-      pos: -5.5,26.5
-      parent: 1
   - uid: 1324
     components:
     - type: Transform
-      pos: 5.5,26.5
+      pos: -2.5,26.5
       parent: 1
   - uid: 1325
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,30.5
+      pos: 9.5,26.5
       parent: 1
   - uid: 1326
+    components:
+    - type: Transform
+      pos: -3.5,26.5
+      parent: 1
+  - uid: 1327
+    components:
+    - type: Transform
+      pos: -6.5,26.5
+      parent: 1
+  - uid: 1328
+    components:
+    - type: Transform
+      pos: -4.5,26.5
+      parent: 1
+  - uid: 1329
+    components:
+    - type: Transform
+      pos: -0.5,25.5
+      parent: 1
+  - uid: 1330
+    components:
+    - type: Transform
+      pos: 2.5,26.5
+      parent: 1
+  - uid: 1331
+    components:
+    - type: Transform
+      pos: 3.5,26.5
+      parent: 1
+  - uid: 1332
+    components:
+    - type: Transform
+      pos: -5.5,26.5
+      parent: 1
+  - uid: 1333
+    components:
+    - type: Transform
+      pos: 5.5,26.5
+      parent: 1
+  - uid: 1334
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,30.5
+      parent: 1
+  - uid: 1335
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,34.5
       parent: 1
-  - uid: 1327
+  - uid: 1336
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,34.5
       parent: 1
-  - uid: 1328
+  - uid: 1337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,34.5
       parent: 1
-  - uid: 1329
+  - uid: 1338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,7.5
       parent: 1
-  - uid: 1330
+  - uid: 1339
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,7.5
       parent: 1
-  - uid: 1331
+  - uid: 1340
     components:
     - type: Transform
       pos: -19.5,25.5
       parent: 1
-  - uid: 1332
+  - uid: 1341
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,7.5
       parent: 1
-  - uid: 1333
+  - uid: 1342
     components:
     - type: Transform
       pos: -5.5,20.5
       parent: 1
-  - uid: 1334
+  - uid: 1343
     components:
     - type: Transform
       pos: -18.5,25.5
       parent: 1
-  - uid: 1335
+  - uid: 1344
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,7.5
       parent: 1
-  - uid: 1336
+  - uid: 1345
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,40.5
       parent: 1
-  - uid: 1337
+  - uid: 1346
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,39.5
       parent: 1
-  - uid: 1338
+  - uid: 1347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,7.5
       parent: 1
-  - uid: 1339
+  - uid: 1348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,22.5
       parent: 1
-  - uid: 1340
+  - uid: 1349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,21.5
       parent: 1
-  - uid: 1341
+  - uid: 1350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,22.5
       parent: 1
-  - uid: 1342
+  - uid: 1351
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,38.5
       parent: 1
-  - uid: 1343
+  - uid: 1352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,38.5
       parent: 1
-  - uid: 1344
+  - uid: 1353
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 1345
+  - uid: 1354
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 1346
+  - uid: 1355
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,38.5
       parent: 1
-  - uid: 1347
+  - uid: 1356
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,20.5
       parent: 1
-  - uid: 1348
+  - uid: 1357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,21.5
       parent: 1
-  - uid: 1349
+  - uid: 1358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,31.5
       parent: 1
-  - uid: 1350
+  - uid: 1359
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 1351
+  - uid: 1360
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 1352
+  - uid: 1361
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 1353
+  - uid: 1362
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 1354
+  - uid: 1363
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 1355
+  - uid: 1364
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 1356
+  - uid: 1365
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 1357
-    components:
-    - type: Transform
-      pos: 2.5,12.5
-      parent: 1
-  - uid: 1358
+  - uid: 1367
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,27.5
       parent: 1
-  - uid: 1359
+  - uid: 1368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,32.5
       parent: 1
-  - uid: 1360
+  - uid: 1369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,31.5
       parent: 1
-  - uid: 1361
-    components:
-    - type: Transform
-      pos: 3.5,42.5
-      parent: 1
-  - uid: 1362
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,36.5
-      parent: 1
-  - uid: 1363
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,32.5
-      parent: 1
-  - uid: 1364
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,33.5
-      parent: 1
-  - uid: 1365
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,35.5
-      parent: 1
-  - uid: 1366
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,36.5
-      parent: 1
-  - uid: 1367
-    components:
-    - type: Transform
-      pos: 7.5,35.5
-      parent: 1
-  - uid: 1368
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,26.5
-      parent: 1
-  - uid: 1369
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,31.5
-      parent: 1
   - uid: 1370
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,31.5
+      pos: 3.5,42.5
       parent: 1
   - uid: 1371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -0.5,33.5
+      pos: -0.5,36.5
       parent: 1
   - uid: 1372
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -0.5,34.5
+      pos: -0.5,32.5
       parent: 1
   - uid: 1373
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,33.5
+      parent: 1
+  - uid: 1374
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,35.5
+      parent: 1
+  - uid: 1375
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,36.5
+      parent: 1
+  - uid: 1376
+    components:
+    - type: Transform
+      pos: 7.5,35.5
+      parent: 1
+  - uid: 1377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,26.5
+      parent: 1
+  - uid: 1378
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,31.5
+      parent: 1
+  - uid: 1379
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,31.5
+      parent: 1
+  - uid: 1380
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,33.5
+      parent: 1
+  - uid: 1381
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,34.5
+      parent: 1
+  - uid: 1382
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,38.5
       parent: 1
+  - uid: 4084
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 4338
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
 - proto: Chair
   entities:
-  - uid: 1374
+  - uid: 1383
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,38.5
       parent: 1
-  - uid: 1375
+  - uid: 1384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11296,24 +11306,24 @@ entities:
       parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 1376
+  - uid: 1385
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 1377
+  - uid: 1386
     components:
     - type: Transform
       pos: -10.5,3.5
       parent: 1
-  - uid: 1378
+  - uid: 1387
     components:
     - type: Transform
       pos: -4.549364,34.358597
       parent: 1
-  - uid: 1379
+  - uid: 1388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11321,97 +11331,97 @@ entities:
       parent: 1
 - proto: ChairOfficeLight
   entities:
-  - uid: 1380
+  - uid: 1389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.157587,34.51467
       parent: 1
-  - uid: 1381
+  - uid: 1390
     components:
     - type: Transform
       pos: -15.548659,34.235767
       parent: 1
-  - uid: 1382
+  - uid: 1391
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.665554,25.698372
       parent: 1
-  - uid: 1383
+  - uid: 1392
     components:
     - type: Transform
       pos: -5.6755104,21.507347
       parent: 1
 - proto: ChemDispenser
   entities:
-  - uid: 1384
+  - uid: 1393
     components:
     - type: Transform
       pos: 4.5,36.5
       parent: 1
-  - uid: 1385
+  - uid: 1394
     components:
     - type: Transform
       pos: -15.5,35.5
       parent: 1
 - proto: ChemistryHotplate
   entities:
-  - uid: 1386
+  - uid: 1395
     components:
     - type: Transform
       pos: 5.5,34.5
       parent: 1
-  - uid: 1387
+  - uid: 1396
     components:
     - type: Transform
       pos: -15.5,33.5
       parent: 1
 - proto: ChemMaster
   entities:
-  - uid: 1388
+  - uid: 1397
     components:
     - type: Transform
       pos: -16.5,35.5
       parent: 1
-  - uid: 1389
+  - uid: 1398
     components:
     - type: Transform
       pos: 3.5,36.5
       parent: 1
 - proto: CigarSpent
   entities:
-  - uid: 1390
+  - uid: 1399
     components:
     - type: Transform
       pos: -3.4545374,29.79673
       parent: 1
 - proto: ClockworkGrilleBroken
   entities:
-  - uid: 1391
+  - uid: 1400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,11.5
       parent: 1
-  - uid: 1392
+  - uid: 1401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,13.5
       parent: 1
-  - uid: 1393
+  - uid: 1402
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 1
-  - uid: 1394
+  - uid: 1403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,30.5
       parent: 1
-  - uid: 1395
+  - uid: 1404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11419,196 +11429,196 @@ entities:
       parent: 1
 - proto: ClosetL3ScienceFilled
   entities:
-  - uid: 1396
+  - uid: 1405
     components:
     - type: Transform
       pos: 7.5,23.5
       parent: 1
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 1397
+  - uid: 1406
     components:
     - type: Transform
       pos: 6.5,23.5
       parent: 1
 - proto: ClosetWallO2N2Filled
   entities:
-  - uid: 1398
+  - uid: 1407
     components:
     - type: Transform
       pos: -13.5,55.5
       parent: 1
-  - uid: 1399
+  - uid: 1408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,51.5
       parent: 1
-  - uid: 1400
+  - uid: 1409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,1.5
       parent: 1
-  - uid: 1401
+  - uid: 1410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-15.5
       parent: 1
-  - uid: 1402
+  - uid: 1411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,2.5
       parent: 1
-  - uid: 1403
+  - uid: 1412
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,7.5
       parent: 1
-  - uid: 1404
+  - uid: 1413
     components:
     - type: Transform
       pos: -13.5,-11.5
       parent: 1
-  - uid: 1405
+  - uid: 1414
     components:
     - type: Transform
       pos: -13.5,-25.5
       parent: 1
-  - uid: 1406
+  - uid: 1415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-29.5
       parent: 1
-  - uid: 1407
+  - uid: 1416
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-30.5
       parent: 1
-  - uid: 1408
+  - uid: 1417
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,1.5
       parent: 1
-  - uid: 1409
+  - uid: 1418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,7.5
       parent: 1
-  - uid: 1410
+  - uid: 1419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,56.5
       parent: 1
-  - uid: 1411
+  - uid: 1420
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,33.5
       parent: 1
-  - uid: 1412
+  - uid: 1421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,7.5
       parent: 1
-  - uid: 1413
+  - uid: 1422
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,1.5
       parent: 1
-  - uid: 1414
+  - uid: 1423
     components:
     - type: Transform
       pos: -49.5,6.5
       parent: 1
 - proto: ClothingBackpackDuffelSurgeryFilled
   entities:
-  - uid: 1415
+  - uid: 1424
     components:
     - type: Transform
       pos: -18.506779,28.697758
       parent: 1
 - proto: ClothingBeltMedicalEMTFilled
   entities:
-  - uid: 1416
+  - uid: 1425
     components:
     - type: Transform
       pos: 4.425496,40.73831
       parent: 1
 - proto: ClothingEyesEyepatchHudBeer
   entities:
-  - uid: 1417
+  - uid: 1426
     components:
     - type: Transform
       pos: -24.434708,8.631045
       parent: 1
 - proto: ClothingHandsGlovesNitrile
   entities:
-  - uid: 1419
+  - uid: 1428
     components:
     - type: Transform
-      parent: 1418
+      parent: 1427
     - type: Physics
       canCollide: False
 - proto: ClothingHeadHatBeretBrigmedic
   entities:
-  - uid: 1422
+  - uid: 1431
     components:
     - type: Transform
-      parent: 1421
+      parent: 1430
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1423
+  - uid: 1432
     components:
     - type: Transform
-      parent: 1421
+      parent: 1430
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1427
+  - uid: 1436
     components:
     - type: Transform
       pos: 4.706746,40.51956
       parent: 1
 - proto: ClothingHeadHatCone
   entities:
-  - uid: 1428
+  - uid: 1437
     components:
     - type: Transform
       pos: -16.690865,10.035296
       parent: 1
-  - uid: 1429
+  - uid: 1438
     components:
     - type: Transform
       pos: -16.544098,10.842515
       parent: 1
-  - uid: 1430
+  - uid: 1439
     components:
     - type: Transform
       pos: -16.556328,11.735349
       parent: 1
-  - uid: 1431
+  - uid: 1440
     components:
     - type: Transform
       pos: 1.445529,17.342342
       parent: 1
-  - uid: 1432
+  - uid: 1441
     components:
     - type: Transform
       pos: 1.6901407,16.584045
       parent: 1
-  - uid: 1433
+  - uid: 1442
     components:
     - type: Transform
       pos: 1.2009168,15.336524
@@ -11643,33 +11653,33 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1435
+  - uid: 1444
     components:
     - type: Transform
-      parent: 1434
+      parent: 1443
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1442
+  - uid: 1451
     components:
     - type: Transform
-      parent: 1441
+      parent: 1450
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1449
+  - uid: 1458
     components:
     - type: Transform
-      parent: 1448
+      parent: 1457
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingMaskSterile
   entities:
-  - uid: 1420
+  - uid: 1429
     components:
     - type: Transform
-      parent: 1418
+      parent: 1427
     - type: Physics
       canCollide: False
 - proto: ClothingOuterCoatAMG
@@ -11681,47 +11691,47 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1424
+  - uid: 1433
     components:
     - type: Transform
-      parent: 1421
+      parent: 1430
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1436
+  - uid: 1445
     components:
     - type: Transform
-      parent: 1434
+      parent: 1443
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1443
+  - uid: 1452
     components:
     - type: Transform
-      parent: 1441
+      parent: 1450
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1450
+  - uid: 1459
     components:
     - type: Transform
-      parent: 1448
+      parent: 1457
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1456
+  - uid: 1465
     components:
     - type: Transform
-      parent: 1455
+      parent: 1464
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitRd
   entities:
-  - uid: 1461
+  - uid: 1470
     components:
     - type: Transform
-      parent: 1460
+      parent: 1469
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -11734,26 +11744,26 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1437
+  - uid: 1446
     components:
     - type: Transform
-      parent: 1434
+      parent: 1443
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1444
+  - uid: 1453
     components:
     - type: Transform
-      parent: 1441
+      parent: 1450
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingOuterHardsuitTraumaLeader
   entities:
-  - uid: 1451
+  - uid: 1460
     components:
     - type: Transform
-      parent: 1448
+      parent: 1457
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -11766,33 +11776,33 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1438
+  - uid: 1447
     components:
     - type: Transform
-      parent: 1434
+      parent: 1443
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1445
+  - uid: 1454
     components:
     - type: Transform
-      parent: 1441
+      parent: 1450
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1452
+  - uid: 1461
     components:
     - type: Transform
-      parent: 1448
+      parent: 1457
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtBrigmedic
   entities:
-  - uid: 1425
+  - uid: 1434
     components:
     - type: Transform
-      parent: 1421
+      parent: 1430
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -11805,80 +11815,80 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1439
+  - uid: 1448
     components:
     - type: Transform
-      parent: 1434
+      parent: 1443
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1446
+  - uid: 1455
     components:
     - type: Transform
-      parent: 1441
+      parent: 1450
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1453
+  - uid: 1462
     components:
     - type: Transform
-      parent: 1448
+      parent: 1457
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitBrigmedic
   entities:
-  - uid: 1426
+  - uid: 1435
     components:
     - type: Transform
-      parent: 1421
+      parent: 1430
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: Cobweb1
   entities:
-  - uid: 1462
+  - uid: 1471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,23.5
       parent: 1
-  - uid: 1463
+  - uid: 1472
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,23.5
       parent: 1
-  - uid: 1464
+  - uid: 1473
     components:
     - type: Transform
       pos: -6.5,26.5
       parent: 1
-  - uid: 1465
+  - uid: 1474
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
 - proto: Cobweb2
   entities:
-  - uid: 1466
+  - uid: 1475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,22.5
       parent: 1
-  - uid: 1467
+  - uid: 1476
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,20.5
       parent: 1
-  - uid: 1468
+  - uid: 1477
     components:
     - type: Transform
       pos: -18.5,16.5
       parent: 1
-  - uid: 1469
+  - uid: 1478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11886,19 +11896,19 @@ entities:
       parent: 1
 - proto: ComfyChair
   entities:
-  - uid: 1470
+  - uid: 1479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,21.5
       parent: 1
-  - uid: 1471
+  - uid: 1480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,21.5
       parent: 1
-  - uid: 1472
+  - uid: 1481
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11906,7 +11916,7 @@ entities:
       parent: 1
 - proto: ComputerBankATM
   entities:
-  - uid: 1473
+  - uid: 1482
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11918,7 +11928,7 @@ entities:
       startingCharge: 0
 - proto: ComputerShipyardMedical
   entities:
-  - uid: 1474
+  - uid: 1483
     components:
     - type: Transform
       pos: -2.5,4.5
@@ -11927,7 +11937,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1475
+  - uid: 1484
     components:
     - type: Transform
       pos: -18.5,4.5
@@ -11936,7 +11946,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1476
+  - uid: 1485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11946,7 +11956,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1477
+  - uid: 1486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11958,7 +11968,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopAnalysisConsole
   entities:
-  - uid: 1478
+  - uid: 1487
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11970,14 +11980,14 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopBroken
   entities:
-  - uid: 1479
+  - uid: 1488
     components:
     - type: Transform
       pos: 5.5,23.5
       parent: 1
 - proto: ComputerTabletopCloningConsole
   entities:
-  - uid: 1480
+  - uid: 1489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11989,7 +11999,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopComms
   entities:
-  - uid: 1481
+  - uid: 1490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12001,7 +12011,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopCrewMonitoring
   entities:
-  - uid: 1482
+  - uid: 1491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12011,7 +12021,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1483
+  - uid: 1492
     components:
     - type: Transform
       pos: 11.5,40.5
@@ -12022,7 +12032,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopCriminalRecords
   entities:
-  - uid: 1484
+  - uid: 1493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12034,14 +12044,14 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopFrame
   entities:
-  - uid: 1485
+  - uid: 1494
     components:
     - type: Transform
       pos: -18.5,40.5
       parent: 1
 - proto: ComputerTabletopId
   entities:
-  - uid: 1486
+  - uid: 1495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12053,7 +12063,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopMedicalRecords
   entities:
-  - uid: 1487
+  - uid: 1496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12063,7 +12073,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1488
+  - uid: 1497
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12073,7 +12083,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1489
+  - uid: 1498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12083,7 +12093,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1490
+  - uid: 1499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12095,7 +12105,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopRadar
   entities:
-  - uid: 1491
+  - uid: 1500
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12107,7 +12117,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopShuttle
   entities:
-  - uid: 1492
+  - uid: 1501
     components:
     - type: Transform
       pos: -17.5,22.5
@@ -12118,7 +12128,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopStationAdminBankATMMedical
   entities:
-  - uid: 1493
+  - uid: 1502
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12128,7 +12138,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1494
+  - uid: 1503
     components:
     - type: Transform
       pos: 12.5,40.5
@@ -12139,7 +12149,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopStationRecords
   entities:
-  - uid: 1495
+  - uid: 1504
     components:
     - type: Transform
       pos: -16.5,22.5
@@ -12150,7 +12160,7 @@ entities:
       startingCharge: 0
 - proto: ComputerWallmountBankATM
   entities:
-  - uid: 1496
+  - uid: 1505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12162,7 +12172,7 @@ entities:
       startingCharge: 0
 - proto: ConveyorBelt
   entities:
-  - uid: 1497
+  - uid: 1506
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12170,7 +12180,7 @@ entities:
       parent: 1
 - proto: CounterMetalFrame
   entities:
-  - uid: 1498
+  - uid: 1507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12178,113 +12188,113 @@ entities:
       parent: 1
 - proto: CrateFreezer
   entities:
-  - uid: 1499
+  - uid: 1508
     components:
     - type: Transform
       pos: -3.5,22.5
       parent: 1
 - proto: CrateMaterialsBasicFilled
   entities:
-  - uid: 1500
+  - uid: 1509
     components:
     - type: Transform
       pos: -2.5,25.5
       parent: 1
-  - uid: 1501
+  - uid: 1510
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 1
 - proto: CrateMedicalRollerBeds
   entities:
-  - uid: 1502
+  - uid: 1511
     components:
     - type: Transform
       pos: -16.5,41.5
       parent: 1
 - proto: CrateMedicalScrubs
   entities:
-  - uid: 1503
+  - uid: 1512
     components:
     - type: Transform
       pos: -5.5,25.5
       parent: 1
 - proto: CrateMedicalSecureDoctor
   entities:
-  - uid: 1504
+  - uid: 1513
     components:
     - type: Transform
       pos: -1.5,25.5
       parent: 1
 - proto: CrateMedicalSurgery
   entities:
-  - uid: 1505
+  - uid: 1514
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 1
 - proto: CrewMonitoringServer
   entities:
-  - uid: 4335
+  - uid: 1515
     components:
     - type: Transform
       pos: -15.5,42.5
       parent: 1
 - proto: CryoPod
   entities:
-  - uid: 1506
+  - uid: 1516
     components:
     - type: Transform
       pos: -4.5,23.5
       parent: 1
 - proto: CryoxadoneBeakerSmall
   entities:
-  - uid: 1507
+  - uid: 1517
     components:
     - type: Transform
       pos: -3.6452894,21.664505
       parent: 1
-  - uid: 1508
+  - uid: 1518
     components:
     - type: Transform
       pos: -3.3640394,21.74263
       parent: 1
-  - uid: 1509
+  - uid: 1519
     components:
     - type: Transform
       pos: -3.6025934,21.205265
       parent: 1
-  - uid: 1510
+  - uid: 1520
     components:
     - type: Transform
       pos: -3.2484274,21.413597
       parent: 1
 - proto: CurtainsBlueOpen
   entities:
-  - uid: 1511
+  - uid: 1521
     components:
     - type: Transform
       pos: 12.5,38.5
       parent: 1
-  - uid: 1512
+  - uid: 1522
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,40.5
       parent: 1
-  - uid: 1513
+  - uid: 1523
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,40.5
       parent: 1
-  - uid: 1514
+  - uid: 1524
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,40.5
       parent: 1
-  - uid: 1515
+  - uid: 1525
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12292,34 +12302,34 @@ entities:
       parent: 1
 - proto: DecalSpawnerBloodSplatters
   entities:
-  - uid: 1516
+  - uid: 1526
     components:
     - type: Transform
       pos: -6.5,40.5
       parent: 1
-  - uid: 1517
+  - uid: 1527
     components:
     - type: Transform
       pos: -3.5,39.5
       parent: 1
-  - uid: 1518
+  - uid: 1528
     components:
     - type: Transform
       pos: 5.5,36.5
       parent: 1
-  - uid: 1519
+  - uid: 1529
     components:
     - type: Transform
       pos: -4.5,32.5
       parent: 1
 - proto: DefaultStationBeacon
   entities:
-  - uid: 1520
+  - uid: 1530
     components:
     - type: Transform
       pos: -4.5,31.5
       parent: 1
-  - uid: 1521
+  - uid: 1531
     components:
     - type: Transform
       pos: 0.5,39.5
@@ -12328,50 +12338,50 @@ entities:
       text: ATU wing
 - proto: DefaultStationBeaconBar
   entities:
-  - uid: 1522
+  - uid: 1532
     components:
     - type: Transform
       pos: -23.5,13.5
       parent: 1
 - proto: DefaultStationBeaconCryonics
   entities:
-  - uid: 1523
+  - uid: 1533
     components:
     - type: Transform
       pos: -5.5,21.5
       parent: 1
 - proto: DefaultStationBeaconCryosleep
   entities:
-  - uid: 1524
+  - uid: 1534
     components:
     - type: Transform
       pos: -19.5,8.5
       parent: 1
 - proto: DefaultStationBeaconDisposals
   entities:
-  - uid: 1525
+  - uid: 1535
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 1
 - proto: DefaultStationBeaconDockingArm
   entities:
-  - uid: 1526
+  - uid: 1536
     components:
     - type: Transform
       pos: -10.5,-20.5
       parent: 1
-  - uid: 1527
+  - uid: 1537
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 1528
+  - uid: 1538
     components:
     - type: Transform
       pos: -10.5,53.5
       parent: 1
-  - uid: 1529
+  - uid: 1539
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12379,131 +12389,131 @@ entities:
       parent: 1
 - proto: DefaultStationBeaconFrontierDoCOffice
   entities:
-  - uid: 1530
+  - uid: 1540
     components:
     - type: Transform
       pos: -17.5,21.5
       parent: 1
 - proto: DefaultStationBeaconFrontierLobby
   entities:
-  - uid: 1531
+  - uid: 1541
     components:
     - type: Transform
       pos: -10.5,3.5
       parent: 1
 - proto: DefaultStationBeaconMedbay
   entities:
-  - uid: 1532
+  - uid: 1542
     components:
     - type: Transform
       pos: -17.5,31.5
       parent: 1
 - proto: DefaultStationBeaconMorgue
   entities:
-  - uid: 1533
+  - uid: 1543
     components:
     - type: Transform
       pos: -4.5,40.5
       parent: 1
 - proto: DefaultStationBeaconRND
   entities:
-  - uid: 1534
+  - uid: 1544
     components:
     - type: Transform
       pos: 5.5,21.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 1535
+  - uid: 1545
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,27.5
       parent: 1
-  - uid: 1536
+  - uid: 1546
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,27.5
       parent: 1
-  - uid: 1537
+  - uid: 1547
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,9.5
       parent: 1
-  - uid: 1538
+  - uid: 1548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,9.5
       parent: 1
-  - uid: 1539
+  - uid: 1549
     components:
     - type: Transform
       pos: -1.5,18.5
       parent: 1
 - proto: DemagUnlimited
   entities:
-  - uid: 1457
+  - uid: 1466
     components:
     - type: Transform
-      parent: 1455
+      parent: 1464
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: DeskBell
   entities:
-  - uid: 1540
+  - uid: 1550
     components:
     - type: Transform
       pos: -9.538251,2.738927
       parent: 1
 - proto: DimLightBulb
   entities:
-  - uid: 1542
+  - uid: 1552
     components:
     - type: Transform
-      parent: 1541
+      parent: 1551
     - type: Physics
       canCollide: False
 - proto: DisposalBend
   entities:
-  - uid: 1543
+  - uid: 1553
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,41.5
       parent: 1
-  - uid: 1544
+  - uid: 1554
     components:
     - type: Transform
       pos: -9.5,8.5
       parent: 1
-  - uid: 1545
+  - uid: 1555
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,8.5
       parent: 1
-  - uid: 1546
+  - uid: 1556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,6.5
       parent: 1
-  - uid: 1547
+  - uid: 1557
     components:
     - type: Transform
       pos: -20.5,35.5
       parent: 1
-  - uid: 1548
+  - uid: 1558
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,31.5
       parent: 1
-  - uid: 1549
+  - uid: 1559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12511,470 +12521,470 @@ entities:
       parent: 1
 - proto: DisposalJunction
   entities:
-  - uid: 1550
+  - uid: 1560
     components:
     - type: Transform
       pos: -10.5,31.5
       parent: 1
 - proto: DisposalJunctionFlipped
   entities:
-  - uid: 1551
+  - uid: 1561
     components:
     - type: Transform
       pos: -10.5,22.5
       parent: 1
-  - uid: 1552
+  - uid: 1562
     components:
     - type: Transform
       pos: -10.5,19.5
       parent: 1
-  - uid: 1553
+  - uid: 1563
     components:
     - type: Transform
       pos: -10.5,29.5
       parent: 1
 - proto: DisposalPipe
   entities:
-  - uid: 1554
+  - uid: 1564
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,35.5
       parent: 1
-  - uid: 1555
+  - uid: 1565
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,36.5
       parent: 1
-  - uid: 1556
+  - uid: 1566
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,30.5
       parent: 1
-  - uid: 1557
-    components:
-    - type: Transform
-      pos: -9.5,7.5
-      parent: 1
-  - uid: 1558
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,9.5
-      parent: 1
-  - uid: 1559
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,10.5
-      parent: 1
-  - uid: 1560
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,11.5
-      parent: 1
-  - uid: 1561
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,12.5
-      parent: 1
-  - uid: 1562
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,13.5
-      parent: 1
-  - uid: 1563
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,14.5
-      parent: 1
-  - uid: 1564
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,15.5
-      parent: 1
-  - uid: 1565
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,16.5
-      parent: 1
-  - uid: 1566
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,17.5
-      parent: 1
   - uid: 1567
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,18.5
+      pos: -9.5,7.5
       parent: 1
   - uid: 1568
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,20.5
+      pos: -10.5,9.5
       parent: 1
   - uid: 1569
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,21.5
+      pos: -10.5,10.5
       parent: 1
   - uid: 1570
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,22.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,11.5
       parent: 1
   - uid: 1571
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,23.5
+      pos: -10.5,12.5
       parent: 1
   - uid: 1572
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,24.5
+      pos: -10.5,13.5
       parent: 1
   - uid: 1573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,25.5
+      pos: -10.5,14.5
       parent: 1
   - uid: 1574
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,26.5
+      pos: -10.5,15.5
       parent: 1
   - uid: 1575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,27.5
+      pos: -10.5,16.5
       parent: 1
   - uid: 1576
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,29.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,17.5
       parent: 1
   - uid: 1577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,30.5
+      pos: -10.5,18.5
       parent: 1
   - uid: 1578
     components:
     - type: Transform
-      pos: -10.5,28.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,20.5
       parent: 1
   - uid: 1579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,32.5
+      pos: -10.5,21.5
       parent: 1
   - uid: 1580
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,33.5
+      rot: -1.5707963267948966 rad
+      pos: -9.5,22.5
       parent: 1
   - uid: 1581
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,34.5
+      pos: -10.5,23.5
       parent: 1
   - uid: 1582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,35.5
+      pos: -10.5,24.5
       parent: 1
   - uid: 1583
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,36.5
+      pos: -10.5,25.5
       parent: 1
   - uid: 1584
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,37.5
+      pos: -10.5,26.5
       parent: 1
   - uid: 1585
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,38.5
+      pos: -10.5,27.5
       parent: 1
   - uid: 1586
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,39.5
+      rot: -1.5707963267948966 rad
+      pos: -9.5,29.5
       parent: 1
   - uid: 1587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,40.5
+      pos: -10.5,30.5
       parent: 1
   - uid: 1588
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,41.5
+      pos: -10.5,28.5
       parent: 1
   - uid: 1589
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,41.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,32.5
       parent: 1
   - uid: 1590
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,33.5
       parent: 1
   - uid: 1591
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,34.5
       parent: 1
   - uid: 1592
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,35.5
       parent: 1
   - uid: 1593
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,36.5
       parent: 1
   - uid: 1594
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,37.5
       parent: 1
   - uid: 1595
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,38.5
       parent: 1
   - uid: 1596
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,39.5
       parent: 1
   - uid: 1597
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,40.5
       parent: 1
   - uid: 1598
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,19.5
+      pos: -8.5,41.5
       parent: 1
   - uid: 1599
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,19.5
+      pos: -9.5,41.5
       parent: 1
   - uid: 1600
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,19.5
+      pos: -9.5,19.5
       parent: 1
   - uid: 1601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,19.5
+      pos: -8.5,19.5
       parent: 1
   - uid: 1602
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -8.5,29.5
+      pos: -7.5,19.5
       parent: 1
   - uid: 1603
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,29.5
+      pos: -6.5,19.5
       parent: 1
   - uid: 1604
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,29.5
+      pos: -5.5,19.5
       parent: 1
   - uid: 1605
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,35.5
+      rot: -1.5707963267948966 rad
+      pos: -4.5,19.5
       parent: 1
   - uid: 1606
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,35.5
+      rot: -1.5707963267948966 rad
+      pos: -3.5,19.5
       parent: 1
   - uid: 1607
     components:
     - type: Transform
-      pos: -20.5,34.5
+      rot: -1.5707963267948966 rad
+      pos: -2.5,19.5
       parent: 1
   - uid: 1608
     components:
     - type: Transform
-      pos: -20.5,33.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,19.5
       parent: 1
   - uid: 1609
     components:
     - type: Transform
-      pos: -20.5,32.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,19.5
       parent: 1
   - uid: 1610
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,31.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,19.5
       parent: 1
   - uid: 1611
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,31.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,19.5
       parent: 1
   - uid: 1612
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,31.5
+      rot: -1.5707963267948966 rad
+      pos: -8.5,29.5
       parent: 1
   - uid: 1613
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,31.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,29.5
       parent: 1
   - uid: 1614
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,31.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,29.5
       parent: 1
   - uid: 1615
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -14.5,31.5
+      pos: -22.5,35.5
       parent: 1
   - uid: 1616
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,31.5
+      pos: -21.5,35.5
       parent: 1
   - uid: 1617
+    components:
+    - type: Transform
+      pos: -20.5,34.5
+      parent: 1
+  - uid: 1618
+    components:
+    - type: Transform
+      pos: -20.5,33.5
+      parent: 1
+  - uid: 1619
+    components:
+    - type: Transform
+      pos: -20.5,32.5
+      parent: 1
+  - uid: 1620
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,31.5
+      parent: 1
+  - uid: 1621
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,31.5
+      parent: 1
+  - uid: 1622
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,31.5
+      parent: 1
+  - uid: 1623
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -16.5,31.5
+      parent: 1
+  - uid: 1624
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,31.5
+      parent: 1
+  - uid: 1625
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,31.5
+      parent: 1
+  - uid: 1626
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,31.5
+      parent: 1
+  - uid: 1627
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,31.5
       parent: 1
-  - uid: 1618
+  - uid: 1628
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,31.5
       parent: 1
-  - uid: 1619
+  - uid: 1629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,29.5
       parent: 1
-  - uid: 1620
+  - uid: 1630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,33.5
       parent: 1
-  - uid: 1621
+  - uid: 1631
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,29.5
       parent: 1
-  - uid: 1622
+  - uid: 1632
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,32.5
       parent: 1
-  - uid: 1623
+  - uid: 1633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,37.5
       parent: 1
-  - uid: 1624
+  - uid: 1634
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,29.5
       parent: 1
-  - uid: 1625
+  - uid: 1635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,31.5
       parent: 1
-  - uid: 1626
+  - uid: 1636
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,29.5
       parent: 1
-  - uid: 1627
+  - uid: 1637
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,29.5
       parent: 1
-  - uid: 1628
+  - uid: 1638
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12982,36 +12992,36 @@ entities:
       parent: 1
 - proto: DisposalTrunk
   entities:
-  - uid: 1629
+  - uid: 1639
     components:
     - type: Transform
       pos: -0.5,38.5
       parent: 1
-  - uid: 1630
+  - uid: 1640
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,22.5
       parent: 1
-  - uid: 1631
+  - uid: 1641
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,41.5
       parent: 1
-  - uid: 1632
+  - uid: 1642
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,19.5
       parent: 1
-  - uid: 1633
+  - uid: 1643
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,6.5
       parent: 1
-  - uid: 1634
+  - uid: 1644
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13019,7 +13029,7 @@ entities:
       parent: 1
 - proto: DisposalUnit
   entities:
-  - uid: 1418
+  - uid: 1427
     components:
     - type: Transform
       pos: -7.5,41.5
@@ -13032,31 +13042,31 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1420
-          - 1419
-  - uid: 1635
+          - 1429
+          - 1428
+  - uid: 1645
     components:
     - type: Transform
       pos: -8.5,22.5
       parent: 1
-  - uid: 1636
+  - uid: 1646
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 1
-  - uid: 1637
+  - uid: 1647
     components:
     - type: Transform
       pos: -23.5,35.5
       parent: 1
-  - uid: 1638
+  - uid: 1648
     components:
     - type: Transform
       pos: -0.5,38.5
       parent: 1
 - proto: DogBed
   entities:
-  - uid: 1639
+  - uid: 1649
     components:
     - type: Transform
       pos: -16.5,26.5
@@ -13078,49 +13088,49 @@ entities:
           ents:
           - 4
     - type: InsideEntityStorage
-  - uid: 1440
+  - uid: 1449
     components:
     - type: Transform
-      parent: 1434
+      parent: 1443
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1447
+  - uid: 1456
     components:
     - type: Transform
-      parent: 1441
+      parent: 1450
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 1454
+  - uid: 1463
     components:
     - type: Transform
-      parent: 1448
+      parent: 1457
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: DresserChiefMedicalOfficerFilled
   entities:
-  - uid: 1640
+  - uid: 1650
     components:
     - type: Transform
       pos: 13.5,38.5
       parent: 1
-  - uid: 1641
+  - uid: 1651
     components:
     - type: Transform
       pos: -15.5,26.5
       parent: 1
 - proto: DrinkBeerglass
   entities:
-  - uid: 1642
+  - uid: 1652
     components:
     - type: Transform
       pos: -23.33569,12.574788
       parent: 1
 - proto: DrinkBottleCoffeeLiqueur
   entities:
-  - uid: 1643
+  - uid: 1653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13128,52 +13138,52 @@ entities:
       parent: 1
 - proto: DrinkHotCoffee
   entities:
-  - uid: 1644
+  - uid: 1654
     components:
     - type: Transform
       pos: -22.435581,18.289581
       parent: 1
-  - uid: 1645
+  - uid: 1655
     components:
     - type: Transform
       pos: -23.531647,38.726833
       parent: 1
-  - uid: 1646
+  - uid: 1656
     components:
     - type: Transform
       pos: -23.281647,38.49246
       parent: 1
 - proto: ExplosivesSignMed
   entities:
-  - uid: 1647
+  - uid: 1657
     components:
     - type: Transform
       pos: 14.5,23.5
       parent: 1
 - proto: FaxMachineBase
   entities:
-  - uid: 1648
+  - uid: 1658
     components:
     - type: Transform
       pos: -6.5,36.5
       parent: 1
 - proto: FaxMachineNFMedicalDispatch
   entities:
-  - uid: 1649
+  - uid: 1659
     components:
     - type: Transform
       pos: -19.5,19.5
       parent: 1
 - proto: filingCabinetDrawerRandom
   entities:
-  - uid: 1650
+  - uid: 1660
     components:
     - type: Transform
       pos: -17.5,19.5
       parent: 1
 - proto: Firelock
   entities:
-  - uid: 1651
+  - uid: 1661
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13183,7 +13193,7 @@ entities:
       deviceLists:
       - 30
       - 28
-  - uid: 1652
+  - uid: 1662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13193,7 +13203,7 @@ entities:
       deviceLists:
       - 30
       - 31
-  - uid: 1653
+  - uid: 1663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13203,7 +13213,7 @@ entities:
       deviceLists:
       - 28
       - 30
-  - uid: 1654
+  - uid: 1664
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13213,7 +13223,7 @@ entities:
       deviceLists:
       - 28
       - 30
-  - uid: 1655
+  - uid: 1665
     components:
     - type: Transform
       pos: -17.5,8.5
@@ -13222,7 +13232,7 @@ entities:
       deviceLists:
       - 21
       - 15
-  - uid: 1656
+  - uid: 1666
     components:
     - type: Transform
       pos: -7.5,32.5
@@ -13230,7 +13240,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 28
-  - uid: 1657
+  - uid: 1667
     components:
     - type: Transform
       pos: -7.5,31.5
@@ -13238,7 +13248,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 28
-  - uid: 1658
+  - uid: 1668
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13248,7 +13258,7 @@ entities:
       deviceLists:
       - 19
       - 25
-  - uid: 1659
+  - uid: 1669
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13257,7 +13267,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 18
-  - uid: 1660
+  - uid: 1670
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13267,7 +13277,7 @@ entities:
       deviceLists:
       - 22
       - 18
-  - uid: 1661
+  - uid: 1671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13276,7 +13286,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 22
-  - uid: 1662
+  - uid: 1672
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13285,7 +13295,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 16
-  - uid: 1663
+  - uid: 1673
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13294,7 +13304,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 16
-  - uid: 1664
+  - uid: 1674
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13303,19 +13313,19 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 27
-  - uid: 1665
+  - uid: 1675
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,21.5
       parent: 1
-  - uid: 1666
+  - uid: 1676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,21.5
       parent: 1
-  - uid: 1667
+  - uid: 1677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13326,7 +13336,7 @@ entities:
       - 18
       - 26
       - 15
-  - uid: 1668
+  - uid: 1678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13337,7 +13347,7 @@ entities:
       - 18
       - 26
       - 15
-  - uid: 1669
+  - uid: 1679
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13348,7 +13358,7 @@ entities:
       - 18
       - 26
       - 15
-  - uid: 1670
+  - uid: 1680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13359,7 +13369,7 @@ entities:
       - 24
       - 18
       - 26
-  - uid: 1671
+  - uid: 1681
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13370,7 +13380,7 @@ entities:
       - 24
       - 18
       - 26
-  - uid: 1672
+  - uid: 1682
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13381,7 +13391,7 @@ entities:
       - 24
       - 18
       - 26
-  - uid: 1673
+  - uid: 1683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13392,7 +13402,7 @@ entities:
       - 26
       - 17
       - 18
-  - uid: 1674
+  - uid: 1684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13402,7 +13412,7 @@ entities:
       deviceLists:
       - 14
       - 13
-  - uid: 1675
+  - uid: 1685
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13412,7 +13422,7 @@ entities:
       deviceLists:
       - 14
       - 13
-  - uid: 1676
+  - uid: 1686
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13422,7 +13432,7 @@ entities:
       deviceLists:
       - 14
       - 13
-  - uid: 1677
+  - uid: 1687
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13432,7 +13442,7 @@ entities:
       deviceLists:
       - 14
       - 12
-  - uid: 1678
+  - uid: 1688
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13442,7 +13452,7 @@ entities:
       deviceLists:
       - 14
       - 12
-  - uid: 1679
+  - uid: 1689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13452,7 +13462,7 @@ entities:
       deviceLists:
       - 14
       - 12
-  - uid: 1680
+  - uid: 1690
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13462,7 +13472,7 @@ entities:
       deviceLists:
       - 14
       - 34
-  - uid: 1681
+  - uid: 1691
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13472,7 +13482,7 @@ entities:
       deviceLists:
       - 14
       - 34
-  - uid: 1682
+  - uid: 1692
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13482,7 +13492,7 @@ entities:
       deviceLists:
       - 14
       - 34
-  - uid: 1683
+  - uid: 1693
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13492,7 +13502,7 @@ entities:
       deviceLists:
       - 14
       - 15
-  - uid: 1684
+  - uid: 1694
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13502,7 +13512,7 @@ entities:
       deviceLists:
       - 14
       - 15
-  - uid: 1685
+  - uid: 1695
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13512,7 +13522,7 @@ entities:
       deviceLists:
       - 14
       - 15
-  - uid: 1686
+  - uid: 1696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13521,7 +13531,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 15
-  - uid: 1687
+  - uid: 1697
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13530,7 +13540,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 15
-  - uid: 1688
+  - uid: 1698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13539,7 +13549,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 15
-  - uid: 1689
+  - uid: 1699
     components:
     - type: Transform
       pos: -17.5,10.5
@@ -13548,7 +13558,7 @@ entities:
       deviceLists:
       - 20
       - 15
-  - uid: 1690
+  - uid: 1700
     components:
     - type: Transform
       pos: -17.5,11.5
@@ -13557,7 +13567,7 @@ entities:
       deviceLists:
       - 20
       - 15
-  - uid: 1691
+  - uid: 1701
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13567,7 +13577,7 @@ entities:
       deviceLists:
       - 26
       - 18
-  - uid: 1692
+  - uid: 1702
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13577,7 +13587,7 @@ entities:
       deviceLists:
       - 26
       - 18
-  - uid: 1693
+  - uid: 1703
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13586,17 +13596,17 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 25
-  - uid: 1694
+  - uid: 1704
     components:
     - type: Transform
       pos: 4.5,26.5
       parent: 1
-  - uid: 1695
+  - uid: 1705
     components:
     - type: Transform
       pos: 6.5,26.5
       parent: 1
-  - uid: 1696
+  - uid: 1706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13605,7 +13615,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 32
-  - uid: 1697
+  - uid: 1707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13614,19 +13624,19 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 32
-  - uid: 1698
+  - uid: 1708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,39.5
       parent: 1
-  - uid: 1699
+  - uid: 1709
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,28.5
       parent: 1
-  - uid: 1700
+  - uid: 1710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13635,7 +13645,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 30
-  - uid: 1701
+  - uid: 1711
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13645,7 +13655,7 @@ entities:
       deviceLists:
       - 31
       - 30
-  - uid: 1702
+  - uid: 1712
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13654,7 +13664,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 31
-  - uid: 1703
+  - uid: 1713
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13663,7 +13673,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 33
-  - uid: 1704
+  - uid: 1714
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13672,7 +13682,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 33
-  - uid: 1705
+  - uid: 1715
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13681,7 +13691,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 33
-  - uid: 1706
+  - uid: 1716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13692,7 +13702,7 @@ entities:
       - 33
 - proto: FirelockEdge
   entities:
-  - uid: 1707
+  - uid: 1717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13701,7 +13711,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 31
-  - uid: 1708
+  - uid: 1718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13710,7 +13720,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 31
-  - uid: 1709
+  - uid: 1719
     components:
     - type: Transform
       pos: -4.5,33.5
@@ -13718,12 +13728,12 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 28
-  - uid: 1710
+  - uid: 1720
     components:
     - type: Transform
       pos: -17.5,33.5
       parent: 1
-  - uid: 1711
+  - uid: 1721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13732,7 +13742,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 31
-  - uid: 1712
+  - uid: 1722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13743,7 +13753,7 @@ entities:
       - 31
 - proto: FirelockGlass
   entities:
-  - uid: 1713
+  - uid: 1723
     components:
     - type: Transform
       pos: -0.5,14.5
@@ -13753,7 +13763,7 @@ entities:
       - 18
       - 27
       - 26
-  - uid: 1714
+  - uid: 1724
     components:
     - type: Transform
       pos: -3.5,9.5
@@ -13762,7 +13772,7 @@ entities:
       deviceLists:
       - 27
       - 15
-  - uid: 1715
+  - uid: 1725
     components:
     - type: Transform
       pos: -11.5,18.5
@@ -13772,7 +13782,7 @@ entities:
       - 27
       - 18
       - 26
-  - uid: 1716
+  - uid: 1726
     components:
     - type: Transform
       pos: -10.5,18.5
@@ -13782,7 +13792,7 @@ entities:
       - 27
       - 18
       - 26
-  - uid: 1717
+  - uid: 1727
     components:
     - type: Transform
       pos: -9.5,18.5
@@ -13792,7 +13802,7 @@ entities:
       - 27
       - 18
       - 26
-  - uid: 1718
+  - uid: 1728
     components:
     - type: Transform
       pos: -11.5,29.5
@@ -13801,7 +13811,7 @@ entities:
       deviceLists:
       - 18
       - 26
-  - uid: 1719
+  - uid: 1729
     components:
     - type: Transform
       pos: -10.5,29.5
@@ -13810,7 +13820,7 @@ entities:
       deviceLists:
       - 18
       - 26
-  - uid: 1720
+  - uid: 1730
     components:
     - type: Transform
       pos: -9.5,29.5
@@ -13821,21 +13831,21 @@ entities:
       - 26
 - proto: Fireplace
   entities:
-  - uid: 1721
+  - uid: 1731
     components:
     - type: Transform
       pos: -14.5,26.5
       parent: 1
 - proto: FloorCarpetItemBlue
   entities:
-  - uid: 1722
+  - uid: 1732
     components:
     - type: Transform
       pos: -19.561886,15.577346
       parent: 1
 - proto: FloorDrain
   entities:
-  - uid: 1723
+  - uid: 1733
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13843,7 +13853,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1724
+  - uid: 1734
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13851,7 +13861,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1725
+  - uid: 1735
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13859,14 +13869,14 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1726
+  - uid: 1736
     components:
     - type: Transform
       pos: -10.5,9.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1727
+  - uid: 1737
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13874,7 +13884,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1728
+  - uid: 1738
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13884,56 +13894,56 @@ entities:
       fixtures: {}
 - proto: FloorTileItemWhite
   entities:
-  - uid: 1729
+  - uid: 1739
     components:
     - type: Transform
       pos: 4.2302084,20.612091
       parent: 1
-  - uid: 1730
+  - uid: 1740
     components:
     - type: Transform
       pos: 3.8343754,22.060009
       parent: 1
-  - uid: 1731
+  - uid: 1741
     components:
     - type: Transform
       pos: 4.1677084,22.341259
       parent: 1
-  - uid: 1732
+  - uid: 1742
     components:
     - type: Transform
       pos: 6.667709,21.893341
       parent: 1
-  - uid: 1733
+  - uid: 1743
     components:
     - type: Transform
       pos: 7.2197924,19.976677
       parent: 1
-  - uid: 1734
+  - uid: 1744
     components:
     - type: Transform
       pos: 7.511459,22.185009
       parent: 1
-  - uid: 1735
+  - uid: 1745
     components:
     - type: Transform
       pos: 7.2510424,22.080841
       parent: 1
 - proto: FoodBakedCookieOatmeal
   entities:
-  - uid: 1736
+  - uid: 1746
     components:
     - type: Transform
       pos: -15.691304,22.02221
       parent: 1
-  - uid: 1737
+  - uid: 1747
     components:
     - type: Transform
       pos: -15.385539,22.095592
       parent: 1
 - proto: GasFilter
   entities:
-  - uid: 1738
+  - uid: 1748
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13943,21 +13953,21 @@ entities:
       color: '#990000FF'
 - proto: GasMinerNitrogenStationLarge
   entities:
-  - uid: 1739
+  - uid: 1749
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
 - proto: GasMinerOxygenStationLarge
   entities:
-  - uid: 1740
+  - uid: 1750
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
 - proto: GasMixerOnFlipped
   entities:
-  - uid: 1741
+  - uid: 1751
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13971,7 +13981,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasOutletInjector
   entities:
-  - uid: 1742
+  - uid: 1752
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13979,7 +13989,7 @@ entities:
       parent: 1
 - proto: GasPassiveGate
   entities:
-  - uid: 1743
+  - uid: 1753
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13989,7 +13999,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPassiveGateAlt1
   entities:
-  - uid: 1744
+  - uid: 1754
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13999,7 +14009,7 @@ entities:
       color: '#990000FF'
 - proto: GasPassiveGateAlt2
   entities:
-  - uid: 1745
+  - uid: 1755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14009,7 +14019,7 @@ entities:
       color: '#090D91FF'
 - proto: GasPassiveVent
   entities:
-  - uid: 1746
+  - uid: 1756
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14017,7 +14027,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 1747
+  - uid: 1757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14025,13 +14035,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1748
+  - uid: 1758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,20.5
       parent: 1
-  - uid: 1749
+  - uid: 1759
     components:
     - type: Transform
       pos: 7.5,27.5
@@ -14042,7 +14052,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 1750
+  - uid: 1760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14050,7 +14060,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1751
+  - uid: 1761
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14058,7 +14068,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1752
+  - uid: 1762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14066,14 +14076,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1753
+  - uid: 1763
     components:
     - type: Transform
       pos: -8.5,53.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1754
+  - uid: 1764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14081,14 +14091,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1755
+  - uid: 1765
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1756
+  - uid: 1766
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14096,7 +14106,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1757
+  - uid: 1767
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14104,7 +14114,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 1758
+  - uid: 1768
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14112,7 +14122,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1759
+  - uid: 1769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14120,7 +14130,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1760
+  - uid: 1770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14128,7 +14138,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1761
+  - uid: 1771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14136,7 +14146,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1762
+  - uid: 1772
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14144,21 +14154,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1763
+  - uid: 1773
     components:
     - type: Transform
       pos: -8.5,-27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1764
+  - uid: 1774
     components:
     - type: Transform
       pos: -8.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1765
+  - uid: 1775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14166,7 +14176,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1766
+  - uid: 1776
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14174,7 +14184,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1767
+  - uid: 1777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14182,7 +14192,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1768
+  - uid: 1778
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14190,14 +14200,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1769
+  - uid: 1779
     components:
     - type: Transform
       pos: -15.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1770
+  - uid: 1780
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14205,14 +14215,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1771
+  - uid: 1781
     components:
     - type: Transform
       pos: 6.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1772
+  - uid: 1782
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14220,7 +14230,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1773
+  - uid: 1783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14228,27 +14238,27 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1774
+  - uid: 1784
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,21.5
       parent: 1
-  - uid: 1775
+  - uid: 1785
     components:
     - type: Transform
       pos: -17.5,34.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1776
+  - uid: 1786
     components:
     - type: Transform
       pos: -7.5,40.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1777
+  - uid: 1787
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14256,7 +14266,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1778
+  - uid: 1788
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14264,7 +14274,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1779
+  - uid: 1789
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14272,7 +14282,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1780
+  - uid: 1790
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14280,13 +14290,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1781
+  - uid: 1791
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,22.5
       parent: 1
-  - uid: 1782
+  - uid: 1792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14294,7 +14304,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1783
+  - uid: 1793
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14302,20 +14312,20 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1784
+  - uid: 1794
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,21.5
       parent: 1
-  - uid: 1785
+  - uid: 1795
     components:
     - type: Transform
       pos: -19.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1786
+  - uid: 1796
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14323,7 +14333,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1787
+  - uid: 1797
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14331,14 +14341,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1788
+  - uid: 1798
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1789
+  - uid: 1799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14346,14 +14356,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1790
+  - uid: 1800
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1791
+  - uid: 1801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14361,7 +14371,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1792
+  - uid: 1802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14369,7 +14379,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1793
+  - uid: 1803
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14377,7 +14387,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1794
+  - uid: 1804
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14385,14 +14395,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1795
+  - uid: 1805
     components:
     - type: Transform
       pos: 12.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1796
+  - uid: 1806
     components:
     - type: Transform
       pos: -47.5,5.5
@@ -14401,7 +14411,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeBendAlt1
   entities:
-  - uid: 1797
+  - uid: 1807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14409,7 +14419,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1798
+  - uid: 1808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14417,7 +14427,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1799
+  - uid: 1809
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14425,7 +14435,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1800
+  - uid: 1810
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14433,14 +14443,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1801
+  - uid: 1811
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1802
+  - uid: 1812
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14448,7 +14458,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1803
+  - uid: 1813
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14456,7 +14466,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1804
+  - uid: 1814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14464,7 +14474,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1805
+  - uid: 1815
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14472,7 +14482,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1806
+  - uid: 1816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14480,7 +14490,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1807
+  - uid: 1817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14488,7 +14498,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1808
+  - uid: 1818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14496,7 +14506,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1809
+  - uid: 1819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14504,21 +14514,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1810
+  - uid: 1820
     components:
     - type: Transform
       pos: -19.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1811
+  - uid: 1821
     components:
     - type: Transform
       pos: -9.5,-28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1812
+  - uid: 1822
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14526,7 +14536,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1813
+  - uid: 1823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14534,7 +14544,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1814
+  - uid: 1824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14542,7 +14552,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1815
+  - uid: 1825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14550,7 +14560,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1816
+  - uid: 1826
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14558,14 +14568,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1817
+  - uid: 1827
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1818
+  - uid: 1828
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14573,7 +14583,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1819
+  - uid: 1829
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14581,7 +14591,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1820
+  - uid: 1830
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14589,7 +14599,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1821
+  - uid: 1831
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14597,7 +14607,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1822
+  - uid: 1832
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14605,7 +14615,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1823
+  - uid: 1833
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14613,7 +14623,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1824
+  - uid: 1834
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14621,7 +14631,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1825
+  - uid: 1835
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14629,7 +14639,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1826
+  - uid: 1836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14637,96 +14647,17 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1827
+  - uid: 1837
     components:
     - type: Transform
       pos: -22.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1828
-    components:
-    - type: Transform
-      pos: -6.5,40.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1829
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,21.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1830
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,19.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1831
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,19.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1832
-    components:
-    - type: Transform
-      pos: -14.5,25.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1833
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,25.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1834
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -16.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1835
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1836
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,36.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1837
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1838
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,35.5
+      pos: -6.5,40.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -14734,11 +14665,90 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,31.5
+      pos: 6.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1840
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,19.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1841
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,19.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1842
+    components:
+    - type: Transform
+      pos: -14.5,25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1843
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -16.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1845
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,39.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1846
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,36.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1847
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,39.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1848
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1849
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1850
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14748,7 +14758,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBendAlt2
   entities:
-  - uid: 1841
+  - uid: 1851
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14756,7 +14766,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 1842
+  - uid: 1852
     components:
     - type: Transform
       pos: 8.5,8.5
@@ -14765,28 +14775,28 @@ entities:
       color: '#090D91FF'
 - proto: GasPipeFourway
   entities:
-  - uid: 1843
+  - uid: 1853
     components:
     - type: Transform
       pos: -18.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1844
+  - uid: 1854
     components:
     - type: Transform
       pos: -10.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1845
+  - uid: 1855
     components:
     - type: Transform
       pos: -10.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1846
+  - uid: 1856
     components:
     - type: Transform
       pos: -5.5,2.5
@@ -14795,21 +14805,21 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeFourwayAlt1
   entities:
-  - uid: 1847
+  - uid: 1857
     components:
     - type: Transform
       pos: -10.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1848
+  - uid: 1858
     components:
     - type: Transform
       pos: -10.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1849
+  - uid: 1859
     components:
     - type: Transform
       pos: -18.5,20.5
@@ -14818,28 +14828,28 @@ entities:
       color: '#990000FF'
 - proto: GasPipeManifold
   entities:
-  - uid: 1850
+  - uid: 1860
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1851
+  - uid: 1861
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 1852
+  - uid: 1862
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1853
+  - uid: 1863
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14847,7 +14857,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1854
+  - uid: 1864
     components:
     - type: Transform
       pos: -5.5,20.5
@@ -14856,7 +14866,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 1855
+  - uid: 1865
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14864,7 +14874,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1856
+  - uid: 1866
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14872,7 +14882,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1857
+  - uid: 1867
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14880,7 +14890,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1858
+  - uid: 1868
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14888,7 +14898,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1859
+  - uid: 1869
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14896,7 +14906,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1860
+  - uid: 1870
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14904,7 +14914,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1861
+  - uid: 1871
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14912,7 +14922,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1862
+  - uid: 1872
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14920,7 +14930,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1863
+  - uid: 1873
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14928,7 +14938,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1864
+  - uid: 1874
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14936,7 +14946,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1865
+  - uid: 1875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14944,7 +14954,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1866
+  - uid: 1876
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14952,7 +14962,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1867
+  - uid: 1877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14960,7 +14970,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1868
+  - uid: 1878
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14968,7 +14978,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1869
+  - uid: 1879
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14976,7 +14986,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1870
+  - uid: 1880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14984,7 +14994,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1871
+  - uid: 1881
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14992,14 +15002,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 1872
+  - uid: 1882
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1873
+  - uid: 1883
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15007,7 +15017,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1874
+  - uid: 1884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15017,7 +15027,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1875
+  - uid: 1885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15027,14 +15037,14 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1876
+  - uid: 1886
     components:
     - type: Transform
       pos: -18.5,23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1877
+  - uid: 1887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15042,7 +15052,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1878
+  - uid: 1888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15050,7 +15060,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1879
+  - uid: 1889
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15058,97 +15068,17 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1880
+  - uid: 1890
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1881
-    components:
-    - type: Transform
-      pos: -0.5,14.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1882
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1883
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1884
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,54.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1885
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1886
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1887
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,40.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1888
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,38.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1889
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,33.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1890
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,36.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1891
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,32.5
+      pos: -0.5,14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -15156,15 +15086,15 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,9.5
+      pos: 4.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1893
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,9.5
+      rot: -1.5707963267948966 rad
+      pos: -13.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -15172,22 +15102,23 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,39.5
+      pos: -12.5,54.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1895
     components:
     - type: Transform
-      pos: -5.5,6.5
+      rot: -1.5707963267948966 rad
+      pos: -11.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1896
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,35.5
+      rot: -1.5707963267948966 rad
+      pos: -16.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -15195,31 +15126,31 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,13.5
+      pos: -9.5,40.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#0055CCFF'
   - uid: 1898
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,19.5
+      rot: 1.5707963267948966 rad
+      pos: -20.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1899
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,19.5
+      rot: 3.141592653589793 rad
+      pos: -21.5,33.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1900
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-28.5
+      rot: 3.141592653589793 rad
+      pos: -21.5,36.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -15227,14 +15158,15 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -8.5,-14.5
+      pos: -9.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1902
     components:
     - type: Transform
-      pos: -33.5,2.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -15242,21 +15174,22 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -12.5,19.5
+      pos: -1.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1904
     components:
     - type: Transform
-      pos: -10.5,50.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1905
     components:
     - type: Transform
-      pos: -9.5,55.5
+      pos: -5.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -15264,38 +15197,39 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -8.5,52.5
+      pos: -2.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1907
     components:
     - type: Transform
-      pos: -10.5,36.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1908
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,52.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1909
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,38.5
+      rot: 1.5707963267948966 rad
+      pos: -15.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1910
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -15303,18 +15237,94 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -16.5,38.5
+      pos: -8.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1912
     components:
     - type: Transform
-      pos: -10.5,46.5
+      pos: -33.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1913
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,19.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1914
+    components:
+    - type: Transform
+      pos: -10.5,50.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1915
+    components:
+    - type: Transform
+      pos: -9.5,55.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1916
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,52.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1917
+    components:
+    - type: Transform
+      pos: -10.5,36.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1918
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,52.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1919
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,38.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1920
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1921
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -16.5,38.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1922
+    components:
+    - type: Transform
+      pos: -10.5,46.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1923
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15322,49 +15332,49 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1914
+  - uid: 1924
     components:
     - type: Transform
       pos: -10.5,-22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1915
+  - uid: 1925
     components:
     - type: Transform
       pos: -10.5,-24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1916
+  - uid: 1926
     components:
     - type: Transform
       pos: -10.5,-17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1917
+  - uid: 1927
     components:
     - type: Transform
       pos: -10.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1918
+  - uid: 1928
     components:
     - type: Transform
       pos: -10.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1919
+  - uid: 1929
     components:
     - type: Transform
       pos: -10.5,-19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1920
+  - uid: 1930
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15372,14 +15382,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1921
+  - uid: 1931
     components:
     - type: Transform
       pos: -20.5,13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1922
+  - uid: 1932
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15389,31 +15399,31 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1923
+  - uid: 1933
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,20.5
       parent: 1
-  - uid: 1924
+  - uid: 1934
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,20.5
       parent: 1
-  - uid: 1925
+  - uid: 1935
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,22.5
       parent: 1
-  - uid: 1926
+  - uid: 1936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,22.5
       parent: 1
-  - uid: 1927
+  - uid: 1937
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15423,7 +15433,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1928
+  - uid: 1938
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15433,7 +15443,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1929
+  - uid: 1939
     components:
     - type: Transform
       pos: -9.5,-29.5
@@ -15442,7 +15452,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1930
+  - uid: 1940
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15452,7 +15462,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1931
+  - uid: 1941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15462,7 +15472,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1932
+  - uid: 1942
     components:
     - type: Transform
       pos: 12.5,2.5
@@ -15471,7 +15481,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1933
+  - uid: 1943
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15479,7 +15489,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1934
+  - uid: 1944
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15487,7 +15497,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1935
+  - uid: 1945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15495,7 +15505,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1936
+  - uid: 1946
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15505,7 +15515,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1937
+  - uid: 1947
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15515,7 +15525,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1938
+  - uid: 1948
     components:
     - type: Transform
       pos: -31.5,2.5
@@ -15524,7 +15534,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1939
+  - uid: 1949
     components:
     - type: Transform
       pos: -33.5,6.5
@@ -15533,7 +15543,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1940
+  - uid: 1950
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15541,14 +15551,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1941
+  - uid: 1951
     components:
     - type: Transform
       pos: -20.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1942
+  - uid: 1952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15556,7 +15566,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1943
+  - uid: 1953
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15564,14 +15574,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1944
+  - uid: 1954
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1945
+  - uid: 1955
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15579,7 +15589,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1946
+  - uid: 1956
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15587,42 +15597,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1947
+  - uid: 1957
     components:
     - type: Transform
       pos: -7.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1948
+  - uid: 1958
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1949
+  - uid: 1959
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1950
+  - uid: 1960
     components:
     - type: Transform
       pos: -10.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1951
+  - uid: 1961
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1952
+  - uid: 1962
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15630,7 +15640,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1953
+  - uid: 1963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15638,7 +15648,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1954
+  - uid: 1964
     components:
     - type: Transform
       anchored: False
@@ -15648,7 +15658,7 @@ entities:
     - type: Physics
       canCollide: True
       bodyType: Dynamic
-  - uid: 1955
+  - uid: 1965
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15656,7 +15666,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1956
+  - uid: 1966
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15664,7 +15674,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1957
+  - uid: 1967
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15672,7 +15682,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1958
+  - uid: 1968
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15680,7 +15690,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1959
+  - uid: 1969
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15688,7 +15698,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1960
+  - uid: 1970
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15696,7 +15706,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1961
+  - uid: 1971
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15704,49 +15714,49 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1962
+  - uid: 1972
     components:
     - type: Transform
       pos: -10.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1963
+  - uid: 1973
     components:
     - type: Transform
       pos: -10.5,22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1964
+  - uid: 1974
     components:
     - type: Transform
       pos: -10.5,33.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1965
+  - uid: 1975
     components:
     - type: Transform
       pos: -10.5,25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1966
+  - uid: 1976
     components:
     - type: Transform
       pos: -10.5,53.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1967
+  - uid: 1977
     components:
     - type: Transform
       pos: -10.5,37.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1968
+  - uid: 1978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15754,7 +15764,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1969
+  - uid: 1979
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15762,14 +15772,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1970
+  - uid: 1980
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1971
+  - uid: 1981
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15777,7 +15787,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1972
+  - uid: 1982
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15785,7 +15795,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1973
+  - uid: 1983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15793,89 +15803,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1974
-    components:
-    - type: Transform
-      pos: -18.5,20.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1975
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1976
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1977
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1978
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1979
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1980
-    components:
-    - type: Transform
-      pos: -14.5,9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1981
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,19.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1982
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1983
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1984
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,11.5
+      pos: -18.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -15883,18 +15814,97 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,11.5
+      pos: -6.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1986
     components:
     - type: Transform
-      pos: -11.5,-29.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1987
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1988
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1989
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1990
+    components:
+    - type: Transform
+      pos: -14.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1991
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,19.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1992
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1993
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1994
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1995
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1996
+    components:
+    - type: Transform
+      pos: -11.5,-29.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1997
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15902,7 +15912,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1988
+  - uid: 1998
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15910,7 +15920,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1989
+  - uid: 1999
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15918,7 +15928,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1990
+  - uid: 2000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15926,7 +15936,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1991
+  - uid: 2001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15934,7 +15944,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1992
+  - uid: 2002
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15942,7 +15952,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1993
+  - uid: 2003
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15950,7 +15960,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1994
+  - uid: 2004
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15958,7 +15968,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1995
+  - uid: 2005
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15966,7 +15976,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1996
+  - uid: 2006
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15974,7 +15984,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1997
+  - uid: 2007
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15982,7 +15992,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1998
+  - uid: 2008
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15990,7 +16000,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1999
+  - uid: 2009
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15998,7 +16008,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2000
+  - uid: 2010
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16006,88 +16016,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2001
-    components:
-    - type: Transform
-      pos: -18.5,22.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2002
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,19.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2003
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2004
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,20.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2005
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2006
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 2007
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,21.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2008
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,29.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2009
-    components:
-    - type: Transform
-      pos: -10.5,-8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2010
-    components:
-    - type: Transform
-      pos: -10.5,-9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 2011
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,4.5
+      pos: -18.5,22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16095,7 +16027,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -18.5,2.5
+      pos: -14.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16103,61 +16035,61 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,20.5
+      pos: -2.5,32.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 2014
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,4.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2015
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,4.5
+      rot: 3.141592653589793 rad
+      pos: 10.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2016
     components:
     - type: Transform
-      pos: -10.5,-4.5
+      rot: 3.141592653589793 rad
+      pos: -4.5,4.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#0335FCFF'
   - uid: 2017
     components:
     - type: Transform
-      pos: -10.5,-5.5
+      rot: -1.5707963267948966 rad
+      pos: -16.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2018
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -22.5,29.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2019
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,4.5
+      pos: -10.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2020
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
+      pos: -10.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16165,11 +16097,89 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -18.5,38.5
+      pos: 9.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2022
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2023
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,20.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 2024
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2025
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2026
+    components:
+    - type: Transform
+      pos: -10.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2027
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2028
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -28.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2029
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2030
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2031
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,38.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2032
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16177,7 +16187,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2023
+  - uid: 2033
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16185,49 +16195,49 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2024
+  - uid: 2034
     components:
     - type: Transform
       pos: -10.5,51.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2025
+  - uid: 2035
     components:
     - type: Transform
       pos: -10.5,49.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2026
+  - uid: 2036
     components:
     - type: Transform
       pos: -10.5,44.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2027
+  - uid: 2037
     components:
     - type: Transform
       pos: -10.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2028
+  - uid: 2038
     components:
     - type: Transform
       pos: -10.5,42.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2029
+  - uid: 2039
     components:
     - type: Transform
       pos: -10.5,43.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2030
+  - uid: 2040
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16235,21 +16245,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2031
+  - uid: 2041
     components:
     - type: Transform
       pos: -10.5,18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2032
+  - uid: 2042
     components:
     - type: Transform
       pos: -10.5,17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2033
+  - uid: 2043
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16257,35 +16267,35 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2034
+  - uid: 2044
     components:
     - type: Transform
       pos: -10.5,24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2035
+  - uid: 2045
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2036
+  - uid: 2046
     components:
     - type: Transform
       pos: -20.5,12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2037
+  - uid: 2047
     components:
     - type: Transform
       pos: -10.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2038
+  - uid: 2048
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16293,7 +16303,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2039
+  - uid: 2049
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16301,106 +16311,31 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2040
+  - uid: 2050
     components:
     - type: Transform
       pos: -10.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2041
+  - uid: 2051
     components:
     - type: Transform
       pos: -10.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2042
+  - uid: 2052
     components:
     - type: Transform
       pos: -10.5,-25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2043
-    components:
-    - type: Transform
-      pos: -19.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2044
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,22.5
-      parent: 1
-  - uid: 2045
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,30.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2046
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,30.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2047
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -31.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2048
-    components:
-    - type: Transform
-      pos: -5.5,30.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2049
-    components:
-    - type: Transform
-      pos: -5.5,31.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2050
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,33.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2051
-    components:
-    - type: Transform
-      pos: -10.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2052
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 2053
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,2.5
+      pos: -19.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16408,11 +16343,86 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: -5.5,22.5
+      parent: 1
+  - uid: 2055
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2056
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2057
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -31.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2058
+    components:
+    - type: Transform
+      pos: -5.5,30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2059
+    components:
+    - type: Transform
+      pos: -5.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2060
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,33.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2061
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2062
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2063
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2064
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -16.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2055
+  - uid: 2065
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16420,7 +16430,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2056
+  - uid: 2066
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16428,7 +16438,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2057
+  - uid: 2067
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16436,7 +16446,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2058
+  - uid: 2068
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16444,7 +16454,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2059
+  - uid: 2069
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16452,7 +16462,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2060
+  - uid: 2070
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16460,7 +16470,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2061
+  - uid: 2071
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16468,56 +16478,56 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2062
+  - uid: 2072
     components:
     - type: Transform
       pos: -10.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2063
+  - uid: 2073
     components:
     - type: Transform
       pos: -10.5,29.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2064
+  - uid: 2074
     components:
     - type: Transform
       pos: -10.5,28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2065
+  - uid: 2075
     components:
     - type: Transform
       pos: -10.5,27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2066
+  - uid: 2076
     components:
     - type: Transform
       pos: -10.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2067
+  - uid: 2077
     components:
     - type: Transform
       pos: -10.5,34.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2068
+  - uid: 2078
     components:
     - type: Transform
       pos: -10.5,41.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2069
+  - uid: 2079
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16525,7 +16535,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2070
+  - uid: 2080
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16533,7 +16543,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2071
+  - uid: 2081
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16541,14 +16551,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2072
+  - uid: 2082
     components:
     - type: Transform
       pos: -10.5,-27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2073
+  - uid: 2083
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16556,7 +16566,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2074
+  - uid: 2084
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16564,7 +16574,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2075
+  - uid: 2085
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16572,14 +16582,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2076
+  - uid: 2086
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2077
+  - uid: 2087
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16587,7 +16597,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2078
+  - uid: 2088
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16595,7 +16605,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2079
+  - uid: 2089
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16603,7 +16613,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2080
+  - uid: 2090
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16611,7 +16621,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2081
+  - uid: 2091
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16619,7 +16629,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2082
+  - uid: 2092
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16627,14 +16637,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2083
+  - uid: 2093
     components:
     - type: Transform
       pos: -10.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2084
+  - uid: 2094
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16642,7 +16652,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2085
+  - uid: 2095
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16650,7 +16660,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2086
+  - uid: 2096
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16658,7 +16668,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2087
+  - uid: 2097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16666,7 +16676,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2088
+  - uid: 2098
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16674,49 +16684,49 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2089
+  - uid: 2099
     components:
     - type: Transform
       pos: -10.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2090
+  - uid: 2100
     components:
     - type: Transform
       pos: -10.5,-18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2091
+  - uid: 2101
     components:
     - type: Transform
       pos: -10.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2092
+  - uid: 2102
     components:
     - type: Transform
       pos: -10.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2093
+  - uid: 2103
     components:
     - type: Transform
       pos: -18.5,24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2094
+  - uid: 2104
     components:
     - type: Transform
       pos: -18.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2095
+  - uid: 2105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16724,14 +16734,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2096
+  - uid: 2106
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2097
+  - uid: 2107
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -16739,87 +16749,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2098
-    components:
-    - type: Transform
-      pos: -10.5,48.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2099
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,21.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2100
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,25.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2101
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2102
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2103
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2104
-    components:
-    - type: Transform
-      pos: -10.5,45.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2105
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2106
-    components:
-    - type: Transform
-      pos: -25.5,9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2107
-    components:
-    - type: Transform
-      pos: -5.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 2108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,4.5
+      pos: -10.5,48.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16827,7 +16760,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -17.5,25.5
+      pos: 5.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16835,23 +16768,23 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,21.5
+      pos: -16.5,25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,32.5
+      rot: -1.5707963267948966 rad
+      pos: -17.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16859,14 +16792,14 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -16.5,8.5
+      pos: -17.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2114
     components:
     - type: Transform
-      pos: -10.5,31.5
+      pos: -10.5,45.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16874,38 +16807,37 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -21.5,4.5
+      pos: -20.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2116
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,2.5
+      pos: -25.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2117
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,21.5
+      pos: -5.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2118
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,34.5
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2119
     components:
     - type: Transform
-      pos: -5.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -17.5,25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16913,7 +16845,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -14.5,32.5
+      pos: 4.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16921,14 +16853,15 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,38.5
+      pos: -0.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2122
     components:
     - type: Transform
-      pos: -5.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16936,14 +16869,14 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,9.5
+      pos: -16.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2124
     components:
     - type: Transform
-      pos: -5.5,3.5
+      pos: -10.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -16951,11 +16884,88 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: -21.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,21.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2128
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,34.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2129
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,38.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2132
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2133
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2134
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -13.5,37.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 2126
+  - uid: 2136
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16963,14 +16973,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 2127
+  - uid: 2137
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2128
+  - uid: 2138
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16978,7 +16988,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 2129
+  - uid: 2139
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16986,7 +16996,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 2130
+  - uid: 2140
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -16994,14 +17004,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 2131
+  - uid: 2141
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 2132
+  - uid: 2142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17009,7 +17019,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 2133
+  - uid: 2143
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17017,14 +17027,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2134
+  - uid: 2144
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2135
+  - uid: 2145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17032,7 +17042,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2136
+  - uid: 2146
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17040,7 +17050,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2137
+  - uid: 2147
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17048,7 +17058,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2138
+  - uid: 2148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17056,7 +17066,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2139
+  - uid: 2149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17064,7 +17074,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2140
+  - uid: 2150
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17072,14 +17082,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2141
+  - uid: 2151
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2142
+  - uid: 2152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17087,7 +17097,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2143
+  - uid: 2153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17095,7 +17105,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2144
+  - uid: 2154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17103,7 +17113,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 2145
+  - uid: 2155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17111,7 +17121,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 2146
+  - uid: 2156
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17119,7 +17129,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2147
+  - uid: 2157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17127,7 +17137,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2148
+  - uid: 2158
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17135,7 +17145,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2149
+  - uid: 2159
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17143,7 +17153,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2150
+  - uid: 2160
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17151,7 +17161,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2151
+  - uid: 2161
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17159,7 +17169,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2152
+  - uid: 2162
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17167,7 +17177,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2153
+  - uid: 2163
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17175,7 +17185,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2154
+  - uid: 2164
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17183,7 +17193,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2155
+  - uid: 2165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17191,7 +17201,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2156
+  - uid: 2166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17199,7 +17209,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2157
+  - uid: 2167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17207,7 +17217,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2158
+  - uid: 2168
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17215,7 +17225,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2159
+  - uid: 2169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17223,7 +17233,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2160
+  - uid: 2170
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17231,7 +17241,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2161
+  - uid: 2171
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17239,7 +17249,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2162
+  - uid: 2172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17247,7 +17257,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2163
+  - uid: 2173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17255,7 +17265,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2164
+  - uid: 2174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17263,7 +17273,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2165
+  - uid: 2175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17271,7 +17281,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2166
+  - uid: 2176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17279,7 +17289,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2167
+  - uid: 2177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17287,7 +17297,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2168
+  - uid: 2178
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17295,7 +17305,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2169
+  - uid: 2179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17303,7 +17313,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2170
+  - uid: 2180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17311,7 +17321,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2171
+  - uid: 2181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17319,7 +17329,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2172
+  - uid: 2182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17327,7 +17337,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2173
+  - uid: 2183
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17335,7 +17345,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2174
+  - uid: 2184
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17343,7 +17353,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2175
+  - uid: 2185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17351,7 +17361,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2176
+  - uid: 2186
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17359,7 +17369,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2177
+  - uid: 2187
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17367,7 +17377,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2178
+  - uid: 2188
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17375,7 +17385,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2179
+  - uid: 2189
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17383,7 +17393,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2180
+  - uid: 2190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17391,7 +17401,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2181
+  - uid: 2191
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17399,7 +17409,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2182
+  - uid: 2192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17407,7 +17417,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2183
+  - uid: 2193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17415,7 +17425,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2184
+  - uid: 2194
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17423,7 +17433,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2185
+  - uid: 2195
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17431,7 +17441,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2186
+  - uid: 2196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17439,21 +17449,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2187
+  - uid: 2197
     components:
     - type: Transform
       pos: -40.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2188
+  - uid: 2198
     components:
     - type: Transform
       pos: -38.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2189
+  - uid: 2199
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17461,28 +17471,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2190
+  - uid: 2200
     components:
     - type: Transform
       pos: -47.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2191
+  - uid: 2201
     components:
     - type: Transform
       pos: -47.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2192
+  - uid: 2202
     components:
     - type: Transform
       pos: -45.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2193
+  - uid: 2203
     components:
     - type: Transform
       pos: -45.5,6.5
@@ -17491,14 +17501,14 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeStraightAlt1
   entities:
-  - uid: 2194
+  - uid: 2204
     components:
     - type: Transform
       pos: -47.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2195
+  - uid: 2205
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17506,90 +17516,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2196
-    components:
-    - type: Transform
-      pos: -47.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2197
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,33.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2198
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,38.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2199
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,34.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2200
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2201
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2202
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2203
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-25.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2204
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2205
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,17.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 2206
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,18.5
+      pos: -47.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17597,15 +17527,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,19.5
+      pos: -0.5,33.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2208
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,21.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17613,7 +17543,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,20.5
+      pos: 3.5,34.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17621,60 +17551,63 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,21.5
+      pos: 9.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2211
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: -8.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2213
     components:
     - type: Transform
-      pos: 0.5,11.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2214
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: -12.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2215
     components:
     - type: Transform
-      pos: 0.5,12.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2216
     components:
     - type: Transform
-      pos: -5.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2217
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,11.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17682,15 +17615,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -11.5,11.5
+      pos: 5.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2219
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17698,53 +17631,52 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -23.5,10.5
+      pos: 4.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2221
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: 3.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2222
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: -16.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2223
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,7.5
+      pos: 0.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2224
     components:
     - type: Transform
-      pos: -14.5,9.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2225
     components:
     - type: Transform
-      pos: -0.5,14.5
+      pos: 0.5,12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2226
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,13.5
+      pos: -5.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17752,31 +17684,31 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 12.5,35.5
+      pos: -6.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2228
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-4.5
+      rot: -1.5707963267948966 rad
+      pos: -11.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2229
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-5.5
+      rot: 1.5707963267948966 rad
+      pos: -17.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2230
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-8.5
+      rot: -1.5707963267948966 rad
+      pos: -23.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17784,7 +17716,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-10.5
+      pos: -13.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17792,38 +17724,37 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-7.5
+      pos: -13.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2233
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-23.5
+      rot: 1.5707963267948966 rad
+      pos: -12.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2234
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-17.5
+      pos: -14.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2235
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-21.5
+      pos: -0.5,14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2236
     components:
     - type: Transform
-      pos: -7.5,0.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17831,87 +17762,86 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -11.5,-14.5
+      pos: 12.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2238
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-12.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2239
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,35.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2240
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,35.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2241
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,9.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2242
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,11.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2243
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,11.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2244
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,8.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2245
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,8.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2246
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,1.5
+      pos: -7.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2247
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -31.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17919,23 +17849,23 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -27.5,4.5
+      pos: -9.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2249
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2250
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,4.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17943,7 +17873,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,4.5
+      pos: -4.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17951,46 +17881,47 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 11.5,4.5
+      pos: -13.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2253
     components:
     - type: Transform
-      pos: -1.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: -12.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2254
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,2.5
+      rot: 1.5707963267948966 rad
+      pos: -17.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2255
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
+      rot: 1.5707963267948966 rad
+      pos: -18.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2256
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,10.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2257
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -31.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -17998,70 +17929,70 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -23.5,4.5
+      pos: -27.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2259
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,16.5
+      rot: -1.5707963267948966 rad
+      pos: -32.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2260
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,16.5
+      rot: -1.5707963267948966 rad
+      pos: -28.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2261
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2262
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: 11.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2263
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,8.5
+      pos: -1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2264
     components:
     - type: Transform
-      pos: -25.5,9.5
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2265
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,11.5
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2266
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: -22.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18069,7 +18000,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -24.5,10.5
+      pos: -20.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18077,23 +18008,23 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -21.5,14.5
+      pos: -23.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2269
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-24.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2270
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-15.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18101,7 +18032,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-19.5
+      pos: -5.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18109,7 +18040,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-9.5
+      pos: -5.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18117,15 +18048,14 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-11.5
+      pos: -5.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2274
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-2.5
+      pos: -25.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18133,23 +18063,23 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-3.5
+      pos: -26.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2276
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: -19.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2277
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: -24.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18157,78 +18087,79 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -21.5,4.5
+      pos: -21.5,14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2279
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2280
     components:
     - type: Transform
-      pos: -19.5,3.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2281
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2282
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -24.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2283
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2284
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2285
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2286
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2287
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18236,7 +18167,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,4.5
+      pos: -21.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18244,15 +18175,14 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -8.5,2.5
+      pos: -26.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2290
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,2.5
+      pos: -19.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18260,7 +18190,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -14.5,2.5
+      pos: -29.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18268,23 +18198,23 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -15.5,2.5
+      pos: -24.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2293
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,16.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2294
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18292,23 +18222,23 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -9.5,-6.5
+      pos: 3.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2296
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2297
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18316,7 +18246,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -11.5,-28.5
+      pos: -0.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -18324,11 +18254,91 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -9.5,-26.5
+      pos: -8.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2300
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2302
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2303
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2306
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2307
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-28.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-26.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18336,7 +18346,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2301
+  - uid: 2311
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18344,7 +18354,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2302
+  - uid: 2312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18352,7 +18362,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2303
+  - uid: 2313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18360,7 +18370,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2304
+  - uid: 2314
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18368,7 +18378,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2305
+  - uid: 2315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18376,7 +18386,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2306
+  - uid: 2316
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18384,7 +18394,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2307
+  - uid: 2317
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18392,7 +18402,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2308
+  - uid: 2318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18400,7 +18410,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2309
+  - uid: 2319
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18408,7 +18418,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2310
+  - uid: 2320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18416,7 +18426,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2311
+  - uid: 2321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18424,7 +18434,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2312
+  - uid: 2322
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18432,7 +18442,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2313
+  - uid: 2323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18440,7 +18450,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2314
+  - uid: 2324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18448,7 +18458,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2315
+  - uid: 2325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18456,7 +18466,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2316
+  - uid: 2326
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18464,21 +18474,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2317
+  - uid: 2327
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2318
+  - uid: 2328
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2319
+  - uid: 2329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18486,14 +18496,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2320
+  - uid: 2330
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2321
+  - uid: 2331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18501,7 +18511,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2322
+  - uid: 2332
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18509,7 +18519,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2323
+  - uid: 2333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18517,14 +18527,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2324
+  - uid: 2334
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2325
+  - uid: 2335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18532,7 +18542,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2326
+  - uid: 2336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18540,7 +18550,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2327
+  - uid: 2337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18548,7 +18558,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2328
+  - uid: 2338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18556,7 +18566,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2329
+  - uid: 2339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18564,7 +18574,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2330
+  - uid: 2340
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18572,7 +18582,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2331
+  - uid: 2341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18580,7 +18590,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2332
+  - uid: 2342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18588,7 +18598,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2333
+  - uid: 2343
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18596,7 +18606,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2334
+  - uid: 2344
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18604,7 +18614,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2335
+  - uid: 2345
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18612,7 +18622,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2336
+  - uid: 2346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18620,7 +18630,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2337
+  - uid: 2347
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18628,7 +18638,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2338
+  - uid: 2348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18636,7 +18646,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2339
+  - uid: 2349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18644,7 +18654,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2340
+  - uid: 2350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18652,7 +18662,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2341
+  - uid: 2351
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18660,7 +18670,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2342
+  - uid: 2352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18668,7 +18678,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2343
+  - uid: 2353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18676,7 +18686,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2344
+  - uid: 2354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18684,7 +18694,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2345
+  - uid: 2355
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18692,7 +18702,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2346
+  - uid: 2356
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18700,7 +18710,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2347
+  - uid: 2357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18708,7 +18718,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2348
+  - uid: 2358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18716,7 +18726,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2349
+  - uid: 2359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18724,7 +18734,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2350
+  - uid: 2360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18732,7 +18742,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2351
+  - uid: 2361
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18740,7 +18750,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2352
+  - uid: 2362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18748,7 +18758,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2353
+  - uid: 2363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18756,7 +18766,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2354
+  - uid: 2364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18764,7 +18774,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2355
+  - uid: 2365
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18772,7 +18782,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2356
+  - uid: 2366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18780,7 +18790,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2357
+  - uid: 2367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18788,7 +18798,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2358
+  - uid: 2368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18796,14 +18806,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2359
+  - uid: 2369
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2360
+  - uid: 2370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18811,7 +18821,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2361
+  - uid: 2371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18819,7 +18829,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2362
+  - uid: 2372
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18827,7 +18837,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2363
+  - uid: 2373
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18835,7 +18845,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2364
+  - uid: 2374
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18843,7 +18853,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2365
+  - uid: 2375
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18851,7 +18861,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2366
+  - uid: 2376
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18859,217 +18869,217 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2367
+  - uid: 2377
     components:
     - type: Transform
       pos: -10.5,17.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2368
+  - uid: 2378
     components:
     - type: Transform
       pos: -10.5,18.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2369
+  - uid: 2379
     components:
     - type: Transform
       pos: -10.5,20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2370
+  - uid: 2380
     components:
     - type: Transform
       pos: -10.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2371
+  - uid: 2381
     components:
     - type: Transform
       pos: -10.5,22.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2372
+  - uid: 2382
     components:
     - type: Transform
       pos: -10.5,23.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2373
+  - uid: 2383
     components:
     - type: Transform
       pos: -10.5,24.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2374
+  - uid: 2384
     components:
     - type: Transform
       pos: -10.5,25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2375
+  - uid: 2385
     components:
     - type: Transform
       pos: -10.5,27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2376
+  - uid: 2386
     components:
     - type: Transform
       pos: -10.5,28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2377
+  - uid: 2387
     components:
     - type: Transform
       pos: -10.5,29.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2378
+  - uid: 2388
     components:
     - type: Transform
       pos: -10.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2379
+  - uid: 2389
     components:
     - type: Transform
       pos: -10.5,33.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2380
+  - uid: 2390
     components:
     - type: Transform
       pos: -10.5,34.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2381
+  - uid: 2391
     components:
     - type: Transform
       pos: -10.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2382
+  - uid: 2392
     components:
     - type: Transform
       pos: -10.5,36.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2383
+  - uid: 2393
     components:
     - type: Transform
       pos: -10.5,37.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2384
+  - uid: 2394
     components:
     - type: Transform
       pos: -10.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2385
+  - uid: 2395
     components:
     - type: Transform
       pos: -10.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2386
+  - uid: 2396
     components:
     - type: Transform
       pos: -10.5,41.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2387
+  - uid: 2397
     components:
     - type: Transform
       pos: -10.5,42.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2388
+  - uid: 2398
     components:
     - type: Transform
       pos: -10.5,43.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2389
+  - uid: 2399
     components:
     - type: Transform
       pos: -10.5,44.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2390
+  - uid: 2400
     components:
     - type: Transform
       pos: -10.5,45.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2391
+  - uid: 2401
     components:
     - type: Transform
       pos: -10.5,46.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2392
+  - uid: 2402
     components:
     - type: Transform
       pos: -10.5,48.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2393
+  - uid: 2403
     components:
     - type: Transform
       pos: -10.5,49.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2394
+  - uid: 2404
     components:
     - type: Transform
       pos: -10.5,50.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2395
+  - uid: 2405
     components:
     - type: Transform
       pos: -10.5,51.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2396
+  - uid: 2406
     components:
     - type: Transform
       pos: -10.5,53.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2397
+  - uid: 2407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19077,7 +19087,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2398
+  - uid: 2408
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19085,7 +19095,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2399
+  - uid: 2409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19093,7 +19103,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2400
+  - uid: 2410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19101,7 +19111,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2401
+  - uid: 2411
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19109,7 +19119,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2402
+  - uid: 2412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19117,7 +19127,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2403
+  - uid: 2413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19125,7 +19135,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2404
+  - uid: 2414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19133,7 +19143,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2405
+  - uid: 2415
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19141,117 +19151,38 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2406
+  - uid: 2416
     components:
     - type: Transform
       pos: -21.5,33.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2407
+  - uid: 2417
     components:
     - type: Transform
       pos: -21.5,34.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2408
+  - uid: 2418
     components:
     - type: Transform
       pos: -21.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2409
+  - uid: 2419
     components:
     - type: Transform
       pos: -21.5,36.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2410
-    components:
-    - type: Transform
-      pos: -21.5,37.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2411
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,38.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2412
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,38.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2413
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,38.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2414
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,38.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2415
-    components:
-    - type: Transform
-      pos: -22.5,30.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2416
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,31.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2417
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,30.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2418
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,47.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2419
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,40.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 2420
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,40.5
+      pos: -21.5,37.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19259,25 +19190,104 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,40.5
+      pos: -20.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2422
     components:
     - type: Transform
-      pos: 2.5,20.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2423
     components:
     - type: Transform
-      pos: 6.5,22.5
+      rot: -1.5707963267948966 rad
+      pos: -17.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2424
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,38.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2425
+    components:
+    - type: Transform
+      pos: -22.5,30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2426
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2427
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,47.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,40.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,40.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2431
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,40.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2432
+    components:
+    - type: Transform
+      pos: 2.5,20.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2433
+    components:
+    - type: Transform
+      pos: 6.5,22.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2434
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19285,7 +19295,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2425
+  - uid: 2435
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19293,7 +19303,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2426
+  - uid: 2436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19301,7 +19311,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2427
+  - uid: 2437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19309,7 +19319,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2428
+  - uid: 2438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19317,7 +19327,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2429
+  - uid: 2439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19325,7 +19335,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2430
+  - uid: 2440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19333,7 +19343,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2431
+  - uid: 2441
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19341,7 +19351,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2432
+  - uid: 2442
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19349,7 +19359,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2433
+  - uid: 2443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19357,7 +19367,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2434
+  - uid: 2444
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19365,7 +19375,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2435
+  - uid: 2445
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19373,7 +19383,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2436
+  - uid: 2446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19381,7 +19391,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2437
+  - uid: 2447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19389,7 +19399,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2438
+  - uid: 2448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19397,7 +19407,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2439
+  - uid: 2449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19405,7 +19415,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2440
+  - uid: 2450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19413,7 +19423,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2441
+  - uid: 2451
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19421,7 +19431,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2442
+  - uid: 2452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19429,7 +19439,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2443
+  - uid: 2453
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19437,7 +19447,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2444
+  - uid: 2454
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19445,7 +19455,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2445
+  - uid: 2455
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19453,7 +19463,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2446
+  - uid: 2456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19461,7 +19471,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2447
+  - uid: 2457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19469,7 +19479,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2448
+  - uid: 2458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19477,7 +19487,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2449
+  - uid: 2459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19485,7 +19495,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2450
+  - uid: 2460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19493,7 +19503,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2451
+  - uid: 2461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19501,7 +19511,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2452
+  - uid: 2462
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19509,97 +19519,17 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2453
+  - uid: 2463
     components:
     - type: Transform
       pos: -4.5,30.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2454
-    components:
-    - type: Transform
-      pos: -4.5,31.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2455
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,36.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2456
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,34.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2457
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,35.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2458
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2459
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2460
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2461
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2462
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,35.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2463
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,35.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 2464
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,35.5
+      pos: -4.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19607,71 +19537,71 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 7.5,35.5
+      pos: 14.5,36.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2466
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,39.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,34.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2467
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,39.5
+      rot: 1.5707963267948966 rad
+      pos: -1.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2468
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,35.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2469
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,30.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2470
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,27.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2471
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,29.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2472
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,28.5
+      rot: 1.5707963267948966 rad
+      pos: 10.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2473
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,37.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19679,7 +19609,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,31.5
+      pos: 9.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19687,23 +19617,23 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,32.5
+      pos: 7.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2476
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,35.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2477
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,35.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19711,23 +19641,23 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,35.5
+      pos: 1.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2479
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,31.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,30.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2480
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,35.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19735,23 +19665,23 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,33.5
+      pos: -0.5,29.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2482
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -34.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2483
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -35.5,4.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,37.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19759,7 +19689,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -36.5,4.5
+      pos: 0.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19767,7 +19697,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -37.5,4.5
+      pos: -1.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19775,7 +19705,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -39.5,4.5
+      pos: 8.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19783,7 +19713,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -41.5,4.5
+      pos: 2.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19791,7 +19721,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -42.5,4.5
+      pos: 4.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19799,7 +19729,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -43.5,4.5
+      pos: 1.5,31.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -19807,11 +19737,91 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -44.5,4.5
+      pos: 6.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2491
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,33.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2492
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -34.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2493
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -35.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2494
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -36.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2495
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -37.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -39.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2497
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -41.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2498
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -42.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2499
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -43.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2500
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -44.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19819,28 +19829,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2492
+  - uid: 2502
     components:
     - type: Transform
       pos: -38.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2493
+  - uid: 2503
     components:
     - type: Transform
       pos: -40.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2494
+  - uid: 2504
     components:
     - type: Transform
       pos: -45.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2495
+  - uid: 2505
     components:
     - type: Transform
       pos: -45.5,3.5
@@ -19849,7 +19859,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraightAlt2
   entities:
-  - uid: 2496
+  - uid: 2506
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19857,7 +19867,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 2497
+  - uid: 2507
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19865,7 +19875,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 2498
+  - uid: 2508
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19875,7 +19885,7 @@ entities:
       color: '#0335FCFF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 2499
+  - uid: 2509
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19883,28 +19893,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2500
+  - uid: 2510
     components:
     - type: Transform
       pos: -0.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2501
+  - uid: 2511
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2502
+  - uid: 2512
     components:
     - type: Transform
       pos: -25.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2503
+  - uid: 2513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -19912,28 +19922,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2504
+  - uid: 2514
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2505
+  - uid: 2515
     components:
     - type: Transform
       pos: 6.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2506
+  - uid: 2516
     components:
     - type: Transform
       pos: -19.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2507
+  - uid: 2517
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19941,7 +19951,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2508
+  - uid: 2518
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19949,13 +19959,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2509
+  - uid: 2519
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,22.5
       parent: 1
-  - uid: 2510
+  - uid: 2520
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -19963,14 +19973,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2511
+  - uid: 2521
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 2512
+  - uid: 2522
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19978,7 +19988,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2513
+  - uid: 2523
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -19986,19 +19996,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2514
+  - uid: 2524
     components:
     - type: Transform
       pos: -4.5,21.5
       parent: 1
-  - uid: 2515
+  - uid: 2525
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2516
+  - uid: 2526
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20006,21 +20016,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2517
+  - uid: 2527
     components:
     - type: Transform
       pos: -18.5,25.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2518
+  - uid: 2528
     components:
     - type: Transform
       pos: 3.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2519
+  - uid: 2529
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20028,84 +20038,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2520
-    components:
-    - type: Transform
-      pos: -10.5,54.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2521
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,19.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2522
-    components:
-    - type: Transform
-      pos: -27.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2523
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2524
-    components:
-    - type: Transform
-      pos: -15.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2525
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2526
-    components:
-    - type: Transform
-      pos: -20.5,14.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2527
-    components:
-    - type: Transform
-      pos: -10.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2528
-    components:
-    - type: Transform
-      pos: -21.5,38.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2529
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 2530
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,52.5
+      pos: -10.5,54.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -20113,61 +20049,57 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-28.5
+      pos: -6.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2532
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-26.5
+      pos: -27.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2533
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-14.5
+      pos: 4.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2534
     components:
     - type: Transform
-      pos: -5.5,32.5
+      pos: -15.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2535
     components:
     - type: Transform
-      pos: -18.5,32.5
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2536
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,32.5
+      pos: -20.5,14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2537
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,11.5
+      pos: -10.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2538
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,38.5
+      pos: -21.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -20175,9 +20107,87 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: -17.5,32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2540
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,52.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2541
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-28.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2542
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-26.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2544
+    components:
+    - type: Transform
+      pos: -5.5,32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2545
+    components:
+    - type: Transform
+      pos: -18.5,32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2546
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2547
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2548
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,38.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2549
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -4.5,22.5
       parent: 1
-  - uid: 2540
+  - uid: 2550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20185,7 +20195,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2541
+  - uid: 2551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20193,14 +20203,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2542
+  - uid: 2552
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2543
+  - uid: 2553
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20208,7 +20218,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2544
+  - uid: 2554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20216,7 +20226,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2545
+  - uid: 2555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20224,7 +20234,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2546
+  - uid: 2556
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20232,7 +20242,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2547
+  - uid: 2557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20240,7 +20250,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2548
+  - uid: 2558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20248,85 +20258,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2549
-    components:
-    - type: Transform
-      pos: -3.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2550
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,35.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2551
-    components:
-    - type: Transform
-      pos: 11.5,35.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2552
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,34.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2553
-    components:
-    - type: Transform
-      pos: 4.5,35.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2554
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2555
-    components:
-    - type: Transform
-      pos: 3.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2556
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,31.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2557
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,31.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 2558
-    components:
-    - type: Transform
-      pos: -33.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 2559
     components:
     - type: Transform
-      pos: -40.5,4.5
+      pos: -3.5,16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -20334,11 +20269,86 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -38.5,4.5
+      pos: 0.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 2561
+    components:
+    - type: Transform
+      pos: 11.5,35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2562
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,34.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2563
+    components:
+    - type: Transform
+      pos: 4.5,35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2564
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2565
+    components:
+    - type: Transform
+      pos: 3.5,39.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2566
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2567
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2568
+    components:
+    - type: Transform
+      pos: -33.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2569
+    components:
+    - type: Transform
+      pos: -40.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2570
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -38.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 2571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20348,7 +20358,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeTJunctionAlt1
   entities:
-  - uid: 2562
+  - uid: 2572
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20356,7 +20366,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2563
+  - uid: 2573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20364,7 +20374,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2564
+  - uid: 2574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20372,94 +20382,17 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2565
+  - uid: 2575
     components:
     - type: Transform
       pos: 3.5,35.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2566
-    components:
-    - type: Transform
-      pos: 8.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2567
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,26.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2568
-    components:
-    - type: Transform
-      pos: 1.5,39.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2569
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2570
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-28.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2571
-    components:
-    - type: Transform
-      pos: 3.5,21.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2572
-    components:
-    - type: Transform
-      pos: 2.5,21.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2573
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2574
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2575
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 2576
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,10.5
+      pos: 8.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -20467,21 +20400,22 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -10.5,-20.5
+      pos: -0.5,26.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2578
     components:
     - type: Transform
-      pos: -21.5,38.5
+      pos: 1.5,39.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2579
     components:
     - type: Transform
-      pos: -31.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -17.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -20489,53 +20423,53 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,4.5
+      pos: -10.5,-28.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2581
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,4.5
+      pos: 3.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2582
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-12.5
+      pos: 2.5,21.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2583
     components:
     - type: Transform
-      pos: -20.5,14.5
+      rot: 1.5707963267948966 rad
+      pos: -5.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2584
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,30.5
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2585
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,16.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2586
     components:
     - type: Transform
-      pos: -7.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -20543,18 +20477,94 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -10.5,-26.5
+      pos: -10.5,-20.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2588
     components:
     - type: Transform
-      pos: -10.5,2.5
+      pos: -21.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2589
+    components:
+    - type: Transform
+      pos: -31.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2590
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2591
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2592
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2593
+    components:
+    - type: Transform
+      pos: -20.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2594
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2595
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2596
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2597
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-26.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2598
+    components:
+    - type: Transform
+      pos: -10.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2599
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20562,42 +20572,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2590
+  - uid: 2600
     components:
     - type: Transform
       pos: -10.5,54.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2591
+  - uid: 2601
     components:
     - type: Transform
       pos: -25.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2592
+  - uid: 2602
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2593
+  - uid: 2603
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2594
+  - uid: 2604
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2595
+  - uid: 2605
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20605,7 +20615,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2596
+  - uid: 2606
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20613,14 +20623,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2597
+  - uid: 2607
     components:
     - type: Transform
       pos: -19.5,38.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2598
+  - uid: 2608
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20628,14 +20638,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2599
+  - uid: 2609
     components:
     - type: Transform
       pos: -18.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2600
+  - uid: 2610
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20643,14 +20653,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2601
+  - uid: 2611
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2602
+  - uid: 2612
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20658,88 +20668,10 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2603
-    components:
-    - type: Transform
-      pos: -4.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2604
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2605
-    components:
-    - type: Transform
-      pos: 4.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2606
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2607
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2608
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,47.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2609
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -19.5,32.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2610
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,19.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2611
-    components:
-    - type: Transform
-      pos: -18.5,25.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 2612
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,16.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 2613
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,35.5
+      pos: -4.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -20747,38 +20679,38 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,31.5
+      pos: -10.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2615
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,32.5
+      pos: 4.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2616
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,32.5
+      rot: 3.141592653589793 rad
+      pos: -20.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2617
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,35.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2618
     components:
     - type: Transform
-      pos: -0.5,35.5
+      rot: 1.5707963267948966 rad
+      pos: -10.5,47.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -20786,18 +20718,96 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -40.5,4.5
+      pos: -19.5,32.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2620
     components:
     - type: Transform
-      pos: -38.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -6.5,19.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 2621
+    components:
+    - type: Transform
+      pos: -18.5,25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2623
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2624
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2625
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2627
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2628
+    components:
+    - type: Transform
+      pos: -0.5,35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2629
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -40.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2630
+    components:
+    - type: Transform
+      pos: -38.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 2631
     components:
     - type: Transform
       pos: -45.5,4.5
@@ -20806,7 +20816,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunctionAlt2
   entities:
-  - uid: 2622
+  - uid: 2632
     components:
     - type: Transform
       pos: 7.5,8.5
@@ -20815,25 +20825,25 @@ entities:
       color: '#090D91FF'
 - proto: GasPort
   entities:
-  - uid: 2623
+  - uid: 2633
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,22.5
       parent: 1
-  - uid: 2624
+  - uid: 2634
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,20.5
       parent: 1
-  - uid: 2625
+  - uid: 2635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,8.5
       parent: 1
-  - uid: 2626
+  - uid: 2636
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20843,7 +20853,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 2627
+  - uid: 2637
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20853,7 +20863,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2628
+  - uid: 2638
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20863,7 +20873,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 2629
+  - uid: 2639
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20873,7 +20883,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2630
+  - uid: 2640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20883,7 +20893,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPressurePump
   entities:
-  - uid: 2631
+  - uid: 2641
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20891,14 +20901,14 @@ entities:
       parent: 1
 - proto: GasPressurePumpOn
   entities:
-  - uid: 2632
+  - uid: 2642
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2633
+  - uid: 2643
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20906,7 +20916,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2634
+  - uid: 2644
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20914,7 +20924,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2635
+  - uid: 2645
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20922,7 +20932,7 @@ entities:
       parent: 1
 - proto: GasThermoMachineFreezerEnabled
   entities:
-  - uid: 2636
+  - uid: 2646
     components:
     - type: Transform
       pos: -3.5,23.5
@@ -20931,7 +20941,7 @@ entities:
       targetTemperature: 200
 - proto: GasVentPump
   entities:
-  - uid: 2637
+  - uid: 2647
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20939,7 +20949,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2638
+  - uid: 2648
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20950,7 +20960,7 @@ entities:
       - 31
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2639
+  - uid: 2649
     components:
     - type: Transform
       pos: -9.5,56.5
@@ -20960,7 +20970,7 @@ entities:
       - 24
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2640
+  - uid: 2650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20971,7 +20981,7 @@ entities:
       - 15
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2641
+  - uid: 2651
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20984,7 +20994,7 @@ entities:
       - 12
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2642
+  - uid: 2652
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20996,7 +21006,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2643
+  - uid: 2653
     components:
     - type: Transform
       pos: -6.5,20.5
@@ -21006,7 +21016,7 @@ entities:
       - 22
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2644
+  - uid: 2654
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21017,7 +21027,7 @@ entities:
       - 18
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2645
+  - uid: 2655
     components:
     - type: Transform
       pos: -12.5,12.5
@@ -21031,7 +21041,7 @@ entities:
       - 20
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2646
+  - uid: 2656
     components:
     - type: Transform
       pos: -21.5,15.5
@@ -21041,7 +21051,7 @@ entities:
       - 20
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2647
+  - uid: 2657
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21054,7 +21064,7 @@ entities:
       - 12
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2648
+  - uid: 2658
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21066,7 +21076,7 @@ entities:
       - 34
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2649
+  - uid: 2659
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21077,7 +21087,7 @@ entities:
       - 20
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2650
+  - uid: 2660
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21089,7 +21099,7 @@ entities:
       - 21
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2651
+  - uid: 2661
     components:
     - type: Transform
       pos: -19.5,15.5
@@ -21099,7 +21109,7 @@ entities:
       - 20
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2652
+  - uid: 2662
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21110,7 +21120,7 @@ entities:
       - 17
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2653
+  - uid: 2663
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21121,7 +21131,7 @@ entities:
       - 24
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2654
+  - uid: 2664
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21133,7 +21143,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2655
+  - uid: 2665
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21144,7 +21154,7 @@ entities:
       - 18
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2656
+  - uid: 2666
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21155,7 +21165,7 @@ entities:
       - 20
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2657
+  - uid: 2667
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21166,7 +21176,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2658
+  - uid: 2668
     components:
     - type: Transform
       pos: -14.5,26.5
@@ -21176,7 +21186,7 @@ entities:
       - 18
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2659
+  - uid: 2669
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21187,7 +21197,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2660
+  - uid: 2670
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21198,7 +21208,7 @@ entities:
       - 28
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2661
+  - uid: 2671
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21210,7 +21220,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2662
+  - uid: 2672
     components:
     - type: Transform
       pos: -19.5,39.5
@@ -21221,7 +21231,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2663
+  - uid: 2673
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21233,7 +21243,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2664
+  - uid: 2674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21244,7 +21254,7 @@ entities:
       - 18
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2665
+  - uid: 2675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21255,7 +21265,7 @@ entities:
       - 24
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2666
+  - uid: 2676
     components:
     - type: Transform
       pos: 12.5,7.5
@@ -21265,7 +21275,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2667
+  - uid: 2677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21276,7 +21286,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2668
+  - uid: 2678
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21287,7 +21297,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2669
+  - uid: 2679
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21298,7 +21308,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2670
+  - uid: 2680
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21309,7 +21319,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2671
+  - uid: 2681
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21320,7 +21330,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2672
+  - uid: 2682
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21331,7 +21341,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2673
+  - uid: 2683
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21342,7 +21352,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2674
+  - uid: 2684
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21353,7 +21363,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 34
-  - uid: 2675
+  - uid: 2685
     components:
     - type: Transform
       pos: -31.5,7.5
@@ -21363,7 +21373,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 34
-  - uid: 2676
+  - uid: 2686
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21374,7 +21384,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2677
+  - uid: 2687
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21386,7 +21396,7 @@ entities:
       - 12
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2678
+  - uid: 2688
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21398,7 +21408,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2679
+  - uid: 2689
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21411,7 +21421,7 @@ entities:
       - 15
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2680
+  - uid: 2690
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21422,7 +21432,7 @@ entities:
       - 28
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2681
+  - uid: 2691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21434,7 +21444,7 @@ entities:
       - 12
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2682
+  - uid: 2692
     components:
     - type: Transform
       pos: 2.5,23.5
@@ -21444,7 +21454,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2683
+  - uid: 2693
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21459,7 +21469,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2684
+  - uid: 2694
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21471,7 +21481,7 @@ entities:
       - 25
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2685
+  - uid: 2695
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21482,7 +21492,7 @@ entities:
       - 24
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2686
+  - uid: 2696
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21497,7 +21507,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2687
+  - uid: 2697
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21514,7 +21524,7 @@ entities:
       - 24
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2688
+  - uid: 2698
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21531,7 +21541,7 @@ entities:
       - 24
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2689
+  - uid: 2699
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21539,20 +21549,20 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2690
+  - uid: 2700
     components:
     - type: Transform
       pos: 11.5,40.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2691
+  - uid: 2701
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,34.5
       parent: 1
-  - uid: 2692
+  - uid: 2702
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21563,7 +21573,7 @@ entities:
       - 30
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2693
+  - uid: 2703
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21574,7 +21584,7 @@ entities:
       - 33
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2694
+  - uid: 2704
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21585,7 +21595,7 @@ entities:
       - 33
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2695
+  - uid: 2705
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21596,7 +21606,7 @@ entities:
       - 32
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2696
+  - uid: 2706
     components:
     - type: Transform
       pos: -38.5,6.5
@@ -21606,7 +21616,7 @@ entities:
       - 34
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2697
+  - uid: 2707
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21617,7 +21627,7 @@ entities:
       - 34
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2698
+  - uid: 2708
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21628,7 +21638,7 @@ entities:
       - 34
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2699
+  - uid: 2709
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21639,7 +21649,7 @@ entities:
       - 34
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2700
+  - uid: 2710
     components:
     - type: Transform
       pos: -45.5,7.5
@@ -21651,13 +21661,13 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 2701
+  - uid: 2711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,34.5
       parent: 1
-  - uid: 2702
+  - uid: 2712
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21670,7 +21680,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2703
+  - uid: 2713
     components:
     - type: Transform
       pos: -26.5,12.5
@@ -21682,7 +21692,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2704
+  - uid: 2714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21695,7 +21705,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2705
+  - uid: 2715
     components:
     - type: Transform
       pos: -3.5,17.5
@@ -21711,7 +21721,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2706
+  - uid: 2716
     components:
     - type: Transform
       pos: -8.5,12.5
@@ -21727,7 +21737,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2707
+  - uid: 2717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21741,7 +21751,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2708
+  - uid: 2718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21755,7 +21765,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2709
+  - uid: 2719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21768,7 +21778,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2710
+  - uid: 2720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21783,7 +21793,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2711
+  - uid: 2721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21798,7 +21808,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2712
+  - uid: 2722
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21812,7 +21822,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2713
+  - uid: 2723
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21829,7 +21839,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2714
+  - uid: 2724
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21842,7 +21852,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2715
+  - uid: 2725
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21855,7 +21865,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2716
+  - uid: 2726
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -21868,7 +21878,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2717
+  - uid: 2727
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21881,7 +21891,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2718
+  - uid: 2728
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21894,7 +21904,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 2719
+  - uid: 2729
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21907,7 +21917,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 34
-  - uid: 2720
+  - uid: 2730
     components:
     - type: Transform
       pos: -33.5,7.5
@@ -21919,7 +21929,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 34
-  - uid: 2721
+  - uid: 2731
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -21932,7 +21942,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2722
+  - uid: 2732
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21945,7 +21955,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2723
+  - uid: 2733
     components:
     - type: Transform
       pos: 10.5,7.5
@@ -21957,7 +21967,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2724
+  - uid: 2734
     components:
     - type: Transform
       pos: -11.5,56.5
@@ -21969,7 +21979,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2725
+  - uid: 2735
     components:
     - type: Transform
       pos: -18.5,15.5
@@ -21981,7 +21991,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2726
+  - uid: 2736
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -21995,7 +22005,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2727
+  - uid: 2737
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22008,7 +22018,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2728
+  - uid: 2738
     components:
     - type: Transform
       pos: -22.5,15.5
@@ -22020,7 +22030,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2729
+  - uid: 2739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22035,7 +22045,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2730
+  - uid: 2740
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22049,7 +22059,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2731
+  - uid: 2741
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22063,7 +22073,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2732
+  - uid: 2742
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22077,7 +22087,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2733
+  - uid: 2743
     components:
     - type: Transform
       pos: -19.5,33.5
@@ -22090,7 +22100,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2734
+  - uid: 2744
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22104,7 +22114,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2735
+  - uid: 2745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22118,7 +22128,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2736
+  - uid: 2746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22131,7 +22141,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2737
+  - uid: 2747
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22144,7 +22154,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2738
+  - uid: 2748
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22157,7 +22167,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2739
+  - uid: 2749
     components:
     - type: Transform
       pos: 0.5,22.5
@@ -22169,7 +22179,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2740
+  - uid: 2750
     components:
     - type: Transform
       pos: 6.5,23.5
@@ -22181,7 +22191,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2741
+  - uid: 2751
     components:
     - type: Transform
       pos: -20.5,26.5
@@ -22193,7 +22203,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2742
+  - uid: 2752
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22206,7 +22216,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2743
+  - uid: 2753
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22219,7 +22229,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2744
+  - uid: 2754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22232,7 +22242,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2745
+  - uid: 2755
     components:
     - type: Transform
       pos: -6.5,21.5
@@ -22244,7 +22254,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2746
+  - uid: 2756
     components:
     - type: Transform
       pos: -16.5,17.5
@@ -22260,7 +22270,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2747
+  - uid: 2757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22279,7 +22289,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2748
+  - uid: 2758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22298,7 +22308,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2749
+  - uid: 2759
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22311,7 +22321,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2750
+  - uid: 2760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22324,7 +22334,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2751
+  - uid: 2761
     components:
     - type: Transform
       pos: -15.5,39.5
@@ -22337,7 +22347,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2752
+  - uid: 2762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -22350,7 +22360,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2753
+  - uid: 2763
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22360,7 +22370,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2754
+  - uid: 2764
     components:
     - type: Transform
       pos: 11.5,36.5
@@ -22372,7 +22382,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2755
+  - uid: 2765
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22382,12 +22392,12 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2756
+  - uid: 2766
     components:
     - type: Transform
       pos: 4.5,40.5
       parent: 1
-  - uid: 2757
+  - uid: 2767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22400,7 +22410,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2758
+  - uid: 2768
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22413,7 +22423,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2759
+  - uid: 2769
     components:
     - type: Transform
       pos: 12.5,40.5
@@ -22422,7 +22432,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2760
+  - uid: 2770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22435,7 +22445,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2761
+  - uid: 2771
     components:
     - type: Transform
       pos: -47.5,7.5
@@ -22447,7 +22457,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2762
+  - uid: 2772
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22460,7 +22470,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2763
+  - uid: 2773
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22473,7 +22483,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2764
+  - uid: 2774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -22486,7 +22496,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 2765
+  - uid: 2775
     components:
     - type: Transform
       pos: -40.5,6.5
@@ -22500,7 +22510,7 @@ entities:
       color: '#990000FF'
 - proto: GasVolumePumpOn
   entities:
-  - uid: 2766
+  - uid: 2776
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22508,7 +22518,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 2767
+  - uid: 2777
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22518,7 +22528,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#090D91FF'
-  - uid: 2768
+  - uid: 2778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -22530,732 +22540,732 @@ entities:
       color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 2769
+  - uid: 2779
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 2770
+  - uid: 2780
     components:
     - type: Transform
       pos: 1.5,32.5
       parent: 1
-  - uid: 2771
+  - uid: 2781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,31.5
       parent: 1
-  - uid: 2772
+  - uid: 2782
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,38.5
       parent: 1
-  - uid: 2773
+  - uid: 2783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,40.5
       parent: 1
-  - uid: 2774
+  - uid: 2784
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,41.5
       parent: 1
-  - uid: 2775
+  - uid: 2785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,30.5
       parent: 1
-  - uid: 2776
+  - uid: 2786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,39.5
       parent: 1
-  - uid: 2777
+  - uid: 2787
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,29.5
       parent: 1
-  - uid: 2778
+  - uid: 2788
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,41.5
       parent: 1
-  - uid: 2779
+  - uid: 2789
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,41.5
       parent: 1
-  - uid: 2780
+  - uid: 2790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,41.5
       parent: 1
-  - uid: 2781
+  - uid: 2791
     components:
     - type: Transform
       pos: -7.5,48.5
       parent: 1
-  - uid: 2782
+  - uid: 2792
     components:
     - type: Transform
       pos: -13.5,46.5
       parent: 1
-  - uid: 2783
+  - uid: 2793
     components:
     - type: Transform
       pos: -13.5,48.5
       parent: 1
-  - uid: 2784
+  - uid: 2794
     components:
     - type: Transform
       pos: -7.5,46.5
       parent: 1
-  - uid: 2785
+  - uid: 2795
     components:
     - type: Transform
       pos: -13.5,47.5
       parent: 1
-  - uid: 2786
+  - uid: 2796
     components:
     - type: Transform
       pos: -7.5,47.5
       parent: 1
-  - uid: 2787
+  - uid: 2797
     components:
     - type: Transform
       pos: -24.5,38.5
       parent: 1
-  - uid: 2788
+  - uid: 2798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,36.5
       parent: 1
-  - uid: 2789
+  - uid: 2799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-7.5
       parent: 1
-  - uid: 2790
+  - uid: 2800
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-5.5
       parent: 1
-  - uid: 2791
+  - uid: 2801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-6.5
       parent: 1
-  - uid: 2792
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-  - uid: 2793
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-  - uid: 2794
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 1
-  - uid: 2795
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-1.5
-      parent: 1
-  - uid: 2796
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-0.5
-      parent: 1
-  - uid: 2797
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 1
-  - uid: 2798
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 2799
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 2800
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,-1.5
-      parent: 1
-  - uid: 2801
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-1.5
-      parent: 1
   - uid: 2802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -15.5,-1.5
+      pos: -7.5,-1.5
       parent: 1
   - uid: 2803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -17.5,-0.5
+      pos: -7.5,-1.5
       parent: 1
   - uid: 2804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -16.5,-0.5
+      pos: -6.5,-1.5
       parent: 1
   - uid: 2805
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -18.5,0.5
+      pos: -5.5,-1.5
       parent: 1
   - uid: 2806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -19.5,0.5
+      pos: -3.5,-0.5
       parent: 1
   - uid: 2807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,-5.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 2808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,-6.5
+      pos: -2.5,0.5
       parent: 1
   - uid: 2809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,-7.5
+      pos: -1.5,0.5
       parent: 1
   - uid: 2810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,1.5
+      pos: -13.5,-1.5
       parent: 1
   - uid: 2811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,1.5
+      pos: -14.5,-1.5
       parent: 1
   - uid: 2812
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,1.5
+      pos: -15.5,-1.5
       parent: 1
   - uid: 2813
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -25.5,1.5
+      pos: -17.5,-0.5
       parent: 1
   - uid: 2814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,-19.5
+      pos: -16.5,-0.5
       parent: 1
   - uid: 2815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,-20.5
+      pos: -18.5,0.5
       parent: 1
   - uid: 2816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,-21.5
+      pos: -19.5,0.5
       parent: 1
   - uid: 2817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,-21.5
+      pos: -13.5,-5.5
       parent: 1
   - uid: 2818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,-20.5
+      pos: -13.5,-6.5
       parent: 1
   - uid: 2819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,-19.5
+      pos: -13.5,-7.5
       parent: 1
   - uid: 2820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -26.5,1.5
+      pos: 4.5,1.5
       parent: 1
   - uid: 2821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -27.5,1.5
+      pos: 5.5,1.5
       parent: 1
   - uid: 2822
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,24.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
       parent: 1
   - uid: 2823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 10.5,22.5
+      pos: -25.5,1.5
       parent: 1
   - uid: 2824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 10.5,20.5
+      pos: -7.5,-19.5
       parent: 1
   - uid: 2825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,20.5
+      pos: -7.5,-20.5
       parent: 1
   - uid: 2826
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,22.5
+      pos: -7.5,-21.5
       parent: 1
   - uid: 2827
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,25.5
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-21.5
       parent: 1
   - uid: 2828
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,22.5
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-20.5
       parent: 1
   - uid: 2829
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,21.5
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-19.5
       parent: 1
   - uid: 2830
     components:
     - type: Transform
-      pos: -24.5,31.5
+      rot: -1.5707963267948966 rad
+      pos: -26.5,1.5
       parent: 1
   - uid: 2831
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,22.5
+      rot: -1.5707963267948966 rad
+      pos: -27.5,1.5
       parent: 1
   - uid: 2832
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,21.5
+      pos: -21.5,24.5
       parent: 1
   - uid: 2833
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,20.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,22.5
       parent: 1
   - uid: 2834
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,12.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,20.5
       parent: 1
   - uid: 2835
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,13.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,20.5
       parent: 1
   - uid: 2836
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,14.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,22.5
       parent: 1
   - uid: 2837
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,15.5
+      rot: 1.5707963267948966 rad
+      pos: -21.5,25.5
       parent: 1
   - uid: 2838
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,16.5
+      rot: 1.5707963267948966 rad
+      pos: -21.5,22.5
       parent: 1
   - uid: 2839
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,16.5
+      rot: 1.5707963267948966 rad
+      pos: -21.5,21.5
       parent: 1
   - uid: 2840
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,17.5
+      pos: -24.5,31.5
       parent: 1
   - uid: 2841
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,17.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,22.5
       parent: 1
   - uid: 2842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,26.5
+      pos: -13.5,21.5
       parent: 1
   - uid: 2843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,20.5
+      pos: -13.5,20.5
       parent: 1
   - uid: 2844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,12.5
+      parent: 1
+  - uid: 2845
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -26.5,13.5
+      parent: 1
+  - uid: 2846
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -26.5,14.5
+      parent: 1
+  - uid: 2847
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.5,15.5
+      parent: 1
+  - uid: 2848
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,16.5
+      parent: 1
+  - uid: 2849
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,16.5
+      parent: 1
+  - uid: 2850
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,17.5
+      parent: 1
+  - uid: 2851
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,17.5
+      parent: 1
+  - uid: 2852
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,26.5
+      parent: 1
+  - uid: 2853
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,20.5
+      parent: 1
+  - uid: 2854
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,33.5
       parent: 1
-  - uid: 2845
+  - uid: 2855
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,33.5
       parent: 1
-  - uid: 2846
+  - uid: 2856
     components:
     - type: Transform
       pos: -24.5,34.5
       parent: 1
-  - uid: 2847
+  - uid: 2857
     components:
     - type: Transform
       pos: -24.5,39.5
       parent: 1
-  - uid: 2848
+  - uid: 2858
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,30.5
       parent: 1
-  - uid: 2849
+  - uid: 2859
     components:
     - type: Transform
       pos: -23.5,28.5
       parent: 1
-  - uid: 2850
+  - uid: 2860
     components:
     - type: Transform
       pos: -24.5,33.5
       parent: 1
-  - uid: 2851
+  - uid: 2861
     components:
     - type: Transform
       pos: -24.5,35.5
       parent: 1
-  - uid: 2852
+  - uid: 2862
     components:
     - type: Transform
       pos: -23.5,29.5
       parent: 1
-  - uid: 2853
+  - uid: 2863
     components:
     - type: Transform
       pos: -24.5,32.5
       parent: 1
-  - uid: 2854
+  - uid: 2864
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 1
-  - uid: 2855
+  - uid: 2865
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 2856
+  - uid: 2866
     components:
     - type: Transform
       pos: -22.5,41.5
       parent: 1
-  - uid: 2857
+  - uid: 2867
     components:
     - type: Transform
       pos: -21.5,41.5
       parent: 1
-  - uid: 2858
+  - uid: 2868
     components:
     - type: Transform
       pos: -23.5,40.5
       parent: 1
-  - uid: 2859
+  - uid: 2869
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 2860
+  - uid: 2870
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 2861
+  - uid: 2871
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 2862
+  - uid: 2872
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 2863
+  - uid: 2873
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
-  - uid: 2864
+  - uid: 2874
     components:
     - type: Transform
       pos: -13.5,14.5
       parent: 1
-  - uid: 2865
+  - uid: 2875
     components:
     - type: Transform
       pos: -12.5,14.5
       parent: 1
-  - uid: 2866
+  - uid: 2876
     components:
     - type: Transform
       pos: -8.5,14.5
       parent: 1
-  - uid: 2867
+  - uid: 2877
     components:
     - type: Transform
       pos: -7.5,14.5
       parent: 1
-  - uid: 2868
+  - uid: 2878
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 1
-  - uid: 2869
+  - uid: 2879
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 1
-  - uid: 2870
+  - uid: 2880
     components:
     - type: Transform
       pos: 7.5,15.5
       parent: 1
-  - uid: 2871
+  - uid: 2881
     components:
     - type: Transform
       pos: 7.5,14.5
       parent: 1
-  - uid: 2872
+  - uid: 2882
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,9.5
       parent: 1
-  - uid: 2873
+  - uid: 2883
     components:
     - type: Transform
       pos: 8.5,31.5
       parent: 1
-  - uid: 2874
+  - uid: 2884
     components:
     - type: Transform
       pos: -40.5,7.5
       parent: 1
-  - uid: 2875
+  - uid: 2885
     components:
     - type: Transform
       pos: -39.5,7.5
       parent: 1
-  - uid: 2876
+  - uid: 2886
     components:
     - type: Transform
       pos: -38.5,7.5
       parent: 1
-  - uid: 2877
+  - uid: 2887
     components:
     - type: Transform
       pos: -38.5,1.5
       parent: 1
-  - uid: 2878
+  - uid: 2888
     components:
     - type: Transform
       pos: -39.5,1.5
       parent: 1
-  - uid: 2879
+  - uid: 2889
     components:
     - type: Transform
       pos: -40.5,1.5
       parent: 1
-  - uid: 2880
+  - uid: 2890
     components:
     - type: Transform
       pos: 10.5,31.5
       parent: 1
-  - uid: 2881
+  - uid: 2891
     components:
     - type: Transform
       pos: 10.5,30.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 2882
+  - uid: 2892
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,40.5
       parent: 1
-  - uid: 2883
+  - uid: 2893
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,41.5
       parent: 1
-  - uid: 2884
+  - uid: 2894
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,-1.5
       parent: 1
-  - uid: 2885
+  - uid: 2895
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-0.5
       parent: 1
-  - uid: 2886
+  - uid: 2896
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,0.5
       parent: 1
-  - uid: 2887
+  - uid: 2897
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 2888
+  - uid: 2898
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 2889
+  - uid: 2899
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 2890
+  - uid: 2900
     components:
     - type: Transform
       pos: -27.5,13.5
       parent: 1
-  - uid: 2891
+  - uid: 2901
     components:
     - type: Transform
       pos: -26.5,15.5
       parent: 1
-  - uid: 2892
+  - uid: 2902
     components:
     - type: Transform
       pos: -25.5,16.5
       parent: 1
-  - uid: 2893
+  - uid: 2903
     components:
     - type: Transform
       pos: -23.5,17.5
       parent: 1
-  - uid: 2894
+  - uid: 2904
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,30.5
       parent: 1
-  - uid: 2895
+  - uid: 2905
     components:
     - type: Transform
       pos: -24.5,40.5
       parent: 1
-  - uid: 2896
+  - uid: 2906
     components:
     - type: Transform
       pos: -23.5,41.5
       parent: 1
 - proto: GunSafe
   entities:
-  - uid: 2897
+  - uid: 2907
     components:
     - type: Transform
       pos: 10.5,40.5
@@ -23288,15 +23298,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 2899
-          - 2898
+          - 2909
+          - 2908
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: GunSafeTurretsCdet
   entities:
-  - uid: 467
+  - uid: 476
     components:
     - type: Transform
       pos: 7.5,40.5
@@ -23333,24 +23343,24 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 469
-          - 470
-          - 471
-          - 468
+          - 478
+          - 479
+          - 480
+          - 477
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: HappyHonkMcCargo
   entities:
-  - uid: 2906
+  - uid: 2916
     components:
     - type: Transform
       pos: -22.595062,10.905408
       parent: 1
 - proto: HighSecCommandLocked
   entities:
-  - uid: 2907
+  - uid: 2917
     components:
     - type: Transform
       pos: 5.5,39.5
@@ -23362,7 +23372,7 @@ entities:
     - Destructible
 - proto: HighSecDoor
   entities:
-  - uid: 2916
+  - uid: 2918
     components:
     - type: Transform
       pos: -2.5,8.5
@@ -23380,46 +23390,46 @@ entities:
       - - Frontier
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 2917
+  - uid: 2919
     components:
     - type: Transform
       pos: -21.5,7.5
       parent: 1
-  - uid: 2918
+  - uid: 2920
     components:
     - type: Transform
       pos: -20.5,7.5
       parent: 1
-  - uid: 2919
-    components:
-    - type: Transform
-      pos: -19.5,7.5
-      parent: 1
-  - uid: 2920
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,29.5
-      parent: 1
   - uid: 2921
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,30.5
+      pos: -19.5,7.5
       parent: 1
   - uid: 2922
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -16.5,30.5
+      pos: -20.5,29.5
       parent: 1
   - uid: 2923
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -16.5,29.5
+      pos: -20.5,30.5
       parent: 1
   - uid: 2924
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -16.5,30.5
+      parent: 1
+  - uid: 2925
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -16.5,29.5
+      parent: 1
+  - uid: 2926
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23427,24 +23437,24 @@ entities:
       parent: 1
 - proto: InflatableWall
   entities:
-  - uid: 2925
+  - uid: 2927
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 1
-  - uid: 2926
+  - uid: 2928
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 2927
+  - uid: 2929
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
 - proto: JukeboxWallmount
   entities:
-  - uid: 2928
+  - uid: 2930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -23452,61 +23462,61 @@ entities:
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 2929
+  - uid: 2931
     components:
     - type: Transform
       pos: 5.5,33.5
       parent: 1
-  - uid: 2930
+  - uid: 2932
     components:
     - type: Transform
       pos: -16.5,33.5
       parent: 1
 - proto: KitchenReagentGrinderPOI
   entities:
-  - uid: 2931
+  - uid: 2933
     components:
     - type: Transform
       pos: -26.5,12.5
       parent: 1
 - proto: LauncherSyringe
   entities:
-  - uid: 2898
+  - uid: 2908
     components:
     - type: Transform
-      parent: 2897
+      parent: 2907
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: LedLightTube
   entities:
-  - uid: 2932
+  - uid: 2934
     components:
     - type: Transform
       pos: -22.475082,10.504655
       parent: 1
 - proto: LessLethalVendingMachinePOI
   entities:
-  - uid: 2933
+  - uid: 2935
     components:
     - type: Transform
       pos: -2.5,36.5
       parent: 1
-  - uid: 2934
+  - uid: 2936
     components:
     - type: Transform
       pos: -12.5,25.5
       parent: 1
 - proto: LightBulbBroken
   entities:
-  - uid: 2935
+  - uid: 2937
     components:
     - type: Transform
       pos: -21.572205,16.20174
       parent: 1
 - proto: LightReplacerEmpty
   entities:
-  - uid: 2936
+  - uid: 2938
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23514,28 +23524,28 @@ entities:
       parent: 1
 - proto: LightTubeBroken
   entities:
-  - uid: 2938
-    components:
-    - type: Transform
-      parent: 2937
-    - type: Physics
-      canCollide: False
   - uid: 2940
     components:
     - type: Transform
       parent: 2939
     - type: Physics
       canCollide: False
+  - uid: 2942
+    components:
+    - type: Transform
+      parent: 2941
+    - type: Physics
+      canCollide: False
 - proto: LightTubeOld
   entities:
-  - uid: 2941
+  - uid: 2943
     components:
     - type: Transform
       pos: 4.6615624,23.653759
       parent: 1
 - proto: LockerBoozeFilled
   entities:
-  - uid: 2942
+  - uid: 2944
     components:
     - type: Transform
       pos: -23.5,8.5
@@ -23570,14 +23580,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 2943
+          - 2945
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: LockerChiefMedicalOfficerFilledHardsuit
   entities:
-  - uid: 1455
+  - uid: 1464
     components:
     - type: Transform
       pos: -17.5,26.5
@@ -23610,31 +23620,31 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1457
-          - 1458
-          - 1459
-          - 1456
+          - 1466
+          - 1467
+          - 1468
+          - 1465
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 2944
+  - uid: 2946
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
 - proto: LockerJanitorFilled
   entities:
-  - uid: 2945
+  - uid: 2947
     components:
     - type: Transform
       pos: -11.5,9.5
       parent: 1
 - proto: LockerMedical
   entities:
-  - uid: 1421
+  - uid: 1430
     components:
     - type: Transform
       pos: -18.5,37.5
@@ -23667,30 +23677,30 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1424
-          - 1422
-          - 1425
-          - 1426
-          - 1423
+          - 1433
+          - 1431
+          - 1434
+          - 1435
+          - 1432
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 2946
+  - uid: 2948
     components:
     - type: Transform
       pos: -19.5,37.5
       parent: 1
 - proto: LockerMedicalFilled
   entities:
-  - uid: 2947
+  - uid: 2949
     components:
     - type: Transform
       pos: -23.5,31.5
       parent: 1
 - proto: LockerResearchDirectorFilled
   entities:
-  - uid: 1460
+  - uid: 1469
     components:
     - type: Transform
       pos: 4.5,19.5
@@ -23723,21 +23733,21 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1461
+          - 1470
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: LockerSteel
   entities:
-  - uid: 2948
+  - uid: 2950
     components:
     - type: Transform
       pos: 4.5,38.5
       parent: 1
 - proto: LockerWallColorChemistryFilled
   entities:
-  - uid: 2949
+  - uid: 2951
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23745,48 +23755,48 @@ entities:
       parent: 1
 - proto: MachineCentrifuge
   entities:
-  - uid: 2950
+  - uid: 2952
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 1
-  - uid: 2951
+  - uid: 2953
     components:
     - type: Transform
       pos: -14.5,33.5
       parent: 1
 - proto: MachineCryoSleepPod
   entities:
-  - uid: 2952
+  - uid: 2954
     components:
     - type: Transform
       pos: -20.5,7.5
       parent: 1
-  - uid: 2953
+  - uid: 2955
     components:
     - type: Transform
       pos: -21.5,7.5
       parent: 1
-  - uid: 2954
+  - uid: 2956
     components:
     - type: Transform
       pos: -19.5,7.5
       parent: 1
 - proto: MachineFrame
   entities:
-  - uid: 2955
+  - uid: 2957
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,28.5
       parent: 1
-  - uid: 2956
+  - uid: 2958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,37.5
       parent: 1
-  - uid: 2957
+  - uid: 2959
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23794,41 +23804,41 @@ entities:
       parent: 1
 - proto: MachineFrameDestroyed
   entities:
-  - uid: 2958
+  - uid: 2960
     components:
     - type: Transform
       pos: 12.5,21.5
       parent: 1
-  - uid: 2959
+  - uid: 2961
     components:
     - type: Transform
       pos: 4.5,28.5
       parent: 1
 - proto: MachineMedicalBountyRedemption
   entities:
-  - uid: 2960
+  - uid: 2962
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 2961
+  - uid: 2963
     components:
     - type: Transform
       pos: -17.5,4.5
       parent: 1
-  - uid: 2962
+  - uid: 2964
     components:
     - type: Transform
       pos: -6.5,15.5
       parent: 1
-  - uid: 2963
+  - uid: 2965
     components:
     - type: Transform
       pos: -14.5,15.5
       parent: 1
 - proto: MachineOutpostCore
   entities:
-  - uid: 2964
+  - uid: 2966
     components:
     - type: Transform
       pos: -1.5,7.5
@@ -23837,37 +23847,37 @@ entities:
     - Anchorable
 - proto: Magazine12_gaugeBeanbag
   entities:
-  - uid: 469
+  - uid: 478
     components:
     - type: Transform
-      parent: 467
+      parent: 476
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 470
+  - uid: 479
     components:
     - type: Transform
-      parent: 467
+      parent: 476
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 471
+  - uid: 480
     components:
     - type: Transform
-      parent: 467
+      parent: 476
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: MaintenancePlantSpawner
   entities:
-  - uid: 2965
+  - uid: 2967
     components:
     - type: Transform
       pos: 3.5,25.5
       parent: 1
 - proto: MaterialCloth1
   entities:
-  - uid: 2966
+  - uid: 2968
     components:
     - type: Transform
       pos: -18.461132,13.644912
@@ -23876,198 +23886,205 @@ entities:
       count: 4
 - proto: MaterialReclaimer
   entities:
-  - uid: 2967
+  - uid: 2969
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 1
 - proto: MaterialWoodPlank10
   entities:
-  - uid: 2968
+  - uid: 2970
     components:
     - type: Transform
       pos: -22.471554,11.886996
       parent: 1
 - proto: MedalCase
   entities:
-  - uid: 1458
+  - uid: 1467
     components:
     - type: Transform
-      parent: 1455
+      parent: 1464
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: MedicalBed
   entities:
-  - uid: 2969
+  - uid: 2971
     components:
     - type: Transform
       pos: 5.5,30.5
       parent: 1
-  - uid: 2970
+  - uid: 2972
     components:
     - type: Transform
       pos: -14.5,24.5
       parent: 1
-  - uid: 2971
+  - uid: 2973
     components:
     - type: Transform
       pos: -20.5,30.5
       parent: 1
-  - uid: 2972
+  - uid: 2974
     components:
     - type: Transform
       pos: -20.5,29.5
       parent: 1
-  - uid: 2973
+  - uid: 2975
     components:
     - type: Transform
       pos: -16.5,30.5
       parent: 1
-  - uid: 2974
+  - uid: 2976
     components:
     - type: Transform
       pos: -16.5,29.5
       parent: 1
-  - uid: 2975
+  - uid: 2977
     components:
     - type: Transform
       pos: 5.5,29.5
       parent: 1
 - proto: MedicalBiofabMachineBoard
   entities:
-  - uid: 2976
+  - uid: 2978
     components:
     - type: Transform
       pos: -14.603368,37.70611
       parent: 1
 - proto: MedicalTechFabCircuitboard
   entities:
-  - uid: 2977
+  - uid: 2979
     components:
     - type: Transform
       pos: -14.436702,37.48736
       parent: 1
 - proto: MedicatedSuture
   entities:
-  - uid: 2978
+  - uid: 2980
     components:
     - type: Transform
       pos: -18.527233,35.67614
       parent: 1
-  - uid: 2979
+  - uid: 2981
     components:
     - type: Transform
       pos: -18.443897,35.561554
       parent: 1
 - proto: MemorialDisplay
   entities:
-  - uid: 2980
+  - uid: 2982
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,18.5
       parent: 1
-  - uid: 2981
+  - uid: 2983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,18.5
       parent: 1
+- proto: MiniStationAnchor
+  entities:
+  - uid: 4337
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
 - proto: MiniSyringe
   entities:
-  - uid: 2900
+  - uid: 2910
     components:
     - type: Transform
-      parent: 2899
+      parent: 2909
     - type: Physics
       canCollide: False
-  - uid: 2901
+  - uid: 2911
     components:
     - type: Transform
-      parent: 2899
+      parent: 2909
     - type: Physics
       canCollide: False
-  - uid: 2902
+  - uid: 2912
     components:
     - type: Transform
-      parent: 2899
+      parent: 2909
     - type: Physics
       canCollide: False
-  - uid: 2903
+  - uid: 2913
     components:
     - type: Transform
-      parent: 2899
+      parent: 2909
     - type: Physics
       canCollide: False
-  - uid: 2904
+  - uid: 2914
     components:
     - type: Transform
-      parent: 2899
+      parent: 2909
     - type: Physics
       canCollide: False
-  - uid: 2905
+  - uid: 2915
     components:
     - type: Transform
-      parent: 2899
+      parent: 2909
     - type: Physics
       canCollide: False
 - proto: MopBucket
   entities:
-  - uid: 2982
+  - uid: 2984
     components:
     - type: Transform
       pos: -11.332791,37.214375
       parent: 1
 - proto: MopBucketFull
   entities:
-  - uid: 2983
+  - uid: 2985
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 1
 - proto: MopItem
   entities:
-  - uid: 2984
+  - uid: 2986
     components:
     - type: Transform
       pos: -11.207791,36.620625
       parent: 1
-  - uid: 2985
+  - uid: 2987
     components:
     - type: Transform
       pos: -8.690322,8.458985
       parent: 1
 - proto: Morgue
   entities:
-  - uid: 2986
+  - uid: 2988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,38.5
       parent: 1
-  - uid: 2987
+  - uid: 2989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,38.5
       parent: 1
-  - uid: 2988
+  - uid: 2990
     components:
     - type: Transform
       pos: -5.5,41.5
       parent: 1
-  - uid: 2989
+  - uid: 2991
     components:
     - type: Transform
       pos: -4.5,41.5
       parent: 1
-  - uid: 2990
+  - uid: 2992
     components:
     - type: Transform
       pos: -3.5,41.5
       parent: 1
-  - uid: 2991
+  - uid: 2993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -24077,56 +24094,56 @@ entities:
       open: True
 - proto: NewtonCradle
   entities:
-  - uid: 2992
+  - uid: 2994
     components:
     - type: Transform
       pos: -19.5,40.5
       parent: 1
 - proto: NFAshtray
   entities:
-  - uid: 2993
+  - uid: 2995
     components:
     - type: Transform
       pos: -3.5795374,29.60923
       parent: 1
 - proto: NFHolopadMedicalDispatch
   entities:
-  - uid: 2994
+  - uid: 2996
     components:
     - type: Transform
       pos: -10.5,4.5
       parent: 1
 - proto: NFHolopadMedicalDispatchDoC
   entities:
-  - uid: 2995
+  - uid: 2997
     components:
     - type: Transform
       pos: -19.5,22.5
       parent: 1
 - proto: NFPouchFirstAid
   entities:
-  - uid: 2899
+  - uid: 2909
     components:
     - type: Transform
-      parent: 2897
+      parent: 2907
     - type: Storage
       storedItems:
-        2900:
+        2910:
           position: 0,0
           _rotation: South
-        2901:
+        2911:
           position: 1,0
           _rotation: South
-        2902:
+        2912:
           position: 2,0
           _rotation: South
-        2903:
+        2913:
           position: 0,1
           _rotation: South
-        2904:
+        2914:
           position: 1,1
           _rotation: South
-        2905:
+        2915:
           position: 2,1
           _rotation: South
     - type: ContainerContainer
@@ -24135,32 +24152,32 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 2900
-          - 2901
-          - 2902
-          - 2903
-          - 2904
-          - 2905
+          - 2910
+          - 2911
+          - 2912
+          - 2913
+          - 2914
+          - 2915
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: NFSignBus
   entities:
-  - uid: 2996
+  - uid: 2998
     components:
     - type: Transform
       pos: 9.5,6.5
       parent: 1
 - proto: NFVendingMachineCart
   entities:
-  - uid: 2997
+  - uid: 2999
     components:
     - type: Transform
       pos: -18.5,26.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 2998
+  - uid: 3000
     components:
     - type: Transform
       anchored: True
@@ -24168,7 +24185,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-  - uid: 2999
+  - uid: 3001
     components:
     - type: Transform
       anchored: True
@@ -24178,14 +24195,14 @@ entities:
       bodyType: Static
 - proto: NonLethalVendingMachine
   entities:
-  - uid: 3000
+  - uid: 3002
     components:
     - type: Transform
       pos: -3.5,36.5
       parent: 1
 - proto: NoticeBoard
   entities:
-  - uid: 3001
+  - uid: 3003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -24193,14 +24210,14 @@ entities:
       parent: 1
 - proto: OperatingTable
   entities:
-  - uid: 3002
+  - uid: 3004
     components:
     - type: Transform
       pos: -6.5,41.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 3003
+  - uid: 3005
     components:
     - type: Transform
       anchored: True
@@ -24208,7 +24225,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-  - uid: 3004
+  - uid: 3006
     components:
     - type: Transform
       anchored: True
@@ -24218,13 +24235,13 @@ entities:
       bodyType: Static
 - proto: PaperBin20
   entities:
-  - uid: 3005
+  - uid: 3007
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,36.5
       parent: 1
-  - uid: 3006
+  - uid: 3008
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24232,23 +24249,23 @@ entities:
       parent: 1
 - proto: PartRodMetal1
   entities:
-  - uid: 3007
+  - uid: 3009
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.56737,22.360672
       parent: 1
-  - uid: 3008
+  - uid: 3010
     components:
     - type: Transform
       pos: 11.853622,20.868542
       parent: 1
-  - uid: 3009
+  - uid: 3011
     components:
     - type: Transform
       pos: 11.666087,20.95823
       parent: 1
-  - uid: 3010
+  - uid: 3012
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -24256,37 +24273,37 @@ entities:
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 3011
+  - uid: 3013
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,40.5
-      parent: 1
-  - uid: 3012
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,40.5
-      parent: 1
-  - uid: 3013
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,40.5
       parent: 1
   - uid: 3014
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,40.5
+      parent: 1
+  - uid: 3015
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,40.5
+      parent: 1
+  - uid: 3016
+    components:
+    - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,40.5
       parent: 1
-  - uid: 3015
+  - uid: 3017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,23.5
       parent: 1
-  - uid: 3016
+  - uid: 3018
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -24294,36 +24311,36 @@ entities:
       parent: 1
 - proto: PlastitaniumWindow
   entities:
-  - uid: 3017
-    components:
-    - type: Transform
-      pos: 1.5,32.5
-      parent: 1
-  - uid: 3018
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,41.5
-      parent: 1
   - uid: 3019
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,30.5
+      pos: 1.5,32.5
       parent: 1
   - uid: 3020
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,41.5
+      pos: 0.5,41.5
       parent: 1
   - uid: 3021
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,31.5
+      pos: 6.5,30.5
       parent: 1
   - uid: 3022
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,41.5
+      parent: 1
+  - uid: 3023
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,31.5
+      parent: 1
+  - uid: 3024
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -24331,13 +24348,13 @@ entities:
       parent: 1
 - proto: PlastitaniumWindowDiagonalIndestructible
   entities:
-  - uid: 3023
+  - uid: 3025
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,40.5
       parent: 1
-  - uid: 3024
+  - uid: 3026
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24345,51 +24362,51 @@ entities:
       parent: 1
 - proto: PlastitaniumWindowIndestructible
   entities:
-  - uid: 3025
+  - uid: 3027
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 3026
+  - uid: 3028
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 3027
+  - uid: 3029
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 3028
-    components:
-    - type: Transform
-      pos: 3.5,12.5
-      parent: 1
-  - uid: 3029
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,40.5
-      parent: 1
   - uid: 3030
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,41.5
+      pos: 3.5,12.5
       parent: 1
   - uid: 3031
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,38.5
+      pos: 13.5,40.5
       parent: 1
   - uid: 3032
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 12.5,41.5
+      pos: 11.5,41.5
       parent: 1
   - uid: 3033
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,38.5
+      parent: 1
+  - uid: 3034
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,41.5
+      parent: 1
+  - uid: 3035
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24397,37 +24414,37 @@ entities:
       parent: 1
 - proto: PlastitaniumWindowOutpost
   entities:
-  - uid: 3034
+  - uid: 3036
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,22.5
       parent: 1
-  - uid: 3035
+  - uid: 3037
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,20.5
       parent: 1
-  - uid: 3036
+  - uid: 3038
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,20.5
       parent: 1
-  - uid: 3037
+  - uid: 3039
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,22.5
       parent: 1
-  - uid: 3038
+  - uid: 3040
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,33.5
       parent: 1
-  - uid: 3039
+  - uid: 3041
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -24435,14 +24452,14 @@ entities:
       parent: 1
 - proto: PlushieAtmosian
   entities:
-  - uid: 3040
+  - uid: 3042
     components:
     - type: Transform
       pos: 2.583004,10.719718
       parent: 1
 - proto: PlushieCatSiames
   entities:
-  - uid: 3041
+  - uid: 3043
     components:
     - type: MetaData
       name: Morgan plushie
@@ -24451,7 +24468,7 @@ entities:
       parent: 1
 - proto: PosterLegitScience
   entities:
-  - uid: 3042
+  - uid: 3044
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -24459,121 +24476,121 @@ entities:
       parent: 1
 - proto: PottedPlant10
   entities:
-  - uid: 3043
+  - uid: 3045
     components:
     - type: Transform
       pos: -15.5,22.5
       parent: 1
 - proto: PottedPlantRandomPlastic
   entities:
-  - uid: 3044
+  - uid: 3046
     components:
     - type: Transform
       pos: 3.5,42.5
       parent: 1
-  - uid: 3045
+  - uid: 3047
     components:
     - type: Transform
       pos: 0.5,42.5
       parent: 1
-  - uid: 3046
+  - uid: 3048
     components:
     - type: Transform
       pos: -8.5,47.5
       parent: 1
-  - uid: 3047
+  - uid: 3049
     components:
     - type: Transform
       pos: -12.5,47.5
       parent: 1
-  - uid: 3048
+  - uid: 3050
     components:
     - type: Transform
       pos: -12.5,17.5
       parent: 1
-  - uid: 3049
+  - uid: 3051
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 1
-  - uid: 3050
+  - uid: 3052
     components:
     - type: Transform
       pos: -26.5,2.5
       parent: 1
-  - uid: 3051
+  - uid: 3053
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 3052
+  - uid: 3054
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 1
-  - uid: 3053
+  - uid: 3055
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 1
-  - uid: 3054
+  - uid: 3056
     components:
     - type: Transform
       pos: -12.5,-20.5
       parent: 1
-  - uid: 3055
+  - uid: 3057
     components:
     - type: Transform
       pos: -8.5,-20.5
       parent: 1
-  - uid: 3056
+  - uid: 3058
     components:
     - type: Transform
       pos: -12.5,-0.5
       parent: 1
-  - uid: 3057
+  - uid: 3059
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
-  - uid: 3058
+  - uid: 3060
     components:
     - type: Transform
       pos: -8.5,33.5
       parent: 1
-  - uid: 3059
+  - uid: 3061
     components:
     - type: Transform
       pos: -8.5,17.5
       parent: 1
-  - uid: 3060
+  - uid: 3062
     components:
     - type: Transform
       pos: -12.5,33.5
       parent: 1
-  - uid: 3061
+  - uid: 3063
     components:
     - type: Transform
       pos: -22.5,40.5
       parent: 1
-  - uid: 3062
+  - uid: 3064
     components:
     - type: Transform
       pos: -2.5,29.5
       parent: 1
-  - uid: 3063
+  - uid: 3065
     components:
     - type: Transform
       pos: -39.5,2.5
       parent: 1
-  - uid: 3064
+  - uid: 3066
     components:
     - type: Transform
       pos: -39.5,6.5
       parent: 1
 - proto: PowerCellRecharger
   entities:
-  - uid: 3065
+  - uid: 3067
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24581,356 +24598,340 @@ entities:
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 3066
+  - uid: 3068
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,38.5
       parent: 1
-  - uid: 3067
+  - uid: 3069
     components:
     - type: Transform
       pos: 10.5,40.5
       parent: 1
-  - uid: 3068
+  - uid: 3070
     components:
     - type: Transform
       pos: -13.5,54.5
       parent: 1
-  - uid: 3069
+  - uid: 3071
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,56.5
       parent: 1
-  - uid: 3070
+  - uid: 3072
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,50.5
       parent: 1
-  - uid: 3071
+  - uid: 3073
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,44.5
       parent: 1
-  - uid: 3072
+  - uid: 3074
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-3.5
       parent: 1
-  - uid: 3073
+  - uid: 3075
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-3.5
       parent: 1
-  - uid: 3074
+  - uid: 3076
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-10.5
       parent: 1
-  - uid: 3075
+  - uid: 3077
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-9.5
       parent: 1
-  - uid: 3076
+  - uid: 3078
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-16.5
       parent: 1
-  - uid: 3077
+  - uid: 3079
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-17.5
       parent: 1
-  - uid: 3078
+  - uid: 3080
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-24.5
       parent: 1
-  - uid: 3079
+  - uid: 3081
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-23.5
       parent: 1
-  - uid: 3080
+  - uid: 3082
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-28.5
       parent: 1
-  - uid: 3081
+  - uid: 3083
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-30.5
       parent: 1
-  - uid: 3082
+  - uid: 3084
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-14.5
       parent: 1
-  - uid: 3083
+  - uid: 3085
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-14.5
       parent: 1
-  - uid: 3084
+  - uid: 3086
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,1.5
       parent: 1
-  - uid: 3085
+  - uid: 3087
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,7.5
       parent: 1
-  - uid: 3086
-    components:
-    - type: Transform
-      pos: -26.5,5.5
-      parent: 1
-  - uid: 3087
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,3.5
-      parent: 1
   - uid: 3088
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -29.5,3.5
+      pos: -26.5,5.5
       parent: 1
   - uid: 3089
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,3.5
+      pos: -23.5,3.5
       parent: 1
   - uid: 3090
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 8.5,3.5
+      pos: -29.5,3.5
       parent: 1
   - uid: 3091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,3.5
+      pos: 2.5,3.5
       parent: 1
   - uid: 3092
     components:
     - type: Transform
-      pos: -13.5,-26.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,3.5
       parent: 1
   - uid: 3093
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,7.5
+      rot: 3.141592653589793 rad
+      pos: 14.5,3.5
       parent: 1
   - uid: 3094
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,1.5
+      pos: -13.5,-26.5
       parent: 1
   - uid: 3095
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -8.5,8.5
+      pos: 12.5,7.5
       parent: 1
   - uid: 3096
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -12.5,8.5
+      pos: 10.5,1.5
       parent: 1
   - uid: 3097
     components:
     - type: Transform
-      pos: -18.5,26.5
+      rot: -1.5707963267948966 rad
+      pos: -8.5,8.5
       parent: 1
   - uid: 3098
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,38.5
+      rot: 1.5707963267948966 rad
+      pos: -12.5,8.5
       parent: 1
   - uid: 3099
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,30.5
+      pos: -18.5,26.5
       parent: 1
   - uid: 3100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -15.5,37.5
+      pos: 11.5,38.5
       parent: 1
   - uid: 3101
     components:
     - type: Transform
-      pos: -4.5,23.5
+      rot: -1.5707963267948966 rad
+      pos: -2.5,30.5
       parent: 1
   - uid: 3102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,37.5
+      parent: 1
+  - uid: 3103
+    components:
+    - type: Transform
+      pos: -4.5,23.5
+      parent: 1
+  - uid: 3104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,21.5
       parent: 1
-  - uid: 3103
+  - uid: 3105
     components:
     - type: Transform
       pos: -21.5,8.5
       parent: 1
-  - uid: 3104
+  - uid: 3106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,7.5
       parent: 1
-  - uid: 3105
+  - uid: 3107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,7.5
       parent: 1
-  - uid: 3106
+  - uid: 3108
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,6.5
       parent: 1
-  - uid: 3107
+  - uid: 3109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,52.5
       parent: 1
-  - uid: 3108
+  - uid: 3110
     components:
     - type: Transform
       pos: -4.5,36.5
       parent: 1
-  - uid: 3109
+  - uid: 3111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,30.5
       parent: 1
-  - uid: 3110
+  - uid: 3112
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,38.5
       parent: 1
-  - uid: 3111
+  - uid: 3113
     components:
     - type: Transform
       pos: 6.5,40.5
       parent: 1
-  - uid: 3112
+  - uid: 3114
     components:
     - type: Transform
       pos: 9.5,36.5
       parent: 1
-  - uid: 3113
+  - uid: 3115
     components:
     - type: Transform
       pos: 1.5,40.5
       parent: 1
-  - uid: 3114
-    components:
-    - type: Transform
-      pos: 13.5,36.5
-      parent: 1
-  - uid: 3115
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,34.5
-      parent: 1
   - uid: 3116
     components:
     - type: Transform
-      pos: -35.5,5.5
+      pos: 13.5,36.5
       parent: 1
   - uid: 3117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -36.5,3.5
+      pos: 11.5,34.5
       parent: 1
   - uid: 3118
+    components:
+    - type: Transform
+      pos: -35.5,5.5
+      parent: 1
+  - uid: 3119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -36.5,3.5
+      parent: 1
+  - uid: 3120
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,3.5
       parent: 1
-  - uid: 3119
+  - uid: 3121
     components:
     - type: Transform
       pos: -42.5,5.5
       parent: 1
-  - uid: 3120
+  - uid: 3122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,7.5
       parent: 1
-  - uid: 3121
+  - uid: 3123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -47.5,1.5
       parent: 1
-  - uid: 3122
+  - uid: 3124
     components:
     - type: Transform
       pos: -49.5,5.5
       parent: 1
 - proto: PoweredlightEmpty
   entities:
-  - uid: 2937
+  - uid: 2939
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,12.5
-      parent: 1
-    - type: ContainerContainer
-      containers:
-        light_bulb: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 2938
-    - type: ApcPowerReceiver
-      powerLoad: 0
-    - type: DamageOnInteract
-      isDamageActive: False
-  - uid: 2939
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,19.5
       parent: 1
     - type: ContainerContainer
       containers:
@@ -24942,13 +24943,29 @@ entities:
       powerLoad: 0
     - type: DamageOnInteract
       isDamageActive: False
-  - uid: 3123
+  - uid: 2941
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,19.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        light_bulb: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 2942
+    - type: ApcPowerReceiver
+      powerLoad: 0
+    - type: DamageOnInteract
+      isDamageActive: False
+  - uid: 3125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,10.5
       parent: 1
-  - uid: 3124
+  - uid: 3126
     components:
     - type: Transform
       pos: 4.5,23.5
@@ -24957,7 +24974,7 @@ entities:
       powerLoad: 0
     - type: DamageOnInteract
       isDamageActive: False
-  - uid: 3125
+  - uid: 3127
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -24965,85 +24982,85 @@ entities:
       parent: 1
 - proto: PoweredlightGreen
   entities:
-  - uid: 3126
+  - uid: 3128
     components:
     - type: Transform
       pos: 16.5,32.5
       parent: 1
-  - uid: 3127
+  - uid: 3129
     components:
     - type: Transform
       pos: -6.5,50.5
       parent: 1
-  - uid: 3128
+  - uid: 3130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,8.5
       parent: 1
-  - uid: 3129
+  - uid: 3131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-31.5
       parent: 1
-  - uid: 3130
+  - uid: 3132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-24.5
       parent: 1
-  - uid: 3131
+  - uid: 3133
     components:
     - type: Transform
       pos: -6.5,-30.5
       parent: 1
-  - uid: 3132
+  - uid: 3134
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 3133
+  - uid: 3135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-10.5
       parent: 1
-  - uid: 3134
+  - uid: 3136
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 1
-  - uid: 3135
+  - uid: 3137
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,0.5
       parent: 1
-  - uid: 3136
+  - uid: 3138
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,8.5
       parent: 1
-  - uid: 3137
+  - uid: 3139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,57.5
       parent: 1
-  - uid: 3138
+  - uid: 3140
     components:
     - type: Transform
       pos: -14.5,50.5
       parent: 1
-  - uid: 3139
+  - uid: 3141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 1
-  - uid: 3140
+  - uid: 3142
     components:
     - type: Transform
       anchored: False
@@ -25052,19 +25069,19 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 3141
+  - uid: 3143
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,0.5
       parent: 1
-  - uid: 3142
+  - uid: 3144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,7.5
       parent: 1
-  - uid: 3143
+  - uid: 3145
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -25072,201 +25089,201 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 3144
+  - uid: 3146
     components:
     - type: Transform
       pos: -20.5,40.5
       parent: 1
-  - uid: 3145
+  - uid: 3147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,30.5
       parent: 1
-  - uid: 3146
+  - uid: 3148
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 1
-  - uid: 3147
+  - uid: 3149
     components:
     - type: Transform
       pos: -12.5,33.5
       parent: 1
-  - uid: 3148
+  - uid: 3150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,10.5
       parent: 1
-  - uid: 3149
+  - uid: 3151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,7.5
       parent: 1
-  - uid: 3150
+  - uid: 3152
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,1.5
       parent: 1
-  - uid: 3151
+  - uid: 3153
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 1
-  - uid: 3152
+  - uid: 3154
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 3153
+  - uid: 3155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-0.5
       parent: 1
-  - uid: 3154
+  - uid: 3156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-0.5
       parent: 1
-  - uid: 3155
+  - uid: 3157
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,8.5
       parent: 1
-  - uid: 3156
+  - uid: 3158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 1
-  - uid: 3157
+  - uid: 3159
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,11.5
       parent: 1
-  - uid: 3158
+  - uid: 3160
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,11.5
       parent: 1
-  - uid: 3159
+  - uid: 3161
     components:
     - type: Transform
       pos: -7.5,17.5
       parent: 1
-  - uid: 3160
+  - uid: 3162
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 1
-  - uid: 3161
-    components:
-    - type: Transform
-      pos: -13.5,17.5
-      parent: 1
-  - uid: 3162
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,15.5
-      parent: 1
   - uid: 3163
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -15.5,19.5
+      pos: -13.5,17.5
       parent: 1
   - uid: 3164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -8.5,24.5
+      pos: -2.5,15.5
       parent: 1
   - uid: 3165
     components:
     - type: Transform
-      pos: -12.5,27.5
+      rot: 3.141592653589793 rad
+      pos: -15.5,19.5
       parent: 1
   - uid: 3166
     components:
     - type: Transform
-      pos: -12.5,22.5
+      rot: 3.141592653589793 rad
+      pos: -8.5,24.5
       parent: 1
   - uid: 3167
+    components:
+    - type: Transform
+      pos: -12.5,27.5
+      parent: 1
+  - uid: 3168
+    components:
+    - type: Transform
+      pos: -12.5,22.5
+      parent: 1
+  - uid: 3169
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,19.5
       parent: 1
-  - uid: 3168
+  - uid: 3170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,39.5
       parent: 1
-  - uid: 3169
+  - uid: 3171
     components:
     - type: Transform
       pos: -20.5,35.5
       parent: 1
-  - uid: 3170
+  - uid: 3172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,34.5
       parent: 1
-  - uid: 3171
+  - uid: 3173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,19.5
       parent: 1
-  - uid: 3172
+  - uid: 3174
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,16.5
       parent: 1
-  - uid: 3173
+  - uid: 3175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,28.5
       parent: 1
-  - uid: 3174
+  - uid: 3176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,28.5
       parent: 1
-  - uid: 3175
+  - uid: 3177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,31.5
       parent: 1
-  - uid: 3176
+  - uid: 3178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,37.5
       parent: 1
-  - uid: 3177
+  - uid: 3179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,34.5
       parent: 1
-  - uid: 3178
+  - uid: 3180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -25274,7 +25291,7 @@ entities:
       parent: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 3179
+  - uid: 3181
     components:
     - type: Transform
       anchored: False
@@ -25283,88 +25300,88 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Dynamic
-  - uid: 3180
+  - uid: 3182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,38.5
       parent: 1
-  - uid: 3181
+  - uid: 3183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,0.5
       parent: 1
-  - uid: 3182
-    components:
-    - type: Transform
-      pos: -14.5,-16.5
-      parent: 1
-  - uid: 3183
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-10.5
-      parent: 1
   - uid: 3184
     components:
     - type: Transform
-      pos: -14.5,-30.5
+      pos: -14.5,-16.5
       parent: 1
   - uid: 3185
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -6.5,-24.5
+      pos: -6.5,-10.5
       parent: 1
   - uid: 3186
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-31.5
+      pos: -14.5,-30.5
       parent: 1
   - uid: 3187
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 15.5,7.5
+      pos: -6.5,-24.5
       parent: 1
   - uid: 3188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 14.5,0.5
+      pos: -7.5,-31.5
       parent: 1
   - uid: 3189
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -6.5,56.5
+      pos: 15.5,7.5
       parent: 1
   - uid: 3190
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 3191
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,56.5
+      parent: 1
+  - uid: 3192
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,56.5
       parent: 1
-  - uid: 3191
+  - uid: 3193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,57.5
       parent: 1
-  - uid: 3192
+  - uid: 3194
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,0.5
       parent: 1
-  - uid: 3193
+  - uid: 3195
     components:
     - type: Transform
       pos: -50.5,1.5
       parent: 1
-  - uid: 3194
+  - uid: 3196
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25372,81 +25389,81 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 3195
+  - uid: 3197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,29.5
       parent: 1
-  - uid: 3196
+  - uid: 3198
     components:
     - type: Transform
       pos: 7.5,35.5
       parent: 1
-  - uid: 3197
+  - uid: 3199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,33.5
       parent: 1
-  - uid: 3198
+  - uid: 3200
     components:
     - type: Transform
       pos: -4.5,41.5
       parent: 1
-  - uid: 3199
+  - uid: 3201
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,38.5
       parent: 1
-  - uid: 3200
+  - uid: 3202
     components:
     - type: Transform
       pos: 2.5,26.5
       parent: 1
-  - uid: 3201
+  - uid: 3203
     components:
     - type: Transform
       pos: 13.5,22.5
       parent: 1
-  - uid: 3202
+  - uid: 3204
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,20.5
       parent: 1
-  - uid: 3203
+  - uid: 3205
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,26.5
       parent: 1
-  - uid: 3205
+  - uid: 3206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,34.5
       parent: 1
-  - uid: 3206
+  - uid: 3207
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 1
-  - uid: 3207
+  - uid: 3208
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,38.5
       parent: 1
-  - uid: 4337
+  - uid: 3209
     components:
     - type: Transform
       pos: -16.5,41.5
       parent: 1
 - proto: PoweredSmallLightEmpty
   entities:
-  - uid: 1541
+  - uid: 1551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25457,12 +25474,12 @@ entities:
         light_bulb: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 1542
+          ent: 1552
     - type: ApcPowerReceiver
       powerLoad: 60
     - type: DamageOnInteract
       isDamageActive: False
-  - uid: 3208
+  - uid: 3210
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25470,83 +25487,83 @@ entities:
       parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 3209
+  - uid: 3211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 3210
+  - uid: 3212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,11.5
       parent: 1
-  - uid: 3211
+  - uid: 3213
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
 - proto: PuddleVomit
   entities:
-  - uid: 3212
+  - uid: 3214
     components:
     - type: Transform
       pos: -11.5,36.5
       parent: 1
-  - uid: 3213
+  - uid: 3215
     components:
     - type: Transform
       pos: -10.5,37.5
       parent: 1
 - proto: PunPunIDCard
   entities:
-  - uid: 2943
+  - uid: 2945
     components:
     - type: Transform
-      parent: 2942
+      parent: 2944
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: Rack
   entities:
-  - uid: 3214
+  - uid: 3216
     components:
     - type: Transform
       pos: 0.5,34.5
       parent: 1
-  - uid: 3215
+  - uid: 3217
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 1
-  - uid: 3216
+  - uid: 3218
     components:
     - type: Transform
       pos: 4.5,40.5
       parent: 1
-  - uid: 3217
+  - uid: 3219
     components:
     - type: Transform
       pos: 3.5,40.5
       parent: 1
-  - uid: 3218
+  - uid: 3220
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 3219
+  - uid: 3221
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 3220
+  - uid: 3222
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,37.5
       parent: 1
-  - uid: 3221
+  - uid: 3223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25554,131 +25571,131 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 3222
+  - uid: 3224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,42.5
       parent: 1
-  - uid: 3223
+  - uid: 3225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,42.5
       parent: 1
-  - uid: 3224
+  - uid: 3226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,42.5
       parent: 1
-  - uid: 3225
+  - uid: 3227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,42.5
       parent: 1
-  - uid: 3226
+  - uid: 3228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,42.5
       parent: 1
-  - uid: 3227
+  - uid: 3229
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,42.5
       parent: 1
-  - uid: 3228
+  - uid: 3230
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,42.5
       parent: 1
-  - uid: 3229
+  - uid: 3231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,42.5
       parent: 1
-  - uid: 3230
+  - uid: 3232
     components:
     - type: Transform
       pos: 4.5,40.5
       parent: 1
-  - uid: 3231
+  - uid: 3233
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 3232
+  - uid: 3234
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,15.5
       parent: 1
-  - uid: 3233
+  - uid: 3235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-  - uid: 3234
+  - uid: 3236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,25.5
       parent: 1
-  - uid: 3235
+  - uid: 3237
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,25.5
       parent: 1
-  - uid: 3236
+  - uid: 3238
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,25.5
       parent: 1
-  - uid: 3237
+  - uid: 3239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,25.5
       parent: 1
-  - uid: 3238
+  - uid: 3240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,6.5
       parent: 1
-  - uid: 3239
+  - uid: 3241
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,4.5
       parent: 1
-  - uid: 3240
+  - uid: 3242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,4.5
       parent: 1
-  - uid: 3241
+  - uid: 3243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-  - uid: 3242
+  - uid: 3244
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,15.5
       parent: 1
-  - uid: 3243
+  - uid: 3245
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -25686,133 +25703,127 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 3244
+  - uid: 3246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,40.5
       parent: 1
-  - uid: 3245
+  - uid: 3247
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,33.5
       parent: 1
-  - uid: 3246
+  - uid: 3248
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,25.5
       parent: 1
-  - uid: 3247
+  - uid: 3249
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,25.5
       parent: 1
-  - uid: 3248
+  - uid: 3250
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,25.5
       parent: 1
-  - uid: 3249
+  - uid: 3251
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 3250
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,7.5
-      parent: 1
-  - uid: 3251
+  - uid: 3253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,27.5
       parent: 1
-  - uid: 3252
+  - uid: 3254
     components:
     - type: Transform
       pos: -1.5,27.5
       parent: 1
 - proto: RandomPosterLegit
   entities:
-  - uid: 3253
+  - uid: 3255
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 1
-  - uid: 3254
+  - uid: 3256
     components:
     - type: Transform
       pos: -29.5,6.5
       parent: 1
-  - uid: 3255
+  - uid: 3257
     components:
     - type: Transform
       pos: -27.5,6.5
       parent: 1
-  - uid: 3256
+  - uid: 3258
     components:
     - type: Transform
       pos: -12.5,-9.5
       parent: 1
-  - uid: 3257
+  - uid: 3259
     components:
     - type: Transform
       pos: -8.5,-24.5
       parent: 1
-  - uid: 3258
+  - uid: 3260
     components:
     - type: Transform
       pos: -8.5,-25.5
       parent: 1
-  - uid: 3259
+  - uid: 3261
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 1
-  - uid: 3260
+  - uid: 3262
     components:
     - type: Transform
       pos: -9.5,10.5
       parent: 1
-  - uid: 3261
+  - uid: 3263
     components:
     - type: Transform
       pos: -5.5,18.5
       parent: 1
-  - uid: 3262
+  - uid: 3264
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 3263
+  - uid: 3265
     components:
     - type: Transform
       pos: -12.5,36.5
       parent: 1
-  - uid: 3264
+  - uid: 3266
     components:
     - type: Transform
       pos: -12.5,41.5
       parent: 1
-  - uid: 3265
+  - uid: 3267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,2.5
       parent: 1
-  - uid: 3266
+  - uid: 3268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,6.5
       parent: 1
-  - uid: 3267
+  - uid: 3269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -25820,576 +25831,576 @@ entities:
       parent: 1
 - proto: RandomVendingClothing
   entities:
-  - uid: 3268
+  - uid: 3270
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 1
 - proto: RandomVendingDrinks
   entities:
-  - uid: 3269
+  - uid: 3271
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
 - proto: RegenerativeMesh
   entities:
-  - uid: 3270
+  - uid: 3272
     components:
     - type: Transform
       pos: -20.361012,20.600967
       parent: 1
-  - uid: 3271
+  - uid: 3273
     components:
     - type: Transform
       pos: -20.595387,20.866592
       parent: 1
 - proto: ReinforcedUraniumWindow
   entities:
-  - uid: 3272
+  - uid: 3274
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
 - proto: ReinforcedWindowDiagonalOutpost
   entities:
-  - uid: 3273
+  - uid: 3275
     components:
     - type: Transform
       pos: -23.5,41.5
       parent: 1
-  - uid: 3274
+  - uid: 3276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 3275
+  - uid: 3277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 3276
+  - uid: 3278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,-1.5
       parent: 1
-  - uid: 3277
+  - uid: 3279
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-0.5
       parent: 1
-  - uid: 3278
+  - uid: 3280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 3279
+  - uid: 3281
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,0.5
       parent: 1
-  - uid: 3280
+  - uid: 3282
     components:
     - type: Transform
       pos: -25.5,16.5
       parent: 1
-  - uid: 3281
+  - uid: 3283
     components:
     - type: Transform
       pos: -27.5,13.5
       parent: 1
-  - uid: 3282
+  - uid: 3284
     components:
     - type: Transform
       pos: -23.5,17.5
       parent: 1
-  - uid: 3283
+  - uid: 3285
     components:
     - type: Transform
       pos: -26.5,15.5
       parent: 1
-  - uid: 3284
+  - uid: 3286
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,30.5
       parent: 1
-  - uid: 3285
+  - uid: 3287
     components:
     - type: Transform
       pos: -24.5,40.5
       parent: 1
 - proto: ReinforcedWindowOutpost
   entities:
-  - uid: 3286
+  - uid: 3288
     components:
     - type: Transform
       pos: -13.5,48.5
       parent: 1
-  - uid: 3287
+  - uid: 3289
     components:
     - type: Transform
       pos: -7.5,47.5
       parent: 1
-  - uid: 3288
+  - uid: 3290
     components:
     - type: Transform
       pos: -7.5,46.5
       parent: 1
-  - uid: 3289
+  - uid: 3291
     components:
     - type: Transform
       pos: -13.5,47.5
       parent: 1
-  - uid: 3290
+  - uid: 3292
     components:
     - type: Transform
       pos: -13.5,46.5
       parent: 1
-  - uid: 3291
-    components:
-    - type: Transform
-      pos: -7.5,48.5
-      parent: 1
-  - uid: 3292
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,41.5
-      parent: 1
   - uid: 3293
     components:
     - type: Transform
-      pos: -24.5,38.5
+      pos: -7.5,48.5
       parent: 1
   - uid: 3294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -23.5,40.5
+      pos: -21.5,41.5
       parent: 1
   - uid: 3295
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-1.5
+      pos: -24.5,38.5
       parent: 1
   - uid: 3296
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: -23.5,40.5
       parent: 1
   - uid: 3297
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -16.5,-0.5
+      pos: -14.5,-1.5
       parent: 1
   - uid: 3298
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,-0.5
+      pos: -15.5,-1.5
       parent: 1
   - uid: 3299
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,-1.5
+      pos: -16.5,-0.5
       parent: 1
   - uid: 3300
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -18.5,0.5
+      pos: -17.5,-0.5
       parent: 1
   - uid: 3301
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-5.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-1.5
       parent: 1
   - uid: 3302
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -7.5,-1.5
+      pos: -18.5,0.5
       parent: 1
   - uid: 3303
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: -7.5,-5.5
       parent: 1
   - uid: 3304
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-6.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-1.5
       parent: 1
   - uid: 3305
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,-0.5
+      pos: -6.5,-1.5
       parent: 1
   - uid: 3306
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: -7.5,-6.5
       parent: 1
   - uid: 3307
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
+      pos: -3.5,-0.5
       parent: 1
   - uid: 3308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,0.5
+      pos: -5.5,-1.5
       parent: 1
   - uid: 3309
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,0.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 3310
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 3311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,0.5
+      parent: 1
+  - uid: 3312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-7.5
       parent: 1
-  - uid: 3311
+  - uid: 3313
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-19.5
       parent: 1
-  - uid: 3312
+  - uid: 3314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-5.5
       parent: 1
-  - uid: 3313
+  - uid: 3315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-6.5
       parent: 1
-  - uid: 3314
+  - uid: 3316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-7.5
       parent: 1
-  - uid: 3315
+  - uid: 3317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-20.5
       parent: 1
-  - uid: 3316
+  - uid: 3318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-21.5
       parent: 1
-  - uid: 3317
+  - uid: 3319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,1.5
       parent: 1
-  - uid: 3318
+  - uid: 3320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-21.5
       parent: 1
-  - uid: 3319
+  - uid: 3321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-20.5
       parent: 1
-  - uid: 3320
+  - uid: 3322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-19.5
       parent: 1
-  - uid: 3321
+  - uid: 3323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,1.5
       parent: 1
-  - uid: 3322
+  - uid: 3324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,1.5
       parent: 1
-  - uid: 3323
+  - uid: 3325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 3324
+  - uid: 3326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 3325
+  - uid: 3327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 3326
+  - uid: 3328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,14.5
       parent: 1
-  - uid: 3327
+  - uid: 3329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,14.5
       parent: 1
-  - uid: 3328
+  - uid: 3330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,14.5
       parent: 1
-  - uid: 3329
+  - uid: 3331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,14.5
       parent: 1
-  - uid: 3330
+  - uid: 3332
     components:
     - type: Transform
       pos: -26.5,13.5
       parent: 1
-  - uid: 3331
+  - uid: 3333
     components:
     - type: Transform
       pos: -26.5,14.5
       parent: 1
-  - uid: 3332
+  - uid: 3334
     components:
     - type: Transform
       pos: -23.5,16.5
       parent: 1
-  - uid: 3333
+  - uid: 3335
     components:
     - type: Transform
       pos: -21.5,17.5
       parent: 1
-  - uid: 3334
+  - uid: 3336
     components:
     - type: Transform
       pos: -24.5,16.5
       parent: 1
-  - uid: 3335
+  - uid: 3337
     components:
     - type: Transform
       pos: -27.5,12.5
       parent: 1
-  - uid: 3336
+  - uid: 3338
     components:
     - type: Transform
       pos: -25.5,15.5
       parent: 1
-  - uid: 3337
-    components:
-    - type: Transform
-      pos: -22.5,17.5
-      parent: 1
-  - uid: 3338
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,22.5
-      parent: 1
   - uid: 3339
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,21.5
+      pos: -22.5,17.5
       parent: 1
   - uid: 3340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,21.5
+      pos: -21.5,22.5
       parent: 1
   - uid: 3341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,22.5
+      pos: -21.5,21.5
       parent: 1
   - uid: 3342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,20.5
+      pos: -13.5,21.5
       parent: 1
   - uid: 3343
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -24.5,33.5
+      pos: -13.5,22.5
       parent: 1
   - uid: 3344
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,25.5
+      pos: -13.5,20.5
       parent: 1
   - uid: 3345
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,26.5
+      pos: -24.5,33.5
       parent: 1
   - uid: 3346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,18.5
+      pos: -21.5,25.5
       parent: 1
   - uid: 3347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,18.5
+      pos: -21.5,26.5
       parent: 1
   - uid: 3348
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,24.5
+      pos: 2.5,18.5
       parent: 1
   - uid: 3349
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,20.5
+      pos: 4.5,18.5
       parent: 1
   - uid: 3350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -24.5,31.5
+      pos: -21.5,24.5
       parent: 1
   - uid: 3351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -23.5,28.5
+      pos: -21.5,20.5
       parent: 1
   - uid: 3352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -23.5,29.5
+      pos: -24.5,31.5
       parent: 1
   - uid: 3353
     components:
     - type: Transform
-      pos: -24.5,34.5
+      rot: 1.5707963267948966 rad
+      pos: -23.5,28.5
       parent: 1
   - uid: 3354
     components:
     - type: Transform
-      pos: -24.5,35.5
+      rot: 1.5707963267948966 rad
+      pos: -23.5,29.5
       parent: 1
   - uid: 3355
     components:
     - type: Transform
-      pos: -24.5,39.5
+      pos: -24.5,34.5
       parent: 1
   - uid: 3356
+    components:
+    - type: Transform
+      pos: -24.5,35.5
+      parent: 1
+  - uid: 3357
+    components:
+    - type: Transform
+      pos: -24.5,39.5
+      parent: 1
+  - uid: 3358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,36.5
       parent: 1
-  - uid: 3357
+  - uid: 3359
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,30.5
       parent: 1
-  - uid: 3358
+  - uid: 3360
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 3359
+  - uid: 3361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,32.5
       parent: 1
-  - uid: 3360
+  - uid: 3362
     components:
     - type: Transform
       pos: -22.5,41.5
       parent: 1
-  - uid: 3361
+  - uid: 3363
     components:
     - type: Transform
       pos: -38.5,1.5
       parent: 1
-  - uid: 3362
+  - uid: 3364
     components:
     - type: Transform
       pos: -39.5,1.5
       parent: 1
-  - uid: 3363
+  - uid: 3365
     components:
     - type: Transform
       pos: -40.5,1.5
       parent: 1
-  - uid: 3364
+  - uid: 3366
     components:
     - type: Transform
       pos: -40.5,7.5
       parent: 1
-  - uid: 3365
+  - uid: 3367
     components:
     - type: Transform
       pos: -39.5,7.5
       parent: 1
-  - uid: 3366
+  - uid: 3368
     components:
     - type: Transform
       pos: -38.5,7.5
       parent: 1
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 3367
+  - uid: 3369
     components:
     - type: Transform
       pos: 3.5,23.5
@@ -26398,64 +26409,64 @@ entities:
     - Anchorable
 - proto: ResearchComputerCircuitboard
   entities:
-  - uid: 3368
+  - uid: 3370
     components:
     - type: Transform
       pos: -19.381195,40.21826
       parent: 1
 - proto: RollerBed
   entities:
-  - uid: 3369
+  - uid: 3371
     components:
     - type: Transform
       pos: -9.5,35.5
       parent: 1
-  - uid: 3370
+  - uid: 3372
     components:
     - type: Transform
       pos: -9.5,36.5
       parent: 1
-  - uid: 3371
+  - uid: 3373
     components:
     - type: Transform
       pos: -11.5,38.5
       parent: 1
 - proto: Screwdriver
   entities:
-  - uid: 3372
+  - uid: 3374
     components:
     - type: Transform
       pos: -15.433362,37.510056
       parent: 1
 - proto: ServiceTechFab
   entities:
-  - uid: 3373
+  - uid: 3375
     components:
     - type: Transform
       pos: -16.5,39.5
       parent: 1
 - proto: SheetSteel1
   entities:
-  - uid: 3374
+  - uid: 3376
     components:
     - type: Transform
       pos: -18.33548,12.882249
       parent: 1
-  - uid: 3375
+  - uid: 3377
     components:
     - type: Transform
       pos: -18.408394,12.996831
       parent: 1
 - proto: SheetSteel10
   entities:
-  - uid: 3376
+  - uid: 3378
     components:
     - type: Transform
       pos: -18.574192,12.643563
       parent: 1
 - proto: ShelfBar
   entities:
-  - uid: 3377
+  - uid: 3379
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26463,456 +26474,456 @@ entities:
       parent: 1
 - proto: ShotGunCabinetFilled
   entities:
-  - uid: 3378
+  - uid: 3380
     components:
     - type: Transform
       pos: -0.5,37.5
       parent: 1
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 3379
+  - uid: 3381
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,46.5
       parent: 1
-  - uid: 3380
+  - uid: 3382
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,47.5
       parent: 1
-  - uid: 3381
+  - uid: 3383
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,46.5
       parent: 1
-  - uid: 3382
+  - uid: 3384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,47.5
       parent: 1
-  - uid: 3383
+  - uid: 3385
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,48.5
       parent: 1
-  - uid: 3384
+  - uid: 3386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,48.5
       parent: 1
-  - uid: 3385
-    components:
-    - type: Transform
-      pos: -25.5,15.5
-      parent: 1
-  - uid: 3386
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -26.5,13.5
-      parent: 1
   - uid: 3387
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -26.5,14.5
+      pos: -25.5,15.5
       parent: 1
   - uid: 3388
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -27.5,12.5
+      pos: -26.5,13.5
       parent: 1
   - uid: 3389
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: -26.5,14.5
       parent: 1
   - uid: 3390
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,20.5
+      pos: -27.5,12.5
       parent: 1
   - uid: 3391
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,21.5
+      rot: 3.141592653589793 rad
+      pos: -7.5,-1.5
       parent: 1
   - uid: 3392
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,22.5
+      pos: -13.5,20.5
       parent: 1
   - uid: 3393
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,21.5
       parent: 1
   - uid: 3394
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,22.5
       parent: 1
   - uid: 3395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,-0.5
+      pos: -2.5,0.5
       parent: 1
   - uid: 3396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-0.5
+      pos: -1.5,0.5
       parent: 1
   - uid: 3397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-1.5
+      pos: -3.5,-0.5
       parent: 1
   - uid: 3398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -6.5,-1.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 3399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -19.5,0.5
+      pos: -5.5,-1.5
       parent: 1
   - uid: 3400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -18.5,0.5
+      pos: -6.5,-1.5
       parent: 1
   - uid: 3401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -17.5,-0.5
+      pos: -19.5,0.5
       parent: 1
   - uid: 3402
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -16.5,-0.5
+      pos: -18.5,0.5
       parent: 1
   - uid: 3403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -15.5,-1.5
+      pos: -17.5,-0.5
       parent: 1
   - uid: 3404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -14.5,-1.5
+      pos: -16.5,-0.5
       parent: 1
   - uid: 3405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -13.5,-1.5
+      pos: -15.5,-1.5
       parent: 1
   - uid: 3406
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,1.5
+      pos: -14.5,-1.5
       parent: 1
   - uid: 3407
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,1.5
+      pos: -13.5,-1.5
       parent: 1
   - uid: 3408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,1.5
+      pos: 4.5,1.5
       parent: 1
   - uid: 3409
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-5.5
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
       parent: 1
   - uid: 3410
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-6.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,1.5
       parent: 1
   - uid: 3411
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,-7.5
+      pos: -7.5,-5.5
       parent: 1
   - uid: 3412
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,-7.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-6.5
       parent: 1
   - uid: 3413
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,-6.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-7.5
       parent: 1
   - uid: 3414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,-5.5
+      pos: -13.5,-7.5
       parent: 1
   - uid: 3415
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,-19.5
+      pos: -13.5,-6.5
       parent: 1
   - uid: 3416
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,-20.5
+      pos: -13.5,-5.5
       parent: 1
   - uid: 3417
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,-21.5
+      pos: -13.5,-19.5
       parent: 1
   - uid: 3418
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-21.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-20.5
       parent: 1
   - uid: 3419
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-20.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-21.5
       parent: 1
   - uid: 3420
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,-19.5
+      pos: -7.5,-21.5
       parent: 1
   - uid: 3421
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,1.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-20.5
       parent: 1
   - uid: 3422
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,1.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-19.5
       parent: 1
   - uid: 3423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -27.5,1.5
+      pos: -25.5,1.5
       parent: 1
   - uid: 3424
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,20.5
+      rot: 3.141592653589793 rad
+      pos: -26.5,1.5
       parent: 1
   - uid: 3425
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,21.5
+      rot: 3.141592653589793 rad
+      pos: -27.5,1.5
       parent: 1
   - uid: 3426
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,22.5
+      pos: -21.5,20.5
       parent: 1
   - uid: 3427
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,24.5
+      pos: -21.5,21.5
       parent: 1
   - uid: 3428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,25.5
+      pos: -21.5,22.5
       parent: 1
   - uid: 3429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,26.5
+      pos: -21.5,24.5
       parent: 1
   - uid: 3430
     components:
     - type: Transform
-      pos: -24.5,16.5
+      rot: 1.5707963267948966 rad
+      pos: -21.5,25.5
       parent: 1
   - uid: 3431
     components:
     - type: Transform
-      pos: -23.5,16.5
+      rot: 1.5707963267948966 rad
+      pos: -21.5,26.5
       parent: 1
   - uid: 3432
     components:
     - type: Transform
-      pos: -22.5,17.5
+      pos: -24.5,16.5
       parent: 1
   - uid: 3433
     components:
     - type: Transform
-      pos: -21.5,17.5
+      pos: -23.5,16.5
       parent: 1
   - uid: 3434
+    components:
+    - type: Transform
+      pos: -22.5,17.5
+      parent: 1
+  - uid: 3435
+    components:
+    - type: Transform
+      pos: -21.5,17.5
+      parent: 1
+  - uid: 3436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,38.5
       parent: 1
-  - uid: 3435
+  - uid: 3437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,39.5
       parent: 1
-  - uid: 3436
+  - uid: 3438
     components:
     - type: Transform
       pos: -23.5,40.5
       parent: 1
-  - uid: 3437
+  - uid: 3439
     components:
     - type: Transform
       pos: -22.5,41.5
       parent: 1
-  - uid: 3438
-    components:
-    - type: Transform
-      pos: -21.5,41.5
-      parent: 1
-  - uid: 3439
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,35.5
-      parent: 1
   - uid: 3440
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,34.5
+      pos: -21.5,41.5
       parent: 1
   - uid: 3441
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -24.5,33.5
+      pos: -24.5,35.5
       parent: 1
   - uid: 3442
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -24.5,32.5
+      pos: -24.5,34.5
       parent: 1
   - uid: 3443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -24.5,31.5
+      pos: -24.5,33.5
       parent: 1
   - uid: 3444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -23.5,30.5
+      pos: -24.5,32.5
       parent: 1
   - uid: 3445
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -23.5,29.5
+      pos: -24.5,31.5
       parent: 1
   - uid: 3446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -23.5,28.5
+      pos: -23.5,30.5
       parent: 1
   - uid: 3447
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -38.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: -23.5,29.5
       parent: 1
   - uid: 3448
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -39.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: -23.5,28.5
       parent: 1
   - uid: 3449
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -40.5,1.5
+      pos: -38.5,1.5
       parent: 1
   - uid: 3450
     components:
     - type: Transform
-      pos: -40.5,7.5
+      rot: 3.141592653589793 rad
+      pos: -39.5,1.5
       parent: 1
   - uid: 3451
     components:
     - type: Transform
-      pos: -39.5,7.5
+      rot: 3.141592653589793 rad
+      pos: -40.5,1.5
       parent: 1
   - uid: 3452
+    components:
+    - type: Transform
+      pos: -40.5,7.5
+      parent: 1
+  - uid: 3453
+    components:
+    - type: Transform
+      pos: -39.5,7.5
+      parent: 1
+  - uid: 3454
     components:
     - type: Transform
       pos: -38.5,7.5
       parent: 1
 - proto: ShuttersRadiation
   entities:
-  - uid: 3453
+  - uid: 3455
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 3454
+  - uid: 3456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26920,19 +26931,35 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        444:
+        453:
         - - Pressed
           - Toggle
-        450:
+        459:
         - - Pressed
           - Toggle
-        448:
+        457:
         - - Pressed
           - Toggle
-  - uid: 3455
+  - uid: 3457
     components:
     - type: Transform
       pos: -12.5,49.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        3385:
+        - - Pressed
+          - Toggle
+        3384:
+        - - Pressed
+          - Toggle
+        3381:
+        - - Pressed
+          - Toggle
+  - uid: 3458
+    components:
+    - type: Transform
+      pos: -8.5,49.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
@@ -26942,26 +26969,10 @@ entities:
         3382:
         - - Pressed
           - Toggle
-        3379:
+        3386:
         - - Pressed
           - Toggle
-  - uid: 3456
-    components:
-    - type: Transform
-      pos: -8.5,49.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        3381:
-        - - Pressed
-          - Toggle
-        3380:
-        - - Pressed
-          - Toggle
-        3384:
-        - - Pressed
-          - Toggle
-  - uid: 3457
+  - uid: 3459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26969,12 +26980,6 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        3434:
-        - - Pressed
-          - Toggle
-        3435:
-        - - Pressed
-          - Toggle
         3436:
         - - Pressed
           - Toggle
@@ -26984,19 +26989,19 @@ entities:
         3438:
         - - Pressed
           - Toggle
-  - uid: 3458
-    components:
-    - type: Transform
-      pos: -20.5,36.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
         3439:
         - - Pressed
           - Toggle
         3440:
         - - Pressed
           - Toggle
+  - uid: 3460
+    components:
+    - type: Transform
+      pos: -20.5,36.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
         3441:
         - - Pressed
           - Toggle
@@ -27015,7 +27020,13 @@ entities:
         3446:
         - - Pressed
           - Toggle
-  - uid: 3459
+        3447:
+        - - Pressed
+          - Toggle
+        3448:
+        - - Pressed
+          - Toggle
+  - uid: 3461
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27023,16 +27034,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        3427:
-        - - Pressed
-          - Toggle
-        3428:
-        - - Pressed
-          - Toggle
         3429:
         - - Pressed
           - Toggle
-  - uid: 3460
+        3430:
+        - - Pressed
+          - Toggle
+        3431:
+        - - Pressed
+          - Toggle
+  - uid: 3462
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27040,32 +27051,32 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        437:
+        446:
         - - Pressed
           - Toggle
-        438:
+        447:
         - - Pressed
           - Toggle
-        439:
+        448:
         - - Pressed
           - Toggle
-  - uid: 3461
+  - uid: 3463
     components:
     - type: Transform
       pos: -8.5,-18.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        3422:
+        - - Pressed
+          - Toggle
+        3421:
+        - - Pressed
+          - Toggle
         3420:
         - - Pressed
           - Toggle
-        3419:
-        - - Pressed
-          - Toggle
-        3418:
-        - - Pressed
-          - Toggle
-  - uid: 3462
+  - uid: 3464
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27073,16 +27084,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        3419:
+        - - Pressed
+          - Toggle
+        3418:
+        - - Pressed
+          - Toggle
         3417:
         - - Pressed
           - Toggle
-        3416:
-        - - Pressed
-          - Toggle
-        3415:
-        - - Pressed
-          - Toggle
-  - uid: 3463
+  - uid: 3465
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27090,45 +27101,51 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        3411:
-        - - Pressed
-          - Toggle
-        3410:
-        - - Pressed
-          - Toggle
-        3409:
-        - - Pressed
-          - Toggle
-  - uid: 3464
-    components:
-    - type: Transform
-      pos: -12.5,-4.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        3414:
-        - - Pressed
-          - Toggle
         3413:
         - - Pressed
           - Toggle
         3412:
         - - Pressed
           - Toggle
-  - uid: 3465
+        3411:
+        - - Pressed
+          - Toggle
+  - uid: 3466
+    components:
+    - type: Transform
+      pos: -12.5,-4.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        3416:
+        - - Pressed
+          - Toggle
+        3415:
+        - - Pressed
+          - Toggle
+        3414:
+        - - Pressed
+          - Toggle
+  - uid: 3467
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 3466
+  - uid: 3468
     components:
     - type: Transform
       pos: -10.5,5.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        3389:
+        3391:
+        - - Pressed
+          - Toggle
+        3400:
+        - - Pressed
+          - Toggle
+        3399:
         - - Pressed
           - Toggle
         3398:
@@ -27137,16 +27154,16 @@ entities:
         3397:
         - - Pressed
           - Toggle
-        3396:
-        - - Pressed
-          - Toggle
         3395:
         - - Pressed
           - Toggle
-        3393:
+        3396:
         - - Pressed
           - Toggle
-        3394:
+        3407:
+        - - Pressed
+          - Toggle
+        3406:
         - - Pressed
           - Toggle
         3405:
@@ -27164,13 +27181,7 @@ entities:
         3401:
         - - Pressed
           - Toggle
-        3400:
-        - - Pressed
-          - Toggle
-        3399:
-        - - Pressed
-          - Toggle
-  - uid: 3467
+  - uid: 3469
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27178,25 +27189,25 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        3390:
-        - - Pressed
-          - Toggle
-        3391:
-        - - Pressed
-          - Toggle
         3392:
         - - Pressed
           - Toggle
-        3424:
+        3393:
         - - Pressed
           - Toggle
-        3425:
+        3394:
         - - Pressed
           - Toggle
         3426:
         - - Pressed
           - Toggle
-  - uid: 3468
+        3427:
+        - - Pressed
+          - Toggle
+        3428:
+        - - Pressed
+          - Toggle
+  - uid: 3470
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27204,22 +27215,22 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        3425:
+        - - Pressed
+          - Toggle
+        3424:
+        - - Pressed
+          - Toggle
         3423:
         - - Pressed
           - Toggle
-        3422:
-        - - Pressed
-          - Toggle
-        3421:
-        - - Pressed
-          - Toggle
-  - uid: 3469
+  - uid: 3471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,34.5
       parent: 1
-  - uid: 3470
+  - uid: 3472
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27227,31 +27238,31 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        3435:
+        - - Pressed
+          - Toggle
+        3434:
+        - - Pressed
+          - Toggle
         3433:
         - - Pressed
           - Toggle
         3432:
         - - Pressed
           - Toggle
-        3431:
-        - - Pressed
-          - Toggle
-        3430:
-        - - Pressed
-          - Toggle
-        3385:
-        - - Pressed
-          - Toggle
         3387:
         - - Pressed
           - Toggle
-        3386:
+        3389:
         - - Pressed
           - Toggle
         3388:
         - - Pressed
           - Toggle
-  - uid: 3471
+        3390:
+        - - Pressed
+          - Toggle
+  - uid: 3473
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27259,19 +27270,19 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        443:
+        452:
         - - Pressed
           - Toggle
-        445:
+        454:
         - - Pressed
           - Toggle
-        451:
+        460:
         - - Pressed
           - Toggle
-        449:
+        458:
         - - Pressed
           - Toggle
-  - uid: 3472
+  - uid: 3474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27279,13 +27290,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        446:
+        455:
         - - Pressed
           - Toggle
-        447:
+        456:
         - - Pressed
           - Toggle
-  - uid: 3473
+  - uid: 3475
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27293,16 +27304,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        3451:
+        - - Pressed
+          - Toggle
+        3450:
+        - - Pressed
+          - Toggle
         3449:
         - - Pressed
           - Toggle
-        3448:
-        - - Pressed
-          - Toggle
-        3447:
-        - - Pressed
-          - Toggle
-  - uid: 3474
+  - uid: 3476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27310,16 +27321,16 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        3454:
+        - - Pressed
+          - Toggle
+        3453:
+        - - Pressed
+          - Toggle
         3452:
         - - Pressed
           - Toggle
-        3451:
-        - - Pressed
-          - Toggle
-        3450:
-        - - Pressed
-          - Toggle
-  - uid: 3475
+  - uid: 3477
     components:
     - type: Transform
       pos: 12.5,37.5
@@ -27337,7 +27348,7 @@ entities:
           - DoorBolt
 - proto: SignalSwitch
   entities:
-  - uid: 3476
+  - uid: 3478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27345,35 +27356,35 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1497:
+        1506:
         - - On
           - Forward
         - - Off
           - Off
 - proto: SignBar
   entities:
-  - uid: 3477
+  - uid: 3479
     components:
     - type: Transform
       pos: -17.5,12.5
       parent: 1
 - proto: SignBiohazardMed
   entities:
-  - uid: 3478
+  - uid: 3480
     components:
     - type: Transform
       pos: 14.5,19.5
       parent: 1
 - proto: SignCryo
   entities:
-  - uid: 3479
+  - uid: 3481
     components:
     - type: Transform
       pos: -17.5,7.5
       parent: 1
 - proto: SignCryogenicsMed
   entities:
-  - uid: 3480
+  - uid: 3482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27381,7 +27392,7 @@ entities:
       parent: 1
 - proto: SignDirectionalBar
   entities:
-  - uid: 3481
+  - uid: 3483
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27389,48 +27400,48 @@ entities:
       parent: 1
 - proto: SignDirectionalMed
   entities:
-  - uid: 3482
+  - uid: 3484
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,5.5
       parent: 1
-  - uid: 3483
+  - uid: 3485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,5.5
       parent: 1
-  - uid: 3484
+  - uid: 3486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,18.5
       parent: 1
-  - uid: 3485
+  - uid: 3487
     components:
     - type: Transform
       pos: -12.5,42.5
       parent: 1
-  - uid: 3486
+  - uid: 3488
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 3487
+  - uid: 3489
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,2.5
       parent: 1
-  - uid: 3488
+  - uid: 3490
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-18.5
       parent: 1
-  - uid: 3489
+  - uid: 3491
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27438,26 +27449,26 @@ entities:
       parent: 1
 - proto: SignDirectionalSci
   entities:
-  - uid: 3490
+  - uid: 3492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,5.5
       parent: 1
-  - uid: 3491
+  - uid: 3493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,18.5
       parent: 1
-  - uid: 3492
+  - uid: 3494
     components:
     - type: Transform
       pos: -8.5,42.5
       parent: 1
 - proto: SignDirectionalShop
   entities:
-  - uid: 3493
+  - uid: 3495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27465,7 +27476,7 @@ entities:
       parent: 1
 - proto: SignDirectionalSolar
   entities:
-  - uid: 3494
+  - uid: 3496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27473,7 +27484,7 @@ entities:
       parent: 1
 - proto: SignDirectionalVending
   entities:
-  - uid: 3495
+  - uid: 3497
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27481,24 +27492,24 @@ entities:
       parent: 1
 - proto: SignJanitor
   entities:
-  - uid: 3496
+  - uid: 3498
     components:
     - type: Transform
       pos: -7.5,8.5
       parent: 1
-  - uid: 3497
+  - uid: 3499
     components:
     - type: Transform
       pos: -13.5,8.5
       parent: 1
 - proto: SignMedical
   entities:
-  - uid: 3498
+  - uid: 3500
     components:
     - type: Transform
       pos: -13.5,33.5
       parent: 1
-  - uid: 3499
+  - uid: 3501
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27506,39 +27517,39 @@ entities:
       parent: 1
 - proto: SignMorgue
   entities:
-  - uid: 3500
+  - uid: 3502
     components:
     - type: Transform
       pos: -8.5,39.5
       parent: 1
 - proto: SinkStemlessWater
   entities:
-  - uid: 3501
+  - uid: 3503
     components:
     - type: Transform
       pos: -17.5,35.5
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 3502
+  - uid: 3504
     components:
     - type: Transform
       pos: 5.5,36.5
       parent: 1
-  - uid: 3503
+  - uid: 3505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,11.5
       parent: 1
-  - uid: 3504
+  - uid: 3506
     components:
     - type: Transform
       pos: -10.5,9.5
       parent: 1
 - proto: SmartFridgeMedical
   entities:
-  - uid: 3505
+  - uid: 3507
     components:
     - type: Transform
       pos: -19.5,35.5
@@ -27547,19 +27558,19 @@ entities:
     - Anchorable
 - proto: SMESAdvanced
   entities:
-  - uid: 3506
+  - uid: 3508
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 3507
+  - uid: 3509
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
 - proto: SodaDispenser
   entities:
-  - uid: 3508
+  - uid: 3510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27567,21 +27578,21 @@ entities:
       parent: 1
 - proto: SpawnMobCatBingus
   entities:
-  - uid: 3509
+  - uid: 3511
     components:
     - type: Transform
       pos: -16.5,26.5
       parent: 1
 - proto: SpawnPointDirectorOfCare
   entities:
-  - uid: 3510
+  - uid: 3512
     components:
     - type: Transform
       pos: -16.5,25.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 3511
+  - uid: 3513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27589,149 +27600,149 @@ entities:
       parent: 1
 - proto: SpawnPointMdMedic
   entities:
-  - uid: 3512
+  - uid: 3514
     components:
     - type: Transform
       pos: -9.5,32.5
       parent: 1
-  - uid: 3513
+  - uid: 3515
     components:
     - type: Transform
       pos: -11.5,30.5
       parent: 1
-  - uid: 3514
+  - uid: 3516
     components:
     - type: Transform
       pos: -9.5,30.5
       parent: 1
-  - uid: 3515
+  - uid: 3517
     components:
     - type: Transform
       pos: -11.5,32.5
       parent: 1
-  - uid: 3516
+  - uid: 3518
     components:
     - type: Transform
       pos: -10.5,32.5
       parent: 1
-  - uid: 3517
+  - uid: 3519
     components:
     - type: Transform
       pos: -11.5,31.5
       parent: 1
-  - uid: 3518
+  - uid: 3520
     components:
     - type: Transform
       pos: -9.5,31.5
       parent: 1
-  - uid: 3519
+  - uid: 3521
     components:
     - type: Transform
       pos: -10.5,30.5
       parent: 1
 - proto: SpawnPointMercenary
   entities:
-  - uid: 3520
+  - uid: 3522
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 1
-  - uid: 3521
+  - uid: 3523
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 1
-  - uid: 3522
+  - uid: 3524
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 1
-  - uid: 3523
+  - uid: 3525
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 1
-  - uid: 3524
+  - uid: 3526
     components:
     - type: Transform
       pos: -14.5,1.5
       parent: 1
-  - uid: 3525
+  - uid: 3527
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 1
-  - uid: 3526
+  - uid: 3528
     components:
     - type: Transform
       pos: -13.5,3.5
       parent: 1
-  - uid: 3527
+  - uid: 3529
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 1
-  - uid: 3528
+  - uid: 3530
     components:
     - type: Transform
       pos: -15.5,1.5
       parent: 1
 - proto: SpawnPointPilot
   entities:
-  - uid: 3529
+  - uid: 3531
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 1
-  - uid: 3530
+  - uid: 3532
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 1
-  - uid: 3531
+  - uid: 3533
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 1
-  - uid: 3532
+  - uid: 3534
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 1
-  - uid: 3533
+  - uid: 3535
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 3534
+  - uid: 3536
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 1
-  - uid: 3535
+  - uid: 3537
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
-  - uid: 3536
+  - uid: 3538
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 3537
+  - uid: 3539
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
 - proto: SpawnVehicleWheelchair
   entities:
-  - uid: 3538
+  - uid: 3540
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,0.5
       parent: 1
-  - uid: 3539
+  - uid: 3541
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27739,24 +27750,24 @@ entities:
       parent: 1
 - proto: StasisBed
   entities:
-  - uid: 3540
+  - uid: 3542
     components:
     - type: Transform
       pos: 5.5,31.5
       parent: 1
-  - uid: 3541
+  - uid: 3543
     components:
     - type: Transform
       pos: -20.5,28.5
       parent: 1
-  - uid: 3542
+  - uid: 3544
     components:
     - type: Transform
       pos: -16.5,28.5
       parent: 1
 - proto: StationMap
   entities:
-  - uid: 3543
+  - uid: 3545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27766,7 +27777,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3544
+  - uid: 3546
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27776,7 +27787,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3545
+  - uid: 3547
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27786,7 +27797,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3546
+  - uid: 3548
     components:
     - type: Transform
       pos: -25.5,6.5
@@ -27795,7 +27806,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3547
+  - uid: 3549
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27805,7 +27816,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3548
+  - uid: 3550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27815,7 +27826,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3549
+  - uid: 3551
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27825,7 +27836,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 3550
+  - uid: 3552
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27837,13 +27848,13 @@ entities:
       startingCharge: 0
 - proto: SteelBench
   entities:
-  - uid: 3551
+  - uid: 3553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,23.5
       parent: 1
-  - uid: 3552
+  - uid: 3554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27851,23 +27862,23 @@ entities:
       parent: 1
 - proto: StoolBar
   entities:
-  - uid: 3553
+  - uid: 3555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,13.5
       parent: 1
-  - uid: 3554
+  - uid: 3556
     components:
     - type: Transform
       pos: -24.5,13.5
       parent: 1
-  - uid: 3555
+  - uid: 3557
     components:
     - type: Transform
       pos: -22.5,13.5
       parent: 1
-  - uid: 3556
+  - uid: 3558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27875,21 +27886,21 @@ entities:
       parent: 1
 - proto: StorageCanister
   entities:
-  - uid: 3557
+  - uid: 3559
     components:
     - type: Transform
       pos: 7.578024,20.546268
       parent: 1
     - type: Pullable
       prevFixedRotation: True
-  - uid: 3558
+  - uid: 3560
     components:
     - type: Transform
       pos: 1.5,25.5
       parent: 1
 - proto: StructureGunRack
   entities:
-  - uid: 3559
+  - uid: 3561
     components:
     - type: Transform
       pos: -4.5,36.5
@@ -27899,11 +27910,11 @@ entities:
         weapon1: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 3561
+          ent: 3563
         weapon2: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 3560
+          ent: 3562
         weapon3: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -27916,12 +27927,12 @@ entities:
           showEnts: False
           occludes: True
           ent: null
-  - uid: 3562
+  - uid: 3564
     components:
     - type: Transform
       pos: 6.5,40.5
       parent: 1
-  - uid: 3563
+  - uid: 3565
     components:
     - type: Transform
       pos: 8.5,40.5
@@ -27931,11 +27942,11 @@ entities:
         weapon1: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 3564
+          ent: 3566
         weapon2: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 3565
+          ent: 3567
         weapon3: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -27950,12 +27961,12 @@ entities:
           ent: null
 - proto: SubstationBasic
   entities:
-  - uid: 3566
+  - uid: 3568
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 3567
+  - uid: 3569
     components:
     - type: Transform
       pos: -2.5,13.5
@@ -28005,7 +28016,7 @@ entities:
           - 9
           - 3
           - 6
-  - uid: 1434
+  - uid: 1443
     components:
     - type: Transform
       pos: 7.5,38.5
@@ -28043,13 +28054,13 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1438
-          - 1437
-          - 1435
-          - 1439
-          - 1440
-          - 1436
-  - uid: 1441
+          - 1447
+          - 1446
+          - 1444
+          - 1448
+          - 1449
+          - 1445
+  - uid: 1450
     components:
     - type: Transform
       pos: 6.5,38.5
@@ -28087,13 +28098,13 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1446
-          - 1443
-          - 1442
-          - 1445
-          - 1444
-          - 1447
-  - uid: 1448
+          - 1455
+          - 1452
+          - 1451
+          - 1454
+          - 1453
+          - 1456
+  - uid: 1457
     components:
     - type: Transform
       pos: 10.5,38.5
@@ -28129,15 +28140,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1452
-          - 1450
-          - 1449
-          - 1453
-          - 1454
-          - 1451
+          - 1461
+          - 1459
+          - 1458
+          - 1462
+          - 1463
+          - 1460
 - proto: Table
   entities:
-  - uid: 3568
+  - uid: 3570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28145,26 +28156,26 @@ entities:
       parent: 1
 - proto: TableCounterMetal
   entities:
-  - uid: 3569
+  - uid: 3571
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,6.5
       parent: 1
-  - uid: 3570
+  - uid: 3572
     components:
     - type: Transform
       pos: -24.5,8.5
       parent: 1
 - proto: TableCounterWood
   entities:
-  - uid: 3571
+  - uid: 3573
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,10.5
       parent: 1
-  - uid: 3572
+  - uid: 3574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28172,7 +28183,7 @@ entities:
       parent: 1
 - proto: TableFancyBlue
   entities:
-  - uid: 3573
+  - uid: 3575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28180,7 +28191,7 @@ entities:
       parent: 1
 - proto: TableFolding
   entities:
-  - uid: 3574
+  - uid: 3576
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28188,286 +28199,286 @@ entities:
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 3575
+  - uid: 3577
     components:
     - type: Transform
       pos: -18.5,35.5
       parent: 1
-  - uid: 3576
+  - uid: 3578
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,40.5
       parent: 1
-  - uid: 3577
+  - uid: 3579
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,40.5
       parent: 1
-  - uid: 3578
+  - uid: 3580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,28.5
       parent: 1
-  - uid: 3579
+  - uid: 3581
     components:
     - type: Transform
       pos: -6.5,35.5
       parent: 1
-  - uid: 3580
-    components:
-    - type: Transform
-      pos: -9.5,3.5
-      parent: 1
-  - uid: 3581
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,20.5
-      parent: 1
   - uid: 3582
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,20.5
+      pos: -9.5,3.5
       parent: 1
   - uid: 3583
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,21.5
+      pos: -3.5,20.5
       parent: 1
   - uid: 3584
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,20.5
       parent: 1
   - uid: 3585
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,21.5
       parent: 1
   - uid: 3586
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -9.5,2.5
+      pos: -11.5,2.5
       parent: 1
   - uid: 3587
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -11.5,3.5
+      pos: -10.5,2.5
       parent: 1
   - uid: 3588
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,20.5
+      pos: -9.5,2.5
       parent: 1
   - uid: 3589
     components:
     - type: Transform
-      pos: -7.5,38.5
+      rot: 1.5707963267948966 rad
+      pos: -11.5,3.5
       parent: 1
   - uid: 3590
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -15.5,21.5
+      pos: -20.5,20.5
       parent: 1
   - uid: 3591
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,22.5
+      pos: -7.5,38.5
       parent: 1
   - uid: 3592
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,23.5
+      pos: -15.5,21.5
       parent: 1
   - uid: 3593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 6.5,19.5
+      pos: -16.5,22.5
       parent: 1
   - uid: 3594
     components:
     - type: Transform
-      pos: 4.5,23.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,23.5
       parent: 1
   - uid: 3595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,19.5
+      pos: 6.5,19.5
       parent: 1
   - uid: 3596
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,26.5
+      pos: 4.5,23.5
       parent: 1
   - uid: 3597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -15.5,20.5
+      pos: -19.5,19.5
       parent: 1
   - uid: 3598
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -18.5,19.5
+      pos: -20.5,26.5
       parent: 1
   - uid: 3599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,21.5
+      pos: -15.5,20.5
       parent: 1
   - uid: 3600
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,22.5
+      pos: -18.5,19.5
       parent: 1
   - uid: 3601
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -15.5,22.5
+      pos: -20.5,21.5
       parent: 1
   - uid: 3602
     components:
     - type: Transform
-      pos: -18.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: -17.5,22.5
       parent: 1
   - uid: 3603
     components:
     - type: Transform
-      pos: -14.5,33.5
+      rot: 1.5707963267948966 rad
+      pos: -15.5,22.5
       parent: 1
   - uid: 3604
     components:
     - type: Transform
-      pos: -15.5,33.5
+      pos: -18.5,7.5
       parent: 1
   - uid: 3605
     components:
     - type: Transform
-      pos: -16.5,33.5
+      pos: -14.5,33.5
       parent: 1
   - uid: 3606
     components:
     - type: Transform
-      pos: -4.5,33.5
+      pos: -15.5,33.5
       parent: 1
   - uid: 3607
+    components:
+    - type: Transform
+      pos: -16.5,33.5
+      parent: 1
+  - uid: 3608
+    components:
+    - type: Transform
+      pos: -4.5,33.5
+      parent: 1
+  - uid: 3609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,26.5
       parent: 1
-  - uid: 3608
+  - uid: 3610
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,22.5
       parent: 1
-  - uid: 3609
+  - uid: 3611
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,25.5
       parent: 1
-  - uid: 3610
+  - uid: 3612
     components:
     - type: Transform
       pos: -18.5,40.5
       parent: 1
-  - uid: 3611
+  - uid: 3613
     components:
     - type: Transform
       pos: -19.5,40.5
       parent: 1
-  - uid: 3612
+  - uid: 3614
     components:
     - type: Transform
       pos: -19.5,39.5
       parent: 1
-  - uid: 3613
+  - uid: 3615
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,21.5
       parent: 1
-  - uid: 3614
+  - uid: 3616
     components:
     - type: Transform
       pos: -5.5,36.5
       parent: 1
-  - uid: 3615
+  - uid: 3617
     components:
     - type: Transform
       pos: -6.5,36.5
       parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 3616
+  - uid: 3618
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,33.5
       parent: 1
-  - uid: 3617
+  - uid: 3619
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,34.5
       parent: 1
-  - uid: 3618
+  - uid: 3620
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,33.5
       parent: 1
-  - uid: 3619
+  - uid: 3621
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,34.5
       parent: 1
-  - uid: 3620
+  - uid: 3622
     components:
     - type: Transform
       pos: -22.5,28.5
       parent: 1
-  - uid: 3621
+  - uid: 3623
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,33.5
       parent: 1
-  - uid: 3622
+  - uid: 3624
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,32.5
       parent: 1
-  - uid: 3623
+  - uid: 3625
     components:
     - type: Transform
       pos: -18.5,28.5
       parent: 1
-  - uid: 3624
+  - uid: 3626
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28475,18 +28486,18 @@ entities:
       parent: 1
 - proto: TableWood
   entities:
-  - uid: 3625
+  - uid: 3627
     components:
     - type: Transform
       pos: -19.5,15.5
       parent: 1
-  - uid: 3626
+  - uid: 3628
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,39.5
       parent: 1
-  - uid: 3627
+  - uid: 3629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28494,122 +28505,122 @@ entities:
       parent: 1
 - proto: TableWoodReinforced
   entities:
-  - uid: 3628
+  - uid: 3630
     components:
     - type: Transform
       pos: -23.5,12.5
       parent: 1
-  - uid: 3629
+  - uid: 3631
     components:
     - type: Transform
       pos: -24.5,12.5
       parent: 1
-  - uid: 3630
+  - uid: 3632
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,10.5
       parent: 1
-  - uid: 3631
+  - uid: 3633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,13.5
       parent: 1
-  - uid: 3632
+  - uid: 3634
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,12.5
       parent: 1
-  - uid: 3633
+  - uid: 3635
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,12.5
       parent: 1
-  - uid: 3634
+  - uid: 3636
     components:
     - type: Transform
       pos: -22.5,12.5
       parent: 1
-  - uid: 3635
+  - uid: 3637
     components:
     - type: Transform
       pos: -22.5,11.5
       parent: 1
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 3636
+  - uid: 3638
     components:
     - type: Transform
       pos: -24.11694,12.543538
       parent: 1
-  - uid: 3637
+  - uid: 3639
     components:
     - type: Transform
       pos: 1.4710827,7.4721003
       parent: 1
-  - uid: 3638
+  - uid: 3640
     components:
     - type: Transform
       pos: 1.5492077,7.7533503
       parent: 1
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 3639
+  - uid: 3641
     components:
     - type: Transform
       pos: -24.425339,12.72935
       parent: 1
-  - uid: 3640
+  - uid: 3642
     components:
     - type: Transform
       pos: 2.6273327,7.4252253
       parent: 1
-  - uid: 3641
+  - uid: 3643
     components:
     - type: Transform
       pos: 2.5492077,7.7377253
       parent: 1
 - proto: ToyFigurineBartender
   entities:
-  - uid: 3642
+  - uid: 3644
     components:
     - type: Transform
       pos: -24.434708,8.631045
       parent: 1
 - proto: ToyFigurineChiefMedicalOfficer
   entities:
-  - uid: 3643
+  - uid: 3645
     components:
     - type: Transform
       pos: -20.392002,26.386204
       parent: 1
 - proto: ToyFigurineJanitor
   entities:
-  - uid: 3644
+  - uid: 3646
     components:
     - type: Transform
       pos: -10.481616,10.133563
       parent: 1
 - proto: ToyFigurineMedicalDoctor
   entities:
-  - uid: 3645
+  - uid: 3647
     components:
     - type: Transform
       pos: -23.580246,33.0257
       parent: 1
 - proto: ToyFigurineResearchDirector
   entities:
-  - uid: 3646
+  - uid: 3648
     components:
     - type: Transform
       pos: 5.578229,22.841259
       parent: 1
 - proto: UnfinishedMachineFrame
   entities:
-  - uid: 3647
+  - uid: 3649
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28617,14 +28628,20 @@ entities:
       parent: 1
 - proto: UniformPrinter
   entities:
-  - uid: 3648
+  - uid: 3650
     components:
     - type: Transform
       pos: -14.5,40.5
       parent: 1
 - proto: UraniumWindoorSecureEngineeringLocked
   entities:
-  - uid: 3649
+  - uid: 1366
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 3651
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28632,241 +28649,241 @@ entities:
       parent: 1
 - proto: VendingBarDrobe
   entities:
-  - uid: 3650
+  - uid: 3652
     components:
     - type: Transform
       pos: -26.5,8.5
       parent: 1
 - proto: VendingMachineAstroVendPOI
   entities:
-  - uid: 3651
+  - uid: 3653
     components:
     - type: Transform
       pos: -12.5,26.5
       parent: 1
 - proto: VendingMachineBoozePOI
   entities:
-  - uid: 3652
+  - uid: 3654
     components:
     - type: Transform
       pos: -26.5,10.5
       parent: 1
 - proto: VendingMachineChemicals
   entities:
-  - uid: 3653
+  - uid: 3655
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 1
-  - uid: 3654
+  - uid: 3656
     components:
     - type: Transform
       pos: -14.5,35.5
       parent: 1
 - proto: VendingMachineCiviMed
   entities:
-  - uid: 3655
+  - uid: 3657
     components:
     - type: Transform
       pos: -19.5,23.5
       parent: 1
 - proto: VendingMachineCiviMedPlus
   entities:
-  - uid: 3656
+  - uid: 3658
     components:
     - type: Transform
       pos: 5.5,32.5
       parent: 1
-  - uid: 3657
+  - uid: 3659
     components:
     - type: Transform
       pos: -12.5,27.5
       parent: 1
 - proto: VendingMachineCoffee
   entities:
-  - uid: 3658
+  - uid: 3660
     components:
     - type: Transform
       pos: -6.5,13.5
       parent: 1
-  - uid: 3659
+  - uid: 3661
     components:
     - type: Transform
       pos: -20.5,37.5
       parent: 1
 - proto: VendingMachineDrGibb
   entities:
-  - uid: 3660
+  - uid: 3662
     components:
     - type: Transform
       pos: -5.5,13.5
       parent: 1
 - proto: VendingMachineEngivendPOI
   entities:
-  - uid: 3661
+  - uid: 3663
     components:
     - type: Transform
       pos: -8.5,20.5
       parent: 1
 - proto: VendingMachineFlatpackVend
   entities:
-  - uid: 3662
+  - uid: 3664
     components:
     - type: Transform
       pos: -12.5,24.5
       parent: 1
 - proto: VendingMachineFuelVend
   entities:
-  - uid: 3663
+  - uid: 3665
     components:
     - type: Transform
       pos: 9.5,36.5
       parent: 1
-  - uid: 3664
+  - uid: 3666
     components:
     - type: Transform
       pos: -8.5,25.5
       parent: 1
 - proto: VendingMachineJaniDrobe
   entities:
-  - uid: 3665
+  - uid: 3667
     components:
     - type: Transform
       pos: -8.5,9.5
       parent: 1
 - proto: VendingMachineMediDrobePOI
   entities:
-  - uid: 3666
+  - uid: 3668
     components:
     - type: Transform
       pos: -8.5,24.5
       parent: 1
 - proto: VendingMachinePottedPlantVendPOI
   entities:
-  - uid: 3667
+  - uid: 3669
     components:
     - type: Transform
       pos: -8.5,26.5
       parent: 1
 - proto: VendingMachinePwrGame
   entities:
-  - uid: 3668
+  - uid: 3670
     components:
     - type: Transform
       pos: -15.5,13.5
       parent: 1
 - proto: VendingMachineRoboDrobe
   entities:
-  - uid: 3669
+  - uid: 3671
     components:
     - type: Transform
       pos: -1.5,20.5
       parent: 1
 - proto: VendingMachineSciDrobe
   entities:
-  - uid: 3670
+  - uid: 3672
     components:
     - type: Transform
       pos: -1.5,19.5
       parent: 1
 - proto: VendingMachineShamblersJuice
   entities:
-  - uid: 3671
+  - uid: 3673
     components:
     - type: Transform
       pos: -16.5,12.5
       parent: 1
 - proto: VendingMachineSmite
   entities:
-  - uid: 3672
+  - uid: 3674
     components:
     - type: Transform
       pos: -14.5,13.5
       parent: 1
 - proto: VendingMachineStarkist
   entities:
-  - uid: 3673
+  - uid: 3675
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 1
 - proto: VendingMachineSustenance
   entities:
-  - uid: 3674
+  - uid: 3676
     components:
     - type: Transform
       pos: -4.5,11.5
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 3675
+  - uid: 3677
     components:
     - type: Transform
       pos: 10.5,36.5
       parent: 1
-  - uid: 3676
+  - uid: 3678
     components:
     - type: Transform
       pos: -8.5,27.5
       parent: 1
 - proto: VendingMachineYouToolPOI
   entities:
-  - uid: 3677
+  - uid: 3679
     components:
     - type: Transform
       pos: -8.5,21.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 3678
-    components:
-    - type: Transform
-      pos: 5.5,42.5
-      parent: 1
-  - uid: 3679
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,32.5
-      parent: 1
   - uid: 3680
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,42.5
+      pos: 5.5,42.5
       parent: 1
   - uid: 3681
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,28.5
+      pos: 11.5,32.5
       parent: 1
   - uid: 3682
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,42.5
+      parent: 1
+  - uid: 3683
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,28.5
+      parent: 1
+  - uid: 3684
     components:
     - type: Transform
       pos: 10.5,33.5
       parent: 1
 - proto: WallPlastitaniumDiagonalOutpost
   entities:
-  - uid: 3683
+  - uid: 3685
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,22.5
       parent: 1
-  - uid: 3684
+  - uid: 3686
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,18.5
       parent: 1
-  - uid: 3685
+  - uid: 3687
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,20.5
       parent: 1
-  - uid: 3686
+  - uid: 3688
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28874,121 +28891,121 @@ entities:
       parent: 1
 - proto: WallPlastitaniumIndestructible
   entities:
-  - uid: 3687
+  - uid: 3689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,37.5
       parent: 1
-  - uid: 3688
+  - uid: 3690
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,37.5
       parent: 1
-  - uid: 3689
+  - uid: 3691
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,37.5
       parent: 1
-  - uid: 3690
+  - uid: 3692
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,37.5
       parent: 1
-  - uid: 3691
+  - uid: 3693
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,37.5
       parent: 1
-  - uid: 3692
+  - uid: 3694
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,37.5
       parent: 1
-  - uid: 3693
+  - uid: 3695
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,37.5
       parent: 1
-  - uid: 3694
+  - uid: 3696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,41.5
       parent: 1
-  - uid: 3695
+  - uid: 3697
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,37.5
       parent: 1
-  - uid: 3696
+  - uid: 3698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,41.5
       parent: 1
-  - uid: 3697
+  - uid: 3699
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,41.5
       parent: 1
-  - uid: 3698
+  - uid: 3700
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,37.5
       parent: 1
-  - uid: 3699
+  - uid: 3701
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,40.5
       parent: 1
-  - uid: 3700
+  - uid: 3702
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,41.5
       parent: 1
-  - uid: 3701
+  - uid: 3703
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,40.5
       parent: 1
-  - uid: 3702
+  - uid: 3704
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,38.5
       parent: 1
-  - uid: 3703
+  - uid: 3705
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,41.5
       parent: 1
-  - uid: 3704
+  - uid: 3706
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,37.5
       parent: 1
-  - uid: 3705
+  - uid: 3707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,41.5
       parent: 1
-  - uid: 3706
+  - uid: 3708
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28996,569 +29013,569 @@ entities:
       parent: 1
 - proto: WallPlastitaniumOutpost
   entities:
-  - uid: 3707
+  - uid: 3709
     components:
     - type: Transform
       pos: 7.5,32.5
       parent: 1
-  - uid: 3708
+  - uid: 3710
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,30.5
       parent: 1
-  - uid: 3709
+  - uid: 3711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,29.5
       parent: 1
-  - uid: 3710
+  - uid: 3712
     components:
     - type: Transform
       pos: 1.5,34.5
       parent: 1
-  - uid: 3711
+  - uid: 3713
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,33.5
       parent: 1
-  - uid: 3712
+  - uid: 3714
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,34.5
       parent: 1
-  - uid: 3713
+  - uid: 3715
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,36.5
       parent: 1
-  - uid: 3714
+  - uid: 3716
     components:
     - type: Transform
       pos: 14.5,33.5
       parent: 1
-  - uid: 3715
+  - uid: 3717
     components:
     - type: Transform
       pos: 15.5,33.5
       parent: 1
-  - uid: 3716
-    components:
-    - type: Transform
-      pos: -1.5,36.5
-      parent: 1
-  - uid: 3717
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,42.5
-      parent: 1
   - uid: 3718
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,41.5
+      pos: -1.5,36.5
       parent: 1
   - uid: 3719
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,42.5
+      pos: 8.5,42.5
       parent: 1
   - uid: 3720
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,41.5
+      pos: 2.5,41.5
       parent: 1
   - uid: 3721
     components:
     - type: Transform
-      pos: -1.5,40.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,42.5
       parent: 1
   - uid: 3722
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,41.5
+      parent: 1
+  - uid: 3723
+    components:
+    - type: Transform
+      pos: -1.5,40.5
+      parent: 1
+  - uid: 3724
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,37.5
       parent: 1
-  - uid: 3723
-    components:
-    - type: Transform
-      pos: 1.5,36.5
-      parent: 1
-  - uid: 3724
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,33.5
-      parent: 1
   - uid: 3725
     components:
     - type: Transform
-      pos: 9.5,32.5
+      pos: 1.5,36.5
       parent: 1
   - uid: 3726
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,28.5
+      pos: 7.5,33.5
       parent: 1
   - uid: 3727
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,36.5
+      pos: 9.5,32.5
       parent: 1
   - uid: 3728
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,33.5
+      pos: 0.5,28.5
       parent: 1
   - uid: 3729
     components:
     - type: Transform
-      pos: -1.5,37.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,36.5
       parent: 1
   - uid: 3730
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,37.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,33.5
       parent: 1
   - uid: 3731
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,41.5
+      pos: -1.5,37.5
       parent: 1
   - uid: 3732
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -0.5,37.5
+      pos: 1.5,37.5
       parent: 1
   - uid: 3733
     components:
     - type: Transform
-      pos: -1.5,30.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,41.5
       parent: 1
   - uid: 3734
     components:
     - type: Transform
-      pos: 16.5,33.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,37.5
       parent: 1
   - uid: 3735
+    components:
+    - type: Transform
+      pos: -1.5,30.5
+      parent: 1
+  - uid: 3736
+    components:
+    - type: Transform
+      pos: 16.5,33.5
+      parent: 1
+  - uid: 3737
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,36.5
       parent: 1
-  - uid: 3736
+  - uid: 3738
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,42.5
       parent: 1
-  - uid: 3737
+  - uid: 3739
     components:
     - type: Transform
       pos: -1.5,29.5
       parent: 1
-  - uid: 3738
+  - uid: 3740
     components:
     - type: Transform
       pos: 10.5,32.5
       parent: 1
-  - uid: 3739
+  - uid: 3741
     components:
     - type: Transform
       pos: -1.5,34.5
       parent: 1
-  - uid: 3740
+  - uid: 3742
     components:
     - type: Transform
       pos: 16.5,37.5
       parent: 1
-  - uid: 3741
+  - uid: 3743
     components:
     - type: Transform
       pos: -1.5,38.5
       parent: 1
-  - uid: 3742
+  - uid: 3744
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,37.5
       parent: 1
-  - uid: 3743
+  - uid: 3745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,30.5
       parent: 1
-  - uid: 3744
+  - uid: 3746
     components:
     - type: Transform
       pos: -1.5,33.5
       parent: 1
-  - uid: 3745
+  - uid: 3747
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,33.5
       parent: 1
-  - uid: 3746
+  - uid: 3748
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,33.5
       parent: 1
-  - uid: 3747
+  - uid: 3749
     components:
     - type: Transform
       pos: -1.5,28.5
       parent: 1
-  - uid: 3748
+  - uid: 3750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,41.5
       parent: 1
-  - uid: 3749
+  - uid: 3751
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,34.5
       parent: 1
-  - uid: 3750
+  - uid: 3752
     components:
     - type: Transform
       pos: 8.5,32.5
       parent: 1
-  - uid: 3751
-    components:
-    - type: Transform
-      pos: -1.5,39.5
-      parent: 1
-  - uid: 3752
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,34.5
-      parent: 1
   - uid: 3753
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,33.5
+      pos: -1.5,39.5
       parent: 1
   - uid: 3754
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,37.5
+      pos: 6.5,34.5
       parent: 1
   - uid: 3755
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,28.5
+      rot: -1.5707963267948966 rad
+      pos: 13.5,33.5
       parent: 1
   - uid: 3756
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,27.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,37.5
       parent: 1
   - uid: 3757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,33.5
+      pos: 1.5,28.5
       parent: 1
   - uid: 3758
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,27.5
+      parent: 1
+  - uid: 3759
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,33.5
+      parent: 1
+  - uid: 3760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,33.5
       parent: 1
-  - uid: 3759
+  - uid: 3761
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,34.5
       parent: 1
-  - uid: 3760
+  - uid: 3762
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,34.5
       parent: 1
-  - uid: 3761
+  - uid: 3763
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,37.5
       parent: 1
-  - uid: 3762
+  - uid: 3764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,37.5
       parent: 1
-  - uid: 3763
+  - uid: 3765
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,30.5
       parent: 1
-  - uid: 3764
+  - uid: 3766
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,24.5
       parent: 1
-  - uid: 3765
+  - uid: 3767
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,18.5
       parent: 1
-  - uid: 3766
+  - uid: 3768
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,23.5
       parent: 1
-  - uid: 3767
+  - uid: 3769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,22.5
       parent: 1
-  - uid: 3768
+  - uid: 3770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,19.5
       parent: 1
-  - uid: 3769
+  - uid: 3771
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,20.5
       parent: 1
-  - uid: 3770
+  - uid: 3772
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,19.5
       parent: 1
-  - uid: 3771
+  - uid: 3773
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,19.5
       parent: 1
-  - uid: 3772
+  - uid: 3774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,23.5
       parent: 1
-  - uid: 3773
+  - uid: 3775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,23.5
       parent: 1
-  - uid: 3774
+  - uid: 3776
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,23.5
       parent: 1
-  - uid: 3775
+  - uid: 3777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,19.5
       parent: 1
-  - uid: 3776
+  - uid: 3778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,19.5
       parent: 1
-  - uid: 3777
+  - uid: 3779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,23.5
       parent: 1
-  - uid: 3778
+  - uid: 3780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,23.5
       parent: 1
-  - uid: 3779
+  - uid: 3781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,19.5
       parent: 1
-  - uid: 3780
+  - uid: 3782
     components:
     - type: Transform
       pos: -7.5,28.5
       parent: 1
-  - uid: 3781
+  - uid: 3783
     components:
     - type: Transform
       pos: -7.5,29.5
       parent: 1
-  - uid: 3782
+  - uid: 3784
     components:
     - type: Transform
       pos: -4.5,28.5
       parent: 1
-  - uid: 3783
+  - uid: 3785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,37.5
       parent: 1
-  - uid: 3784
+  - uid: 3786
     components:
     - type: Transform
       pos: -5.5,28.5
       parent: 1
-  - uid: 3785
+  - uid: 3787
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,33.5
       parent: 1
-  - uid: 3786
+  - uid: 3788
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 1
-  - uid: 3787
-    components:
-    - type: Transform
-      pos: -2.5,28.5
-      parent: 1
-  - uid: 3788
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,33.5
-      parent: 1
   - uid: 3789
     components:
     - type: Transform
-      pos: 6.5,32.5
+      pos: -2.5,28.5
       parent: 1
   - uid: 3790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,27.5
+      pos: 6.5,33.5
       parent: 1
   - uid: 3791
+    components:
+    - type: Transform
+      pos: 6.5,32.5
+      parent: 1
+  - uid: 3792
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,27.5
+      parent: 1
+  - uid: 3793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,27.5
       parent: 1
-  - uid: 3792
+  - uid: 3794
     components:
     - type: Transform
       pos: -6.5,28.5
       parent: 1
-  - uid: 3793
+  - uid: 3795
     components:
     - type: Transform
       pos: -7.5,34.5
       parent: 1
-  - uid: 3794
+  - uid: 3796
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,27.5
       parent: 1
-  - uid: 3795
+  - uid: 3797
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,37.5
       parent: 1
-  - uid: 3796
+  - uid: 3798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,37.5
       parent: 1
-  - uid: 3797
+  - uid: 3799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,37.5
       parent: 1
-  - uid: 3798
+  - uid: 3800
     components:
     - type: Transform
       pos: -7.5,35.5
       parent: 1
-  - uid: 3799
+  - uid: 3801
     components:
     - type: Transform
       pos: -7.5,36.5
       parent: 1
-  - uid: 3800
-    components:
-    - type: Transform
-      pos: -8.5,34.5
-      parent: 1
-  - uid: 3801
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,29.5
-      parent: 1
   - uid: 3802
     components:
     - type: Transform
-      pos: -1.5,41.5
+      pos: -8.5,34.5
       parent: 1
   - uid: 3803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,28.5
+      pos: 0.5,29.5
       parent: 1
   - uid: 3804
+    components:
+    - type: Transform
+      pos: -1.5,41.5
+      parent: 1
+  - uid: 3805
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,28.5
+      parent: 1
+  - uid: 3806
     components:
     - type: Transform
       pos: 15.5,37.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 3805
+  - uid: 3807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,27.5
       parent: 1
-  - uid: 3806
+  - uid: 3808
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29566,2811 +29583,2804 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonalOutpost
   entities:
-  - uid: 3807
+  - uid: 3809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,7.5
       parent: 1
-  - uid: 3808
+  - uid: 3810
     components:
     - type: Transform
       pos: -41.5,7.5
       parent: 1
-  - uid: 3809
+  - uid: 3811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,42.5
       parent: 1
-  - uid: 3810
+  - uid: 3812
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,43.5
       parent: 1
-  - uid: 3811
+  - uid: 3813
     components:
     - type: Transform
       pos: -13.5,49.5
       parent: 1
-  - uid: 3812
+  - uid: 3814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,45.5
       parent: 1
-  - uid: 3813
+  - uid: 3815
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,45.5
       parent: 1
-  - uid: 3814
+  - uid: 3816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,49.5
       parent: 1
-  - uid: 3816
+  - uid: 3817
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,27.5
       parent: 1
-  - uid: 3817
+  - uid: 3818
     components:
     - type: Transform
       pos: -13.5,-4.5
       parent: 1
-  - uid: 3818
+  - uid: 3819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,1.5
       parent: 1
-  - uid: 3819
+  - uid: 3820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-8.5
       parent: 1
-  - uid: 3820
+  - uid: 3821
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 1
-  - uid: 3821
+  - uid: 3822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,1.5
       parent: 1
-  - uid: 3822
+  - uid: 3823
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 3823
+  - uid: 3824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,5.5
       parent: 1
-  - uid: 3824
+  - uid: 3825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,5.5
       parent: 1
-  - uid: 3825
+  - uid: 3826
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 3826
+  - uid: 3827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,2.5
       parent: 1
-  - uid: 3827
+  - uid: 3828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 3828
+  - uid: 3829
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,1.5
       parent: 1
-  - uid: 3829
+  - uid: 3830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,1.5
       parent: 1
-  - uid: 3830
+  - uid: 3831
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-18.5
       parent: 1
-  - uid: 3831
+  - uid: 3832
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-22.5
       parent: 1
-  - uid: 3832
+  - uid: 3833
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-22.5
       parent: 1
-  - uid: 3833
+  - uid: 3834
     components:
     - type: Transform
       pos: -13.5,-18.5
       parent: 1
-  - uid: 3834
+  - uid: 3835
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 1
-  - uid: 3835
+  - uid: 3836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-8.5
       parent: 1
-  - uid: 3836
+  - uid: 3837
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,6.5
       parent: 1
-  - uid: 3837
+  - uid: 3838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,13.5
       parent: 1
-  - uid: 3838
+  - uid: 3839
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,13.5
       parent: 1
-  - uid: 3839
+  - uid: 3840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,16.5
       parent: 1
-  - uid: 3840
+  - uid: 3841
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,17.5
       parent: 1
-  - uid: 3841
+  - uid: 3842
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,25.5
       parent: 1
-  - uid: 3842
+  - uid: 3843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,19.5
       parent: 1
-  - uid: 3843
+  - uid: 3844
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,27.5
       parent: 1
-  - uid: 3844
+  - uid: 3845
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,1.5
       parent: 1
-  - uid: 3845
+  - uid: 3846
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,1.5
       parent: 1
-  - uid: 4247
+  - uid: 3847
     components:
     - type: Transform
       pos: -18.5,42.5
       parent: 1
-  - uid: 4330
+  - uid: 3848
     components:
     - type: Transform
       pos: -17.5,43.5
       parent: 1
 - proto: WallReinforcedOutpost
   entities:
-  - uid: 3846
+  - uid: 3849
     components:
     - type: Transform
       pos: -35.5,2.5
       parent: 1
-  - uid: 3847
+  - uid: 3850
     components:
     - type: Transform
       pos: -36.5,2.5
       parent: 1
-  - uid: 3848
+  - uid: 3851
     components:
     - type: Transform
       pos: -48.5,6.5
       parent: 1
-  - uid: 3849
+  - uid: 3852
     components:
     - type: Transform
       pos: -41.5,6.5
       parent: 1
-  - uid: 3850
+  - uid: 3853
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,1.5
       parent: 1
-  - uid: 3851
+  - uid: 3854
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,7.5
       parent: 1
-  - uid: 3852
+  - uid: 3855
     components:
     - type: Transform
       pos: -36.5,6.5
       parent: 1
-  - uid: 3853
+  - uid: 3856
     components:
     - type: Transform
       pos: -35.5,6.5
       parent: 1
-  - uid: 3854
+  - uid: 3857
     components:
     - type: Transform
       pos: -42.5,6.5
       parent: 1
-  - uid: 3855
+  - uid: 3858
     components:
     - type: Transform
       pos: -43.5,6.5
       parent: 1
-  - uid: 3856
+  - uid: 3859
     components:
     - type: Transform
       pos: -37.5,6.5
       parent: 1
-  - uid: 3857
+  - uid: 3860
     components:
     - type: Transform
       pos: -44.5,6.5
       parent: 1
-  - uid: 3858
+  - uid: 3861
     components:
     - type: Transform
       pos: -49.5,6.5
       parent: 1
-  - uid: 3859
+  - uid: 3862
     components:
     - type: Transform
       pos: -50.5,6.5
       parent: 1
-  - uid: 3860
+  - uid: 3863
     components:
     - type: Transform
       pos: -37.5,2.5
       parent: 1
-  - uid: 3861
+  - uid: 3864
     components:
     - type: Transform
       pos: -5.5,43.5
       parent: 1
-  - uid: 3862
+  - uid: 3865
     components:
     - type: Transform
       pos: -4.5,43.5
       parent: 1
-  - uid: 3863
+  - uid: 3866
     components:
     - type: Transform
       pos: -2.5,42.5
       parent: 1
-  - uid: 3864
+  - uid: 3867
     components:
     - type: Transform
       pos: -6.5,43.5
       parent: 1
-  - uid: 3865
+  - uid: 3868
     components:
     - type: Transform
       pos: -7.5,43.5
       parent: 1
-  - uid: 3866
+  - uid: 3869
     components:
     - type: Transform
       pos: -7.5,51.5
       parent: 1
-  - uid: 3867
+  - uid: 3870
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,11.5
       parent: 1
-  - uid: 3868
+  - uid: 3871
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 1
-  - uid: 3869
+  - uid: 3872
     components:
     - type: Transform
       pos: -12.5,43.5
       parent: 1
-  - uid: 3870
+  - uid: 3873
     components:
     - type: Transform
       pos: -12.5,44.5
       parent: 1
-  - uid: 3871
+  - uid: 3874
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 1
-  - uid: 3872
+  - uid: 3875
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 3873
+  - uid: 3876
     components:
     - type: Transform
       pos: -12.5,51.5
       parent: 1
-  - uid: 3874
+  - uid: 3877
     components:
     - type: Transform
       pos: -12.5,50.5
       parent: 1
-  - uid: 3875
+  - uid: 3878
     components:
     - type: Transform
       pos: -8.5,49.5
       parent: 1
-  - uid: 3876
+  - uid: 3879
     components:
     - type: Transform
       pos: -12.5,45.5
       parent: 1
-  - uid: 3877
+  - uid: 3880
     components:
     - type: Transform
       pos: -8.5,44.5
       parent: 1
-  - uid: 3878
+  - uid: 3881
     components:
     - type: Transform
       pos: -8.5,43.5
       parent: 1
-  - uid: 3879
+  - uid: 3882
     components:
     - type: Transform
       pos: -8.5,50.5
       parent: 1
-  - uid: 3880
+  - uid: 3883
     components:
     - type: Transform
       pos: -8.5,51.5
       parent: 1
-  - uid: 3881
+  - uid: 3884
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 3882
+  - uid: 3885
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 3883
+  - uid: 3886
     components:
     - type: Transform
       pos: -8.5,56.5
       parent: 1
-  - uid: 3884
+  - uid: 3887
     components:
     - type: Transform
       pos: -8.5,57.5
       parent: 1
-  - uid: 3885
+  - uid: 3888
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 3886
+  - uid: 3889
     components:
     - type: Transform
       pos: -14.5,55.5
       parent: 1
-  - uid: 3887
+  - uid: 3890
     components:
     - type: Transform
       pos: -12.5,49.5
       parent: 1
-  - uid: 3888
+  - uid: 3891
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 1
-  - uid: 3889
+  - uid: 3892
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 3890
+  - uid: 3893
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 3891
+  - uid: 3894
     components:
     - type: Transform
       pos: -7.5,55.5
       parent: 1
-  - uid: 3892
+  - uid: 3895
     components:
     - type: Transform
       pos: -8.5,45.5
       parent: 1
-  - uid: 3893
+  - uid: 3896
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 3894
+  - uid: 3897
     components:
     - type: Transform
       pos: -6.5,55.5
       parent: 1
-  - uid: 3895
+  - uid: 3898
     components:
     - type: Transform
       pos: -13.5,55.5
       parent: 1
-  - uid: 3896
+  - uid: 3899
     components:
     - type: Transform
       pos: 5.5,27.5
       parent: 1
-  - uid: 3897
+  - uid: 3900
     components:
     - type: Transform
       pos: -4.5,18.5
       parent: 1
-  - uid: 3898
+  - uid: 3901
     components:
     - type: Transform
       pos: -1.5,18.5
       parent: 1
-  - uid: 3899
+  - uid: 3902
     components:
     - type: Transform
       pos: -12.5,55.5
       parent: 1
-  - uid: 3900
+  - uid: 3903
     components:
     - type: Transform
       pos: -6.5,51.5
       parent: 1
-  - uid: 3901
+  - uid: 3904
     components:
     - type: Transform
       pos: -12.5,56.5
       parent: 1
-  - uid: 3902
+  - uid: 3905
     components:
     - type: Transform
       pos: -8.5,55.5
       parent: 1
-  - uid: 3903
+  - uid: 3906
     components:
     - type: Transform
       pos: -13.5,51.5
       parent: 1
-  - uid: 3904
+  - uid: 3907
     components:
     - type: Transform
       pos: -12.5,57.5
       parent: 1
-  - uid: 3905
+  - uid: 3908
     components:
     - type: Transform
       pos: -14.5,51.5
       parent: 1
-  - uid: 3906
+  - uid: 3909
     components:
     - type: Transform
       pos: -17.5,39.5
       parent: 1
-  - uid: 3907
+  - uid: 3910
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,41.5
       parent: 1
-  - uid: 3908
+  - uid: 3911
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,41.5
       parent: 1
-  - uid: 3909
+  - uid: 3912
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,41.5
       parent: 1
-  - uid: 3910
+  - uid: 3913
     components:
     - type: Transform
       pos: -17.5,37.5
       parent: 1
-  - uid: 3911
-    components:
-    - type: Transform
-      pos: -17.5,40.5
-      parent: 1
-  - uid: 3912
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,37.5
-      parent: 1
-  - uid: 3913
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,41.5
-      parent: 1
   - uid: 3914
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,42.5
+      pos: -17.5,40.5
       parent: 1
   - uid: 3915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -20.5,41.5
+      pos: -24.5,37.5
       parent: 1
   - uid: 3916
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,5.5
+      pos: -13.5,41.5
       parent: 1
   - uid: 3917
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -14.5,30.5
+      pos: -13.5,42.5
       parent: 1
   - uid: 3918
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -13.5,30.5
+      pos: -20.5,41.5
       parent: 1
   - uid: 3919
     components:
     - type: Transform
-      pos: -19.5,29.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
       parent: 1
   - uid: 3920
     components:
     - type: Transform
-      pos: -2.5,38.5
+      rot: 3.141592653589793 rad
+      pos: -14.5,30.5
       parent: 1
   - uid: 3921
     components:
     - type: Transform
-      pos: -19.5,30.5
+      rot: 3.141592653589793 rad
+      pos: -13.5,30.5
       parent: 1
   - uid: 3922
     components:
     - type: Transform
-      pos: -17.5,42.5
+      pos: -19.5,29.5
       parent: 1
   - uid: 3923
     components:
     - type: Transform
-      pos: -2.5,39.5
+      pos: -2.5,38.5
       parent: 1
   - uid: 3924
     components:
     - type: Transform
-      pos: -2.5,41.5
+      pos: -19.5,30.5
       parent: 1
   - uid: 3925
     components:
     - type: Transform
-      pos: -2.5,40.5
+      pos: -17.5,42.5
       parent: 1
   - uid: 3926
     components:
     - type: Transform
-      pos: -23.5,36.5
+      pos: -2.5,39.5
       parent: 1
   - uid: 3927
     components:
     - type: Transform
-      pos: -15.5,36.5
+      pos: -2.5,41.5
       parent: 1
   - uid: 3928
     components:
     - type: Transform
-      pos: -24.5,36.5
+      pos: -2.5,40.5
       parent: 1
   - uid: 3929
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -15.5,30.5
+      pos: -23.5,36.5
       parent: 1
   - uid: 3930
     components:
     - type: Transform
-      pos: -22.5,27.5
+      pos: -15.5,36.5
       parent: 1
   - uid: 3931
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,25.5
+      pos: -24.5,36.5
       parent: 1
   - uid: 3932
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -13.5,29.5
+      pos: -15.5,30.5
       parent: 1
   - uid: 3933
+    components:
+    - type: Transform
+      pos: -22.5,27.5
+      parent: 1
+  - uid: 3934
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,25.5
+      parent: 1
+  - uid: 3935
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,29.5
+      parent: 1
+  - uid: 3936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-18.5
       parent: 1
-  - uid: 3934
+  - uid: 3937
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-18.5
       parent: 1
-  - uid: 3935
+  - uid: 3938
     components:
     - type: Transform
       pos: -8.5,-11.5
       parent: 1
-  - uid: 3936
+  - uid: 3939
     components:
     - type: Transform
       pos: -7.5,-11.5
       parent: 1
-  - uid: 3937
+  - uid: 3940
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 1
-  - uid: 3938
+  - uid: 3941
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 3939
+  - uid: 3942
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,2.5
       parent: 1
-  - uid: 3940
+  - uid: 3943
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-17.5
       parent: 1
-  - uid: 3941
+  - uid: 3944
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,7.5
       parent: 1
-  - uid: 3942
+  - uid: 3945
     components:
     - type: Transform
       pos: -30.5,7.5
       parent: 1
-  - uid: 3943
+  - uid: 3946
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-11.5
       parent: 1
-  - uid: 3944
+  - uid: 3947
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-15.5
       parent: 1
-  - uid: 3945
+  - uid: 3948
     components:
     - type: Transform
       pos: -30.5,8.5
       parent: 1
-  - uid: 3946
+  - uid: 3949
     components:
     - type: Transform
       pos: -34.5,2.5
       parent: 1
-  - uid: 3947
+  - uid: 3950
     components:
     - type: Transform
       pos: -29.5,6.5
       parent: 1
-  - uid: 3948
+  - uid: 3951
     components:
     - type: Transform
       pos: -8.5,-15.5
       parent: 1
-  - uid: 3949
+  - uid: 3952
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 1
-  - uid: 3950
+  - uid: 3953
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-9.5
       parent: 1
-  - uid: 3951
+  - uid: 3954
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-10.5
       parent: 1
-  - uid: 3952
+  - uid: 3955
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 1
-  - uid: 3953
+  - uid: 3956
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 1
-  - uid: 3954
-    components:
-    - type: Transform
-      pos: -12.5,-2.5
-      parent: 1
-  - uid: 3955
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,1.5
-      parent: 1
-  - uid: 3956
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,1.5
-      parent: 1
   - uid: 3957
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,1.5
+      pos: -12.5,-2.5
       parent: 1
   - uid: 3958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -21.5,1.5
+      pos: -0.5,1.5
       parent: 1
   - uid: 3959
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -22.5,2.5
+      pos: 0.5,1.5
       parent: 1
   - uid: 3960
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,2.5
+      pos: -20.5,1.5
       parent: 1
   - uid: 3961
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,2.5
+      rot: 3.141592653589793 rad
+      pos: -21.5,1.5
       parent: 1
   - uid: 3962
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,2.5
+      rot: 3.141592653589793 rad
+      pos: -22.5,2.5
       parent: 1
   - uid: 3963
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,6.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
       parent: 1
   - uid: 3964
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,6.5
+      pos: -21.5,2.5
       parent: 1
   - uid: 3965
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -22.5,6.5
+      pos: 0.5,2.5
       parent: 1
   - uid: 3966
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,6.5
+      pos: 1.5,6.5
       parent: 1
   - uid: 3967
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,6.5
+      pos: -21.5,6.5
       parent: 1
   - uid: 3968
     components:
     - type: Transform
-      pos: -34.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,6.5
       parent: 1
   - uid: 3969
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -28.5,2.5
+      pos: 0.5,6.5
       parent: 1
   - uid: 3970
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,2.5
+      pos: -20.5,6.5
       parent: 1
   - uid: 3971
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,2.5
+      pos: -34.5,7.5
       parent: 1
   - uid: 3972
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,6.5
+      pos: -28.5,2.5
       parent: 1
   - uid: 3973
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,5.5
+      pos: 3.5,2.5
       parent: 1
   - uid: 3974
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -16.5,5.5
+      pos: -24.5,2.5
       parent: 1
   - uid: 3975
     components:
     - type: Transform
-      pos: -34.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
       parent: 1
   - uid: 3976
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,5.5
+      pos: -17.5,5.5
       parent: 1
   - uid: 3977
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -12.5,5.5
+      pos: -16.5,5.5
       parent: 1
   - uid: 3978
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,5.5
+      pos: -34.5,6.5
       parent: 1
   - uid: 3979
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -10.5,5.5
+      pos: -13.5,5.5
       parent: 1
   - uid: 3980
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -9.5,5.5
+      pos: -12.5,5.5
       parent: 1
   - uid: 3981
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -8.5,5.5
+      pos: -11.5,5.5
       parent: 1
   - uid: 3982
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -7.5,5.5
+      pos: -10.5,5.5
       parent: 1
   - uid: 3983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -24.5,6.5
+      pos: -9.5,5.5
       parent: 1
   - uid: 3984
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -23.5,6.5
+      pos: -8.5,5.5
       parent: 1
   - uid: 3985
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,5.5
+      pos: -7.5,5.5
       parent: 1
   - uid: 3986
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,6.5
+      parent: 1
+  - uid: 3987
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,6.5
+      parent: 1
+  - uid: 3988
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 3989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,5.5
       parent: 1
-  - uid: 3987
+  - uid: 3990
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 3988
+  - uid: 3991
     components:
     - type: Transform
       pos: -30.5,2.5
       parent: 1
-  - uid: 3989
+  - uid: 3992
     components:
     - type: Transform
       pos: -34.5,8.5
       parent: 1
-  - uid: 3990
+  - uid: 3993
     components:
     - type: Transform
       pos: -34.5,1.5
       parent: 1
-  - uid: 3991
+  - uid: 3994
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 3992
+  - uid: 3995
     components:
     - type: Transform
       pos: -30.5,1.5
       parent: 1
-  - uid: 3993
+  - uid: 3996
     components:
     - type: Transform
       pos: -34.5,0.5
       parent: 1
-  - uid: 3994
-    components:
-    - type: Transform
-      pos: -30.5,0.5
-      parent: 1
-  - uid: 3995
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -28.5,6.5
-      parent: 1
-  - uid: 3996
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -48.5,1.5
-      parent: 1
   - uid: 3997
     components:
     - type: Transform
-      pos: -30.5,6.5
+      pos: -30.5,0.5
       parent: 1
   - uid: 3998
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,2.5
+      pos: -28.5,6.5
       parent: 1
   - uid: 3999
     components:
     - type: Transform
-      pos: -7.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: -48.5,1.5
       parent: 1
   - uid: 4000
     components:
     - type: Transform
-      pos: 13.5,2.5
+      pos: -30.5,6.5
       parent: 1
   - uid: 4001
     components:
     - type: Transform
-      pos: 13.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,2.5
       parent: 1
   - uid: 4002
     components:
     - type: Transform
-      pos: 9.5,8.5
+      pos: -7.5,-15.5
       parent: 1
   - uid: 4003
     components:
     - type: Transform
-      pos: 13.5,1.5
+      pos: 13.5,2.5
       parent: 1
   - uid: 4004
     components:
     - type: Transform
-      pos: 9.5,2.5
+      pos: 13.5,0.5
       parent: 1
   - uid: 4005
     components:
     - type: Transform
-      pos: 9.5,0.5
+      pos: 9.5,8.5
       parent: 1
   - uid: 4006
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,-11.5
+      pos: 13.5,1.5
       parent: 1
   - uid: 4007
     components:
     - type: Transform
-      pos: -8.5,-16.5
+      pos: 9.5,2.5
       parent: 1
   - uid: 4008
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,-16.5
+      pos: 9.5,0.5
       parent: 1
   - uid: 4009
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -12.5,-15.5
+      pos: -12.5,-11.5
       parent: 1
   - uid: 4010
     components:
     - type: Transform
-      pos: 9.5,6.5
+      pos: -8.5,-16.5
       parent: 1
   - uid: 4011
     components:
     - type: Transform
-      pos: 13.5,6.5
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-16.5
       parent: 1
   - uid: 4012
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-15.5
+      parent: 1
+  - uid: 4013
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 4014
+    components:
+    - type: Transform
+      pos: 13.5,6.5
+      parent: 1
+  - uid: 4015
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,7.5
       parent: 1
-  - uid: 4013
+  - uid: 4016
     components:
     - type: Transform
       pos: 13.5,7.5
       parent: 1
-  - uid: 4014
+  - uid: 4017
     components:
     - type: Transform
       pos: 14.5,6.5
       parent: 1
-  - uid: 4015
+  - uid: 4018
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-11.5
       parent: 1
-  - uid: 4016
+  - uid: 4019
     components:
     - type: Transform
       pos: -6.5,-11.5
       parent: 1
-  - uid: 4017
+  - uid: 4020
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 1
-  - uid: 4018
+  - uid: 4021
     components:
     - type: Transform
       pos: 13.5,8.5
       parent: 1
-  - uid: 4019
+  - uid: 4022
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 1
-  - uid: 4020
+  - uid: 4023
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 1
-  - uid: 4021
-    components:
-    - type: Transform
-      pos: 15.5,2.5
-      parent: 1
-  - uid: 4022
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,6.5
-      parent: 1
-  - uid: 4023
-    components:
-    - type: Transform
-      pos: 14.5,2.5
-      parent: 1
   - uid: 4024
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-15.5
+      pos: 15.5,2.5
       parent: 1
   - uid: 4025
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -12.5,-17.5
+      pos: 3.5,6.5
       parent: 1
   - uid: 4026
     components:
     - type: Transform
-      pos: -8.5,-10.5
+      pos: 14.5,2.5
       parent: 1
   - uid: 4027
     components:
     - type: Transform
-      pos: -27.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-15.5
       parent: 1
   - uid: 4028
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-17.5
+      parent: 1
+  - uid: 4029
+    components:
+    - type: Transform
+      pos: -8.5,-10.5
+      parent: 1
+  - uid: 4030
+    components:
+    - type: Transform
+      pos: -27.5,9.5
+      parent: 1
+  - uid: 4031
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,6.5
       parent: 1
-  - uid: 4029
+  - uid: 4032
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-22.5
       parent: 1
-  - uid: 4030
+  - uid: 4033
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-22.5
       parent: 1
-  - uid: 4031
+  - uid: 4034
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-23.5
       parent: 1
-  - uid: 4032
+  - uid: 4035
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-24.5
       parent: 1
-  - uid: 4033
+  - uid: 4036
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-25.5
       parent: 1
-  - uid: 4034
+  - uid: 4037
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-25.5
       parent: 1
-  - uid: 4035
+  - uid: 4038
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-24.5
       parent: 1
-  - uid: 4036
+  - uid: 4039
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-23.5
       parent: 1
-  - uid: 4037
+  - uid: 4040
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-29.5
       parent: 1
-  - uid: 4038
+  - uid: 4041
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-29.5
       parent: 1
-  - uid: 4039
+  - uid: 4042
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-30.5
       parent: 1
-  - uid: 4040
+  - uid: 4043
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-31.5
       parent: 1
-  - uid: 4041
+  - uid: 4044
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-30.5
       parent: 1
-  - uid: 4042
+  - uid: 4045
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-31.5
       parent: 1
-  - uid: 4043
+  - uid: 4046
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-25.5
       parent: 1
-  - uid: 4044
+  - uid: 4047
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-25.5
       parent: 1
-  - uid: 4045
+  - uid: 4048
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-29.5
       parent: 1
-  - uid: 4046
+  - uid: 4049
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-29.5
       parent: 1
-  - uid: 4047
+  - uid: 4050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-29.5
       parent: 1
-  - uid: 4048
+  - uid: 4051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-29.5
       parent: 1
-  - uid: 4049
+  - uid: 4052
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-25.5
       parent: 1
-  - uid: 4050
+  - uid: 4053
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-25.5
       parent: 1
-  - uid: 4051
+  - uid: 4054
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 1
-  - uid: 4052
+  - uid: 4055
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 1
-  - uid: 4053
+  - uid: 4056
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 1
-  - uid: 4054
+  - uid: 4057
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 1
-  - uid: 4055
-    components:
-    - type: Transform
-      pos: -8.5,-9.5
-      parent: 1
-  - uid: 4056
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,6.5
-      parent: 1
-  - uid: 4057
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,8.5
-      parent: 1
   - uid: 4058
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,6.5
+      pos: -8.5,-9.5
       parent: 1
   - uid: 4059
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -27.5,7.5
+      pos: -26.5,6.5
       parent: 1
   - uid: 4060
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,8.5
+      parent: 1
+  - uid: 4061
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,6.5
+      parent: 1
+  - uid: 4062
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,7.5
+      parent: 1
+  - uid: 4063
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,14.5
       parent: 1
-  - uid: 4061
+  - uid: 4064
     components:
     - type: Transform
       pos: -17.5,9.5
       parent: 1
-  - uid: 4062
+  - uid: 4065
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,10.5
       parent: 1
-  - uid: 4063
+  - uid: 4066
     components:
     - type: Transform
       pos: -27.5,10.5
       parent: 1
-  - uid: 4064
+  - uid: 4067
     components:
     - type: Transform
       pos: -22.5,8.5
       parent: 1
-  - uid: 4065
-    components:
-    - type: Transform
-      pos: -22.5,7.5
-      parent: 1
-  - uid: 4066
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,14.5
-      parent: 1
-  - uid: 4067
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,14.5
-      parent: 1
   - uid: 4068
     components:
     - type: Transform
-      pos: -17.5,16.5
+      pos: -22.5,7.5
       parent: 1
   - uid: 4069
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -20.5,15.5
+      pos: -17.5,14.5
       parent: 1
   - uid: 4070
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,18.5
+      pos: -16.5,14.5
       parent: 1
   - uid: 4071
     components:
     - type: Transform
-      pos: -19.5,17.5
+      pos: -17.5,16.5
       parent: 1
   - uid: 4072
     components:
     - type: Transform
-      pos: -18.5,18.5
+      rot: -1.5707963267948966 rad
+      pos: -20.5,15.5
       parent: 1
   - uid: 4073
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,18.5
+      parent: 1
+  - uid: 4074
+    components:
+    - type: Transform
+      pos: -19.5,17.5
+      parent: 1
+  - uid: 4075
+    components:
+    - type: Transform
+      pos: -18.5,18.5
+      parent: 1
+  - uid: 4076
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,23.5
       parent: 1
-  - uid: 4074
+  - uid: 4077
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,15.5
       parent: 1
-  - uid: 4075
+  - uid: 4078
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,28.5
       parent: 1
-  - uid: 4076
+  - uid: 4079
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,16.5
       parent: 1
-  - uid: 4077
+  - uid: 4080
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,14.5
       parent: 1
-  - uid: 4078
+  - uid: 4081
     components:
     - type: Transform
       pos: -17.5,17.5
       parent: 1
-  - uid: 4079
+  - uid: 4082
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,14.5
       parent: 1
-  - uid: 4080
+  - uid: 4083
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,6.5
-      parent: 1
-  - uid: 4081
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,6.5
       parent: 1
-  - uid: 4082
+  - uid: 4085
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 4083
-    components:
-    - type: Transform
-      pos: -18.5,9.5
-      parent: 1
-  - uid: 4084
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,6.5
-      parent: 1
-  - uid: 4085
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,6.5
-      parent: 1
   - uid: 4086
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,6.5
+      pos: -18.5,9.5
       parent: 1
   - uid: 4087
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,8.5
+      pos: -17.5,6.5
       parent: 1
   - uid: 4088
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -13.5,9.5
+      pos: -18.5,6.5
       parent: 1
   - uid: 4089
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,18.5
+      pos: -19.5,6.5
       parent: 1
   - uid: 4090
     components:
     - type: Transform
-      pos: -7.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: -13.5,8.5
       parent: 1
   - uid: 4091
     components:
     - type: Transform
-      pos: -13.5,10.5
+      rot: -1.5707963267948966 rad
+      pos: -13.5,9.5
       parent: 1
   - uid: 4092
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,18.5
+      parent: 1
+  - uid: 4093
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+  - uid: 4094
+    components:
+    - type: Transform
+      pos: -13.5,10.5
+      parent: 1
+  - uid: 4095
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,18.5
       parent: 1
-  - uid: 4093
-    components:
-    - type: Transform
-      pos: -17.5,7.5
-      parent: 1
-  - uid: 4094
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,6.5
-      parent: 1
-  - uid: 4095
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,10.5
-      parent: 1
   - uid: 4096
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,8.5
+      pos: -17.5,7.5
       parent: 1
   - uid: 4097
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,6.5
+      pos: -13.5,6.5
       parent: 1
   - uid: 4098
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,9.5
+      pos: -8.5,10.5
       parent: 1
   - uid: 4099
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,18.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,8.5
       parent: 1
   - uid: 4100
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -9.5,10.5
+      pos: -7.5,6.5
       parent: 1
   - uid: 4101
     components:
     - type: Transform
-      pos: -3.5,7.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,9.5
       parent: 1
   - uid: 4102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,18.5
+      parent: 1
+  - uid: 4103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,10.5
+      parent: 1
+  - uid: 4104
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 4105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,10.5
       parent: 1
-  - uid: 4103
-    components:
-    - type: Transform
-      pos: -20.5,9.5
-      parent: 1
-  - uid: 4104
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,10.5
-      parent: 1
-  - uid: 4105
-    components:
-    - type: Transform
-      pos: -18.5,17.5
-      parent: 1
   - uid: 4106
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,14.5
+      pos: -20.5,9.5
       parent: 1
   - uid: 4107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,14.5
+      pos: -12.5,10.5
       parent: 1
   - uid: 4108
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,14.5
+      pos: -18.5,17.5
       parent: 1
   - uid: 4109
     components:
     - type: Transform
-      pos: -17.5,12.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,14.5
       parent: 1
   - uid: 4110
     components:
     - type: Transform
-      pos: -17.5,13.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,14.5
       parent: 1
   - uid: 4111
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,14.5
+      pos: -2.5,14.5
       parent: 1
   - uid: 4112
     components:
     - type: Transform
-      pos: -3.5,13.5
+      pos: -17.5,12.5
       parent: 1
   - uid: 4113
     components:
     - type: Transform
-      pos: -3.5,12.5
+      pos: -17.5,13.5
       parent: 1
   - uid: 4114
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,14.5
+      pos: -3.5,14.5
       parent: 1
   - uid: 4115
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,14.5
+      pos: -3.5,13.5
       parent: 1
   - uid: 4116
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,14.5
+      pos: -3.5,12.5
       parent: 1
   - uid: 4117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -14.5,14.5
+      pos: -4.5,14.5
       parent: 1
   - uid: 4118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -5.5,14.5
+      pos: -15.5,14.5
       parent: 1
   - uid: 4119
     components:
     - type: Transform
-      pos: 5.5,9.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,14.5
       parent: 1
   - uid: 4120
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,24.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,14.5
       parent: 1
   - uid: 4121
     components:
     - type: Transform
-      pos: -12.5,29.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,14.5
       parent: 1
   - uid: 4122
     components:
     - type: Transform
-      pos: 5.5,11.5
+      pos: 5.5,9.5
       parent: 1
   - uid: 4123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -12.5,42.5
+      pos: -4.5,24.5
       parent: 1
   - uid: 4124
     components:
     - type: Transform
-      pos: -20.5,18.5
+      pos: -12.5,29.5
       parent: 1
   - uid: 4125
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,36.5
+      pos: 5.5,11.5
       parent: 1
   - uid: 4126
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,23.5
+      rot: 3.141592653589793 rad
+      pos: -12.5,42.5
       parent: 1
   - uid: 4127
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,34.5
+      pos: -20.5,18.5
       parent: 1
   - uid: 4128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -12.5,35.5
+      pos: -14.5,36.5
       parent: 1
   - uid: 4129
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -8.5,37.5
+      pos: -16.5,23.5
       parent: 1
   - uid: 4130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,34.5
+      pos: -12.5,34.5
       parent: 1
   - uid: 4131
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,19.5
+      rot: 1.5707963267948966 rad
+      pos: -12.5,35.5
       parent: 1
   - uid: 4132
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,20.5
+      rot: 1.5707963267948966 rad
+      pos: -8.5,37.5
       parent: 1
   - uid: 4133
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,22.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,34.5
       parent: 1
   - uid: 4134
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,23.5
+      pos: 1.5,19.5
       parent: 1
   - uid: 4135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,24.5
+      pos: 1.5,20.5
       parent: 1
   - uid: 4136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,22.5
+      parent: 1
+  - uid: 4137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,23.5
+      parent: 1
+  - uid: 4138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,24.5
+      parent: 1
+  - uid: 4139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,27.5
       parent: 1
-  - uid: 4137
+  - uid: 4140
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,24.5
       parent: 1
-  - uid: 4138
+  - uid: 4141
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,24.5
       parent: 1
-  - uid: 4139
+  - uid: 4142
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,24.5
       parent: 1
-  - uid: 4140
+  - uid: 4143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,11.5
       parent: 1
-  - uid: 4141
+  - uid: 4144
     components:
     - type: Transform
       pos: -24.5,9.5
       parent: 1
-  - uid: 4142
+  - uid: 4145
     components:
     - type: Transform
       pos: -23.5,9.5
       parent: 1
-  - uid: 4143
+  - uid: 4146
     components:
     - type: Transform
       pos: -20.5,17.5
       parent: 1
-  - uid: 4144
+  - uid: 4147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,41.5
       parent: 1
-  - uid: 4145
+  - uid: 4148
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 4146
+  - uid: 4149
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 4147
-    components:
-    - type: Transform
-      pos: 5.5,10.5
-      parent: 1
-  - uid: 4148
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,17.5
-      parent: 1
-  - uid: 4149
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,18.5
-      parent: 1
   - uid: 4150
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,18.5
+      pos: 5.5,10.5
       parent: 1
   - uid: 4151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,17.5
+      pos: 5.5,17.5
       parent: 1
   - uid: 4152
     components:
     - type: Transform
-      pos: 7.5,18.5
+      rot: 3.141592653589793 rad
+      pos: 5.5,18.5
       parent: 1
   - uid: 4153
     components:
     - type: Transform
-      pos: 8.5,18.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,18.5
       parent: 1
   - uid: 4154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,18.5
+      pos: 6.5,17.5
       parent: 1
   - uid: 4155
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,17.5
+      pos: 7.5,18.5
       parent: 1
   - uid: 4156
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,17.5
+      pos: 8.5,18.5
       parent: 1
   - uid: 4157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,17.5
+      pos: 9.5,18.5
       parent: 1
   - uid: 4158
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,18.5
+      pos: 7.5,17.5
       parent: 1
   - uid: 4159
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,24.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,17.5
       parent: 1
   - uid: 4160
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,24.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,17.5
       parent: 1
   - uid: 4161
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,24.5
+      rot: 3.141592653589793 rad
+      pos: 10.5,18.5
       parent: 1
   - uid: 4162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,25.5
+      pos: 10.5,24.5
       parent: 1
   - uid: 4163
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,25.5
+      pos: 9.5,24.5
       parent: 1
   - uid: 4164
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,27.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,24.5
       parent: 1
   - uid: 4165
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,25.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,25.5
       parent: 1
   - uid: 4166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,24.5
+      pos: 9.5,25.5
       parent: 1
   - uid: 4167
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,24.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,27.5
       parent: 1
   - uid: 4168
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,24.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,25.5
       parent: 1
   - uid: 4169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,24.5
+      pos: 7.5,24.5
       parent: 1
   - uid: 4170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,24.5
+      pos: 6.5,24.5
       parent: 1
   - uid: 4171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,24.5
+      pos: 5.5,24.5
       parent: 1
   - uid: 4172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,23.5
+      pos: 4.5,24.5
       parent: 1
   - uid: 4173
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,22.5
+      pos: 3.5,24.5
       parent: 1
   - uid: 4174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,21.5
+      pos: 2.5,24.5
       parent: 1
   - uid: 4175
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,20.5
+      pos: -2.5,23.5
       parent: 1
   - uid: 4176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,19.5
+      pos: -2.5,22.5
       parent: 1
   - uid: 4177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,18.5
+      pos: -2.5,21.5
       parent: 1
   - uid: 4178
     components:
     - type: Transform
-      pos: -17.5,15.5
+      rot: -1.5707963267948966 rad
+      pos: -2.5,20.5
       parent: 1
   - uid: 4179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -5.5,18.5
+      pos: -2.5,19.5
       parent: 1
   - uid: 4180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,18.5
+      pos: -3.5,18.5
       parent: 1
   - uid: 4181
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,18.5
+      pos: -17.5,15.5
       parent: 1
   - uid: 4182
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,18.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,18.5
       parent: 1
   - uid: 4183
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -8.5,23.5
+      pos: -6.5,18.5
       parent: 1
   - uid: 4184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,23.5
+      pos: -7.5,18.5
       parent: 1
   - uid: 4185
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,18.5
+      parent: 1
+  - uid: 4186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,23.5
+      parent: 1
+  - uid: 4187
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,23.5
+      parent: 1
+  - uid: 4188
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,24.5
       parent: 1
-  - uid: 4186
+  - uid: 4189
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,18.5
       parent: 1
-  - uid: 4187
+  - uid: 4190
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,24.5
       parent: 1
-  - uid: 4188
+  - uid: 4191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,18.5
       parent: 1
-  - uid: 4189
+  - uid: 4192
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,18.5
       parent: 1
-  - uid: 4190
+  - uid: 4193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,18.5
       parent: 1
-  - uid: 4191
+  - uid: 4194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,18.5
       parent: 1
-  - uid: 4192
+  - uid: 4195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,18.5
       parent: 1
-  - uid: 4193
+  - uid: 4196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,27.5
       parent: 1
-  - uid: 4194
-    components:
-    - type: Transform
-      pos: -12.5,28.5
-      parent: 1
-  - uid: 4195
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,18.5
-      parent: 1
-  - uid: 4196
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,26.5
-      parent: 1
   - uid: 4197
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,27.5
+      pos: -12.5,28.5
       parent: 1
   - uid: 4198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -14.5,27.5
+      pos: -19.5,18.5
       parent: 1
   - uid: 4199
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,24.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,26.5
       parent: 1
   - uid: 4200
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,25.5
+      rot: 1.5707963267948966 rad
+      pos: -13.5,27.5
       parent: 1
   - uid: 4201
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,26.5
+      rot: 1.5707963267948966 rad
+      pos: -14.5,27.5
       parent: 1
   - uid: 4202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,27.5
+      pos: -7.5,24.5
       parent: 1
   - uid: 4203
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,27.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,25.5
       parent: 1
   - uid: 4204
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,28.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,26.5
       parent: 1
   - uid: 4205
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,29.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,27.5
       parent: 1
   - uid: 4206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -15.5,23.5
+      pos: -16.5,27.5
       parent: 1
   - uid: 4207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,27.5
+      pos: -8.5,28.5
       parent: 1
   - uid: 4208
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -14.5,23.5
+      pos: -8.5,29.5
       parent: 1
   - uid: 4209
     components:
     - type: Transform
-      pos: -20.5,27.5
+      rot: 1.5707963267948966 rad
+      pos: -15.5,23.5
       parent: 1
   - uid: 4210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -15.5,27.5
+      pos: -19.5,27.5
       parent: 1
   - uid: 4211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,25.5
+      pos: -14.5,23.5
       parent: 1
   - uid: 4212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,23.5
+      pos: -20.5,27.5
       parent: 1
   - uid: 4213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,23.5
+      pos: -15.5,27.5
       parent: 1
   - uid: 4214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -12.5,23.5
+      pos: -13.5,25.5
       parent: 1
   - uid: 4215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -18.5,27.5
+      pos: -13.5,23.5
       parent: 1
   - uid: 4216
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,23.5
+      pos: -20.5,23.5
       parent: 1
   - uid: 4217
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,23.5
+      parent: 1
+  - uid: 4218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,27.5
+      parent: 1
+  - uid: 4219
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,23.5
+      parent: 1
+  - uid: 4220
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,16.5
       parent: 1
-  - uid: 4218
+  - uid: 4221
     components:
     - type: Transform
       pos: -26.5,9.5
       parent: 1
-  - uid: 4219
+  - uid: 4222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,36.5
       parent: 1
-  - uid: 4220
+  - uid: 4223
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,38.5
       parent: 1
-  - uid: 4221
+  - uid: 4224
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,38.5
       parent: 1
-  - uid: 4222
-    components:
-    - type: Transform
-      pos: -7.5,42.5
-      parent: 1
-  - uid: 4223
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,41.5
-      parent: 1
-  - uid: 4224
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,24.5
-      parent: 1
   - uid: 4225
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,42.5
+      pos: -7.5,42.5
       parent: 1
   - uid: 4226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -12.5,39.5
+      pos: -8.5,41.5
       parent: 1
   - uid: 4227
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,37.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,24.5
       parent: 1
   - uid: 4228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -12.5,40.5
+      pos: -8.5,42.5
       parent: 1
   - uid: 4229
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,36.5
+      rot: 3.141592653589793 rad
+      pos: -12.5,39.5
       parent: 1
   - uid: 4230
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,20.5
+      rot: 3.141592653589793 rad
+      pos: -12.5,37.5
       parent: 1
   - uid: 4231
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,21.5
+      rot: 3.141592653589793 rad
+      pos: -12.5,40.5
       parent: 1
   - uid: 4232
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -7.5,22.5
+      pos: -8.5,36.5
       parent: 1
   - uid: 4233
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,27.5
+      pos: -7.5,20.5
       parent: 1
   - uid: 4234
     components:
     - type: Transform
-      pos: 7.5,25.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,21.5
       parent: 1
   - uid: 4235
     components:
     - type: Transform
-      pos: 6.5,25.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,22.5
       parent: 1
   - uid: 4236
     components:
     - type: Transform
-      pos: 7.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,27.5
       parent: 1
   - uid: 4237
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,27.5
+      pos: 7.5,25.5
       parent: 1
   - uid: 4238
     components:
     - type: Transform
-      pos: -13.5,33.5
+      pos: 6.5,25.5
       parent: 1
   - uid: 4239
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,36.5
+      pos: 7.5,8.5
       parent: 1
   - uid: 4240
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -13.5,35.5
+      pos: -6.5,27.5
       parent: 1
   - uid: 4241
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,36.5
+      pos: -13.5,33.5
       parent: 1
   - uid: 4242
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -17.5,36.5
+      pos: -13.5,36.5
       parent: 1
   - uid: 4243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -18.5,36.5
+      pos: -13.5,35.5
       parent: 1
   - uid: 4244
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -19.5,36.5
+      pos: -16.5,36.5
       parent: 1
   - uid: 4245
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,36.5
+      pos: -17.5,36.5
       parent: 1
   - uid: 4246
     components:
     - type: Transform
-      pos: -16.5,42.5
+      rot: 1.5707963267948966 rad
+      pos: -18.5,36.5
+      parent: 1
+  - uid: 4247
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,36.5
       parent: 1
   - uid: 4248
     components:
     - type: Transform
-      pos: -14.5,42.5
+      rot: 1.5707963267948966 rad
+      pos: -20.5,36.5
       parent: 1
   - uid: 4249
     components:
     - type: Transform
-      pos: -13.5,40.5
+      pos: -16.5,42.5
       parent: 1
   - uid: 4250
+    components:
+    - type: Transform
+      pos: -14.5,42.5
+      parent: 1
+  - uid: 4251
+    components:
+    - type: Transform
+      pos: -13.5,40.5
+      parent: 1
+  - uid: 4252
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,27.5
       parent: 1
-  - uid: 4251
+  - uid: 4253
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,35.5
       parent: 1
-  - uid: 4252
+  - uid: 4254
     components:
     - type: Transform
       pos: -8.5,39.5
       parent: 1
-  - uid: 4253
+  - uid: 4255
     components:
     - type: Transform
       pos: -6.5,42.5
       parent: 1
-  - uid: 4254
+  - uid: 4256
     components:
     - type: Transform
       pos: -5.5,42.5
       parent: 1
-  - uid: 4255
+  - uid: 4257
     components:
     - type: Transform
       pos: -4.5,42.5
       parent: 1
-  - uid: 4256
+  - uid: 4258
     components:
     - type: Transform
       pos: -3.5,42.5
       parent: 1
-  - uid: 4257
+  - uid: 4259
     components:
     - type: Transform
       pos: -19.5,9.5
       parent: 1
-  - uid: 4258
+  - uid: 4260
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 1
-  - uid: 4259
-    components:
-    - type: Transform
-      pos: -21.5,9.5
-      parent: 1
-  - uid: 4260
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,23.5
-      parent: 1
   - uid: 4261
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,19.5
+      pos: -21.5,9.5
       parent: 1
   - uid: 4262
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -21.5,27.5
+      pos: -21.5,23.5
       parent: 1
   - uid: 4263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,19.5
+      parent: 1
+  - uid: 4264
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,27.5
+      parent: 1
+  - uid: 4265
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,28.5
       parent: 1
-  - uid: 4264
+  - uid: 4266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,29.5
       parent: 1
-  - uid: 4265
+  - uid: 4267
     components:
     - type: Transform
       pos: -15.5,28.5
       parent: 1
-  - uid: 4266
+  - uid: 4268
     components:
     - type: Transform
       pos: -15.5,29.5
       parent: 1
-  - uid: 4267
+  - uid: 4269
     components:
     - type: Transform
       pos: -19.5,28.5
       parent: 1
-  - uid: 4268
+  - uid: 4270
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 4269
+  - uid: 4271
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 4270
+  - uid: 4272
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 4271
+  - uid: 4273
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 1
-  - uid: 4272
+  - uid: 4274
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 4273
+  - uid: 4275
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 1
-  - uid: 4274
+  - uid: 4276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 1
-  - uid: 4275
+  - uid: 4277
     components:
     - type: Transform
       pos: -41.5,2.5
       parent: 1
-  - uid: 4276
+  - uid: 4278
     components:
     - type: Transform
       pos: -42.5,2.5
       parent: 1
-  - uid: 4277
+  - uid: 4279
     components:
     - type: Transform
       pos: -43.5,2.5
       parent: 1
-  - uid: 4278
+  - uid: 4280
     components:
     - type: Transform
       pos: -44.5,2.5
       parent: 1
-  - uid: 4279
+  - uid: 4281
     components:
     - type: Transform
       pos: -48.5,2.5
       parent: 1
-  - uid: 4280
+  - uid: 4282
     components:
     - type: Transform
       pos: -49.5,2.5
       parent: 1
-  - uid: 4281
-    components:
-    - type: Transform
-      pos: -50.5,2.5
-      parent: 1
-  - uid: 4282
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -48.5,8.5
-      parent: 1
   - uid: 4283
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -44.5,8.5
+      pos: -50.5,2.5
       parent: 1
   - uid: 4284
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -44.5,0.5
+      pos: -48.5,8.5
       parent: 1
   - uid: 4285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: -44.5,8.5
+      parent: 1
+  - uid: 4286
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -44.5,0.5
+      parent: 1
+  - uid: 4287
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -48.5,0.5
       parent: 1
-  - uid: 4331
+  - uid: 4288
     components:
     - type: Transform
       pos: -16.5,43.5
       parent: 1
-  - uid: 4332
+  - uid: 4289
     components:
     - type: Transform
       pos: -13.5,43.5
       parent: 1
-  - uid: 4333
+  - uid: 4290
     components:
     - type: Transform
       pos: -14.5,43.5
       parent: 1
-  - uid: 4334
+  - uid: 4291
     components:
     - type: Transform
       pos: -15.5,43.5
       parent: 1
 - proto: WardrobeScience
   entities:
-  - uid: 4286
+  - uid: 4292
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1
 - proto: WardrobeScienceFilled
   entities:
-  - uid: 4287
+  - uid: 4293
     components:
     - type: Transform
       pos: -1.5,23.5
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 4288
+  - uid: 4294
     components:
     - type: Transform
       pos: -10.5,16.5
       parent: 1
 - proto: WaterCooler
   entities:
-  - uid: 4289
+  - uid: 4295
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 4290
+  - uid: 4296
     components:
     - type: Transform
       pos: -16.5,4.5
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 4291
+  - uid: 4297
     components:
     - type: Transform
       pos: -18.5,7.5
       parent: 1
 - proto: WeaponDisabler
   entities:
-  - uid: 1459
+  - uid: 1468
     components:
     - type: Transform
-      parent: 1455
+      parent: 1464
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 3560
+  - uid: 3562
     components:
     - type: Transform
-      parent: 3559
+      parent: 3561
     - type: Physics
       canCollide: False
 - proto: WeaponDisablerSMG
   entities:
-  - uid: 3561
+  - uid: 3563
     components:
     - type: Transform
-      parent: 3559
+      parent: 3561
     - type: Physics
       canCollide: False
 - proto: WeaponShotgunKammerer
   entities:
-  - uid: 3564
+  - uid: 3566
     components:
     - type: Transform
-      parent: 3563
+      parent: 3565
     - type: Physics
       canCollide: False
-  - uid: 3565
+  - uid: 3567
     components:
     - type: Transform
-      parent: 3563
+      parent: 3565
     - type: Physics
       canCollide: False
 - proto: WetFloorSign
   entities:
-  - uid: 4292
+  - uid: 4298
     components:
     - type: Transform
       pos: -10.777608,36.53113
       parent: 1
 - proto: WindoorSecure
   entities:
-  - uid: 4293
+  - uid: 4299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,12.5
       parent: 1
-  - uid: 4294
+  - uid: 4300
     components:
     - type: Transform
       pos: -4.5,33.5
       parent: 1
-  - uid: 4295
+  - uid: 4301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,30.5
       parent: 1
-  - uid: 4296
+  - uid: 4302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -32378,41 +32388,41 @@ entities:
       parent: 1
 - proto: WindoorSecureFrontierCommandLocked
   entities:
-  - uid: 4336
+  - uid: 4303
     components:
     - type: Transform
       pos: -15.5,42.5
       parent: 1
 - proto: WindoorSecureMedicalLocked
   entities:
-  - uid: 4297
+  - uid: 4304
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,33.5
       parent: 1
-  - uid: 4298
+  - uid: 4305
     components:
     - type: Transform
       pos: -19.5,34.5
       parent: 1
-  - uid: 4299
+  - uid: 4306
     components:
     - type: Transform
       pos: -18.5,33.5
       parent: 1
-  - uid: 4300
+  - uid: 4307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,33.5
       parent: 1
-  - uid: 4301
+  - uid: 4308
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
-  - uid: 4302
+  - uid: 4309
     components:
     - type: Transform
       pos: -17.5,33.5
@@ -32461,7 +32471,7 @@ entities:
       - - Wizard
 - proto: WindoorSecurePlasma
   entities:
-  - uid: 4303
+  - uid: 4310
     components:
     - type: Transform
       pos: 10.5,40.5
@@ -32470,11 +32480,11 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -9229.955
+      secondsUntilStateChange: -9413.455
       state: Opening
     - type: Airlock
       autoClose: False
-  - uid: 4304
+  - uid: 4311
     components:
     - type: Transform
       pos: 6.5,40.5
@@ -32482,7 +32492,7 @@ entities:
     - type: AccessReader
       access:
       - - ChiefMedicalOfficer
-  - uid: 4305
+  - uid: 4312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -32493,7 +32503,7 @@ entities:
       - - Armory
       - - ChiefMedicalOfficer
       - - Medical
-  - uid: 4306
+  - uid: 4313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -32504,7 +32514,7 @@ entities:
       - - Armory
       - - ChiefMedicalOfficer
       - - Medical
-  - uid: 4307
+  - uid: 4314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -32515,7 +32525,7 @@ entities:
       - - Armory
       - - ChiefMedicalOfficer
       - - Medical
-  - uid: 4308
+  - uid: 4315
     components:
     - type: Transform
       pos: 7.5,40.5
@@ -32523,7 +32533,7 @@ entities:
     - type: AccessReader
       access:
       - - ChiefMedicalOfficer
-  - uid: 4309
+  - uid: 4316
     components:
     - type: Transform
       pos: 8.5,40.5
@@ -32533,112 +32543,112 @@ entities:
       - - ChiefMedicalOfficer
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 4310
+  - uid: 4317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,15.5
       parent: 1
-  - uid: 4311
+  - uid: 4318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,15.5
       parent: 1
-  - uid: 4312
+  - uid: 4319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,35.5
       parent: 1
-  - uid: 4313
+  - uid: 4320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,34.5
       parent: 1
-  - uid: 4314
+  - uid: 4321
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,4.5
       parent: 1
-  - uid: 4315
+  - uid: 4322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 1
-  - uid: 4316
+  - uid: 4323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-  - uid: 4317
+  - uid: 4324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,4.5
       parent: 1
-  - uid: 4318
+  - uid: 4325
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,15.5
       parent: 1
-  - uid: 4319
+  - uid: 4326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,15.5
       parent: 1
-  - uid: 4320
+  - uid: 4327
     components:
     - type: Transform
       pos: -14.5,33.5
       parent: 1
-  - uid: 4321
+  - uid: 4328
     components:
     - type: Transform
       pos: -15.5,33.5
       parent: 1
-  - uid: 4322
+  - uid: 4329
     components:
     - type: Transform
       pos: -16.5,33.5
       parent: 1
-  - uid: 4323
+  - uid: 4330
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,30.5
       parent: 1
-  - uid: 4324
+  - uid: 4331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,30.5
       parent: 1
-  - uid: 4325
+  - uid: 4332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,30.5
       parent: 1
-  - uid: 4326
+  - uid: 4333
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,30.5
       parent: 1
-  - uid: 4327
+  - uid: 4334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,39.5
       parent: 1
-  - uid: 4328
+  - uid: 4335
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -32646,7 +32656,7 @@ entities:
       parent: 1
 - proto: Wrench
   entities:
-  - uid: 4329
+  - uid: 4336
     components:
     - type: Transform
       pos: -22.418427,12.400544

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
@@ -316,5 +316,4 @@
   - type: Flatpack
     entity: MiniStationAnchorOff
   - type: StaticPrice
-    price: 3000
-    vendPrice: 15000
+    vendPrice: 7500

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/flatpack.yml
@@ -306,3 +306,15 @@
   - type: StaticPrice
     price: 4000
     vendPrice: 10000
+
+- type: entity
+  parent: BaseNFFlatpack
+  id: MiniStationAnchorFlatpack
+  name: mini station anchor flatpack
+  description: A flatpack used for constructing a mini station anchor.
+  components:
+  - type: Flatpack
+    entity: MiniStationAnchorOff
+  - type: StaticPrice
+    price: 3000
+    vendPrice: 15000

--- a/Resources/Prototypes/_Mono/PointsOfInterest/anomalouslab.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/anomalouslab.yml
@@ -10,7 +10,7 @@
 # The local Science lab
 - type: pointOfInterest
   id: AnomalousLab
-  parent: BasePOI
+  parent: BaseMobilePOI
   name: 'Anomalous Lab'
   minimumDistance: 7000
   maximumDistance: 10800

--- a/Resources/Prototypes/_Mono/PointsOfInterest/derelictdrillsite.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/derelictdrillsite.yml
@@ -9,7 +9,7 @@
 # Notes:
 - type: pointOfInterest
   id: Mining
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'Derelict Drillsite'
   minimumDistance: 3500
   maximumDistance: 7500

--- a/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
@@ -7,7 +7,7 @@
 # Discord: ???
 - type: pointOfInterest
   id: HeliosFortress
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'PDV Helios Fortress'
   minimumDistance: 7500
   maximumDistance: 9500

--- a/Resources/Prototypes/_Mono/PointsOfInterest/tsfmchalcyon.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/tsfmchalcyon.yml
@@ -12,7 +12,7 @@
 #
 - type: pointOfInterest
   id: TSFMCHalcyon
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'TSFMC Flagship Halcyon'
   minimumDistance: 2500 # Mono
   maximumDistance: 4000 # Mono

--- a/Resources/Prototypes/_Mono/PointsOfInterest/tsfmcsecondary.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/tsfmcsecondary.yml
@@ -10,7 +10,7 @@
 #
 - type: pointOfInterest
   id: TSFMCOutpost
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'TSFMC Secondary Outpost'
   minimumDistance: 11000
   maximumDistance: 14000

--- a/Resources/Prototypes/_Mono/PointsOfInterest/ussp.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/ussp.yml
@@ -10,7 +10,7 @@
 #
 - type: pointOfInterest
   id: USSPCamelot
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'Camelot Station'
   minimumDistance: 10650
   maximumDistance: 12400

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/flatpackvend.yml
@@ -34,3 +34,4 @@
     JukeboxFlatpack: 4294967295 # Infinite - Mono
     AtmosDeviceFanDirectionalFlatpack: 4294967295 # Infinite - Mono
     MaterialSiloFlatpack: 4294967295 # Infinite - Mono
+    MiniStationAnchorFlatpack: 4294967295 # Infinite - Mono

--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/station_anchor.yml
@@ -7,7 +7,7 @@
   components:
   - type: PowerCharge
     activePower: 500
-    chargeRate: 0.1
+    chargeRate: 0.05
   - type: ApcPowerReceiver
     powerLoad: 500
   - type: StaticPrice

--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/station_anchor.yml
@@ -7,6 +7,7 @@
   components:
   - type: PowerCharge
     activePower: 500
+    chargeRate: 0.1
   - type: ApcPowerReceiver
     powerLoad: 500
   - type: StaticPrice

--- a/Resources/Prototypes/_NF/PointsOfInterest/bahamamamas.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/bahamamamas.yml
@@ -10,7 +10,7 @@
 # I want to lie, shipwrecked and comatose, drinking fresh mango juice.
 - type: pointOfInterest
   id: Bahama
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: "Bahama Mama's"
   minimumDistance: 3400
   maximumDistance: 5800

--- a/Resources/Prototypes/_NF/PointsOfInterest/caseys.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/caseys.yml
@@ -10,7 +10,7 @@
 # Down at your local saloon
 - type: pointOfInterest
   id: CaseysCasino
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: "Crazy Casey's Casino"
   minimumDistance: 4250
   maximumDistance: 5600

--- a/Resources/Prototypes/_NF/PointsOfInterest/grifty.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/grifty.yml
@@ -10,7 +10,7 @@
 # Down at your local saloon
 - type: pointOfInterest
   id: Grifty
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: "Grifty's Gas n Grub"
   minimumDistance: 6250
   maximumDistance: 8600

--- a/Resources/Prototypes/_NF/PointsOfInterest/mchobo.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/mchobo.yml
@@ -11,7 +11,7 @@
 # Based on the McCargo built by Dvir01 (https://github.com/dvir001) and ruined with drunken pride by Tych0.
 - type: pointOfInterest
   id: McHobo
-  parent: BasePOI
+  parent: BaseMobilePOI
   name: Derelict McCargo
   minimumDistance: 6250
   maximumDistance: 7600

--- a/Resources/Prototypes/_NF/PointsOfInterest/medical.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/medical.yml
@@ -10,7 +10,7 @@
 # Medical ship garage, medical manager base and medical bounty staging area.
 - type: pointOfInterest
   id: Medical
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'Medical Dispatch'
   minimumDistance: 1650
   maximumDistance: 5400

--- a/Resources/Prototypes/_NF/PointsOfInterest/omnichurch.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/omnichurch.yml
@@ -10,7 +10,7 @@
 #
 - type: pointOfInterest
   id: Omnichurch
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: "Omnichurch Beacon"
   minimumDistance: 4200
   maximumDistance: 6900

--- a/Resources/Prototypes/_NF/PointsOfInterest/thepit.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/thepit.yml
@@ -10,7 +10,7 @@
 # Down at your local saloon
 - type: pointOfInterest
   id: ThePit
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: "The Pit"
   minimumDistance: 5200
   maximumDistance: 6200

--- a/Resources/Prototypes/_NF/PointsOfInterest/tinniasrest.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/tinniasrest.yml
@@ -10,7 +10,7 @@
 # Down at your local saloon
 - type: pointOfInterest
   id: Tinnia
-  parent: [BasePOI, BaseRepairablePOI]
+  parent: [BaseMobilePOI, BaseRepairablePOI]
   name: "Tinnia's Rest"
   minimumDistance: 3400
   maximumDistance: 5800


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

makes almost all POIs mobile except CC, Seva, and Trade Mall/Depots

Adds mini station anchor flatpacks to the flatpack vend for 7500 credits each.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Let them fly. Let them be free. Let them make stations and more.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: All POIs except CC, Seva, and Trade Mall/Depots are now mobile and no longer force anchored. Yes, this includes Halcyon and Helios.
- add: Mini Station Anchor flatpacks to Flatpack vend.
- fix: adds missing mini station anchor to MD
- tweak: mini station anchors take longer to charge up than normal anchors