### PR TITLE
Ammo Loader Cartridge Fix

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -7,7 +7,7 @@ namespace Content.Server.Weapons.Ranged.Systems;
 public sealed partial class GunSystem
 {
     /// <summary>
-    /// Adds an ammo entity to a BallisticAmmoProvider 
+    /// Adds an ammo entity to a BallisticAmmoProvider (Mono - entire method)
     /// </summary>
     public void AddBallisticAmmo(EntityUid uid, Entity<BallisticAmmoProviderComponent?> ammoEntity)
     {

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -7,13 +7,12 @@ namespace Content.Server.Weapons.Ranged.Systems;
 public sealed partial class GunSystem
 {
     /// <summary>
-    /// Adds ammo to a ballistic ammo provider by incrementing UnspawnedCount.
+    /// Adds an ammo entity to a BallisticAmmoProvider 
     /// </summary>
-    public void AddBallisticAmmo(EntityUid uid, BallisticAmmoProviderComponent component, int amount = 1)
+    public void AddBallisticAmmo(EntityUid uid, EntityUid ammoEntity, BallisticAmmoProviderComponent component)
     {
-        component.UnspawnedCount += amount;
-
-        DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.UnspawnedCount));
+        component.Entities.Add(ammoEntity);
+        DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
     }
 
     protected override void Cycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates)

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -9,10 +9,12 @@ public sealed partial class GunSystem
     /// <summary>
     /// Adds an ammo entity to a BallisticAmmoProvider 
     /// </summary>
-    public void AddBallisticAmmo(EntityUid uid, EntityUid ammoEntity, BallisticAmmoProviderComponent component)
+    public void AddBallisticAmmo(EntityUid uid, Entity<BallisticAmmoProviderComponent?> ammoEntity)
     {
-        component.Entities.Add(ammoEntity);
-        DirtyField(uid, component, nameof(BallisticAmmoProviderComponent.Entities));
+        if (!Resolve(ammoEntity, ref ammoEntity.Comp))
+            return;
+        ammoEntity.Comp.Entities.Add(ammoEntity);
+        DirtyField(uid, ammoEntity.Comp, nameof(BallisticAmmoProviderComponent.Entities));
     }
 
     protected override void Cycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates)

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -9,12 +9,12 @@ public sealed partial class GunSystem
     /// <summary>
     /// Adds an ammo entity to a BallisticAmmoProvider (Mono - entire method)
     /// </summary>
-    public void AddBallisticAmmo(EntityUid uid, Entity<BallisticAmmoProviderComponent?> ammoEntity)
+    public void AddBallisticAmmo(Entity<BallisticAmmoProviderComponent?> ent, EntityUid ammoEntity)
     {
-        if (!Resolve(ammoEntity, ref ammoEntity.Comp))
+        if (!Resolve(ent, ref ent.Comp))
             return;
-        ammoEntity.Comp.Entities.Add(ammoEntity);
-        DirtyField(uid, ammoEntity.Comp, nameof(BallisticAmmoProviderComponent.Entities));
+        ent.Comp.Entities.Add(ammoEntity);
+        DirtyField(ent, ent.Comp, nameof(BallisticAmmoProviderComponent.Entities));
     }
 
     protected override void Cycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates)

--- a/Content.Server/_Mono/AmmoLoader/AmmoLoaderSystem.cs
+++ b/Content.Server/_Mono/AmmoLoader/AmmoLoaderSystem.cs
@@ -26,7 +26,7 @@ public sealed class AmmoLoaderSystem : EntitySystem
     [Dependency] private readonly GunSystem _gun = default!;
     [Dependency] private readonly ItemSlotsSystem _slots = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-
+    
     public override void Initialize()
     {
         base.Initialize();
@@ -388,8 +388,8 @@ public sealed class AmmoLoaderSystem : EntitySystem
         if (HasComp<CartridgeAmmoComponent>(ammoEntity))
         {
             _containers.Remove(ammoEntity, loader.Comp.Container);
-            _gun.AddBallisticAmmo(gunUid, artilleryAmmo, 1);
-            Del(ammoEntity);
+            _containers.Insert(ammoEntity, artilleryAmmo.Container);
+            _gun.AddBallisticAmmo(gunUid, ammoEntity, artilleryAmmo);
             return true;
         }
 

--- a/Content.Server/_Mono/AmmoLoader/AmmoLoaderSystem.cs
+++ b/Content.Server/_Mono/AmmoLoader/AmmoLoaderSystem.cs
@@ -26,7 +26,6 @@ public sealed class AmmoLoaderSystem : EntitySystem
     [Dependency] private readonly GunSystem _gun = default!;
     [Dependency] private readonly ItemSlotsSystem _slots = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
-    
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Server/_Mono/AmmoLoader/AmmoLoaderSystem.cs
+++ b/Content.Server/_Mono/AmmoLoader/AmmoLoaderSystem.cs
@@ -388,7 +388,7 @@ public sealed class AmmoLoaderSystem : EntitySystem
         {
             _containers.Remove(ammoEntity, loader.Comp.Container);
             _containers.Insert(ammoEntity, artilleryAmmo.Container);
-            _gun.AddBallisticAmmo(gunUid, ammoEntity, artilleryAmmo);
+            _gun.AddBallisticAmmo((gunUid, artilleryAmmo), ammoEntity);
             return true;
         }
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Autoloaders no longer use UnspawnedCount for cartridge projectiles
- Autoloading torpedos no longer bricks the torpedo launcher
- CHARON nuclear slugs no longer turn into regular slugs when autoloaded.
Fixes #3771
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Load things with an ammo loader

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: torpedos no longer break when loaded using an ammo loader.
- fix: CHARON nuclear slugs no longer turn into regular slugs when loaded using an ammo loader.
