### PR TITLE
Fix Borg Hand Whitelist Bug

### DIFF
--- a/Content.Shared/_NF/Interaction/Systems/HandPlaceholderSystem.cs
+++ b/Content.Shared/_NF/Interaction/Systems/HandPlaceholderSystem.cs
@@ -137,7 +137,6 @@ public sealed partial class HandPlaceholderSystem : EntitySystem
             return;
 
         SetPlaceholder(target, ent);
-        SetEnabled(target, true);
 
         SetEnabled(ent, false); // allow inserting into the source container
 
@@ -153,6 +152,7 @@ public sealed partial class HandPlaceholderSystem : EntitySystem
         }
 
         _hands.DoPickup(user, hand, target, hands); // Force pickup - empty hands are not okay
+        SetEnabled(target, true);
         _interaction.DoContactInteraction(user, target); // allow for forensics and other systems to work (why does hands system not do this???)
     }
 }


### PR DESCRIPTION
## About the PR
Closes #2835 

This system to give borgs-psuedo hands should/will be replaced by upstream eventually, but this bug shouldn't exist in the meantime.

I believe what was happening is, this version of borg hands is using ghost items to track swaps, pickups, and putdowns. SwapPlaceholder is getting called too early by prematurely setting Enabled to true, which fucks with containers. This, I believe, ends up putting the ghost item in the bag when attempting to retrieve the whitelisted item, breaking it and causing an invalid metadata flag error.

Now we're doing the swap after the pickup is complete.

## Why / Balance
I think this bug has become fairly prominent even though it's been present for ages.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
- Control a cyborg in dev environment.
- Select Engineering and select your building module
- Swap to the capacitor and place it into a bag then pull it out again.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Cyborgs obtaining non-whitelisted hands.
