### PR TITLE
Fireteam Time Requirement Tweak

### DIFF
--- a/Resources/Prototypes/_Mono/Loadouts/TSFMC/role_loadouts_tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/TSFMC/role_loadouts_tsfmc.yml
@@ -1,6 +1,6 @@
 # Nfsd
 - type: roleLoadout
-  id: JobCadet
+  id: JobCadet # Unused
   groups:
   - TsfmcHead
   - TsfmcNeck
@@ -82,7 +82,7 @@
   canCustomizeName: true
 
 - type: roleLoadout
-  id: JobBailiff
+  id: JobBailiff # Captain
   groups:
   - TsfmcHead
   - TsfmcNeckCaptain

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/senior_officer.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/senior_officer.yml
@@ -8,10 +8,7 @@
       time: 72000 # 20 hours # mono
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 28800 # 8 hours # mono
-    - !type:RoleTimeRequirement
-      role: JobSecurityOfficer
-      time: 36000 # 10 hours # mono
+      time: 64800 # 18 hours # mono
   startingGear: SeniorOfficerGear
   icon: JobIconSergeant
   supervisors: job-supervisors-sheriff

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/senior_officer.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/senior_officer.yml
@@ -8,7 +8,7 @@
       time: 72000 # 20 hours # mono
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 64800 # 18 hours # mono
+      time: 36000 # 10 hours # mono
   startingGear: SeniorOfficerGear
   icon: JobIconSergeant
   supervisors: job-supervisors-sheriff


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Replaces 10 hours of marine time with 10 hours of overall tsfmc playtime required

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Flat improvement, no one should be forced to play marine if they want to play brigmed or something to unlock fireteam leader

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Fireteam leader marine playtime requirement of 10 hours replaced with general tsfmc playtime requirement of 10 hours

