### PR TITLE
Mech Wideswing

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -18,7 +18,7 @@ public sealed partial class MeleeWeaponSystem
     /// <summary>
     /// Does all of the melee effects for a player that are predicted, i.e. character lunge and weapon animation.
     /// </summary>
-    public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)
+    public override void DoLunge(EntityUid user, EntityUid playerUid, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)
     {
         if (!Timing.IsFirstTimePredicted)
             return;

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -66,10 +66,11 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
         var entity = entityNull.Value;
 
-        if (!TryGetWeapon(entity, out var weaponUid, out var weapon))
+        // Mono - add user override
+        if (!TryGetWeapon(entity, out var weaponUid, out var weapon, out var userOverride))
             return;
 
-        if (!CombatMode.IsInCombatMode(entity) || !Blocker.CanAttack(entity, weapon: (weaponUid, weapon)))
+        if (!CombatMode.IsInCombatMode(entity) || !Blocker.CanAttack(userOverride, weapon: (weaponUid, weapon)))
         {
             weapon.Attacking = false;
             return;
@@ -120,15 +121,15 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             switch(altFireComponent.AttackType)
             {
                 case AltFireAttackType.Light:
-                    ClientLightAttack(entity, mousePos, coordinates, weaponUid, weapon);
+                    ClientLightAttack(userOverride, mousePos, coordinates, weaponUid, weapon);
                     break;
 
                 case AltFireAttackType.Heavy:
-                    ClientHeavyAttack(entity, coordinates, weaponUid, weapon);
+                    ClientHeavyAttack(userOverride, coordinates, weaponUid, weapon);
                     break;
 
                 case AltFireAttackType.Disarm:
-                    ClientDisarm(entity, mousePos, coordinates);
+                    ClientDisarm(userOverride, mousePos, coordinates);
                     break;
             }
 
@@ -139,7 +140,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (altDown == BoundKeyState.Down)
         {
             // If it's an unarmed attack then do a disarm
-            if (weapon.AltDisarm && weaponUid == entity)
+            if (weapon.AltDisarm && weaponUid == userOverride)
             {
                 EntityUid? target = null;
 
@@ -155,7 +156,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             // WD EDIT START
             if (TryComp(weaponUid, out BlinkComponent? blink) && blink.IsActive)
             {
-                if (!_xformQuery.TryGetComponent(entity, out var userXform))
+                if (!_xformQuery.TryGetComponent(userOverride, out var userXform))
                     return;
 
                 var targetMap = _transform.ToMapCoordinates(coordinates);
@@ -171,14 +172,14 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
             }
             // WD EDIT END
 
-            ClientHeavyAttack(entity, coordinates, weaponUid, weapon);
+            ClientHeavyAttack(userOverride, coordinates, weaponUid, weapon);
             return;
         }
 
         // Light attack
         if (useDown == BoundKeyState.Down)
         {
-            var attackerPos = TransformSystem.GetMapCoordinates(entity);
+            var attackerPos = TransformSystem.GetMapCoordinates(userOverride);
 
             if (mousePos.MapId != attackerPos.MapId ||
                 (attackerPos.Position - mousePos.Position).Length() > weapon.Range)
@@ -193,15 +194,15 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
                 target = screen.GetDamageableClickedEntity(mousePos); // Goob edit
             }
 
-            // Don't light-attack if interaction will be handling this instead
-            if (Interaction.CombatModeCanHandInteract(entity, target))
+            // Don't light-attack if interaction will be handling this instead // Mono - add hands check (why is this duplicated?)
+            if (HasComp<HandsComponent>(userOverride) && Interaction.CombatModeCanHandInteract(userOverride, target))
                 return;
 
             RaisePredictiveEvent(new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(coordinates)));
         }
 
         if (useDown == BoundKeyState.Down)
-            ClientLightAttack(entity, mousePos, coordinates, weaponUid, weapon);
+            ClientLightAttack(userOverride, mousePos, coordinates, weaponUid, weapon);
     }
 
     protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)
@@ -298,8 +299,8 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (_stateManager.CurrentState is GameplayStateBase screen)
             target = screen.GetClickedEntity(mousePos);
 
-        // Don't light-attack if interaction will be handling this instead
-        if (Interaction.CombatModeCanHandInteract(attacker, target))
+        // Don't light-attack if interaction will be handling this instead // Mono - only if attacker has hands
+        if (HasComp<HandsComponent>(attacker) && Interaction.CombatModeCanHandInteract(attacker, target))
             return;
 
         RaisePredictiveEvent(new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(coordinates)));

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -223,13 +223,13 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         return Math.Clamp(chance, 0f, 1f);
     }
 
-    public override void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)
+    public override void DoLunge(EntityUid user, EntityUid playerUid, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)
     {
         Filter filter;
 
         if (predicted)
         {
-            filter = Filter.PvsExcept(user, entityManager: EntityManager);
+            filter = Filter.PvsExcept(playerUid, entityManager: EntityManager);
         }
         else
         {

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -508,6 +508,7 @@ public abstract class SharedMechSystem : EntitySystem
 
         var weapon = mech.CurrentSelectedEquipment ?? component.Mech;
         args.Weapon = weapon;
+        args.User = component.Mech; // Mono
         args.Handled = true;
     }
 

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -195,4 +195,5 @@ public sealed partial class MeleeWeaponComponent : Component
 public sealed class GetMeleeWeaponEvent : HandledEntityEventArgs
 {
     public EntityUid? Weapon;
+    public EntityUid? User; // Mono
 }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -186,13 +186,14 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return;
         }
 
-        if (!TryGetWeapon(user, out var weaponUid, out var weapon) ||
+        // Mono - also override user
+        if (!TryGetWeapon(user, out var weaponUid, out var weapon, out var userOverride) ||
             weaponUid != GetEntity(msg.Weapon))
         {
             return;
         }
 
-        AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession);
+        AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession, userOverride);
     }
 
     private void OnHeavyAttack(HeavyAttackEvent msg, EntitySessionEventArgs args)
@@ -207,14 +208,15 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return;
         }
 
-        if (!TryGetWeapon(user, out var weaponUid, out var weapon) ||
+        // Mono - also override user
+        if (!TryGetWeapon(user, out var weaponUid, out var weapon, out var userOverride) ||
             weaponUid != GetEntity(msg.Weapon) ||
             !weapon.CanWideSwing) // Goobstation Change
         {
             return;
         }
 
-        AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession);
+        AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession, userOverride);
     }
 
     private void OnDisarmAttack(DisarmAttackEvent msg, EntitySessionEventArgs args)
@@ -229,7 +231,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return;
         }
 
-        if (TryGetWeapon(user, out var weaponUid, out var weapon))
+        // Mono - also override user
+        if (TryGetWeapon(user, out var weaponUid, out var weapon, out user))
             AttemptAttack(user, weaponUid, weapon, msg, args.SenderSession);
     }
 
@@ -289,15 +292,21 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         return ev.ResistanceBypass;
     }
 
-    public bool TryGetWeapon(EntityUid entity, out EntityUid weaponUid, [NotNullWhen(true)] out MeleeWeaponComponent? melee)
+    // Mono - also allow user override
+    public bool TryGetWeapon(EntityUid entity, out EntityUid weaponUid, [NotNullWhen(true)] out MeleeWeaponComponent? melee, out EntityUid user)
     {
         weaponUid = default;
         melee = null;
+        user = entity; // Mono
 
         var ev = new GetMeleeWeaponEvent();
         RaiseLocalEvent(entity, ev);
         if (ev.Handled)
         {
+            // Mono
+            if (ev.User != null)
+                user = ev.User.Value;
+
             if (TryComp(ev.Weapon, out melee))
             {
                 weaponUid = ev.Weapon.Value;
@@ -343,32 +352,42 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         return false;
     }
 
-    public void AttemptLightAttackMiss(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityCoordinates coordinates)
+    // Mono
+    public bool TryGetWeapon(EntityUid entity, out EntityUid weaponUid, [NotNullWhen(true)] out MeleeWeaponComponent? melee)
     {
-        AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(null, GetNetEntity(weaponUid), GetNetCoordinates(coordinates)), null);
+        return TryGetWeapon(entity, out weaponUid, out melee, out _);
     }
 
-    public bool AttemptLightAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target)
+    public void AttemptLightAttackMiss(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityCoordinates coordinates,
+        EntityUid? attackerOverride = null) // Mono
+    {
+        AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(null, GetNetEntity(weaponUid), GetNetCoordinates(coordinates)), null, attackerOverride);
+    }
+
+    public bool AttemptLightAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target,
+        EntityUid? attackerOverride = null) // Mono
     {
         if (!TryComp(target, out TransformComponent? targetXform))
             return false;
 
-        return AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(targetXform.Coordinates)), null);
+        return AttemptAttack(user, weaponUid, weapon, new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(targetXform.Coordinates)), null, attackerOverride);
     }
 
-    public bool AttemptDisarmAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target)
+    public bool AttemptDisarmAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, EntityUid target,
+        EntityUid? attackerOverride = null) // Mono
     {
         if (!TryComp(target, out TransformComponent? targetXform))
             return false;
 
-        return AttemptAttack(user, weaponUid, weapon, new DisarmAttackEvent(GetNetEntity(target), GetNetCoordinates(targetXform.Coordinates)), null);
+        return AttemptAttack(user, weaponUid, weapon, new DisarmAttackEvent(GetNetEntity(target), GetNetCoordinates(targetXform.Coordinates)), null, attackerOverride);
     }
 
     /// <summary>
     /// Called when a windup is finished and an attack is tried.
     /// </summary>
     /// <returns>True if attack successful</returns>
-    private bool AttemptAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, AttackEvent attack, ICommonSession? session)
+    private bool AttemptAttack(EntityUid user, EntityUid weaponUid, MeleeWeaponComponent weapon, AttackEvent attack, ICommonSession? session,
+        EntityUid? attackerOverride = null) // Mono
     {
         var curTime = Timing.CurTime;
 
@@ -378,6 +397,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (!CombatMode.IsInCombatMode(user))
             return false;
 
+        var attacker = attackerOverride ?? user; // Mono
         EntityUid? target = null;
         switch (attack)
         {
@@ -388,7 +408,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                     return false;
                 }
 
-                if (!Blocker.CanAttack(user, target, (weaponUid, weapon)))
+                if (!Blocker.CanAttack(attacker, target, (weaponUid, weapon)))
                     return false;
 
                 // Can't self-attack if you're the weapon
@@ -403,17 +423,17 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                     return false;
                 }
 
-                if (!Blocker.CanAttack(user, target, (weaponUid, weapon), true))
+                if (!Blocker.CanAttack(attacker, target, (weaponUid, weapon), true))
                     return false;
                 break;
             default:
-                if (!Blocker.CanAttack(user, weapon: (weaponUid, weapon)))
+                if (!Blocker.CanAttack(attacker, weapon: (weaponUid, weapon)))
                     return false;
                 break;
         }
 
         // Windup time checked elsewhere.
-        var fireRate = TimeSpan.FromSeconds(1f / GetAttackRate(weaponUid, user, weapon));
+        var fireRate = TimeSpan.FromSeconds(1f / GetAttackRate(weaponUid, attacker, weapon));
         var swings = 0;
 
         // TODO: If we get autoattacks then probably need a shotcounter like guns so we can do timing properly.
@@ -450,17 +470,17 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             switch (attack)
             {
                 case LightAttackEvent light:
-                    DoLightAttack(user, light, weaponUid, weapon, session);
+                    DoLightAttack(attacker, light, weaponUid, weapon, session, user);
                     animation = weapon.Animation;
                     break;
                 case DisarmAttackEvent disarm:
-                    if (!DoDisarm(user, disarm, weaponUid, weapon, session))
+                    if (!DoDisarm(attacker, disarm, weaponUid, weapon, session))
                         return false;
 
                     animation = weapon.Animation;
                     break;
                 case HeavyAttackEvent heavy:
-                    if (!DoHeavyAttack(user, heavy, weaponUid, weapon, session))
+                    if (!DoHeavyAttack(attacker, heavy, weaponUid, weapon, session, user))
                         return false;
 
                     animation = weapon.WideAnimation;
@@ -469,11 +489,12 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                     throw new NotImplementedException();
             }
 
-            DoLungeAnimation(user, weaponUid, weapon.Angle, TransformSystem.ToMapCoordinates(GetCoordinates(attack.Coordinates)), weapon.Range, animation);
+            // Mono - except specifically user
+            DoLungeAnimation(attacker, user, weaponUid, weapon.Angle, TransformSystem.ToMapCoordinates(GetCoordinates(attack.Coordinates)), weapon.Range, animation);
         }
 
         var attackEv = new MeleeAttackEvent(weaponUid);
-        RaiseLocalEvent(user, ref attackEv);
+        RaiseLocalEvent(attacker, ref attackEv);
 
         weapon.Attacking = true;
         return true;
@@ -481,8 +502,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
     protected abstract bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session);
 
-    protected virtual void DoLightAttack(EntityUid user, LightAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
+    protected virtual void DoLightAttack(EntityUid user, LightAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session,
+        EntityUid? realUser = null) // Mono
     {
+        var playerUid = realUser ?? user; // Mono
         // If I do not come back later to fix Light Attacks being Heavy Attacks you can throw me in the spider pit -Errant
         var damage = GetDamage(meleeUid, user, component) * GetHeavyDamageModifier(meleeUid, user, component);
         var target = GetEntity(ev.Target);
@@ -503,17 +526,17 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             {
                 AdminLogger.Add(LogType.MeleeHit,
                     LogImpact.Low,
-                    $"{ToPrettyString(user):actor} melee attacked (light) using their hands and missed");
+                    $"{ToPrettyString(playerUid):actor} melee attacked (light) using their hands and missed");
             }
             else
             {
                 AdminLogger.Add(LogType.MeleeHit,
                     LogImpact.Low,
-                    $"{ToPrettyString(user):actor} melee attacked (light) using {ToPrettyString(meleeUid):tool} and missed");
+                    $"{ToPrettyString(playerUid):actor} melee attacked (light) using {ToPrettyString(meleeUid):tool} and missed");
             }
             var missEvent = new MeleeHitEvent(new List<EntityUid>(), user, meleeUid, damage, null);
             RaiseLocalEvent(meleeUid, missEvent);
-            _meleeSound.PlaySwingSound(user, meleeUid, component);
+            _meleeSound.PlaySwingSound(playerUid, meleeUid, component);
             return;
         }
 
@@ -559,35 +582,37 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             {
                 AdminLogger.Add(LogType.MeleeHit,
                     LogImpact.Medium,
-                    $"{ToPrettyString(user):actor} melee attacked (light) {ToPrettyString(target.Value):subject} using their hands and dealt {damageResult.GetTotal():damage} damage");
+                    $"{ToPrettyString(playerUid):actor} melee attacked (light) {ToPrettyString(target.Value):subject} using their hands and dealt {damageResult.GetTotal():damage} damage");
             }
             else
             {
                 AdminLogger.Add(LogType.MeleeHit,
                     LogImpact.Medium,
-                    $"{ToPrettyString(user):actor} melee attacked (light) {ToPrettyString(target.Value):subject} using {ToPrettyString(meleeUid):tool} and dealt {damageResult.GetTotal():damage} damage");
+                    $"{ToPrettyString(playerUid):actor} melee attacked (light) {ToPrettyString(target.Value):subject} using {ToPrettyString(meleeUid):tool} and dealt {damageResult.GetTotal():damage} damage");
             }
 
         }
 
-        _meleeSound.PlayHitSound(target.Value, user, GetHighestDamageSound(modifiedDamage, _protoManager), hitEvent.HitSoundOverride, component);
+        _meleeSound.PlayHitSound(target.Value, playerUid, GetHighestDamageSound(modifiedDamage, _protoManager), hitEvent.HitSoundOverride, component);
 
         if (damageResult?.GetTotal() > FixedPoint2.Zero)
         {
-            DoDamageEffect(targets, user, targetXform);
+            DoDamageEffect(targets, playerUid, targetXform);
         }
     }
 
     protected abstract void DoDamageEffect(List<EntityUid> targets, EntityUid? user,  TransformComponent targetXform);
 
-    private bool DoHeavyAttack(EntityUid user, HeavyAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session)
+    private bool DoHeavyAttack(EntityUid user, HeavyAttackEvent ev, EntityUid meleeUid, MeleeWeaponComponent component, ICommonSession? session,
+        EntityUid? realUser = null) // Mono
     {
         // TODO: This is copy-paste as fuck with DoPreciseAttack
+        var playerUid = realUser ?? user; // Mono
 
         // Validate that the user entity is valid
         if (!user.IsValid())
         {
-            Log.Error($"DoHeavyAttack called with invalid user entity: {user}");
+            Log.Error($"DoHeavyAttack called with invalid user entity: {playerUid}");
             return false;
         }
 
@@ -612,19 +637,19 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             {
                 AdminLogger.Add(LogType.MeleeHit,
                     LogImpact.Low,
-                    $"{ToPrettyString(user):actor} melee attacked (heavy) using their hands and missed");
+                    $"{ToPrettyString(playerUid):actor} melee attacked (heavy) using their hands and missed");
             }
             else
             {
                 AdminLogger.Add(LogType.MeleeHit,
                     LogImpact.Low,
-                    $"{ToPrettyString(user):actor} melee attacked (heavy) using {ToPrettyString(meleeUid):tool} and missed");
+                    $"{ToPrettyString(playerUid):actor} melee attacked (heavy) using {ToPrettyString(meleeUid):tool} and missed");
             }
             var missEvent = new MeleeHitEvent(new List<EntityUid>(), user, meleeUid, damage, direction);
             RaiseLocalEvent(meleeUid, missEvent);
 
             // immediate audio feedback
-            _meleeSound.PlaySwingSound(user, meleeUid, component);
+            _meleeSound.PlaySwingSound(playerUid, meleeUid, component);
 
             return true;
         }
@@ -724,13 +749,13 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 {
                     AdminLogger.Add(LogType.MeleeHit,
                         LogImpact.Medium,
-                        $"{ToPrettyString(user):actor} melee attacked (heavy) {ToPrettyString(entity):subject} using their hands and dealt {damageResult.GetTotal():damage} damage");
+                        $"{ToPrettyString(playerUid):actor} melee attacked (heavy) {ToPrettyString(entity):subject} using their hands and dealt {damageResult.GetTotal():damage} damage");
                 }
                 else
                 {
                     AdminLogger.Add(LogType.MeleeHit,
                         LogImpact.Medium,
-                        $"{ToPrettyString(user):actor} melee attacked (heavy) {ToPrettyString(entity):subject} using {ToPrettyString(meleeUid):tool} and dealt {damageResult.GetTotal():damage} damage");
+                        $"{ToPrettyString(playerUid):actor} melee attacked (heavy) {ToPrettyString(entity):subject} using {ToPrettyString(meleeUid):tool} and dealt {damageResult.GetTotal():damage} damage");
                 }
             }
         }
@@ -738,18 +763,18 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (entities.Count != 0)
         {
             var target = entities.First();
-            _meleeSound.PlayHitSound(target, user, GetHighestDamageSound(appliedDamage, _protoManager), hitEvent.HitSoundOverride, component);
+            _meleeSound.PlayHitSound(target, playerUid, GetHighestDamageSound(appliedDamage, _protoManager), hitEvent.HitSoundOverride, component);
         }
 
         if (appliedDamage.GetTotal() > FixedPoint2.Zero)
         {
-            DoDamageEffect(targets, user, Transform(targets[0]));
+            DoDamageEffect(targets, playerUid, Transform(targets[0]));
         }
 
         // goob edit - stunmeta
         if (TryComp<StaminaComponent>(user, out var stamina))
-            // make it not immediate to prevent annoying stamcrits
-            _stamina.TakeStaminaDamage(user, component.HeavyStaminaCost, stamina, visual: false, immediate: false);
+            // make it not immediate to prevent annoying stamcrits // Mono - scale with targets count
+            _stamina.TakeStaminaDamage(user, component.HeavyStaminaCost * (targets.Count - 1), stamina, visual: false, immediate: false);
 
         return true;
     }
@@ -844,7 +869,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         return true;
     }
 
-    private void DoLungeAnimation(EntityUid user, EntityUid weapon, Angle angle, MapCoordinates coordinates, float length, string? animation)
+    // Mono - separate playerUid
+    private void DoLungeAnimation(EntityUid user, EntityUid playerUid, EntityUid weapon, Angle angle, MapCoordinates coordinates, float length, string? animation)
     {
         // TODO: Assert that offset eyes are still okay.
         if (!TryComp(user, out TransformComponent? userXform))
@@ -865,10 +891,17 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (localPos.Length() > visualLength)
             localPos = localPos.Normalized() * visualLength;
 
-        DoLunge(user, weapon, angle, localPos, animation);
+        DoLunge(user, playerUid, weapon, angle, localPos, animation);
     }
 
-    public abstract void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true);
+    // Mono - add playerUid
+    public abstract void DoLunge(EntityUid user, EntityUid playerUid, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true);
+
+    // Mono
+    public void DoLunge(EntityUid user, EntityUid weapon, Angle angle, Vector2 localPos, string? animation, bool predicted = true)
+    {
+        DoLunge(user, user, weapon, angle, localPos, animation, predicted);
+    }
 
     /// <summary>
     /// Used to update the MeleeWeapon component on item toggle.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
@@ -9,7 +9,6 @@
     state: mecha_chainsword
   - type: MeleeWeapon
     autoAttack: true
-    angle: 0
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Weapons/chainsaw.ogg"

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -15,7 +15,7 @@
     canWideSwing: true
     autoAttack: true
     range: 1.5
-    angle: 0
+    angle: 120
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
@@ -44,7 +44,7 @@
     canWideSwing: true
     autoAttack: true
     range: 1.5
-    angle: 0
+    angle: 120
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -12,8 +12,9 @@
     - Pickaxe
     - IndustrialMech
   - type: MeleeWeapon
-    canWideSwing: false
+    canWideSwing: true
     autoAttack: true
+    range: 1.5
     angle: 0
     wideAnimationRotation: -90
     soundHit:
@@ -40,8 +41,9 @@
     - Pickaxe
     - IndustrialMech
   - type: MeleeWeapon
-    canWideSwing: false
+    canWideSwing: true
     autoAttack: true
+    range: 1.5
     angle: 0
     wideAnimationRotation: -90
     soundHit:


### PR DESCRIPTION
## About the PR
see CL
plus refactors melee weapons to allow for deferring the user and not just the weapon

## Why / Balance
just an annoyance that they can't
other change removes needless stamina cost from wideswinging a single target, and goob also has this

## Media
<img width="217" height="178" alt="image" src="https://github.com/user-attachments/assets/5b1ca757-2ac4-4d4d-b62d-287d472589fc" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Mechs can now wideswing.
- tweak: Wideswinging now only costs stamina if you hit multiple targets.
