### PR TITLE
Reflect Fixes

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -43,7 +43,7 @@ public sealed partial class BlockingSystem : SharedBlockingSystem // Mono
 
     private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)
     {
-        if (TryComp<ItemToggleComponent>(component.BlockingItem, out var toggleComponent) && TryComp<BlockingComponent>(component.BlockingItem, out var blocking)) // Mono
+        if (TryComp<BlockingComponent>(component.BlockingItem, out var blocking)) // Mono
         {
             if (args.Damage.GetTotal() <= 0)
                 return;
@@ -52,7 +52,7 @@ public sealed partial class BlockingSystem : SharedBlockingSystem // Mono
             if (!TryComp<DamageableComponent>(component.BlockingItem, out var dmgComp))
                 return;
 
-            if (!toggleComponent.Activated) // Mono
+            if (TryComp<ItemToggleComponent>(component.BlockingItem, out var toggleComponent) && !toggleComponent.Activated) // Mono
                 return;
 
             var blockFraction = blocking.IsBlocking ? blocking.ActiveBlockFraction : blocking.PassiveBlockFraction;

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
@@ -29,7 +29,7 @@ public sealed class HitscanReflectSystem : EntitySystem
         if (EntityManager.TryGetComponent(hitscan, out HitscanBasicDamageComponent? hitscanDamage))
             damage = hitscanDamage.Damage * _damage.UniversalHitscanDamageModifier;
 
-        // Mono - Added null as default DamageSpecifier? Damage parameter bro what the fuck are you doing
+        // Mono - Use hitscan damage component if available
         var ev = new HitScanReflectAttemptEvent(args.Shooter ?? args.Gun, args.Gun, hitscan.Comp.ReflectiveType, args.ShotDirection, false, damage);
         RaiseLocalEvent(args.HitEntity.Value, ref ev);
 

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage;
 using Content.Shared.Weapons.Hitscan.Components;
 using Content.Shared.Weapons.Hitscan.Events;
 using Content.Shared.Weapons.Ranged.Events;
@@ -8,6 +9,7 @@ namespace Content.Shared.Weapons.Hitscan.Systems;
 
 public sealed class HitscanReflectSystem : EntitySystem
 {
+    [Dependency] private readonly DamageableSystem _damage = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -23,8 +25,12 @@ public sealed class HitscanReflectSystem : EntitySystem
         if (hitscan.Comp.CurrentReflections >= hitscan.Comp.MaxReflections)
             return;
 
-        // Mono - Added null as default DamageSpecifier? Damage parameter
-        var ev = new HitScanReflectAttemptEvent(args.Shooter ?? args.Gun, args.Gun, hitscan.Comp.ReflectiveType, args.ShotDirection, false, null);
+        DamageSpecifier damage = new();
+        if (EntityManager.TryGetComponent(hitscan, out HitscanBasicDamageComponent? hitscanDamage))
+            damage = hitscanDamage.Damage * _damage.UniversalHitscanDamageModifier;
+
+        // Mono - Added null as default DamageSpecifier? Damage parameter bro what the fuck are you doing
+        var ev = new HitScanReflectAttemptEvent(args.Shooter ?? args.Gun, args.Gun, hitscan.Comp.ReflectiveType, args.ShotDirection, false, damage);
         RaiseLocalEvent(args.HitEntity.Value, ref ev);
 
         if (!ev.Reflected)

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
@@ -26,7 +26,7 @@ public sealed class HitscanReflectSystem : EntitySystem
             return;
 
         DamageSpecifier damage = new();
-        if (EntityManager.TryGetComponent(hitscan, out HitscanBasicDamageComponent? hitscanDamage))
+        if (EntityManager.TryGetComponent<HitscanBasicDamageComponent>(hitscan, out var hitscanDamage))
             damage = hitscanDamage.Damage * _damage.UniversalHitscanDamageModifier;
 
         // Mono - Use hitscan damage component if available

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Weapons.Hitscan.Systems;
 
 public sealed class HitscanReflectSystem : EntitySystem
 {
-    [Dependency] private readonly DamageableSystem _damage = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!; // Mono
     public override void Initialize()
     {
         base.Initialize();
@@ -25,12 +25,14 @@ public sealed class HitscanReflectSystem : EntitySystem
         if (hitscan.Comp.CurrentReflections >= hitscan.Comp.MaxReflections)
             return;
 
+        // Mono begin
         DamageSpecifier damage = new();
         if (EntityManager.TryGetComponent<HitscanBasicDamageComponent>(hitscan, out var hitscanDamage))
             damage = hitscanDamage.Damage * _damage.UniversalHitscanDamageModifier;
 
         // Mono - Use hitscan damage component if available
         var ev = new HitScanReflectAttemptEvent(args.Shooter ?? args.Gun, args.Gun, hitscan.Comp.ReflectiveType, args.ShotDirection, false, damage);
+        // Mono End
         RaiseLocalEvent(args.HitEntity.Value, ref ev);
 
         if (!ev.Reflected)

--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -30,6 +30,9 @@ public sealed partial class ReflectComponent : Component
     public SoundSpecifier? SoundOnReflect = new SoundPathSpecifier("/Audio/Weapons/Guns/Hits/laser_sear_wall.ogg");
 
     // WD START
+    /// <summary>
+    /// How much damage does the reflecting item take on reflect?
+    /// </summary>
     [DataField, AutoNetworkedField]
     public float DamageOnReflectModifier;
     // WD END

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -232,7 +232,7 @@ public sealed class ReflectSystem : EntitySystem
             if (reflect.DamageOnReflectModifier != 0)
             {
                 _damageable.TryChangeDamage(reflector, projectileComp.Damage * reflect.DamageOnReflectModifier,
-                    projectileComp.IgnoreResistances, origin: projectileComp.Shooter);
+                    projectileComp.IgnoreResistances, armorPenetration: projectileComp.ArmorPenetration, origin: projectileComp.Shooter); // Mono - Added armorpen
             }
             // WD EDIT END
 


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Reflecting hitscan projectiles respects the "damageonreflect" component, meaning the item will take damage with the damageable component if it is set.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Massive bugfix, hitscan projectiles did nothing to energy shields before.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Energy shields now take damage from reflecting hitscan projectiles, instead of just non-hitscan energy projectiles.
- fix: Riot and non-energy shields work now.
