### PR TITLE
Adjusts ADS Spawntable and Decreases Wyvern Spawnrate

### DIFF
--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -13,6 +13,9 @@
     - id: UnknownShuttleZenithE
     - id: UnknownShuttleRazorN
     - id: UnknownShuttleWyvern
+    - id: UnknownShuttleZenith
+    - id: UnknownShuttleWyrm
+    - id: UnknownShuttleNebula
 
 - type: entity
   parent: BaseRandomShuttleRule
@@ -97,7 +100,7 @@
     startAnnouncement: station-event-ai-capital-detected
     startAudio:
       path: /Audio/Misc/delta_alt.ogg
-    weight: 0.5
+    weight: 1.5
     maxOccurrences: 1
   - type: GameRule
     minPlayers: 60

--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -97,7 +97,7 @@
     startAnnouncement: station-event-ai-capital-detected
     startAudio:
       path: /Audio/Misc/delta_alt.ogg
-    weight: 3
+    weight: 0.5
     maxOccurrences: 1
   - type: GameRule
     minPlayers: 60


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

reduces wyvern spawn weight from 3 to 1.5

Readds t1 ships to the t2 ads pool

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Wyvern isn't really fun for anyone. To be frank.

Its currently so utterly dominant that it should be extremely rare outside of Apoc.

I changed t2 pool to not have t1 ships, this was in hindsight a pretty bad idea.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Wyvern and other t2 ADS ships (razor-N and Zenith-E) are rarer.