### PR TITLE
Fix Mechlag (Hopefully)

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -121,11 +121,14 @@ public sealed partial class MechSystem : SharedMechSystem
         if (!TryComp<BatteryComponent>(ent.Comp.BatterySlot.ContainedEntity, out var battery))
             return;
 
+        //ent.Comp.CriticalPowerState = battery.CurrentCharge / battery.MaxCharge <= 0.05f;
+        // Mono
         var criticalState = battery.CurrentCharge / battery.MaxCharge <= 0.05f;
         if (criticalState == ent.Comp.CriticalPowerState)
             return;
 
         ent.Comp.CriticalPowerState = criticalState;
+        // End Mono
         Dirty(ent);
         _movementSpeed.RefreshMovementSpeedModifiers(ent);
     }

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -121,8 +121,11 @@ public sealed partial class MechSystem : SharedMechSystem
         if (!TryComp<BatteryComponent>(ent.Comp.BatterySlot.ContainedEntity, out var battery))
             return;
 
-        ent.Comp.CriticalPowerState = battery.CurrentCharge / battery.MaxCharge <= 0.05f;
+        var criticalState = battery.CurrentCharge / battery.MaxCharge <= 0.05f;
+        if (criticalState == ent.Comp.CriticalPowerState)
+            return;
 
+        ent.Comp.CriticalPowerState = criticalState;
         Dirty(ent);
         _movementSpeed.RefreshMovementSpeedModifiers(ent);
     }


### PR DESCRIPTION
## About the PR
This should close #3029 

This seemed somewhat similar to the old borg lag (which i still need to relook into). I think what's happening, is that whenever a mech's charge state changes, it's flooding all nearby players with updates. This isn't a problem with a good connection, but high ping will cause massive rubberbanding as they receive this backlog of updates, since we're dirtying every tick in a networked component.

This becomes a massive problem with high-firerate weapons on mechs, as well as batteries that recharge themselves.

We're now only calling to refresh when the mech actually crosses the threshold.

## Why / Balance
Lag and rubberbanding is our biggest problem and i dont think it's any one thing. We have a lot of stuff compounding.

## Media
This is a log from my testing before the change using a high firerate weapon:
<img width="809" height="618" alt="image" src="https://github.com/user-attachments/assets/8df16ae5-fe92-4655-955b-422a78d34cbc" />

This is a log after:
<img width="789" height="553" alt="image" src="https://github.com/user-attachments/assets/0c4a95c8-38b7-4f6f-9808-199a7a450139" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
This may not be the full source of the lag, but same game functionality appears intact in testing.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Possibly fixed mech lag.
