### PR TITLE
Add Compass and Azimuth Ring to Shuttle Radar

### DIFF
--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
@@ -138,6 +138,216 @@ public partial class BaseShuttleControl : MapGridControl
     }
     // End Frontier Corvax
 
+    // Mono
+    protected void DrawAzimuthScale(DrawingHandleScreen handle, Angle rotation)
+    {
+        const int azimuthMinorTickStepDegrees = 10;
+        const int azimuthMajorTickInterval = 3;
+        const int azimuthCardinalTickInterval = 9;
+        const float edgeInset = 10f;
+        const float tickInset = 4f;
+        const float minorTickLength = 5f;
+        const float majorTickLength = 9f;
+        const float cardinalTickLength = 12f;
+        const float labelPadding = 3f;
+        const float labelOffset = tickInset + cardinalTickLength + labelPadding;
+        const float regularLabelScale = 0.62f;
+        const float cardinalLabelScale = 0.72f;
+
+        var origin = MidPointVector;
+        var viewportSize = new Vector2(PixelWidth, PixelHeight);
+
+        var subtleGray = Color.FromHex("#676767");
+        var northAccent = Color.FromHex("#7F7442");
+        var eastAccent = Color.FromHex("#456273");
+        var baseTickColor = subtleGray.WithAlpha(0.34f);
+        var majorTickColor = subtleGray.WithAlpha(0.5f);
+        var cardinalTickColor = subtleGray.WithAlpha(0.68f);
+        var regularLabelColor = subtleGray.WithAlpha(0.76f);
+        var cardinalLabelColor = subtleGray.WithAlpha(0.9f);
+        var labelShadowColor = Color.Black.WithAlpha(0.36f);
+
+        for (var step = 0; step < 360 / azimuthMinorTickStepDegrees; step++)
+        {
+            var degrees = step * azimuthMinorTickStepDegrees;
+            var direction = GetAzimuthDirection(rotation, degrees);
+            var isCardinal = step % azimuthCardinalTickInterval == 0;
+            var isMajor = step % azimuthMajorTickInterval == 0;
+            var isNorth = degrees == 0;
+            var isEast = degrees == 90;
+            var tickLength = isCardinal
+                ? cardinalTickLength
+                : isMajor
+                    ? majorTickLength
+                    : minorTickLength;
+
+            if (!TryGetViewportEdgePoint(origin, direction, viewportSize, edgeInset, out var edgePoint, out var inwardNormal))
+                continue;
+
+            var outer = edgePoint + inwardNormal * tickInset;
+            var inner = outer + inwardNormal * tickLength;
+            var tickColor = isNorth
+                ? northAccent.WithAlpha(0.58f)
+                : isEast
+                    ? eastAccent.WithAlpha(0.58f)
+                    : isCardinal
+                        ? cardinalTickColor
+                        : isMajor
+                            ? majorTickColor
+                            : baseTickColor;
+            handle.DrawLine(outer, inner, tickColor);
+            if (isNorth)
+            {
+                var sideOffset = new Vector2(-inwardNormal.Y, inwardNormal.X) * 0.35f;
+                handle.DrawLine(outer + sideOffset, inner + sideOffset, tickColor.WithAlpha(0.46f));
+            }
+
+            if (!isMajor || isNorth)
+                continue;
+
+            var label = degrees.ToString();
+            var labelScale = isCardinal ? cardinalLabelScale : regularLabelScale;
+            var labelColor = isEast
+                ? eastAccent.WithAlpha(0.76f)
+                : isCardinal
+                    ? cardinalLabelColor
+                    : regularLabelColor;
+            var labelSize = handle.GetDimensions(Font, label, labelScale);
+            var labelPosition = GetEdgeLabelPosition(edgePoint, inwardNormal, labelSize, viewportSize, labelOffset);
+            handle.DrawString(Font, labelPosition + new Vector2(1f, 1f), label, labelScale, labelShadowColor);
+            handle.DrawString(Font, labelPosition, label, labelScale, labelColor);
+        }
+    }
+
+    protected void DrawCompassOverlay(DrawingHandleScreen handle, Angle heading)
+    {
+        var compassCenter = new Vector2(44f, 44f);
+        const float compassRadius = 24f;
+        var ringColor = Color.White.WithAlpha(0.08f);
+        var northColor = Color.FromHex("#776C43");
+        var eastColor = Color.FromHex("#4C6572");
+        handle.DrawCircle(compassCenter, compassRadius, ringColor, false);
+        handle.DrawCircle(compassCenter, 2.5f, ringColor.WithAlpha(0.48f), true);
+
+        DrawCompassNeedle(handle, compassCenter, compassRadius, GetAzimuthDirection(heading, 0f), "N", northColor);
+        DrawCompassNeedle(handle, compassCenter, compassRadius * 0.82f, GetAzimuthDirection(heading, 90f), "E", eastColor);
+    }
+
+    private void DrawCompassNeedle(
+        DrawingHandleScreen handle,
+        Vector2 compassCenter,
+        float radius,
+        Vector2 direction,
+        string label,
+        Color color)
+    {
+        var tip = compassCenter + direction * radius;
+        var tail = compassCenter - direction * (radius * 0.35f);
+        DrawArrowLine(handle, tail, tip, color.WithAlpha(0.58f), 6f);
+
+        var labelSize = handle.GetDimensions(Font, label, 0.9f);
+        var labelPosition = tip + direction * 6f - new Vector2(labelSize.X * 0.5f, labelSize.Y * 0.5f);
+        handle.DrawString(Font, labelPosition, label, 0.9f, color.WithAlpha(0.7f));
+    }
+
+    private static void DrawArrowLine(
+        DrawingHandleScreen handle,
+        Vector2 start,
+        Vector2 end,
+        Color color,
+        float headLength)
+    {
+        var direction = end - start;
+        if (direction.LengthSquared() <= 0.001f)
+            return;
+
+        direction = Vector2.Normalize(direction);
+        var left = new Vector2(-direction.Y, direction.X);
+        handle.DrawLine(start, end, color);
+        handle.DrawLine(end, end - direction * headLength + left * (headLength * 0.45f), color);
+        handle.DrawLine(end, end - direction * headLength - left * (headLength * 0.45f), color);
+    }
+
+    private static bool TryGetViewportEdgePoint(
+        Vector2 origin,
+        Vector2 direction,
+        Vector2 viewportSize,
+        float inset,
+        out Vector2 edgePoint,
+        out Vector2 inwardNormal)
+    {
+        edgePoint = default;
+        inwardNormal = default;
+
+        if (direction.LengthSquared() <= 0.001f)
+            return false;
+
+        direction = Vector2.Normalize(direction);
+        var min = new Vector2(inset, inset);
+        var max = viewportSize - min;
+        if (max.X <= min.X || max.Y <= min.Y)
+            return false;
+
+        var tx = direction.X > 0f
+            ? (max.X - origin.X) / direction.X
+            : direction.X < 0f
+                ? (min.X - origin.X) / direction.X
+                : float.PositiveInfinity;
+        var ty = direction.Y > 0f
+            ? (max.Y - origin.Y) / direction.Y
+            : direction.Y < 0f
+                ? (min.Y - origin.Y) / direction.Y
+                : float.PositiveInfinity;
+
+        var t = Math.Min(tx, ty);
+        if (!float.IsFinite(t) || t <= 0f)
+            return false;
+
+        edgePoint = origin + direction * t;
+
+        if (tx < ty)
+            inwardNormal = direction.X > 0f ? -Vector2.UnitX : Vector2.UnitX;
+        else
+            inwardNormal = direction.Y > 0f ? -Vector2.UnitY : Vector2.UnitY;
+
+        return true;
+    }
+
+    private static Vector2 GetEdgeLabelPosition(
+        Vector2 edgePoint,
+        Vector2 inwardNormal,
+        Vector2 labelSize,
+        Vector2 viewportSize,
+        float offset)
+    {
+        var anchor = edgePoint + inwardNormal * offset;
+        Vector2 requested;
+        if (Math.Abs(inwardNormal.X) > Math.Abs(inwardNormal.Y))
+        {
+            requested = inwardNormal.X > 0f
+                ? new Vector2(anchor.X, anchor.Y - labelSize.Y * 0.5f)
+                : new Vector2(anchor.X - labelSize.X, anchor.Y - labelSize.Y * 0.5f);
+        }
+        else
+        {
+            requested = inwardNormal.Y > 0f
+                ? new Vector2(anchor.X - labelSize.X * 0.5f, anchor.Y)
+                : new Vector2(anchor.X - labelSize.X * 0.5f, anchor.Y - labelSize.Y);
+        }
+
+        var minPosition = new Vector2(offset, offset);
+        var maxPosition = viewportSize - labelSize - minPosition;
+        return Vector2.Clamp(requested, minPosition, maxPosition);
+    }
+
+    private static Vector2 GetAzimuthDirection(Angle baseAngle, float azimuthDegrees)
+    {
+        var angle = baseAngle + Angle.FromDegrees(azimuthDegrees);
+        var radians = (float) angle.Theta - MathF.PI / 2f;
+        return new Vector2(MathF.Cos(radians), MathF.Sin(radians));
+    }
+    // End Mono
+
     protected void DrawGrid(DrawingHandleScreen handle, Matrix3x2 gridToView, Entity<MapGridComponent> grid, Color color, float alpha = 0.01f)
     {
         var rator = Maps.GetAllTilesEnumerator(grid.Owner, grid.Comp);

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -310,7 +310,6 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
             _rotation = Angle.Zero;
 
         var worldRot = _rotation.Value;
-
         var mapPos = _transform.ToMapCoordinates(_coordinates.Value).Offset(_rotation.Value.RotateVec(_panOffset));
         var mapCoord = _transform.ToCoordinates(mapPos);
         var worldToShuttle = Matrix3Helpers.CreateTranslation(-mapCoord.Position) * Matrix3Helpers.CreateRotation(-worldRot);
@@ -323,6 +322,14 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
 
         // Frontier Corvax: north line drawing
         DrawNorthLine(handle, worldRot);
+
+        // Mono
+        DrawAzimuthScale(handle, worldRot);
+
+        if (worldRot != Angle.Zero)
+        {
+            DrawCompassOverlay(handle, coordEntRot);
+        }
 
         // Draw our grid in detail
         var ourGridId = xform.GridUid;


### PR DESCRIPTION
## What
Adds two new orientation aids to the shuttle radar UI:
- a small compass for quick orientation
- an outer azimuth ring for precise bearing readout

Also includes visual tuning for readability:
- gray azimuth labels and ticks
- inward-facing ticks only
- no outer segmented ring fragments

## Why
The shuttle radar previously had no dedicated compass or azimuth bearing scale, which made orientation and precise bearing readout harder during navigation.

This change separates:
- quick orientation via the compass
- precise bearing readout via the azimuth ring

## Notes
- In No Rotate, the azimuth ring is north-up
- In Rotate, the radar follows the selected rotation behavior
- The ring is intentionally subtle so it does not compete with contacts
