### PR TITLE
Thruster Capacitor Uniformity

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
@@ -106,7 +106,7 @@
   - type: MachineBoard
     prototype: ThrusterSecurity
     requirements:
-      Capacitor: 3
+      Capacitor: 1
     stackRequirements:
       Steel: 5
 
@@ -118,7 +118,7 @@
   - type: MachineBoard
     prototype: ThrusterNfsd
     requirements:
-      Capacitor: 3
+      Capacitor: 1
     stackRequirements:
       Steel: 5
 
@@ -130,7 +130,7 @@
   - type: MachineBoard
     prototype: ThrusterUSSP
     requirements:
-      Capacitor: 3
+      Capacitor: 1
     stackRequirements:
       Steel: 5
 
@@ -142,7 +142,7 @@
   - type: MachineBoard
     prototype: ThrusterRogue
     requirements:
-      Capacitor: 3
+      Capacitor: 1
     stackRequirements:
       Steel: 5
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
all faction thrusters now take 1 capacitor

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
uniformity

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
thrust

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: All faction thruster variants now require 1 capacitor from 3, in line with the standard model
