### PR TITLE
Fastify Apoc

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -358,8 +358,8 @@ namespace Content.Server.RoundEnd
                                         : _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallTime));
 
             // Mono
-            var query = EntityQueryEnumerator<RoundEndTimeRuleComponent>();
-            while (query.MoveNext(out _, out var endTimeComp))
+            var query = EntityQueryEnumerator<RoundEndTimeRuleComponent, ActiveGameRuleComponent>();
+            while (query.MoveNext(out _, out var endTimeComp, var _))
             {
                 mins = endTimeComp.EndAt;
             }

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -354,9 +354,17 @@ namespace Content.Server.RoundEnd
         public override void Update(float frameTime)
         {
             // Check if we should auto-call.
-            int mins = _autoCalledBefore ? _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallExtensionTime)
-                                        : _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallTime);
-            if (mins != 0 && _gameTiming.CurTime - AutoCallStartTime > TimeSpan.FromMinutes(mins))
+            var mins = TimeSpan.FromMinutes(_autoCalledBefore ? _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallExtensionTime)
+                                        : _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallTime));
+
+            // Mono
+            var query = EntityQueryEnumerator<RoundEndTimeRuleComponent>();
+            while (query.MoveNext(out _, out var endTimeComp))
+            {
+                mins = endTimeComp.EndAt;
+            }
+
+            if (mins.TotalSeconds != 0 && _gameTiming.CurTime - AutoCallStartTime > mins)
             {
                 if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
                 {

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -359,7 +359,7 @@ namespace Content.Server.RoundEnd
 
             // Mono
             var query = EntityQueryEnumerator<RoundEndTimeRuleComponent, ActiveGameRuleComponent>();
-            while (query.MoveNext(out _, out var endTimeComp, var _))
+            while (query.MoveNext(out _, out var endTimeComp, out _))
             {
                 mins = endTimeComp.EndAt;
             }

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 using Timer = Robust.Shared.Timing.Timer;
 using Content.Server._NF.SectorServices; // Frontier
+using Content.Shared.GameTicking.Components; // Mono
 
 namespace Content.Server.RoundEnd
 {

--- a/Content.Server/RoundEnd/RoundEndTimeRuleComponent.cs
+++ b/Content.Server/RoundEnd/RoundEndTimeRuleComponent.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Content.Server.RoundEnd;
+
+/// <summary>
+/// If a gamerule with this component is present, override the roundend time to the time set in it.
+/// </summary>
+[RegisterComponent]
+public sealed partial class RoundEndTimeRuleComponent : Component
+{
+    [DataField]
+    public TimeSpan EndAt;
+}

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -70,6 +70,12 @@ public sealed partial class StationEventComponent : Component
     public ProtoId<RadioChannelPrototype> EndRadioAnnouncementChannel = "Supply"; // Frontier
 
     /// <summary>
+    ///     Mono - sender of start/warn/end announcements.
+    /// </summary>
+    [DataField]
+    public LocId? AnnounceSender = null;
+
+    /// <summary>
     ///     In minutes, when is the first round time this event can start
     /// </summary>
     [DataField]

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -50,7 +50,7 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
 
         if (stationEvent.StartAnnouncement != null)
-            ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(stationEvent.StartAnnouncement), playSound: false, colorOverride: stationEvent.StartAnnouncementColor);
+            ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(stationEvent.StartAnnouncement), sender: stationEvent.AnnounceSender is { } send ? Loc.GetString(send) : null, playSound: false, colorOverride: stationEvent.StartAnnouncementColor);
 
         // Frontier
         if (stationEvent.StartRadioAnnouncement != null)
@@ -97,7 +97,7 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
 
         if (stationEvent.EndAnnouncement != null)
-            ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(stationEvent.EndAnnouncement), playSound: false, colorOverride: stationEvent.EndAnnouncementColor);
+            ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(stationEvent.EndAnnouncement), sender: stationEvent.AnnounceSender is { } send ? Loc.GetString(send) : null, playSound: false, colorOverride: stationEvent.EndAnnouncementColor);
 
         // Frontier: radio announcements
         if (stationEvent.EndRadioAnnouncement != null)
@@ -139,7 +139,7 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             {
                 Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame); // we don't want to send to players who aren't in game (i.e. in the lobby)
                 if (stationEvent.WarningAnnouncement != null)
-                    ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(stationEvent.WarningAnnouncement), playSound: false, colorOverride: stationEvent.WarningAnnouncementColor);
+                    ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(stationEvent.WarningAnnouncement), sender: stationEvent.AnnounceSender is { } send ? Loc.GetString(send) : null, playSound: false, colorOverride: stationEvent.WarningAnnouncementColor);
                 if (stationEvent.WarningRadioAnnouncement != null)
                 {
                     var message = Loc.GetString(stationEvent.WarningRadioAnnouncement);

--- a/Content.Server/_Mono/StationEvents/BlankRuleComponent.cs
+++ b/Content.Server/_Mono/StationEvents/BlankRuleComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Server._Mono.StationEvents;
+
+[RegisterComponent]
+public sealed partial class BlankRuleComponent : Component;

--- a/Content.Server/_Mono/StationEvents/BlankRuleSystem.cs
+++ b/Content.Server/_Mono/StationEvents/BlankRuleSystem.cs
@@ -1,0 +1,9 @@
+using Content.Server.StationEvents.Events;
+using JetBrains.Annotations;
+
+namespace Content.Server._Mono.StationEvents;
+
+[UsedImplicitly]
+public sealed class FalseAlarmRule : StationEventSystem<BlankRuleComponent>
+{
+}

--- a/Resources/Locale/en-US/_Mono/gamerules/announcement.ftl
+++ b/Resources/Locale/en-US/_Mono/gamerules/announcement.ftl
@@ -1,0 +1,2 @@
+gamerule-portstrike-announce-announcement = Total War has been declared by TSFMC and PDV High Command. Strikes on major military bases have been authorized. Civilians are advised to avoid them.
+gamerule-portstrike-announce-sender = Colossus Diplomatic High Command

--- a/Resources/Locale/en-US/_Mono/gamerules/gamemodes.ftl
+++ b/Resources/Locale/en-US/_Mono/gamerules/gamemodes.ftl
@@ -16,5 +16,5 @@ mono-ads-description = Native PD imperials threaten TSF colonial expansion into 
 mono-chimera-title = Biothreat (TSF|PDV)
 mono-chimera-description = Native PDV imperials threaten TSF colonial expansion into the sector. The effects of a far away letoferol outbreak seep in.
 
-mono-allatonce-title = Apocalypse (ALL)
+mono-allatonce-title = Apocalypse (ALL, 3hr)
 mono-allatonce-description = A battleground between PDV, and TSF forces alike, with ancient ADS systems and Chimera bioweapons seeping in.

--- a/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_schedulers.yml
+++ b/Resources/Prototypes/_Mono/GameRules/Apoc/apocalypse_schedulers.yml
@@ -5,7 +5,7 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: ChimeraShipsTable
-    minimumTimeUntilFirstEvent: 3600 # 60 minutes
+    minimumTimeUntilFirstEvent: 1800 # 30 minutes
     minMaxEventTiming:
       min: 1800 # 30 minutes between events
       max: 1800 # 30 minutes between events
@@ -17,7 +17,7 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: DamagedAIShipsTableApocalypse
-    minimumTimeUntilFirstEvent: 3600 # 60 minutes
+    minimumTimeUntilFirstEvent: 1800 # 30 minutes
     minMaxEventTiming:
       min: 1800 # 30 minutes between events
       max: 1800 # 30 minutes between events

--- a/Resources/Prototypes/_Mono/GameRules/timings.yml
+++ b/Resources/Prototypes/_Mono/GameRules/timings.yml
@@ -1,0 +1,50 @@
+- type: entity
+  id: RoundEndRuleHour3
+  parent: BaseGameRule
+  components:
+  - type: RoundEndTimeRule
+    endAt: 10800 # 3 hour
+
+- type: entity
+  id: PortstrikeAnnounceRuleHour4
+  parent: BaseGameRule
+  components:
+  - type: GameRule
+    delay:
+      min: 14400
+      max: 14400
+  - type: BlankRule
+  - type: StationEvent
+    earliestStart: 0
+    endAnnouncement: gamerule-portstrike-announce-announcement
+    announceSender: gamerule-portstrike-announce-sender
+    endAudio:
+      path: /Audio/Misc/gamma.ogg
+      params:
+        volume: -2
+
+- type: entity
+  id: PortstrikeAnnounceRuleHour1
+  parent: PortstrikeAnnounceRuleHour4
+  components:
+  - type: GameRule
+    delay:
+      min: 3600
+      max: 3600
+
+# debug rules
+- type: entity
+  id: RoundEndRuleMinute2
+  parent: BaseGameRule
+  components:
+  - type: RoundEndTimeRule
+    endAt: 120
+
+- type: entity
+  id: PortstrikeAnnounceRuleSeconds20
+  parent: PortstrikeAnnounceRuleHour4
+  components:
+  - type: GameRule
+    delay:
+      min: 20
+      max: 20

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -9,14 +9,15 @@
   description: mono-standard-description
   showInVote: false # For admin usage really. Not that boring, but I'd rather just let players choose their main threat instead of choosing no threat.
   rules:
-    - NFAdventure
-    - BasicStationEventScheduler
-    - BluespaceEventScheduler
-    - BluespaceDungeonEventScheduler
-    - BluespaceSalvageEventScheduler
-    - SmugglingEventScheduler
-    - FrontierRoundstartVariation
-    - MonoMonolithicEventsScheduler
+  - NFAdventure
+  - BasicStationEventScheduler
+  - BluespaceEventScheduler
+  - BluespaceDungeonEventScheduler
+  - BluespaceSalvageEventScheduler
+  - SmugglingEventScheduler
+  - FrontierRoundstartVariation
+  - MonoMonolithicEventsScheduler
+  - PortstrikeAnnounceRuleHour4
 
 - type: gamePreset
   id: MonoRogueTSF
@@ -32,6 +33,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
+  - PortstrikeAnnounceRuleHour4
 
 - type: gamePreset
   id: MonoRogueUSSP
@@ -47,6 +49,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
+  - PortstrikeAnnounceRuleHour4
 
 - type: gamePreset
   id: MonoTSFUSSP
@@ -62,6 +65,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
+  - PortstrikeAnnounceRuleHour4
 
 - type: gamePreset
   id: MonoADS
@@ -80,6 +84,7 @@
   - MonoAISTCShuttleSpawnerSchedulerTier2
   - MonoAsakimSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
+  - PortstrikeAnnounceRuleHour4
 
 - type: gamePreset
   id: MonoChimera
@@ -96,6 +101,7 @@
   - FrontierRoundstartVariation
   - MonoChimeraSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
+  - PortstrikeAnnounceRuleHour4
 
 - type: gamePreset
   id: MonoMixed
@@ -115,6 +121,7 @@
   - MonoAISTCShuttleSpawnerSchedulerTier2Slow
   - MonoAsakimSTCShuttleSpawnerSchedulerSlow
   - MonoMonolithicEventsScheduler
+  - PortstrikeAnnounceRuleHour4
 
 - type: gamePreset
   id: MonoAllAtOnce
@@ -134,4 +141,5 @@
   - MonoAISTCShuttleSpawnerSchedulerApocalypse
   - MonoAsakimSTCShuttleSpawnerSchedulerApocalypse
   - MonoMonolithicEventsScheduler
-
+  - RoundEndRuleHour3
+  - PortstrikeAnnounceRuleHour1

--- a/Resources/ServerInfo/_Mono/Guidebook/Rules/Conflict/Four_PortStriking.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Rules/Conflict/Four_PortStriking.xml
@@ -3,7 +3,7 @@
 ## Outpost striking is not allowed.
 [bold]See the [textlink="Safe Zones rule" link="MonolithRuleRoleplayEightSafeZones"] for areas that are always protected from strikes.[/bold]
 
-Faction outposts (e.g., [color=blue]Halcyon[/color]) are [color=red][bold]not allowed[/bold][/color] to be striked until the [color=yellow]4 hour mark[/color] in the Round has been reached (can be checked with your PDA), or if [color=yellow]admin permission[/color] has been given.
+Faction outposts (e.g., [color=blue]Halcyon[/color]) are [color=red][bold]not allowed[/bold][/color] to be striked until [color=yellow]a High Command announcement[/color] allowing it has been given, or if [color=yellow]admin permission[/color] has been given.
 -- For clarity, a "strike" in this context refers to any (organized or unorganized) hostile action intended to damage outposts, seize control, eliminate its occupants, or damage docked/undocked ships within a range of 256 meters that were not recently ([color=yellow][bold]2 minutes[/bold][/color]) in combat.
 -- Action should be taken to avoid camping spawn areas inside the outposts if possible.
 
@@ -12,7 +12,7 @@ Mobile bases (e.g., [color=maroon]PDV Jupiter[/color]) do [color=red][bold]not[/
 [color=yellow]Ships are [bold]exempted[/bold] from this rule when they escape combat to their port. It is permitted to attack docked ships if they were in combat within the last two minutes, though you should [/color][color=red]minimize[/color][color=yellow] damage to the port itself.[/color]
 
 [color=orange]Prison breaks[/color] from detained players both in and out of the faction do [color=red][bold]not[/bold][/color] fall under these rules.
--- [color=orange]Detained players[/color] can damage where they're being held, make a path to an exit forcefully, injure others, and steal ships from outposts to escape [bold]if necessary[/bold]. 
--- If anyone is killed, bodies should not be intentionally hidden or made unrecoverable. [bold]You do not[/bold] have to revive anyone. 
+-- [color=orange]Detained players[/color] can damage where they're being held, make a path to an exit forcefully, injure others, and steal ships from outposts to escape [bold]if necessary[/bold].
+-- If anyone is killed, bodies should not be intentionally hidden or made unrecoverable. [bold]You do not[/bold] have to revive anyone.
 -- You should [color=red][bold]not[/bold][/color] be sabotaging an outpost. Such as cutting wires, destroying shields, generators, or gunnery consoles. Detained players may [color=red][bold]not[/bold][/color] get external help when escaping.
 </Document>


### PR DESCRIPTION
## About the PR
- doubles ads and chim spawnrates
- ends at 3hr
- 1hr portstrike
- portstrike is now an announcement
- minor rulechange to account for portstrike announcement (already approved by nigel)

## Why / Balance
6hr of apoc is hell

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Portstrike is now announced.
- tweak: Apocalypse now lasts 3 hours and has 1 hour portstrike.
- tweak: Apocalypse chimera and ADS spawnrates doubled.
