### PR TITLE
Adc Piloting Boost

### DIFF
--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -274,11 +274,19 @@ public sealed class MoverController : SharedMoverController
     //
 
     /// <summary>
+    /// Get a shuttle's torque.
+    /// </summary>
+    public float GetTorque(ShuttleComponent shuttle)
+    {
+        return shuttle.AngularThrust * shuttle.AngularMultiplier;
+    }
+
+    /// <summary>
     /// Get a shuttle's angular acceleration.
     /// </summary>
     public float GetAngularAcceleration(ShuttleComponent shuttle, PhysicsComponent body)
     {
-        return shuttle.AngularThrust * body.InvI;
+        return GetTorque(shuttle) * body.InvI;
     }
 
     /// <summary>
@@ -302,7 +310,7 @@ public sealed class MoverController : SharedMoverController
         // prevent NaNs
         dir *= dir.X == 0 ? vertScale : dir.Y == 0 ? horizScale : MathF.Min(horizScale, vertScale);
 
-        return dir;
+        return dir * shuttle.AccelerationMultiplier;
     }
 
     public Vector2 GetDirectionAccel(Vector2 dir, ShuttleComponent shuttle, PhysicsComponent body)
@@ -323,7 +331,7 @@ public sealed class MoverController : SharedMoverController
         var twr = thrust.Length() / body.Mass;
         var twrMult = MathF.Pow(twr / shuttle.BaseMaxVelocityTWR, shuttle.MaxVelocityScalingExponent);
 
-        return vel.Normalized() * MathF.Min(shuttle.BaseMaxLinearVelocity * twrMult, MathF.Min(shuttle.UpperMaxVelocity, shuttle.SetMaxVelocity));
+        return vel.Normalized() * MathF.Min(shuttle.BaseMaxLinearVelocity * twrMult * shuttle.MaxVelMultiplier, MathF.Min(shuttle.UpperMaxVelocity, shuttle.SetMaxVelocity));
     }
 
     private void HandleShuttleMovement(float frameTime)
@@ -335,6 +343,9 @@ public sealed class MoverController : SharedMoverController
             // query all our pilots for input
             var toRemove = new List<EntityUid>();
 
+            var angularMul = 0f;
+            var accelMul = 0f;
+            var maxVelMul = 0f;
             foreach (var pilot in piloted.InputSources)
             {
                 var inputsEv = new GetShuttleInputsEvent(frameTime, uid);
@@ -343,7 +354,12 @@ public sealed class MoverController : SharedMoverController
                 if (!inputsEv.GotInput)
                     toRemove.Add(pilot);
                 else if (inputsEv.Input != null)
+                {
                     inputs.Add(inputsEv.Input.Value);
+                    angularMul += inputsEv.AngularMul;
+                    accelMul += inputsEv.AccelMul;
+                    maxVelMul += inputsEv.MaxVelMul;
+                }
             }
 
             foreach (var remUid in toRemove)
@@ -359,6 +375,7 @@ public sealed class MoverController : SharedMoverController
             {
                 _thruster.DisableLinearThrusters(shuttle);
                 PhysicsSystem.SetSleepingAllowed(uid, body, true);
+                shuttle.AngularMultiplier = shuttle.AccelerationMultiplier = shuttle.MaxVelMultiplier = 1f;
                 continue;
             }
             PhysicsSystem.SetSleepingAllowed(uid, body, false);
@@ -376,6 +393,13 @@ public sealed class MoverController : SharedMoverController
             linearInput /= count;
             angularInput /= count;
             brakeInput /= count;
+
+            angularMul /= count;
+            accelMul /= count;
+            maxVelMul /= count;
+            shuttle.AngularMultiplier = angularMul;
+            shuttle.AccelerationMultiplier = accelMul;
+            shuttle.MaxVelMultiplier = maxVelMul;
 
             var shuttleNorthAngle = _xformSystem.GetWorldRotation(uid);
 
@@ -524,7 +548,7 @@ public sealed class MoverController : SharedMoverController
             }
             else
             {
-                var torque = shuttle.AngularThrust * -angularInput;
+                var torque = GetTorque(shuttle) * -angularInput;
 
                 // Need to cap the velocity if 1 tick of input brings us over cap so we don't continuously
                 // edge onto the cap over and over.

--- a/Content.Server/Physics/Controllers/MoverEvents.cs
+++ b/Content.Server/Physics/Controllers/MoverEvents.cs
@@ -9,9 +9,10 @@ public record struct ShuttleInput(Vector2 Strafe, float Rotation, float Brakes);
 /// <summary>
 ///     Raised on pilots to get inputs given to a shuttle.
 ///     If GotInput is false, this piloted is removed from input sources.
+///     Also queries for multipliers to acceleration and max speed.
 /// </summary>
 [ByRefEvent]
-public record struct GetShuttleInputsEvent(float FrameTime, EntityUid ShuttleUid, ShuttleInput? Input = null, bool GotInput = false);
+public record struct GetShuttleInputsEvent(float FrameTime, EntityUid ShuttleUid, ShuttleInput? Input = null, bool GotInput = false, float AngularMul = 1f, float AccelMul = 1f, float MaxVelMul = 1f);
 
 [ByRefEvent]
 public record struct PilotedShuttleRelayedEvent<TEvent>(TEvent Args);

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -105,6 +105,24 @@ namespace Content.Server.Shuttles.Components
         /// </summar>
         [DataField]
         public Vector2 LastThrust = Vector2.Zero;
+
+        /// <summary>
+        /// Multiplier to angular thrust. Set depending on pilot.
+        /// </summary
+        [ViewVariables]
+        public float AngularMultiplier = 1f;
+
+        /// <summary>
+        /// Multiplier to linear thrust. Set depending on pilot.
+        /// </summary
+        [ViewVariables]
+        public float AccelerationMultiplier = 1f;
+
+        /// <summary>
+        /// Multiplier to max velocity. Set depending on pilot.
+        /// </summary
+        [ViewVariables]
+        public float MaxVelMultiplier = 1f;
         // </Mono>
     }
 }

--- a/Content.Server/_Mono/Shuttles/Components/ShuttleBoostingPilotComponent.cs
+++ b/Content.Server/_Mono/Shuttles/Components/ShuttleBoostingPilotComponent.cs
@@ -1,0 +1,17 @@
+namespace Content.Server._Mono.Shuttles.Components;
+
+/// <summary>
+/// Modifies how shuttles piloted by this entity drive.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ShuttleBoostingPilotComponent : Component
+{
+    [DataField]
+    public float AngularMultiplier = 1f;
+
+    [DataField]
+    public float AccelerationMultiplier = 1f;
+
+    [DataField]
+    public float MaxVelMultiplier = 1f;
+}

--- a/Content.Server/_Mono/Shuttles/Systems/ShuttleBoostingPilotSystem.cs
+++ b/Content.Server/_Mono/Shuttles/Systems/ShuttleBoostingPilotSystem.cs
@@ -1,0 +1,21 @@
+using Content.Server._Mono.Shuttles.Components;
+using Content.Server.Physics.Controllers;
+
+namespace Content.Server._Mono.Shuttles.Systems;
+
+public sealed partial class ShuttleBoostingPilotSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ShuttleBoostingPilotComponent, GetShuttleInputsEvent>(OnGetInputs);
+    }
+
+    private void OnGetInputs(Entity<ShuttleBoostingPilotComponent> ent, ref GetShuttleInputsEvent args)
+    {
+        args.AngularMul *= ent.Comp.AngularMultiplier;
+        args.AccelMul *= ent.Comp.AccelerationMultiplier;
+        args.MaxVelMul *= ent.Comp.MaxVelMultiplier;
+    }
+}

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Player/silicon.yml
@@ -374,6 +374,10 @@
     - MonoRemnantCoreTitle
     - MonoRemnantAdjective
     - MonoRemnantNoun
+  - type: ShuttleBoostingPilot
+    angularMultiplier: 1.5
+    accelerationMultiplier: 1.4
+    maxVelMultiplier: 1.1
 
 - type: entity
   id: AiHeldRedacted


### PR DESCRIPTION
## About the PR
see cl

## Why / Balance
ADC is currently useless so
might also let it slowly autorepair the grid later

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: ADCs now get piloting boosts (bonus acceleration, turn, max speed) to give them an advantage over ADMs.
