### PR TITLE
Laser Weapon Improvements

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -22,8 +22,8 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
+    maxCharge: 1500 # Mono: 1k >> 1.5k
+    startingCharge: 1500 # Mono: 1k >> 1.5k
   - type: StaticPrice
     price: 500
   - type: Cautery # Shitmed
@@ -68,7 +68,7 @@
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: HitscanBatteryAmmoProvider
     proto: RedLightLaser
-    fireCost: 50
+    fireCost: 20 # Mono: pistol lasers shoot efficiently
   - type: PowerCellSlot
     cellSlotId: gun_magazine
   - type: ItemSlots
@@ -107,6 +107,9 @@
   - type: Tag
     tags:
     - Sidearm
+  - type: Battery # Mono: Keeps charge for smaller energy weapons
+    maxCharge: 1000
+    startingCharge: 1000
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/taser.rsi
     quickEquip: false
@@ -146,6 +149,14 @@
       shader: unshaded
   - type: Item
     sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
+  - type: Gun
+    burstCooldown: 0.75
+    burstFireRate: 3
+    shotsPerBurst: 3
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    - Burst
   - type: MagazineVisuals
     magState: mag
     steps: 5
@@ -169,7 +180,7 @@
       shader: unshaded
   - type: HitscanBatteryAmmoProvider
     proto: RedMediumLaser
-    fireCost: 83.3
+    fireCost: 33.3 # Mono: 83.3 >> 33.3
   - type: MagazineVisuals
     magState: mag
     steps: 5
@@ -201,7 +212,7 @@
     sprite: Objects/Weapons/Guns/Battery/makeshift.rsi
   - type: HitscanBatteryAmmoProvider
     proto: RedLaser
-    fireCost: 62.5
+    fireCost: 35 # Mono: 62.5 >> 35
   - type: Battery
     maxCharge: 500
     startingCharge: 500
@@ -262,7 +273,7 @@
     - SemiAuto
   - type: HitscanBatteryAmmoProvider
     proto: RedLaserPractice
-    fireCost: 35 #Mono: 62.5 >> 35
+    fireCost: 30 #Mono: 62.5 >> 30
   - type: StaticPrice
     price: 300
 
@@ -276,9 +287,14 @@
     price: 500
   - type: HitscanBatteryAmmoProvider
     proto: RedMediumLaser #Mono: RedLaser >> RedMediumLaser
-    fireCost: 35 #Mono: 62.5 >> 35
+    fireCost: 30 #Mono: 62.5 >> 30
   - type: PirateBountyItem # Mono
     id: StandardFactionLongarm
+  - type: Gun
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    - FullAuto
 
 - type: entity
   name: LWC pulse pistol
@@ -495,7 +511,7 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider
     proto: RedHeavyLaser
-    fireCost: 250
+    fireCost: 160
   - type: Battery
     maxCharge: 4000
     startingCharge: 4000
@@ -555,7 +571,7 @@
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
     proto: XrayLaser
-    fireCost: 200
+    fireCost: 133.3
   - type: MagazineVisuals
     magState: mag
     steps: 5
@@ -727,7 +743,7 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider
     proto: RedMediumLaser
-    fireCost: 100
+    fireCost: 50 # Mono: 100 >> 50
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 40
@@ -774,10 +790,10 @@
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider
     proto: RedMediumLaser
-    fireCost: 100
+    fireCost: 50 # Mono: 100 >> 50
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 30
+    autoRechargeRate: 20 # Mono 30 >> 20
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -27,7 +27,7 @@
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
     burstFireRate: 4 # Mono burstfire and modeswitching
-    burstShotsCount: 3
+    shotsPerBurst: 3
     burstCooldown: 0.75
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -26,20 +26,27 @@
       path: /Audio/_DV/Weapons/Guns/Gunshots/laser.ogg
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
+    burstFireRate: 4 # Mono burstfire and modeswitching
+    burstShotsCount: 3
+    burstCooldown: 0.75
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    - Burst
   - type: Battery
     maxCharge: 2250 # Mono 2000->2250
     startingCharge: 2250 # Mono 2000->2250
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 75 # 100->75
+    fireCost: 45 # 100->45
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler
-      fireCost: 75 # 100->75
+      fireCost: 45 # Mono 100->45
       name: disable
       state: disabler
     - proto: BulletEnergyGunLaser
-      fireCost: 150 # 200->150
+      fireCost: 75 # Mono 200->75
       name: kill
       state: lethal
   - type: MagazineVisuals
@@ -86,6 +93,13 @@
       path: /Audio/_DV/Weapons/Guns/Gunshots/laser.ogg
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
+    burstFireRate: 4 # Mono burstfire and modeswitching
+    shotsPerBurst: 3
+    burstCooldown: 0.75
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    - Burst
   - type: Battery
     maxCharge: 2250 # Mono 2000->2250
     startingCharge: 2250 # Mono 2000->2250
@@ -94,15 +108,15 @@
     autoRechargeRate: 25
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 75 # 100->75
+    fireCost: 45 # 100->45
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler
-      fireCost: 75 # 100->75
+      fireCost: 45 # Mono 100->45
       name: disable
       state: disabler
     - proto: BulletEnergyGunLaser
-      fireCost: 150 # 200->150
+      fireCost: 75 # Mono 200->75
       name: kill
       state: lethal
   - type: MagazineVisuals
@@ -144,24 +158,31 @@
     sprite: _DV/Objects/Weapons/Guns/Battery/multiphase_energygun.rsi
   - type: Gun
     fireRate: 2.5
+    shotsPerBurst: 3
+    burstCooldown: 0.5
+    burstFireRate: 6
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    - Burst
     soundGunshot:
       path: /Audio/_DV/Weapons/Guns/Gunshots/laser.ogg
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
   - type: Battery
-    maxCharge: 3750 # Mono 2000->3750
-    startingCharge: 3750 # Mono 2000->3750
+    maxCharge: 3600 # Mono 2000->3600
+    startingCharge: 3600 # Mono 2000->3600
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 75 # Mono 100 -> 75
+    fireCost: 60 # Mono 100 -> 60
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler
-      fireCost: 75 # Mono 100 -> 75
+      fireCost: 60 # Mono 100 -> 60
       name: disable
       state: disabler
     - proto: BulletEnergyGunLaser
-      fireCost: 150 # Mono 200 -> 150
+      fireCost: 90 # Mono 200 -> 90
       name: lethal
       state: lethal
     # - proto: BulletEnergyGunIon

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -91,14 +91,18 @@
     startingCharge: 4000
   - type: HitscanBatteryAmmoProvider
     proto: RedLaser
-    fireCost: 80
+    fireCost: 32
   - type: Gun
     selectedMode: FullAuto
     availableModes:
+    - Burst
     - FullAuto
     fireRate: 8
     minAngle: 1
     maxAngle: 10
+    burstFireRate: 12
+    shotsPerBurst: 5
+    burstCooldown: 0.5
     soundGunshot:
       path: /Audio/_DV/Weapons/Guns/Gunshots/laser.ogg
     soundEmpty:
@@ -135,6 +139,14 @@
       - state: inhand-right
       - state: inhand-right-unshaded
         shader: unshaded
+  - type: Gun
+    burstCooldown: 0.75
+    burstFireRate: 3
+    shotsPerBurst: 3
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    - Burst
   - type: StaticPrice # Mono
     price: 150
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/expedition_guns.yml
@@ -163,6 +163,17 @@
   - WeaponLaserCarbine
   categories: [ HideSpawnMenu ]
   id: WeaponLaserCarbineExpedition
+  components:
+  - type: Gun
+    burstCooldown: 0.5
+    burstFireRate: 3
+    shotsPerBurst: 3
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    - Burst
+    - FullAuto
+    
 
 - type: entity
   parent:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Substantially increased the capacity of many entry-level and a few advanced laser and energy weapons. Pulse weapons of all varieties are left untouched.
Increased the capacity of larger internal-battery energy weapons [BaseWeaponBattery] by 50%. Adjusted the Small child entity back down to the original capacity of 1000.
- Svalinn gets a default capacity of 18 rounds (up to 90 on a hyper-capacity) by reducing the fire cost of base powercell guns and a useful 3-round burst mode (overrides the quick alt-click access to emptying the cell sadly).
- [Frontier] Laser Pistol gets a capacity of 30 rounds and a similar 3-round burst.
- Makeshift Laser Pistol ups its capacity to 14 rounds.
- Advanced Laser Pistol gets 20 shots and lowers its recharge rate a little to compensate for cheaper shooting.
- Antique Laser Pistol increased to 20 shots
- Retro Laser Blaster increased to 30 shots
- Laser Rifle gets a capacity of 50 rounds and a "full auto" mode that isn't faster than just clicking.
- dungeon loot Laser Carbine also gets a Burst fire that improves its DPS slightly.
- Energy Gun (and Cyborg model) gets a Nonlethal capacity of 50 and a Lethal capacity of 30 as well as a slightly beefier Burst fire mode.
- Multiphase gets a substantially beefier burst fire, 60 shots in nonlethal, and 40 shots on lethal.
- Laser Cannon ups its capacity to 25
- Xray Cannon ups its capacity to 30
- Turbo Laser Mk3 turned into a serious contender with 125 shots (from a measly 50) and a 5-round rapid burst
- Disabler Pistol capacity increased to 20
- Disabler SMG capacity increased to 60

Considering the timing, I also feel it important to emphasize that this is not an April 1st PR. ; )

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Handheld laser/energy weapons, especially those that aren't self-charging, are severely deficient in the realm of combat longevity, both PvP and PvE, especially with latency and click prediction issues. Their comparatively lower DPS is retained while allowing them to last around the same length of time as a comparable ballistic gun plus one reload. A few of the especially weak or rare energy guns are also given a slow burst fire mode. Together, this seems like a decent balancing approach compared to the higher DPS and easier reloading of ballistic weapons.
If this has any unusual or unforeseen knock-on effects to some ultra powerful laser/pulse weapons, I'll gladly help address concerns with them. Recoil and spread factors presently untouched, but could be adjusted for weapons given burst fire.
As far as I can tell, this indirectly affects the Asakim Plasma Auto-Pulsers, raising their capacity from 40 to 60 shots without considering their recharge.
All of the Goob magfed/powercell lasers, if they even spawn or can be found anywhere, all fire Light (10 heat) lasers, so having a high capacity by reducing fire cost makes sense and is largely inconsequential. The couple of TSF cell guns set their own fire costs and are thus unaffected by this PR.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Pew Pew

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Improvements to capacity and firing mechanics of many common Laser and Energy weapons.