### PR TITLE
Buffs "Entropy" Electron Torpedo Speed

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -221,7 +221,7 @@
     scale: 4
     shape: triangle
   - type: TimedDespawn
-    lifetime: 15
+    lifetime: 6.5
   - type: PointLight
     radius: 5
     color: orange

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -235,11 +235,11 @@
   - type: MiningGatheringSoft
   - type: MiningGatheringHard
   - type: TargetSeeking
-    acceleration: 30
+    acceleration: 80
     detectionRange: 1000
     scanArc: 45
-    launchSpeed: 25
-    maxSpeed: 100
+    launchSpeed: 100
+    maxSpeed: 300
     trackDelay: 2
   - type: EmpOnTrigger
     range: 7


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
`ShipMissileEntropy` (electron torpedo)
 - acceleration: 30 -> 80
 - launchSpeed: 25 -> 100
 - maxSpeed: 100 -> 300

(Slightly better than the LOSAT torpedo)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Entropy torpedos are so slow that they often explode and EMP your Wyrm on launch, rendering their entire purpose as a weapon utterly moot. I refuse to believe that the creator of the Entropy actually test fired it from a moving vessel.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Shoot torpedo.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: "Entropy" electron torpedos (ADS Wyrm) have received a speed boost.

