### PR TITLE
[WIP] Hitscan AP + Bullet AP % Visuals

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Cartridges.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Cartridges.cs
@@ -1,3 +1,4 @@
+using Content.Server.Popups;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Examine;
@@ -46,6 +47,46 @@ public sealed partial class GunSystem
         return null;
     }
 
+    // Mono start
+    private bool GetProjectileIgnoreResistances(string proto)
+    {
+        if (!ProtoManager.TryIndex<EntityPrototype>(proto, out var entityProto))
+            return false;
+
+        if (entityProto.Components
+            .TryGetValue(Factory.GetComponentName<ProjectileComponent>(), out var projectile))
+        {
+            var p2 = (ProjectileComponent) projectile.Component;
+
+            if (!p2.IgnoreResistances != true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private float GetProjectileArmorPenetration(string proto) // Mono
+    {
+        if (!ProtoManager.TryIndex<EntityPrototype>(proto, out var entityProto))
+            return 0;
+
+        if (entityProto.Components
+            .TryGetValue(Factory.GetComponentName<ProjectileComponent>(), out var projectile))
+        {
+            var p3 = (ProjectileComponent) projectile.Component;
+
+            if (p3.ArmorPenetration != 0)
+            {
+                return p3.ArmorPenetration;
+            }
+        }
+
+        return 0;
+    }
+    // End mono
+
     private void OnCartridgeExamine(EntityUid uid, CartridgeAmmoComponent component, ExaminedEvent args)
     {
         if (component.Spent)
@@ -56,5 +97,19 @@ public sealed partial class GunSystem
         {
             args.PushMarkup(Loc.GetString("gun-cartridge-unspent"));
         }
+
+        // Mono start
+        var ignoreResistancesSpec = GetProjectileIgnoreResistances(component.Prototype); // Mono
+        var armorPenetrationSpec = GetProjectileArmorPenetration(component.Prototype); // Mono
+
+        if (ignoreResistancesSpec == true) // Mono
+        {
+            args.PushMarkup(Loc.GetString("cartridge-full-ap"));
+        }
+        else if (armorPenetrationSpec != 0)
+        {
+            args.PushMarkup(Loc.GetString("cartridge-partial-ap",("percent", armorPenetrationSpec * 100)));
+        }
+        // End Mono
     }
 }

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Cartridges.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Cartridges.cs
@@ -108,7 +108,14 @@ public sealed partial class GunSystem
         }
         else if (armorPenetrationSpec != 0)
         {
-            args.PushMarkup(Loc.GetString("cartridge-partial-ap",("percent", armorPenetrationSpec * 100)));
+            if (armorPenetrationSpec >= 0)
+            {
+                args.PushMarkup(Loc.GetString("cartridge-positive-ap",("percent", armorPenetrationSpec * 100)));
+            }
+            else if (armorPenetrationSpec <= 0)
+            {
+                args.PushMarkup(Loc.GetString("cartridge-negative-ap",("percent", armorPenetrationSpec * -100)));
+            }
         }
         // End Mono
     }

--- a/Content.Shared/Weapons/Hitscan/Components/HitscanBasicDamageComponent.cs
+++ b/Content.Shared/Weapons/Hitscan/Components/HitscanBasicDamageComponent.cs
@@ -14,4 +14,10 @@ public sealed partial class HitscanBasicDamageComponent : Component
     /// </summary>
     [DataField(required: true)]
     public DamageSpecifier Damage;
+
+    /// <summary>
+    /// Mono: % armor piercing the hitscan weapon has when hitting a target.
+    /// </summary>
+    [DataField]
+    public float ArmorPenetration;
 }

--- a/Content.Shared/Weapons/Hitscan/Events/HitscanEvents.cs
+++ b/Content.Shared/Weapons/Hitscan/Events/HitscanEvents.cs
@@ -93,4 +93,9 @@ public record struct HitscanDamageDealtEvent
     /// The amount of damage that the target was dealt.
     /// </summary>
     public DamageSpecifier DamageDealt;
+
+    /// <summary>
+    /// How much the damage is affected by armor.
+    /// </summary>
+    public float ArmorPenetration;
 }

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicDamageSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicDamageSystem.cs
@@ -24,6 +24,8 @@ public sealed class HitscanBasicDamageSystem : EntitySystem
 
         var damageDealt = _damage.TryChangeDamage(args.HitEntity, dmg, origin: args.Gun);
 
+        var armorPenetration = ent.Comp.ArmorPenetration;
+
         if (damageDealt == null)
             return;
 
@@ -31,6 +33,7 @@ public sealed class HitscanBasicDamageSystem : EntitySystem
         {
             Target = args.HitEntity.Value,
             DamageDealt = damageDealt,
+            ArmorPenetration = armorPenetration,
         };
 
         RaiseLocalEvent(ent, ref damageEvent);

--- a/Resources/Locale/en-US/_Mono/weapons/ammo.ftl
+++ b/Resources/Locale/en-US/_Mono/weapons/ammo.ftl
@@ -1,3 +1,4 @@
 
-cartridge-full-ap = This bullet ignores [color=orange]all[/color] armor resistances!
-cartridge-partial-ap = This bullet ignores [color=orange]{NATURALFIXED($percent, 2)}%[/color] of armor resistances!
+cartridge-full-ap = This bullet ignores [color=green]all[/color] armor resistances!
+cartridge-positive-ap = This bullet is affected [color=green]{NATURALFIXED($percent, 2)}%[/color] less by armor resistances!
+cartridge-negative-ap = This bullet is affected [color=red]{NATURALFIXED($percent, 2)}%[/color] more by armor resistances!

--- a/Resources/Locale/en-US/_Mono/weapons/ammo.ftl
+++ b/Resources/Locale/en-US/_Mono/weapons/ammo.ftl
@@ -1,0 +1,3 @@
+
+cartridge-full-ap = This bullet ignores [color=orange]all[/color] armor resistances!
+cartridge-partial-ap = This bullet ignores [color=orange]{NATURALFIXED($percent, 2)}%[/color] of armor resistances!

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -54,6 +54,7 @@
     damage:
       types:
         Heat: 18 # Mono
+    armorPenetration: 1
 
 - type: entity
   parent: BasicHitscan


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Examining bullets lets you see their AP value.
Also lets hitscanbasicdamage specify an armor penetration value.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
should be clear
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- tweak: You can see how much AP a bullet has when examining.

