### PR TITLE
Majorly Buffs Part Wound Tending

### DIFF
--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -150,7 +150,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
         if (HasComp<ForcedSleepingComponent>(args.Body))
             damageChange = damageChange * ent.Comp.SleepModifier;
 
-        SetDamage(args.Body, damageChange, 1f, args.User, args.Part); // 0.5-> 1.0f - Mono
+        SetDamage(args.Body, damageChange, 1f, args.User, args.Part); // 0.5-> 1.0f part damage - Mono
     }
 
     private void OnSurgerySpecialDamageChange(Entity<SurgerySpecialDamageChangeEffectComponent> ent, ref SurgeryStepDamageChangeEvent args)

--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -150,7 +150,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
         if (HasComp<ForcedSleepingComponent>(args.Body))
             damageChange = damageChange * ent.Comp.SleepModifier;
 
-        SetDamage(args.Body, damageChange, 0.5f, args.User, args.Part);
+        SetDamage(args.Body, damageChange, 1f, args.User, args.Part); // 0.5-> 1.0f - Mono
     }
 
     private void OnSurgerySpecialDamageChange(Entity<SurgerySpecialDamageChangeEffectComponent> ent, ref SurgeryStepDamageChangeEvent args)

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -360,7 +360,7 @@ public abstract partial class SharedSurgerySystem
         foreach (var type in group)
             adjustedDamage.DamageDict[type] -= bonus;
 
-        var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, adjustedDamage, 2.5f); // 0.5 -> 2.5f, buffed wound surgery tending
+        var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, adjustedDamage, 2.5f); // 0.5 -> 2.5f, buffed wound surgery tending - Mono
         RaiseLocalEvent(args.Body, ref ev);
     }
 

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -360,7 +360,7 @@ public abstract partial class SharedSurgerySystem
         foreach (var type in group)
             adjustedDamage.DamageDict[type] -= bonus;
 
-        var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, adjustedDamage, 2.5f); // 0.5 -> 2.5f, buffed wound surgery tending - Mono
+        var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, adjustedDamage, 2.5f); // 0.5 -> 2.5f part damage, buffed wound surgery tending - Mono
         RaiseLocalEvent(args.Body, ref ev);
     }
 

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -177,7 +177,7 @@ public abstract partial class SharedSurgerySystem
             if (!HasComp<SanitizedComponent>(args.User))
             {
                 var sepsis = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Poison"), 15);
-                var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, sepsis, 0.5f);
+                var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, sepsis, 1.0f); // Mono - 0.5->1.0f - Mono Part surgery damage increase
                 RaiseLocalEvent(args.Body, ref ev);
             }
         }

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -360,7 +360,7 @@ public abstract partial class SharedSurgerySystem
         foreach (var type in group)
             adjustedDamage.DamageDict[type] -= bonus;
 
-        var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, adjustedDamage, 0.5f);
+        var ev = new SurgeryStepDamageEvent(args.User, args.Body, args.Part, args.Surgery, adjustedDamage, 2.5f); // 0.5 -> 2.5f, buffed wound surgery tending
         RaiseLocalEvent(args.Body, ref ev);
     }
 


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Surgery now heals part damage at 2.5x instead of 0.5x.

Other surgery related damage at 1.0x instead of 0.5x part damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This makes surgery repairing parts not utterly miserable. Note that it still applies to each individual part..

Surgery will still work even if there's no damage on a limb as long as the body is damaged, so this works fine still.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Tending surgery heals bodyparts 2.5x the amount tended, previous value was 0.5x
- tweak: Other surgery based damage increased to 1.0x part damage instead of 0.5x (i.e sepsis)