### PR TITLE
Fix Projectile Raycast

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -144,7 +144,8 @@ public sealed class ProjectileSystem : SharedProjectileSystem
                 continue;
 
             var xform = Transform(uid);
-            var lastPosition = _transformSystem.GetWorldPosition(xform);
+            var lastMap = _transformSystem.GetMapCoordinates(xform);
+            var lastPosition = lastMap.Position;
             var rayDirection = currentVelocity / velLen;
             // Ensure rayDistance is not zero to prevent issues with IntersectRay if frametime or velocity is zero.
             var rayDistance = velLen * frameTime;
@@ -243,9 +244,9 @@ public sealed class ProjectileSystem : SharedProjectileSystem
                     return false;
 
                 // teleport us so we hit it
-                // this is cursed but i don't think there's a better way to force a collision here
                 var hitXform = Transform(minHit.Uid.Value);
-                var hitPos = hitXform.Coordinates;
+                var hitMapCoord = lastMap.Offset(rayDirection * minHit.Distance);
+                var hitPos = _transformSystem.ToCoordinates(hitMapCoord);
                 // if we somehow hit something not directly parented to space or a grid
                 if (hitXform.Coordinates.EntityId != hitXform.GridUid && hitXform.GridUid != null)
                     hitPos = _transformSystem.WithEntityId(hitPos, hitXform.GridUid.Value);


### PR DESCRIPTION
needs balance testing

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Explosive shipgun projectiles no longer sink their explosion into one wall.
