### PR TITLE
Lying Down Makes Projectiles Sometimes Miss You 

### DIFF
--- a/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
+++ b/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
@@ -79,7 +79,7 @@ public sealed class RequireProjectileTargetSystem : EntitySystem
     private void PreventCollide(Entity<RequireProjectileTargetComponent> ent, ref PreventCollideEvent args)
     {
         if (args.Cancelled)
-          return;
+            return;
 
         if (!ent.Comp.Active)
             return;
@@ -128,7 +128,7 @@ public sealed class RequireProjectileTargetSystem : EntitySystem
             }
 
             if (!_container.IsEntityOrParentInContainer(shooter.Value))
-               args.Cancelled = true;
+                args.Cancelled = true;
         }
     }
 

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -18,6 +18,7 @@ public sealed partial class StandingStateComponent : Component
     // Mono Start
     [DataField, AutoNetworkedField]
     public float LyingDodgeChance = 0.5f;
+    // Mono End
 
     [DataField, AutoNetworkedField]
     public bool Standing { get; set; } = true;

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -15,19 +15,17 @@ public sealed partial class StandingStateComponent : Component
     public StandingState CurrentState { get; set; } = StandingState.Standing;
     // WD EDIT END
 
-    // Mono Start
     /// <summary>
-    /// Chance for a projectile to miss the target if they are not standing.
+    /// Mono: Chance for a projectile to miss the target if they are not standing.
     /// </summary>
     [DataField, AutoNetworkedField]
     public float LyingDodgeChance = 0.5f;
 
     /// <summary>
-    /// Range between shooter and target at where projectiles will always hit
+    /// Mono: Range between shooter and target at where projectiles will always hit
     /// </summary>
     [DataField, AutoNetworkedField]
     public float HitRange = 3f;
-    // Mono End
 
     [DataField, AutoNetworkedField]
     public bool Standing { get; set; } = true;

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -16,6 +16,9 @@ public sealed partial class StandingStateComponent : Component
     // WD EDIT END
 
     // Mono Start
+    /// <summary>
+    /// Chance for a projectile to miss the target if they are not standing.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public float LyingDodgeChance = 0.5f;
     // Mono End

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -21,6 +21,12 @@ public sealed partial class StandingStateComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public float LyingDodgeChance = 0.5f;
+
+    /// <summary>
+    /// Range between shooter and target at where projectiles will always hit
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float HitRange = 3f;
     // Mono End
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -15,6 +15,10 @@ public sealed partial class StandingStateComponent : Component
     public StandingState CurrentState { get; set; } = StandingState.Standing;
     // WD EDIT END
 
+    // Mono Start
+    [DataField, AutoNetworkedField]
+    public float LyingDodgeChance = 0.5f;
+
     [DataField, AutoNetworkedField]
     public bool Standing { get; set; } = true;
 

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -181,7 +181,7 @@ public sealed class StandingStateSystem : EntitySystem
         return true;
     }
 
-    /// MONO BEGIN: Crawling causes some projectiles based on rng to miss you.
+    /// MONO: Crawling causes some projectiles based on rng to miss you.
     private void PreventCollide(Entity<StandingStateComponent> ent, ref PreventCollideEvent args)
     {
         if (args.Cancelled)
@@ -199,7 +199,6 @@ public sealed class StandingStateSystem : EntitySystem
         if (ent.Comp.CurrentState != StandingState.Standing && _random.Prob(ent.Comp.LyingDodgeChance))
             args.Cancelled = true;
     }
-    // MONO END
 }
 
 [ByRefEvent]

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -198,7 +198,7 @@ public sealed class StandingStateSystem : EntitySystem
             if (_transform.InRange(shooter, ent.Owner, ent.Comp.HitRange))
                 return;
         }
-        if (TryComp<StandingStateComponent>(ent, out var standingState) && standingState.CurrentState != StandingState.Standing && _random.Prob(ent.Comp.LyingDodgeChance))
+        if (ent.Comp.CurrentState != StandingState.Standing && _random.Prob(ent.Comp.LyingDodgeChance))
         {
             args.Cancelled = true;
         }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -207,7 +207,6 @@ public sealed class StandingStateSystem : EntitySystem
             if (_transform.InRange((Entity<TransformComponent?>)shooter, (Entity<TransformComponent?>)ent.Owner, 3f))
                 return;
         }
-        // Mono
         if (TryComp<StandingStateComponent>(ent, out var standingState) && standingState.CurrentState != StandingState.Standing && _random.Prob(chance))
         {
             args.Cancelled = true;

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -195,7 +195,7 @@ public sealed class StandingStateSystem : EntitySystem
         // Check distance between shooter and target, if too close, hit always.
         if (projectile.Shooter is { } shooter)
         {
-            if (_transform.InRange(shooter, ent.Owner, 3f))
+            if (_transform.InRange(shooter, ent.Owner, ent.Comp.HitRange))
                 return;
         }
         if (TryComp<StandingStateComponent>(ent, out var standingState) && standingState.CurrentState != StandingState.Standing && _random.Prob(ent.Comp.LyingDodgeChance))

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -187,27 +187,18 @@ public sealed class StandingStateSystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        var chance = ent.Comp.LyingDodgeChance;
-
-        if (chance <= 0)
-            return;
-
-        var other = args.OtherEntity;
-
         // ONLY apply collision prevention logic to projectiles
         // This check must come FIRST to prevent non-projectiles from being affected
-        if (!TryComp(other, out ProjectileComponent? projectile))
+        if (!TryComp<ProjectileComponent>(args.OtherEntity, out var projectile))
             return;
 
         // Check distance between shooter and target, if too close, hit always.
-        if (projectile.Shooter is not null)
+        if (projectile.Shooter is { } shooter)
         {
-            var shooter = (EntityUid)projectile.Shooter;
-
-            if (_transform.InRange((Entity<TransformComponent?>)shooter, (Entity<TransformComponent?>)ent.Owner, 3f))
+            if (_transform.InRange(shooter, ent.Owner, 3f))
                 return;
         }
-        if (TryComp<StandingStateComponent>(ent, out var standingState) && standingState.CurrentState != StandingState.Standing && _random.Prob(chance))
+        if (TryComp<StandingStateComponent>(ent, out var standingState) && standingState.CurrentState != StandingState.Standing && _random.Prob(ent.Comp.LyingDodgeChance))
         {
             args.Cancelled = true;
         }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -2,16 +2,22 @@
 // if wizden ever does something to this system we're FUCKED
 // regards.
 
+using System.Xml.Schema;
 using Content.Shared._White;
 using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
+using Content.Shared.Projectiles;
 using Content.Shared.Rotation;
+using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics;
+using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Random;
+using Robust.Shared.Toolshed.Commands.Values;
 
 namespace Content.Shared.Standing;
 
@@ -22,6 +28,8 @@ public sealed class StandingStateSystem : EntitySystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movement = default!; // WD EDIT
     [Dependency] private readonly SharedBuckleSystem _buckle = default!; // WD EDIT
+    [Dependency] private readonly SharedTransformSystem _transform = default!; // Mono
+    [Dependency] private readonly IRobustRandom _random = default!; // Mono
 
     // If StandingCollisionLayer value is ever changed to more than one layer, the logic needs to be edited.
     private const int StandingCollisionLayer = (int) CollisionGroup.MidImpassable;
@@ -31,6 +39,7 @@ public sealed class StandingStateSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<StandingStateComponent, AttemptMobCollideEvent>(OnMobCollide);
         SubscribeLocalEvent<StandingStateComponent, AttemptMobTargetCollideEvent>(OnMobTargetCollide);
+        SubscribeLocalEvent<StandingStateComponent, PreventCollideEvent>(PreventCollide);
     }
 
     private void OnMobTargetCollide(Entity<StandingStateComponent> ent, ref AttemptMobTargetCollideEvent args)
@@ -171,6 +180,40 @@ public sealed class StandingStateSystem : EntitySystem
         _movement.RefreshWeightlessModifiers(uid); // Mono edit
         return true;
     }
+
+    /// MONO BEGIN: Crawling causes some projectiles based on rng to miss you.
+    private void PreventCollide(Entity<StandingStateComponent> ent, ref PreventCollideEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        var chance = ent.Comp.LyingDodgeChance;
+
+        if (chance <= 0)
+            return;
+
+        var other = args.OtherEntity;
+
+        // ONLY apply collision prevention logic to projectiles
+        // This check must come FIRST to prevent non-projectiles from being affected
+        if (!TryComp(other, out ProjectileComponent? projectile))
+            return;
+
+        // Check distance between shooter and target, if too close, hit always.
+        if (projectile.Shooter is not null)
+        {
+            var shooter = (EntityUid)projectile.Shooter;
+
+            if (_transform.InRange((Entity<TransformComponent?>)shooter, (Entity<TransformComponent?>)ent.Owner, 3f))
+                return;
+        }
+        // Mono
+        if (TryComp<StandingStateComponent>(ent, out var standingState) && standingState.CurrentState != StandingState.Standing && _random.Prob(chance))
+        {
+            args.Cancelled = true;
+        }
+    }
+    // MONO END
 }
 
 [ByRefEvent]

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -39,7 +39,7 @@ public sealed class StandingStateSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<StandingStateComponent, AttemptMobCollideEvent>(OnMobCollide);
         SubscribeLocalEvent<StandingStateComponent, AttemptMobTargetCollideEvent>(OnMobTargetCollide);
-        SubscribeLocalEvent<StandingStateComponent, PreventCollideEvent>(PreventCollide);
+        SubscribeLocalEvent<StandingStateComponent, PreventCollideEvent>(PreventCollide); // Mono
     }
 
     private void OnMobTargetCollide(Entity<StandingStateComponent> ent, ref AttemptMobTargetCollideEvent args)

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -193,15 +193,11 @@ public sealed class StandingStateSystem : EntitySystem
             return;
 
         // Check distance between shooter and target, if too close, hit always.
-        if (projectile.Shooter is { } shooter)
-        {
-            if (_transform.InRange(shooter, ent.Owner, ent.Comp.HitRange))
-                return;
-        }
+        if (projectile.Shooter is { } shooter && _transform.InRange(shooter, ent.Owner, ent.Comp.HitRange))
+            return;
+
         if (ent.Comp.CurrentState != StandingState.Standing && _random.Prob(ent.Comp.LyingDodgeChance))
-        {
             args.Cancelled = true;
-        }
     }
     // MONO END
 }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -181,7 +181,7 @@ public sealed class StandingStateSystem : EntitySystem
         return true;
     }
 
-    /// MONO: Crawling causes some projectiles based on rng to miss you.
+    /// Mono Method: Crawling causes some projectiles based on rng to miss you.
     private void PreventCollide(Entity<StandingStateComponent> ent, ref PreventCollideEvent args)
     {
         if (args.Cancelled)


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Lying down now makes 50% projectiles miss you.

If the shooter is close to the target (within a radius of 3 tiles) the projectiles will always hit.

This ignores aiming directly at the target. (It will miss 50% of the time even if you do directly aim at them.)

Critical and Dead people work as intended, bullets don't hit them unless directly aimed.

This applies to shipguns as well.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Makes lying down relevant but not mechanically intensive to counter. Especially with regards to shipguns, hitting the deck should do something.

Counters to lying down include, melee, getting close, and grenades.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Projectiles now miss targets lying down 50% of the time, unless the shooter is close (within 3 tiles)