### PR TITLE
Update Shift Duration in Guidebook

### DIFF
--- a/Resources/ServerInfo/_NF/Guidebook/NewFrontier14.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/NewFrontier14.xml
@@ -29,6 +29,6 @@ To make money, why not:
 
 Be sure to stock up at the Trade Depot if going out on an extended voyage, and take advantage of the [color=#33bbff]medical insurance tracker[/color] in your loadout, or from the NanoMed vendor in medbay.
 
-Shifts on the Colossus Sector typically last for [color=#33bbff]eight hours[/color].
+Shifts on the Colossus Sector typically last for [color=#33bbff]six hours[/color].
 If you need to end your shift early or take a break, use the [color=#33bbff]cryo sleep chambers[/color] in the medbay on Colonial Outpost.
 </Document>


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Updates exactly one word in the guidebook to list the correct shift length.
## Why / Balance
![Screenshot_2026-04-05-21-16-11-05_572064f74bd5f9fa804b05334aa4f912](https://github.com/user-attachments/assets/35d3a124-e1ce-4a58-8554-20d47f49bc06)
![Screenshot_2026-04-05-21-21-30-26_572064f74bd5f9fa804b05334aa4f912](https://github.com/user-attachments/assets/cc00cd48-6e82-403d-9e47-0d252a672041)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Guidebook now correctly lists shift duration as six hours rather than eight.
