### PR TITLE
Various Ground Balancing Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -687,7 +687,7 @@
         Caustic: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.9
-    sprintModifier: 0.9
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing
@@ -768,7 +768,7 @@
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
-        Heat: 0.2
+        Heat: 0.35
         Radiation: 0.01
         Caustic: 0.5
   - type: Item

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -19,7 +19,7 @@
     maxAngle: 20
     angleIncrease: 5
     angleDecay: 25
-    fireRate: 4
+    fireRate: 3
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -69,6 +69,7 @@
     id: StandardFactionLongarm
   # - type: StaticPrice # Frontier: overvalued
   #  price: 1300
+  - type: GunRequiresWield
 
 - type: entity
   name: ceremonial rifle (7.62x51mm)

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -24,6 +24,7 @@
     shotsPerBurst: 4
     fireRate: 6.5
     projectileSpeed: 42.5 # Mono
+    damageModifier: 0.9
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/thock.ogg
   - type: ChamberMagazineAmmoProvider
@@ -59,12 +60,13 @@
   - type: Appearance
   - type: PirateBountyItem # Mono
     id: ExperimentalFactionWeapon
+  - type: GunRequiresWield
 
 - type: entity
   name: CS KMP-WSPR (7.62x39mm)
   parent: BaseWeaponRifle # Mono - C3
   id: WeaponRifleWSPR
-  description: A cutting-edge rifle from Cybersun, versatile, reliable, and Syndicate-approved. Uses 7.62x39mm ammo.
+  description: A cutting-edge Dynasty burst rifle, versatile and reliable. Uses 7.62x39mm ammo.
   components:
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/Rifles/wspr.rsi # Mono
@@ -85,9 +87,10 @@
     - Burst
     selectedMode: Burst
     burstFireRate: 20 # Mono
-    burstCooldown: 0.4 # Mono
+    burstCooldown: 0.6 # Mono
     projectileSpeed: 45 # Mono
     fireRate: 7.5 # Mono, does nothing because its burst only but it makes it clear it can fire at this rate.
+    damageModifier: 0.9
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/wspr_fire.ogg # Mono change - Changed audio path
   - type: ItemSlots
@@ -114,10 +117,11 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+  - type: GunRequiresWield
 
 - type: entity
   name: PA M-90 (7.62x51mm) # mono - 762x51mm
-  parent: BaseWeaponRifle # Mono - pirate contra
+  parent: BaseWeaponRifle
   id: WeaponRifleM90
   description: A compact bullpup design. Uses 7.62x51mm rifle ammo. # mono
   components:
@@ -137,6 +141,19 @@
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: Gun
+    minAngle: 13
+    maxAngle: 20
+    angleIncrease: 5
+    angleDecay: 25
+    fireRate: 3
+    burstFireRate: 6
+    burstCooldown: 0.5
+    shotsPerBurst: 2
+    selectedMode: Burst
+    availableModes:
+    - FullAuto
+    - Burst
+    - SemiAuto
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/light_rifle_2.ogg # Mono
   - type: ItemSlots
@@ -167,6 +184,7 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+  - type: GunRequiresWield
 
 - type: entity
   name: CS Burner (12.7x99mm)
@@ -216,3 +234,4 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+  - type: GunRequiresWield

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -185,6 +185,9 @@
     zeroVisible: true
   - type: Appearance
   - type: GunRequiresWield
+  - type: GunWieldBonus
+    minAngle: 10
+    maxAngle: 8
 
 - type: entity
   name: CS Burner (12.7x99mm)

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
@@ -155,7 +155,7 @@
       helmetcover: ClothingHeadHelmetCoverBlock
       helmetattachment: ClothingHeadHelmetAttachmentBlock
   - type: ExplosionResistance
-    damageCoefficient: 0.2
+    damageCoefficient: 0.3
   - type: FireProtection
     reduction: 0.8
   - type: Armor # Mono - Armor Value Changes

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
@@ -190,7 +190,7 @@
         Poison: 0.8 # Mono
   - type: ClothingSpeedModifier # Mono - Armor Value Changes
     walkModifier: 0.7
-    sprintModifier: 0.8
+    sprintModifier: 0.65
   - type: FactionClothing
     faction: NanoTrasen
   - type: StaminaDamageResistance # Mono - Stamres

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
@@ -189,8 +189,8 @@
         Caustic: 0.8
         Poison: 0.8 # Mono
   - type: ClothingSpeedModifier # Mono - Armor Value Changes
-    walkModifier: 0.9
-    sprintModifier: 0.6
+    walkModifier: 0.7
+    sprintModifier: 0.8
   - type: FactionClothing
     faction: NanoTrasen
   - type: StaminaDamageResistance # Mono - Stamres

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/battery_cell.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/battery_cell.yml
@@ -96,7 +96,7 @@
     startingCharge: 10000
   - type: HitscanBatteryAmmoProvider
     proto: Hitscan400Thz
-    fireCost: 100
+    fireCost: 50
   - type: Tag
     tags:
     - LargeMilitaryPowerCell

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
@@ -46,7 +46,7 @@
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 25
+        Heat: 20
         Structural: 10
   - type: HitscanBasicVisuals
     muzzleFlash:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/tsf.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/tsf.yml
@@ -78,7 +78,7 @@
   name: "'Smilodon' DEW-50-C automatic energy weapon"
   parent: [BaseWeaponRifle, BaseGunWieldable, BaseC2ContrabandUnredeemable]
   id: WeaponDEWSmilodon
-  description: Modified from the original "Calico" DEW, the "Smilodon" carries the philosophy of its predecessor into the world of LMGs - Capable of using battery boxes *and* chemical magazines while also having secondary storage for on-the-go marines, the Smilodon's only failures are the downsides of laser-based weapons and its bulky frame.
+  description: Modified from the original "Calico" DEW, the "Smilodon" carries the philosophy of its predecessor into the world of LMGs - Capable of using battery boxes *and* chemical magazines while also having secondary storage for on-the-go marines, the Smilodon's only failures are the downsides of laser-based weapons and its bulky frame. Continued firing calibrates spread.
   components:
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/LMGs/smilodon.rsi
@@ -90,20 +90,16 @@
     - state: mag2-0
       map: ["enum.ItemCabinetVisuals.Layer"]
   - type: Gun
-    minAngle: 0
-    maxAngle: 20
-    angleIncrease: 2
-    angleDecay: 5
-    fireRate: 6
+    minAngle: 1
+    maxAngle: 22
+    angleIncrease: -0.5
+    angleDecay: -3
+    fireRate: 5
     selectedMode: FullAuto
     availableModes:
     - FullAuto
-    - Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
-    shotsPerBurst: 10
-    burstCooldown: 0.6
-    burstFireRate: 10
   - type: ChamberMagazineAmmoProvider
     soundRack:
       path: /Audio/Weapons/Guns/Cock/batrifle_cock.ogg
@@ -178,3 +174,6 @@
         enum.ItemCabinetVisuals.Layer:
           True: { visible: true }
           False: { visible: false }
+  - type: GunWieldBonus
+    minAngle: 0
+    maxAngle: 0

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -22,7 +22,7 @@
     angleIncrease: 5
     angleDecay: 20
     fireRate: 8
-    DamageModifier: 0.9
+    damageModifier: 0.9
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/mla_fire.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -17,11 +17,12 @@
     minAngle: -20
     maxAngle: -34
   - type: Gun
-    minAngle: 21
-    maxAngle: 38
+    minAngle: 22
+    maxAngle: 40
     angleIncrease: 5
     angleDecay: 20
-    fireRate: 9.5
+    fireRate: 8
+    DamageModifier: 0.9
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/mla_fire.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -166,7 +166,6 @@
     sprite: _Mono/Objects/Weapons/Guns/Shotguns/SultansPulsar_inhands_64x.rsi
   - type: GunRequiresWield
   - type: Gun
-    autoCycle: false
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/bigshotgun_fire.ogg
     fireRate: 0.7
@@ -183,6 +182,7 @@
     proto: ShellShotgun23x75mmBuckshot
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg
+    autoCycle: false
   - type: StaticPrice
     price: 20000
     vendPrice: 20000

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -166,9 +166,10 @@
     sprite: _Mono/Objects/Weapons/Guns/Shotguns/SultansPulsar_inhands_64x.rsi
   - type: GunRequiresWield
   - type: Gun
+    autoCycle: false
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/bigshotgun_fire.ogg
-    fireRate: 1.2
+    fireRate: 0.7
     selectedMode: Semiauto
     availableModes:
     - SemiAuto
@@ -187,7 +188,7 @@
     vendPrice: 20000
   - type: SpeedModifiedOnWield
     walkModifier: 0.8
-    sprintModifier: 0.95
+    sprintModifier: 0.90
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 3


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Made Sultan's Pulsar actually pump action with less firerate, Smilodon properly calibrates its spread with continued firing + 400thz does less damage/has more capacity, nerfed PDV suits slightly, reduced m92x shield movespeed debuff, and nerfed the MLA-73
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Sultan was originally supposed to be pump action but I buffed it under the misconception it was too weak
Smilodon was originally going to become more accurate over time, I just didn't figure it out in the original PR - more ammo for 400thz is to encourage longer firing periods
PDV suits are generally a bit too powerful against the new laser weapons especially since there are multiple ways to counter them
m92x shield was very hard to use with its speed nerf
MLA-73 using 9x19mm is just cracked
Making heavy rifles need wield is part of ground combat rebalancing to compensate for their damage output/accuracy/power
Vulcan, m90, annie and WSPR had really quick ttks, brought them down a little bit and adjusted how they fire to make them feel cooler

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- tweak: Nerfed damage output of Annies/WSPR.
- tweak: Sultan's Pulsar is now actually pump-action.
- tweak: Nerfed PDV CV- armors slightly.
- tweak: Reduced M92-x shield movespeed debuff.
- MLA has reduced damage and increased spread.
- Vulcan and M90 have tweaked firerates.
- tweak: DEW-Smilodon properly calibrates aim while firing.
- tweak: 400thz boxes have doubled capacity but reduced damage.
- tweak: Most heavy rifles now need wielding to fire.