### PR TITLE
Kill Nf Console Depower Autoanchor

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -202,7 +202,6 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     {
         DockingInterfaceState? dockState = null;
         UpdateState(uid, ref dockState);
-        _shuttle.NfSetPowered(uid, component, args.Powered); // Frontier
 
         // Handle job slots when power changes
         HandleJobSlotsOnPowerChange(uid, component, args.Powered);

--- a/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/_NF/Shuttles/Systems/ShuttleSystem.cs
@@ -113,34 +113,4 @@ public sealed partial class ShuttleSystem
         else
             return InertiaDampeningMode.Dampen;
     }
-
-    public void NfSetPowered(EntityUid uid, ShuttleConsoleComponent component, bool powered)
-    {
-        // Ensure that the entity requested is a valid shuttle (stations should not be togglable)
-        if (!EntityManager.TryGetComponent(uid, out TransformComponent? transform) ||
-            !transform.GridUid.HasValue ||
-            !EntityManager.TryGetComponent(transform.GridUid, out PhysicsComponent? physicsComponent) ||
-            !EntityManager.TryGetComponent(transform.GridUid, out ShuttleComponent? shuttleComponent))
-        {
-            return;
-        }
-
-        // Update dampening physics without adjusting requested mode.
-        if (!powered)
-        {
-            SetInertiaDampening(uid, physicsComponent, shuttleComponent, transform, InertiaDampeningMode.Anchor);
-        }
-        else
-        {
-            // Update our dampening mode if we need to, and if we aren't a station.
-            var currentDampening = NfGetInertiaDampeningMode(uid);
-            if (currentDampening != component.DampeningMode &&
-                currentDampening != InertiaDampeningMode.Station &&
-                component.DampeningMode != InertiaDampeningMode.Station)
-            {
-                SetInertiaDampening(uid, physicsComponent, shuttleComponent, transform, component.DampeningMode);
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Shuttle consoles no longer automatically swap to anchor dampening mode when depowered.
-
