### PR TITLE
Makes Jumpsuit Signatures Require No Grid to Show

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -64,6 +64,7 @@
     blip:
       radarColor: Cyan
       scale: 0.5
+      requireNoGrid: true
   - type: DeviceNetwork
     deviceNetId: Wireless
     transmitFrequencyId: SuitSensor


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Makes jumpsuit signatures only show when off grid.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Allows people to leave them on at all times unless they need to be sneaky in space. If they get blown up and launched into space recovering the body will be much easier for instance.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Jumpsuit signature blips now only show when off grid.
