### PR TITLE
Revert "Cable Destruction Lag Reduction"

### DIFF
--- a/Content.Server/Power/EntitySystems/CableSystem.cs
+++ b/Content.Server/Power/EntitySystems/CableSystem.cs
@@ -74,8 +74,7 @@ public sealed partial class CableSystem : EntitySystem
 
         // This entity should not be un-anchorable. But this can happen if the grid-tile is deleted (RCD, explosion,
         // etc). In that case: behave as if the cable had been cut.
-		// Mono: Item drop disabled due to ramming performance
-        /*Spawn(cable.CableDroppedOnCutPrototype, Transform(uid).Coordinates);*/
+        Spawn(cable.CableDroppedOnCutPrototype, Transform(uid).Coordinates);
         QueueDel(uid);
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -79,13 +79,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 250 #Mono 100 >> 250
+        damage: 400
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 300
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -138,13 +138,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 250 #Mono 100 >> 250
+        damage: 350
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 200 #Mono 50 >> 200
+        damage: 250
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -193,13 +193,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 250 #Mono 100 >> 250
+        damage: 250
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 200 #Mono 50 >> 200
+        damage: 150
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -79,13 +79,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 250 #Mono: 100 >> 50
+        damage: 250 #Mono 100 >> 50
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 200 #Mono: 50 >> 200
+        damage: 200 #Mono 50 >> 200
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -138,13 +138,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 250 #Mono: 100 >> 250
+        damage: 250 #Mono 100 >> 250
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: #Mono: 50 >> 200
+        damage: #Mono 50 >> 200
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -193,13 +193,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 250 #Mono: 100 >> 250
+        damage: 250 #Mono 100 >> 250
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 200 #Mono: 50 >> 200
+        damage: 200 #Mono 50 >> 200
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -79,7 +79,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 250 #Mono 100 >> 50
+        damage: 250 #Mono 100 >> 250
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -144,7 +144,7 @@
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: #Mono 50 >> 200
+        damage: 200 #Mono 50 >> 200
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -79,13 +79,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 400
+        damage: 250 #Mono: 100 >> 50
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 200 #Mono: 50 >> 200
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -138,13 +138,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 350
+        damage: 250 #Mono: 100 >> 250
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 250
+        damage: #Mono: 50 >> 200
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -193,13 +193,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 250
+        damage: 250 #Mono: 100 >> 250
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 200 #Mono: 50 >> 200
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:


### PR DESCRIPTION
Partially Reverts Monolith-Station/Monolith#3520

A more sophisticated system was added so we might not need to go as far as to delete the cable degridding mechanic entirely.

https://github.com/Monolith-Station/Monolith/pull/3415