### PR TITLE
Expands Global Passive Healing & Buff Vox Space Resistances

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -245,15 +245,19 @@
       types:
         Blunt: 0.50 #per second, scales with pressure and other constants.
         Heat: 0.1
-  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
+  - type: PassiveDamage # Mono: Slow general passive regen for most types.
     allowedStates:
     - Alive
-    damageCap: 20
+    damageCap: 200
     damage:
       types:
-        Heat: -0.07
+        Heat: -0.05
+        Cold: -0.05
+        Shock: -0.02
+        Radiation: -0.02
+        Poison: -0.02
       groups:
-        Brute: -0.07
+        Brute: -0.15 # Divided among all types whether types exist or not
   - type: Fingerprint
   - type: Blindable
   # Other

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -63,15 +63,21 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Slime
-  - type: PassiveDamage # Around 8 damage a minute healed
+  - type: PassiveDamage # Mono: More resilient against most damage types and even cellular, very weak to cold.
     allowedStates:
     - Alive
-    damageCap: 65
+    damageCap: 200
     damage:
       types:
-        Heat: -0.14
+        Heat: -0.15
+        Cold: -0.01
+        Shock: -0.05
+        Radiation: -0.05
+        Asphyxiation: -0.05
+        Poison: -0.05
+        Cellular: -0.01
       groups:
-        Brute: -0.14
+        Brute: -0.45 # Divided among all types whether types exist or not
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -33,18 +33,25 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Vox
-  - type: PassiveDamage
-    # Augment normal health regen to be able to tank some Poison damage
-    # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
-    allowedStates:
-    - Alive
-    damageCap: 20
+  - type: Barotrauma # Mono: Space-adapted/engineered vox are more resilient against pressure damage
     damage:
       types:
-        Heat: -0.07
-        Poison: -0.2
+        Blunt: 0.20 #per second, scales with pressure and other constants.
+        Heat: 0.04
+  - type: PassiveDamage # Mono: Retain enhanced poison regen, enhance radiation and asphyxiation and cold for space-adapted vox
+    allowedStates:
+    - Alive
+    damageCap: 200
+    damage:
+      types:
+        Heat: -0.05
+        Cold: -0.1
+        Shock: -0.02
+        Radiation: -0.05
+        Asphyxiation: -0.05
+        Poison: -0.1
       groups:
-        Brute: -0.07
+        Brute: -0.15 # Divided among all types whether types exist or not
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:
@@ -54,6 +61,11 @@
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Bloodstream
     bloodReagent: AmmoniaBlood
+  - type: TemperatureSpeed # Mono: Cold Vox are slowed less, space adaptation
+    thresholds:
+      210: 0.8
+      150: 0.6
+      90: 0.4
   - type: MeleeWeapon
     soundHit:
       collection: AlienClaw

--- a/Resources/Prototypes/_Obelisk/Entities/Mobs/Species/hydrakin.yml
+++ b/Resources/Prototypes/_Obelisk/Entities/Mobs/Species/hydrakin.yml
@@ -48,6 +48,7 @@
   - type: Temperature
     coldDamageThreshold: 10 # Mono - Absurd cold resistance
     heatDamageThreshold: 332 # no. just no. suffer.
+    currentTemperature: 210.15 # Mono - reset starting temperature
     coldDamage:
       types:
         Cold : 0.01 #per second, scales with temperature & other constants


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Rebalanced species passive healing to be broader, slightly slower, and with more species-specific quirks for Vox and Slimes.
Passive healing now functions as long as the mob is Alive (not Critical and definitely not Dead), regardless of thresholds (up to 200 technically, but must still be Alive). Most species have a low level of Heat, Cold, and Brute healing, and a very low level of Shock, Radiation, and Poison recovery.
Slimes recover much better in general, even adding a little bit of Cellular regeneration, at the cost of greatly reduced cold damage recovery.
Vox retain their enhanced poison recovery (albeit slower with no cap) and gain traits similar to slimes with enhanced radiation and asphyxiation recovery while also reducing their Barotrauma damage and lowering their speed loss thresholds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This mimics the theme of upstream offmed and passive healing while tuning it for Monolith's gameplay. With the rightful sunset of the Platelet Factories Meta, every Bob, Geoff, and Susan are going to be chugging meds like they're candy with no reasonable source of passive healing, especially when most guns and weapons exceed that passive healing threshold already.
This will not return the previous status of PF players being "PvE Gods," not that they ever were before, nor will it expand that status to everyone; the rate of healing, even for slimes, is too slow, and it only functions when not in Crit. It will ensure that medical is not flooded with players demanding treatment for every bump, scrape, cut, brief glimpse at the reactor, stubbed toe, or burnt finger, but able to serve players actually looking for and needing real medical care and wanting actual roleplay. Healing in the short term for rapid return to combat will still require at least basic first aid if not dedicated meds.
This also gives a little more mechanical flavor to Vox with low pressure/temperature tolerances in ways different from Hydrakin, keeping with the lore/concept of Vox being bioengineered for space scrapping.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Play as your favorite organic species (Sorry IPCs), get injured.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Expanded and rebalanced passive healing across the board
- fix: Made Hydrakin start at their normal body temperature (finally)
- tweak: Adjusted Vox tolerances to being spaced