### PR TITLE
Adds Maintenance Jack to 'Expanding and Repairing Station' Guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Engineering/ExpandingRepairingStation.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/ExpandingRepairingStation.xml
@@ -33,7 +33,7 @@
 
   It is advised to use floor tiles to replace lattice instead of steel sheets, as you can craft 4 floor tiles from a single steel sheet.
 
-  You can use an RCD to deconstruct hull tiles into lattice.
+  You can use an RCD or a maintenance jack to deconstruct hull tiles into lattice.
 
 
 </Document>


### PR DESCRIPTION
## About the PR
Adds the maintenance jack to the list of tools that can convert tiles into lattices, because you can do this. Apparently.
## Why / Balance
The guidebook should tell you how the game works.
## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
## How to test
Join game. Navigate to 'Expanding and Repairing Stations' in the guidebook, and scroll to the bottom.
## Breaking changes
I updated a single line in a .xml file.
**Changelog**
:cl:
- tweak: The 'Expanding and Repairing Station' subsection of the 'Engineering' guidebook now mentions maintenance jacks as valid plating removal tools.

