### PR TITLE
CPRing Now Checks for Unrevivable

### DIFF
--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Medical.CPR;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Traits.Assorted;
 using Content.Shared.Verbs;
 using Robust.Server.Audio;
 using Robust.Shared.Audio;

--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -120,6 +120,7 @@ public sealed class CPRSystem : EntitySystem
             && _mobThreshold.TryGetThresholdForState((EntityUid)args.Target, MobState.Dead, out var threshold)
             && TryComp<DamageableComponent>(args.Target, out var damageableComponent)
             && TryComp<MobStateComponent>(args.Target, out var state)
+            && !HasComp<UnrevivableComponent>(args.Target)
             && damageableComponent.TotalDamage < threshold)
             _mobStateSystem.ChangeMobState(args.Target.Value, MobState.Critical, state, performer);
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes CPRing check for unrevivable (literally just ripped the line from the goob implementation)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I got an ahelp about it and it made me Mildly Annoyed

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Attempt to CPR-revive a humanoid with the unrevivable component 

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: CPRing now respects the unrevivable trait
