### PR TITLE
Increase Cargo Order Capacity From 20 to 60 in the Trade Mall

### DIFF
--- a/Resources/Prototypes/_NF/PointsOfInterest/trademall.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/trademall.yml
@@ -42,6 +42,8 @@
     TradeMall:
       stationProto: MarketFrontierOutpost
       components:
+        - type: StationCargoOrderDatabase
+          capacity: 60
         - type: StationNameSetup
           mapNameTemplate: 'Trade Mall'
         - type: StationDeadDrop


### PR DESCRIPTION
## About the PR
I increased cargo order capacity from 20 to 60 in the Trade Mall

## Why / Balance
There are three buy points on the Trade Mall and the limit of 20 prevents everyone from buying a lot at the same time

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Open cargo trade console in the Trade Mall

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: doublechest
- tweak: Cargo order capacity in the Trade Mall was increased from 20 to 60

