### PR TITLE
2x Drone Targeting Range

### DIFF
--- a/Content.Server/NPC/Queries/Queries/NearbyHostileShuttlesQuery.cs
+++ b/Content.Server/NPC/Queries/Queries/NearbyHostileShuttlesQuery.cs
@@ -11,7 +11,7 @@ namespace Content.Server.NPC.Queries.Queries;
 public sealed partial class NearbyNpcTargetsQuery : UtilityQuery
 {
     [DataField]
-    public float Range = 2000f;
+    public float Range = 4000f;
 
     // TODO: make this use factions
     [DataField]

--- a/Resources/Prototypes/_Mono/NPCs/Shuttle/specific.yml
+++ b/Resources/Prototypes/_Mono/NPCs/Shuttle/specific.yml
@@ -117,13 +117,6 @@
         key: Target
         coordinatesKey: TargetCoordinates
 
-- type: utilityQuery
-  id: NearbyShuttleTargetsLongRange
-  parent: NearbyShuttleTargets
-  query:
-  - !type:NearbyNpcTargetsQuery
-    range: 4000
-
 - type: htnCompound
   id: AttackerShuttleSmartStaticCompound
   branches:
@@ -170,7 +163,7 @@
   - tasks:
     - !type:HTNPrimitiveTask
       operator: !type:UtilityOperator
-        proto: NearbyShuttleTargetsLongRange
+        proto: NearbyShuttleTargets
     - !type:HTNCompoundTask
       task: ShuttleAttackDroneCompoundAssembly
 
@@ -202,7 +195,7 @@
       services:
       - !type:UtilityService
         id: TargetsService
-        proto: NearbyShuttleTargetsLongRange
+        proto: NearbyShuttleTargets
         key: Target
         coordinatesKey: TargetCoordinates
 


### PR DESCRIPTION
pretty sure they can be outranged by some weapons currently

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Far reaches drone targeting range doubled.
