### PR TITLE
Disable Razor-N From Non-Apocalypse Rounds.

### DIFF
--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -11,7 +11,7 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: UnknownShuttleZenithE
-    - id: UnknownShuttleRazorN
+#    - id: UnknownShuttleRazorN
     - id: UnknownShuttleWyvern
     - id: UnknownShuttleZenith
     - id: UnknownShuttleWyrm


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes the Razor N from the pool of T2 ADS ships in non-apocalypse rounds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Low player quality has resulted in players actively _begging_ Staff/Maintainers for permission to violate their laws in order to target a "bigger target", which in all cases has been the Halcyon, Helios, or attempting to destroy CC/MD. This is a player quality issue, but it stems from the fundamental role of ADS and its incompatibility with the Razor-N. 

The Razor-N is an absurdly large "stick" to carry in any situation except for destroying a Station. By existing, it tempts players to look for excuses to violate their laws and target stations. Outside of the high chaos of an apocalypse round this is entirely unnecessarily disruptive, especially for a completely free throwaway role.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Go in-game -> You will not see Razor-N as a random Damaged AI grid spawn.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: The Razor-N has been removed from the standard gamemode ADS pool. It can still appear during Apocalypse rounds.