### PR TITLE
Research Client Fix

### DIFF
--- a/Content.Server/Research/Systems/ResearchSystem.Server.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Server.cs
@@ -69,6 +69,8 @@ public sealed partial class ResearchSystem
         if (serverComponent.Clients.Contains(client))
             return;
 
+        UnregisterClient(client, clientComponent); // Mono Research Fix, unregister a client if applicable before registering to a new server
+
         serverComponent.Clients.Add(client);
         clientComponent.Server = server;
         SyncClientWithServer(client, clientComponent: clientComponent);


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Ensures a research client unregisters from its current server before registering to a new one.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is to prevent data farms and other research point generating things from connecting to multiple servers at once.

If a data farm is created and two servers exist on the grid, the servers will both connect to it while the client will only connect to one, resulting in the client providing points to both at once

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Research generating things no longer connect to multiple servers at once when built