### PR TITLE
Make Drones Target People in Space

### DIFF
--- a/Content.Server/NPC/Queries/Queries/NearbyHostileShuttlesQuery.cs
+++ b/Content.Server/NPC/Queries/Queries/NearbyHostileShuttlesQuery.cs
@@ -6,9 +6,9 @@ using Content.Shared.Whitelist;
 namespace Content.Server.NPC.Queries.Queries;
 
 /// <summary>
-/// Returns nearby shuttles considered hostile from <see cref="FactionSystem"/>
+/// Returns nearby entities tagged with ShipNpcTargetComponent.
 /// </summary>
-public sealed partial class NearbyHostileShuttlesQuery : UtilityQuery
+public sealed partial class NearbyNpcTargetsQuery : UtilityQuery
 {
     [DataField]
     public float Range = 2000f;

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -494,7 +494,7 @@ public sealed class NPCUtilitySystem : EntitySystem
                 break;
             }
             // Mono - TODO: consider factions
-            case NearbyHostileShuttlesQuery shuttlesQuery:
+            case NearbyNpcTargetsQuery shuttlesQuery:
             {
                 var xform = Transform(owner);
                 var ownGrid = xform.GridUid;
@@ -502,11 +502,13 @@ public sealed class NPCUtilitySystem : EntitySystem
                 {
                     var targetXform = Transform(target);
                     var targetGrid = targetXform.GridUid;
-                    if (targetComp.NeedGrid && targetGrid == null ||
-                        targetGrid == ownGrid ||
-                        (_transform.GetWorldPosition(target) - _transform.GetWorldPosition(xform)).Length() > shuttlesQuery.Range ||
-                        targetComp.NeedPower && !this.IsPowered(target, EntityManager) ||
-                        targetGrid != null && _whitelistSystem.IsBlacklistPass(shuttlesQuery.Blacklist, targetGrid.Value))
+                    if (targetComp.NeedGrid != NpcTargetGridMode.Either // if we care about grid..
+                          // ..and our (non-)need for grid is equal to the (non-)absence of a grid
+                          && (targetComp.NeedGrid == NpcTargetGridMode.OnGrid) == (targetGrid == null)
+                        || targetGrid == ownGrid
+                        || (_transform.GetWorldPosition(target) - _transform.GetWorldPosition(xform)).Length() > shuttlesQuery.Range
+                        || targetComp.NeedPower && !this.IsPowered(target, EntityManager)
+                        || targetGrid != null && _whitelistSystem.IsBlacklistPass(shuttlesQuery.Blacklist, targetGrid.Value))
                     {
                         continue;
                     }

--- a/Content.Server/_Mono/NPC/HTN/ShipNpcTargetComponent.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipNpcTargetComponent.cs
@@ -10,5 +10,12 @@ public sealed partial class ShipNpcTargetComponent : Component
     public bool NeedPower = false;
 
     [DataField]
-    public bool NeedGrid = true;
+    public NpcTargetGridMode NeedGrid = NpcTargetGridMode.OnGrid;
+}
+
+public enum NpcTargetGridMode
+{
+    OnGrid,
+    Either,
+    NoGrid
 }

--- a/Content.Server/_Mono/NPC/HTN/ShipTargetingComponent.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipTargetingComponent.cs
@@ -22,6 +22,12 @@ public sealed partial class ShipTargetingComponent : Component
     public float LeadingAccuracy = 1f;
 
     /// <summary>
+    /// How good to lead offgrid targets.
+    /// </summary>
+    [DataField]
+    public float OffgridLeadingAccuracy = 1f; // be more accurate since an offgrid target is presumably maneurable and small
+
+    /// <summary>
     /// Velocity we're currently estimating for imperfect target leading.
     /// </summary>
     [DataField]

--- a/Content.Server/_Mono/NPC/HTN/ShipTargetingSystem.cs
+++ b/Content.Server/_Mono/NPC/HTN/ShipTargetingSystem.cs
@@ -70,8 +70,9 @@ public sealed partial class ShipTargetingSystem : EntitySystem
                 continue;
 
             var linVel = shipBody.LinearVelocity;
-            var targetVel = targetGrid == null ? Vector2.Zero : _physics.GetMapLinearVelocity(targetGrid.Value);
-            var leadBy = 1f - MathF.Pow(1f - comp.LeadingAccuracy, frameTime);
+            var targetVel = targetGrid == null ? _physics.GetMapLinearVelocity(targetUid) : _physics.GetMapLinearVelocity(targetGrid.Value);
+            var leadingAccuracy = targetGrid == null ? comp.OffgridLeadingAccuracy : comp.LeadingAccuracy;
+            var leadBy = 1f - MathF.Pow(1f - leadingAccuracy, frameTime);
             comp.CurrentLeadingVelocity = Vector2.Lerp(comp.CurrentLeadingVelocity, targetVel, leadBy);
 
             comp.WeaponCheckAccum -= frameTime;

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -284,6 +284,8 @@
   - type: DetectionRangeMultiplier # same as mass scanner
     infraredMultiplier: 0.5
     visualMultiplier: 0.75
+  - type: ShipNpcTarget
+    needGrid: NoGrid
   # </Mono>
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -6,6 +6,7 @@
   - MobPolymorphable
   - MobCombat
   - StripableInventoryBase
+  # Mono TODO: PlayerSiliconHumanoidBase is not parented to this for whatever reason, so fix that
   id: BaseMobSpecies
   abstract: true
   components:
@@ -229,6 +230,9 @@
   - type: Targeting # Shitmed Change
   - type: SurgeryTarget # Shitmed Change
   - type: ExaminableCharacter # WWDP
+  # Mono
+  - type: ShipNpcTarget
+    needGrid: NoGrid
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -1,6 +1,7 @@
 - type: entity
   save: false
   id: PlayerSiliconHumanoidBase
+  # Mono TODO: reparent this to BaseMobSpecies
   parent: [BaseMob, MobDamageable, MobCombat, MobAtmosExposed, MobFlammable]
   abstract: true
   components:
@@ -328,3 +329,6 @@
     shape:
       - 0, 0, 4, 4
       - 0, 3, 6, 5
+  # Mono
+  - type: ShipNpcTarget
+    needGrid: NoGrid

--- a/Resources/Prototypes/_Mono/NPCs/Shuttle/shuttle.yml
+++ b/Resources/Prototypes/_Mono/NPCs/Shuttle/shuttle.yml
@@ -116,7 +116,7 @@
 - type: utilityQuery
   id: NearbyShuttleTargets
   query:
-  - !type:NearbyHostileShuttlesQuery
+  - !type:NearbyNpcTargetsQuery
     blacklist:
       tags:
       - ShuttleAIIgnore

--- a/Resources/Prototypes/_Mono/NPCs/Shuttle/specific.yml
+++ b/Resources/Prototypes/_Mono/NPCs/Shuttle/specific.yml
@@ -120,7 +120,7 @@
 - type: utilityQuery
   id: NearbyShuttleTargetsLongRange
   query:
-  - !type:NearbyHostileShuttlesQuery
+  - !type:NearbyNpcTargetsQuery
     range: 4000
     blacklist:
       tags:


### PR DESCRIPTION
## About the PR
people keep cheesing it and i did say i'd do this if they did
also gives them perfect aim if targeting anyone offgrid since mechs/jets are small and maneurable

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Drones will now target people that are offgrid.
