### PR TITLE
Made Bulwark Gauntlets Wideswing

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Hands/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Hands/modsuit.yml
@@ -154,7 +154,7 @@
       flatReductions:
         Heat: 10
   - type: MeleeWeapon # Mono edit
-    canWideSwing: false
+    canWideSwing: true # Mono Edit
     attackRate: 1
     damage:
       types:


### PR DESCRIPTION
## About the PR
Made the bulwarks gauntlets wideswing

## Why / Balance
Its hard to land a hit with no wideswing espeically in combat thats fast and short any melle weapon would beat trying to direct hit.

## Media
None its code changes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Equip the bulwark MOD suit and wideswing in combat mode

## Breaking changes
NA

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl: Scarlet Lightweaver
- tweak: Made the bulwarks gauntlets wideswing.
