### PR TITLE
CPRing Now Checks for Unrevivable + CPR Revivals Now Notify Ghost

### DIFF
--- a/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EinsteinEngines/Medical/CPR/CPRSystem.cs
@@ -1,6 +1,8 @@
 using Content.Server.Atmos.Rotting;
 using Content.Server.Body.Components;
 using Content.Server.DoAfter;
+using Content.Server.EUI;
+using Content.Server.Ghost;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Server.Popups;
 using Content.Shared.Atmos.Rotting;
@@ -9,9 +11,11 @@ using Content.Shared.DoAfter;
 using Content.Shared.Inventory;
 
 using Content.Shared.Medical.CPR;
+using Content.Shared.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Traits.Assorted;
 using Content.Shared.Verbs;
 using Robust.Server.Audio;
 using Robust.Shared.Audio;
@@ -32,6 +36,8 @@ public sealed class CPRSystem : EntitySystem
     [Dependency] private readonly RottingSystem _rottingSystem = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!; // Mono
+    [Dependency] private readonly EuiManager _euiManager = default!; // Mono
 
     public override void Initialize()
     {
@@ -103,25 +109,40 @@ public sealed class CPRSystem : EntitySystem
 
     private void OnCPRDoAfter(Entity<CPRTrainingComponent> performer, ref CPRDoAfterEvent args)
     {
-        if (args.Cancelled || args.Handled || !args.Target.HasValue)
+        if (args.Cancelled || args.Handled || args.Target is not { } target) // Mono: replaces args.Target with target, makes target not nullable
         {
             performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream);
             return;
         }
 
         if (!performer.Comp.CPRHealing.Empty)
-            _damageable.TryChangeDamage(args.Target, performer.Comp.CPRHealing, true, origin: performer);
+            _damageable.TryChangeDamage(target, performer.Comp.CPRHealing, true, origin: performer);
 
         if (performer.Comp.RotReductionMultiplier > 0)
             _rottingSystem.ReduceAccumulator(
                 (EntityUid)args.Target, performer.Comp.DoAfterDuration * performer.Comp.RotReductionMultiplier);
 
         if (_robustRandom.Prob(performer.Comp.ResuscitationChance)
-            && _mobThreshold.TryGetThresholdForState((EntityUid)args.Target, MobState.Dead, out var threshold)
-            && TryComp<DamageableComponent>(args.Target, out var damageableComponent)
-            && TryComp<MobStateComponent>(args.Target, out var state)
+            && _mobThreshold.TryGetThresholdForState(target, MobState.Dead, out var threshold)
+            && TryComp<DamageableComponent>(target, out var damageableComponent)
+            && !HasComp<UnrevivableComponent>(target) // Mono: Checks unreviveability
+            && TryComp<MobStateComponent>(target, out var state)
             && damageableComponent.TotalDamage < threshold)
+        {
             _mobStateSystem.ChangeMobState(args.Target.Value, MobState.Critical, state, performer);
+
+            // Mono Edit: Informs the ghost they've been revived.
+            if (_mind.TryGetMind(target, out _, out var mind) &&
+                mind.Session is { } playerSession)
+            {
+                // notify them they're being revived.
+                if (mind.CurrentEntity != target)
+                {
+                    _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind), playerSession);
+                }
+            }
+        }
+
 
         var isAlive = _mobStateSystem.IsAlive(args.Target.Value);
         args.Repeat = !isAlive;


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

continuation of https://github.com/Monolith-Station/Monolith/pull/3797

Makes CPRing check for unrevivable (literally just ripped the line from the goob implementation)

makes CPR revivals notify the ghost upon a revival (copies defib code)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

bugfixes

thanks to 10kee for finding the first bug and fixing it in a separate pr

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: CPRing now respects the unrevivable trait
- fix: CPR revivals now notify the ghost they've been revived.

