### PR TITLE
Drone Turret Small Fix

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/World/ramdronemedium.yml
+++ b/Resources/Maps/_Mono/Shuttles/World/ramdronemedium.yml
@@ -904,7 +904,7 @@ entities:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-- proto: SpawnMobWeaponTurretUSSP
+- proto: SpawnMobWeaponTurretSyndicate
   entities:
   - uid: 134
     components:


### PR DESCRIPTION
## About the PR
Ram Drone medium has ballistic turrets on the outside. I found it weird they didn't shoot me in game. They now shoot you in game. They don't shoot ADM's though because they're syndicate. Are these early versions of ADS? emergent story telling or whatever

## Why / Balance
I have yet to find the lore document that the USSP built these drones

## Media
it looks the same

## Requirements

- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Spawn the drone and try to pet it

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Drone turrets shoot you now.
