### PR TITLE
Constructible Faction Cyborgs 

### DIFF
--- a/Resources/Locale/en-US/_Mono/research/rogue-research.ftl
+++ b/Resources/Locale/en-US/_Mono/research/rogue-research.ftl
@@ -12,7 +12,7 @@ research-technology-rogue-jaws = Advanced Jaws of Life
 research-technology-rogue-energy-dagger = Experimental Plasma Weaponization
 research-technology-rogue-basic-guns = Basic Ballistics
 research-technology-rogue-thermals = Thermal Imaging
-research-technology-pdv-basic-cyborg = PDV Basic Cyborg Developpment
+research-technology-pdv-basic-cyborg = PDV Basic Cyborg Development
 
 # T2 rogue
 research-technology-rogue-advanced-guns = Advanced Ballistics

--- a/Resources/Locale/en-US/_Mono/research/rogue-research.ftl
+++ b/Resources/Locale/en-US/_Mono/research/rogue-research.ftl
@@ -12,7 +12,7 @@ research-technology-rogue-jaws = Advanced Jaws of Life
 research-technology-rogue-energy-dagger = Experimental Plasma Weaponization
 research-technology-rogue-basic-guns = Basic Ballistics
 research-technology-rogue-thermals = Thermal Imaging
-research-technology-pdv-basic-module = PDV Basic Cyborg Module Developpment
+research-technology-pdv-basic-cyborg = PDV Basic Cyborg Developpment
 
 # T2 rogue
 research-technology-rogue-advanced-guns = Advanced Ballistics

--- a/Resources/Locale/en-US/_Mono/research/tsf-research.ftl
+++ b/Resources/Locale/en-US/_Mono/research/tsf-research.ftl
@@ -17,7 +17,7 @@ research-technology-tsfmc-industrial-processing = Industrial Processing
 research-technology-tsfmc-portable-recharger = Portable Recharger
 research-technology-tsfmc-nvd = Night Vision Devices
 research-technology-tsfmc-motion-detector = Biosignature IFF Technology
-research-technology-tsfmc-basic-module = TSFMC Basic Cyborg Module Developpment
+research-technology-tsfmc-basic-cyborg = TSFMC Basic Cyborg Development
 
 # T2 TSFMC
 research-technology-tsfmc-annie = M-27 Annie
@@ -33,4 +33,4 @@ research-technology-tsfmc-flyssa-voucher = Flyssa Procurement LPC
 research-technology-tsfmc-mr8 = MARSOC Firearms Development
 research-technology-tsfmc-xlr556 = Infantry Combat Weapon System
 research-technology-tsfmc-synthalloy = Experimental Material Science
-research-technology-tsfmc-advanced-module = TSFMC Advanced Cyborg Module Developpment
+research-technology-tsfmc-advanced-module = TSFMC Advanced Cyborg Module Development

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
@@ -5,7 +5,7 @@
   - node: start
     entity: CyborgEndoskeleton
     edges:
-    - to: cyborg
+    - to: finish # mono - cyborg
       steps:
       - assemblyId: generic
         guideString: borg-construction-guide-string
@@ -31,7 +31,40 @@
 
       - tool: Screwing
         doAfter: 0.5
+  #Mono start      
+  - node: finish
+    edges:
+    - to: cyborg
+      steps:
+      - tool: Welding
+        doAfter: 1
+    - to: tsfcyborg
+      steps:
+      - tag: CyborgChipTSF
+        name: TSF Cyborg Chip
+        icon:
+          sprite: _Mono/Objects/Specific/Robotics/borgmodule.rsi
+          state: tsf
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+    - to: pdvcyborg
+      steps:
+      - tag: CyborgChipPDV
+        name: PDV Cyborg Chip
+        icon:
+          sprite: _Mono/Objects/Specific/Robotics/borgmodule.rsi
+          state: pdv
+        doAfter: 1
+      - tool: Welding
+        doAfter: 1
+  
+  - node: tsfcyborg
+    entity: BorgChassisSelectableTSF
 
+  - node: pdvcyborg
+    entity: BorgChassisSelectablePDV
+  #Mono End
   - node: cyborg
     entity: BorgChassisSelectable
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -21,6 +21,20 @@
 # TSF Modules
 
 - type: entity
+  id: BorgChipTSF
+  parent: BaseItem
+  name: TSFMC Cyborg Chip
+  description: A modification chip to transform a civilian cyborg during the last stage of construction.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Robotics/borgmodule.rsi
+    layers:
+    - state: tsf
+  - type: Tag
+    tags:
+    - CyborgChipTSF
+
+- type: entity
   id: BorgModuleTSFStandardWeapon
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseFactionGearTSFT2 ]
   name: TSFMC weapon cyborg module
@@ -75,6 +89,20 @@
     icon: { sprite: _Mono/Interface/Action/actions_borg.rsi, state: tsfadvanced-weapon-module }
 
 # PDV Modules
+
+- type: entity
+  id: BorgChipPDV
+  parent: BaseItem
+  name: PDV Cyborg Chip
+  description: A modification chip to transform a civilian cyborg during the last stage of construction.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Specific/Robotics/borgmodule.rsi
+    layers:
+    - state: pdv
+  - type: Tag
+    tags:
+    - CyborgChipPDV
 
 - type: entity
   id: BorgModulePDVStandardWeapon

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/misc.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/misc.yml
@@ -126,8 +126,8 @@
 
 - type: latheRecipe
   parent: BaseToolRecipe
-  id: BasicBorgCombatModulePDV
-  result: BorgModulePDVStandardWeapon
+  id: BasicBorgPDV
+  result: BorgChipPDV
   categories:
   - Tools
   - FactionEquipment
@@ -140,8 +140,8 @@
 
 - type: latheRecipe
   parent: BaseToolRecipe
-  id: BasicBorgCombatModuleTSF
-  result: BorgModuleTSFStandardWeapon
+  id: BasicBorgTSF
+  result: BorgChipTSF
   categories:
   - Tools
   - FactionEquipment

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Factions/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Factions/phaethon_dynasty.yml
@@ -57,5 +57,5 @@
   - AccessBreakerRogue
   - EmagRogue
   - NaniteApplicatorSyndicate
-  - BasicBorgCombatModulePDV
+  - BasicBorgPDV
   - AdvancedBorgCombatModulePDV

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Factions/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Factions/tsfmc.yml
@@ -44,5 +44,5 @@
   - NanolaminateFoamGrenadeTSF
   - PortableRecharger
   - MotionDetectorTSF
-  - BasicBorgCombatModuleTSF
+  - BasicBorgTSF
   - AdvancedBorgCombatModuleTSF

--- a/Resources/Prototypes/_Mono/Research/Rogue/rogue_misc.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/rogue_misc.yml
@@ -145,5 +145,5 @@
   - AdvancedBorgCombatModulePDV
   technologyPrerequisites:
   - UniversalMaterialResearchT3
-  - PDVBasicBorgModule
+  - PDVBasicBorg
   position: 23, 11

--- a/Resources/Prototypes/_Mono/Research/Rogue/rogue_misc.yml
+++ b/Resources/Prototypes/_Mono/Research/Rogue/rogue_misc.yml
@@ -122,14 +122,14 @@
   position: 20, -3
 
 - type: technology
-  id: PDVBasicBorgModule
-  name: research-technology-pdv-basic-module
-  entityIcon: BorgModulePDVStandardWeapon
+  id: PDVBasicBorg
+  name: research-technology-pdv-basic-cyborg
+  entityIcon: BorgChipPDV
   discipline: RogueGear
   tier: 1
   cost: 10000
   recipeUnlocks:
-  - BasicBorgCombatModulePDV
+  - BasicBorgPDV
   technologyPrerequisites:
   - UniversalMaterialResearchT1
   position: 20, -4

--- a/Resources/Prototypes/_Mono/Research/TSF/tsf_misc.yml
+++ b/Resources/Prototypes/_Mono/Research/TSF/tsf_misc.yml
@@ -180,5 +180,5 @@
   - AdvancedBorgCombatModuleTSF
   technologyPrerequisites:
   - UniversalMaterialResearchT3
-  - TSFBasicBorgModule
+  - TSFBasicBorg
   position: 14, 11

--- a/Resources/Prototypes/_Mono/Research/TSF/tsf_misc.yml
+++ b/Resources/Prototypes/_Mono/Research/TSF/tsf_misc.yml
@@ -157,14 +157,14 @@
   position: 11, -2
 
 - type: technology
-  id: TSFBasicBorgModule
-  name: research-technology-tsfmc-basic-module
-  entityIcon: BorgModuleTSFStandardWeapon
+  id: TSFBasicBorg
+  name: research-technology-tsfmc-basic-cyborg
+  entityIcon: BorgChipTSF
   discipline: TsfmcGear
   tier: 1
   cost: 10000
   recipeUnlocks:
-  - BasicBorgCombatModuleTSF
+  - BasicBorgTSF
   technologyPrerequisites:
   - UniversalMaterialResearchT1
   position: 12, -6

--- a/Resources/Prototypes/_Mono/tags.yml
+++ b/Resources/Prototypes/_Mono/tags.yml
@@ -508,3 +508,9 @@
 
 - type: Tag
   id: BombCollar
+
+- type: Tag
+  id: CyborgChipTSF
+
+- type: Tag
+  id: CyborgChipPDV


### PR DESCRIPTION
## About the PR
Since all faction cyborgs start with the standard weapon module, it's research and crafting was essentially dead.
Added a Faction Cyborg Chip for TSF and PDV in it's place than when added to a cyborg on it's last step (after screwing) will complete into it's respective faction chassis.

## Why / Balance
If your faction cyborg explodes, they're forced to either ghost and respawn, or get moved to a civilian cyborg. This fixes that.

## Media
<img width="378" height="481" alt="image" src="https://github.com/user-attachments/assets/bece48ea-19bd-44b8-bb8c-f48963b20ece" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## Testing
Currently tested:
- Constructing a normal civilian cyborg (added a final step of welding)
- Constructing both factions cyborg using their respective chips
- Check you cannot print them without respective research
- Check that recipe appears in faction lathe after research
- Print Cyborg chip from faction lathe

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: You can now craft Faction cyborgs by using a cyborg chip during construction (after screwing)
