### PR TITLE
Makes Tsf Mech Blips Lighter

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -80,7 +80,7 @@
     openState: tsfgygax-open
     brokenState: tsfgygax-broken
   - type: RadarBlip # Mono
-    radarColor: "#047ABD"
+    radarColor: "#028EDE"
     scale: 1.5
     requireNoGrid: true
     shape: square
@@ -134,7 +134,7 @@
     openState: tsfdurand-open
     brokenState: tsfdurand-broken
   - type: RadarBlip # Mono
-    radarColor: "#047ABD"
+    radarColor: "#028EDE"
     scale: 1.5
     requireNoGrid: true
     shape: square
@@ -297,7 +297,7 @@
     openState: tsfbroadsword-open
     brokenState: tsfbroadsword-broken
   - type: RadarBlip
-    radarColor: "#047ABD"
+    radarColor: "#028EDE"
     scale: 3
     requireNoGrid: true
     shape: square
@@ -380,7 +380,7 @@
     openState: tsfbroadsword-open
     brokenState: tsfbroadsword-broken
   - type: RadarBlip
-    radarColor: "#047ABD"
+    radarColor: "#028EDE"
     scale: 3
     requireNoGrid: true
     shape: square
@@ -525,7 +525,7 @@
     openState: tsfflail-open
     brokenState: tsfflail-broken
   - type: RadarBlip
-    radarColor: "#047ABD"
+    radarColor: "#028EDE"
     scale: 3
     requireNoGrid: true
     shape: square
@@ -616,7 +616,7 @@
     openState: tsfflail-open
     brokenState: tsfflail-broken
   - type: RadarBlip
-    radarColor: "#047ABD"
+    radarColor: "#028EDE"
     scale: 3
     requireNoGrid: true
     shape: square
@@ -691,7 +691,7 @@
     openState: tsfflail-open
     brokenState: tsfflail-broken
   - type: RadarBlip
-    radarColor: "#047ABD"
+    radarColor: "#028EDE"
     scale: 3
     requireNoGrid: true
     shape: square


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

wow they're dark as hell

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

brightness visibility colorblindness yada yada

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Increased TSF Mech Blip visibility

