### PR TITLE
Stops Sloppy Vgroid Debug/Localhost Crashing

### DIFF
--- a/Content.Server/_NF/StationEvents/EventSystems/LinkedLifecycleGridSystem.cs
+++ b/Content.Server/_NF/StationEvents/EventSystems/LinkedLifecycleGridSystem.cs
@@ -177,7 +177,7 @@ public sealed class LinkedLifecycleGridSystem : EntitySystem
     // Deletes a grid, reparenting every humanoid and player character that's on it.
     public void UnparentPlayersFromGrid(EntityUid grid, bool deleteGrid, bool ignoreLifeStage = false)
     {
-        if (!Deleted(grid) && !ignoreLifeStage && MetaData(grid).EntityLifeStage >= EntityLifeStage.Terminating)
+        if (!ignoreLifeStage && TerminatingOrDeleted(grid))
             return;
 
         var reparentEntities = GetEntitiesToReparent(grid);

--- a/Content.Server/_NF/StationEvents/EventSystems/LinkedLifecycleGridSystem.cs
+++ b/Content.Server/_NF/StationEvents/EventSystems/LinkedLifecycleGridSystem.cs
@@ -177,7 +177,7 @@ public sealed class LinkedLifecycleGridSystem : EntitySystem
     // Deletes a grid, reparenting every humanoid and player character that's on it.
     public void UnparentPlayersFromGrid(EntityUid grid, bool deleteGrid, bool ignoreLifeStage = false)
     {
-        if (!ignoreLifeStage && MetaData(grid).EntityLifeStage >= EntityLifeStage.Terminating)
+        if (!Deleted(grid) && !ignoreLifeStage && MetaData(grid).EntityLifeStage >= EntityLifeStage.Terminating)
             return;
 
         var reparentEntities = GetEntitiesToReparent(grid);


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

See CL

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Makes debugs not crash from vgroid based errors

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Vgroid errors involving attempting to delete a terminating/deleted entity.

