### PR TITLE
Fix Scanner Rotation Stuff

### DIFF
--- a/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/RadarConsoleSystem.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Shuttles.Systems;
 
 public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
 {
+    [Dependency] private readonly SharedTransformSystem _transform = default!; // Mono
     [Dependency] private readonly ShuttleConsoleSystem _console = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
 
@@ -39,13 +40,19 @@ public sealed class RadarConsoleSystem : SharedRadarConsoleSystem
     protected override void UpdateState(EntityUid uid, RadarConsoleComponent component)
     {
         var xform = Transform(uid);
-        var onGrid = xform.ParentUid == xform.GridUid;
-        EntityCoordinates? coordinates = onGrid ? xform.Coordinates : null;
-        Angle? angle = onGrid ? xform.LocalRotation : null;
+        // Mono
+        var parentUid = xform.GridUid;
+        EntityCoordinates? coordinates = null;
+        Angle? angle = null;
         if (component.FollowEntity)
         {
             coordinates = new EntityCoordinates(uid, Vector2.Zero);
             angle = Angle.Zero; // Frontier: Angle.Zero<Angle.FromDegrees(180) // Mono - frontier strikes again
+        }
+        else if (parentUid is { } parent)
+        {
+            coordinates = _transform.WithEntityId(xform.Coordinates, parent);
+            angle = _transform.GetWorldRotation(xform) - _transform.GetWorldRotation(parent);
         }
 
         if (_uiSystem.HasUi(uid, RadarConsoleUiKey.Key))

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -577,6 +577,7 @@
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole # Mono
     followEntity: true
+    noRotate: true
     maxIffRange: 0
     hideCoords: false
 

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -54,6 +54,7 @@
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole # Mono
     followEntity: true
+    noRotate: true # Mono
     maxIffRange: 0
     hideCoords: false
   - type: RandomSprite

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -157,6 +157,7 @@
   # <Mono>
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: Magboots
   # </Mono>
 

--- a/Resources/Prototypes/_Crescent/NPCs/Shuttle/control.yml
+++ b/Resources/Prototypes/_Crescent/NPCs/Shuttle/control.yml
@@ -94,6 +94,7 @@
       enum.DroneConsoleUiKey.Key:
         type: DroneConsoleBoundUserInterface
   - type: RadarConsole
+    noRotate: true
   - type: WorldLoader
     radius: 256
   - type: DeviceNetwork

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
@@ -31,6 +31,7 @@
     isEquipment: true
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: DetectionRangeMultiplier # upgraded thermal sensors
     infraredMultiplier: 1.5
     visualMultiplier: 2

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercenaries.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/mercenaries.yml
@@ -27,6 +27,7 @@
     color: "#e24242"
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: DetectionRangeMultiplier
     infraredMultiplier: 0.5
     visualMultiplier: 0.75

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/trauma.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/trauma.yml
@@ -16,6 +16,7 @@
     lowPressureMultiplier: 1000
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: DetectionRangeMultiplier
     infraredMultiplier: 0.5
     visualMultiplier: 0.75
@@ -69,6 +70,7 @@
     toggleAction: PulseThermalVision
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ui.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ui.yml
@@ -49,6 +49,7 @@
     lowPressureMultiplier: 1000
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true
@@ -162,6 +163,7 @@
     lowPressureMultiplier: 1000
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ussp.yml
@@ -106,6 +106,7 @@
     lowPressureMultiplier: 1000
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true
@@ -162,7 +163,7 @@
   id: ClothingHeadHelmetHardsuitOfficerCombat
   name: USSP UF-16 "Voenkom" commissar tacsuit helmet
   description: Cold, imposing, and unmistakably Union -- developed to instill discipline and fear. It's visor grants enhanced battlefield awareness with It's built-in command control map. Ideal for Commissars overseeing frontline operations.
-  categories: [ HideSpawnMenu ]  
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: _Mono/Clothing/Head/Hardsuits/ussp_officer_combat.rsi
@@ -175,6 +176,7 @@
     lowPressureMultiplier: 1000
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
     singleUser: true

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/modsuit.yml
@@ -402,6 +402,7 @@
     - Snout
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: DetectionRangeMultiplier
     infraredMultiplier: 0.5
     visualMultiplier: 0.75

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -252,7 +252,6 @@
           type: WiresBoundUserInterface
   - type: RadarConsole
     relativePanning: true
-    noRotate: true
   - type: WorldLoader
     radius: 384 # Mono
   - type: Computer

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
@@ -88,6 +88,7 @@
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole # Mono
     followEntity: true
+    noRotate: true
     maxIffRange: 0
     hideCoords: false
   - type: RandomSprite

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/silicon.yml
@@ -41,6 +41,7 @@
         toggleAction: ActionObserverShowRadar
   - type: RadarConsole
     followEntity: true
+    noRotate: true
   - type: VehicleHorn
 
 - type: entity


### PR DESCRIPTION
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Gunnery console rotation is no longer always north. Also fixed mech and other mass scanners.
