### PR TITLE
Research Datafarms Buffs

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/datafarms.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/datafarms.yml
@@ -96,7 +96,7 @@
     guides:
     - Science
   - type: ResearchPointSource
-    pointsPerSecond: 10
+    pointsPerSecond: 30
     active: true
 
 - type: entity
@@ -107,7 +107,7 @@
   components:
   - type: ResearchClient
   - type: ResearchPointSource
-    pointsPerSecond: 35
+    pointsPerSecond: 350
     active: true
   - type: ApcPowerReceiver
     powerLoad: 10000

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/datafarms.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/datafarms.yml
@@ -96,7 +96,7 @@
     guides:
     - Science
   - type: ResearchPointSource
-    pointsPerSecond: 30
+    pointsPerSecond: 20
     active: true
 
 - type: entity
@@ -107,7 +107,7 @@
   components:
   - type: ResearchClient
   - type: ResearchPointSource
-    pointsPerSecond: 350
+    pointsPerSecond: 200
     active: true
   - type: ApcPowerReceiver
     powerLoad: 10000
@@ -141,6 +141,8 @@
       color: "#b3aa79"
     - state: stripe2
       color: "#009360"
+  - type: ApcPowerReceiver
+    powerLoad: 40000
   - type: PointLight
     radius: 1.1
     energy: 1.1


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Buffs research datafarm to 20 points per second from 10.

Buffs faction datafarms to 200 points per second from 35.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

A: The amount of research points a datafarm takes to make means that research datafarms made them very underused compared to crypto ones.

B: Faction gameplay really shouldn't center around research. This ensures that, for the most part, unlocking all the tech will be viable around 3 hours or so, even if no one signs up for that faction.

Ultimately, its to help work on discouraging people to camp and scislop.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Faction datafarms now produce 200 science per second instead of 35.
- tweak: Normal research datafarms now produce 20 science per second instead of 10.