### PR TITLE
General LMG/MMG Buffs/Rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -19,7 +19,7 @@
   - type: Wieldable
     unwieldOnUse: false
   - type: GunWieldBonus # Mono
-    minAngle: -20
+    minAngle: -22
     maxAngle: -20
   - type: Gun # L6 LMG stats adjusted
     minAngle: 24
@@ -77,8 +77,8 @@
       sprite: _RMC14/Interface/MousePointer/lmg_mouse.rsi
       state: all
   - type: WieldDelay # Mono
-    baseDelay: 1.4
-    modifiedDelay: 1.4
+    baseDelay: 1
+    modifiedDelay: 1
     preventFiring: true
   # Goobstation edit start
   - type: EmitSoundOnPickup

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -211,10 +211,10 @@
     id: ExperimentalFactionWeapon
 
 - type: entity
-  name: TCA MMG-68 "Grizzly" (6.8x52mm Caseless)
+  name: TCA MMG-68 "Grizzly" (6.8x52mm caseless)
   parent: [BaseWeaponLightMachineGun, BaseGunWieldable]
   id: WeaponLMGGrizzly
-  description: A medium machine gun chambered in 6.8x52mm Caseless, accepts both box and standard magazines. A label on the side reads "FOR MILITARY USE ONLY". The weight of the machine gun make it hard to wield easily. To assist with standardization, it also accepts 5.56x45mm and 7.62x39mm.
+  description: A medium machine gun chambered in 6.8x52mm caseless, accepts both box and standard magazines. A label on the side reads "FOR MILITARY USE ONLY". The weight of the machine gun make it hard to wield easily. To assist with standardization, it also accepts 5.56x45mm and 7.62x39mm.
   components:
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/LMGs/grizzly/Grizzly-icon.rsi
@@ -224,14 +224,14 @@
     - state: mag-0
       map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -20
+    minAngle: -24
+    maxAngle: -28
   - type: Gun
     minAngle: 24
     maxAngle: 36
     angleIncrease: 3
     angleDecay: 34
-    fireRate: 6 # 360 rpm
+    fireRate: 7 # 420 rpm
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -299,8 +299,8 @@
     sprintModifier: 0.9
     walkModifier: 0.9
   - type: SpeedModifiedOnWield
-    walkModifier: 0.4
-    sprintModifier: 0.35
+    walkModifier: 0.6
+    sprintModifier: 0.5
   - type: WieldDelay
     baseDelay: 2
     modifiedDelay: 2
@@ -326,13 +326,13 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/LMGs/ratel/Ratel-inhands.rsi
   - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -30
+    minAngle: -25
+    maxAngle: -35
   - type: Gun
     minAngle: 25
     maxAngle: 40
-    angleIncrease: 5
-    angleDecay: 34
+    angleIncrease: 7
+    angleDecay: 28
     fireRate: 5 # 300 rpm
     selectedMode: FullAuto
     availableModes:
@@ -376,8 +376,8 @@
   - type: StaticPrice
     price: 2500
   - type: SpeedModifiedOnWield
-    walkModifier: 0.85
-    sprintModifier: 0.75
+    walkModifier: 0.6
+    sprintModifier: 0.5 # lower firerate than grizzly but more accurate and more damage
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 3

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -288,7 +288,7 @@
   - type: Appearance
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/LMGs/grizzly/Grizzly-inhands.rsi
-    unequipDelay: 1
+    unequipDelay: 0.5
   - type: StaticPrice
     price: 2500
   - type: GunRequiresWield

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -224,14 +224,14 @@
     - state: mag-0
       map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
-    minAngle: -24
-    maxAngle: -28
+    minAngle: 0
+    maxAngle: 0
   - type: Gun
-    minAngle: 24
-    maxAngle: 36
-    angleIncrease: 3
-    angleDecay: 34
-    fireRate: 7 # 420 rpm
+    minAngle: 0 # forcewield anyways
+    maxAngle: 12
+    angleIncrease: 1
+    angleDecay: 12
+    fireRate: 8 # same as L6, but more accurate and heavier
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -288,7 +288,7 @@
   - type: Appearance
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/LMGs/grizzly/Grizzly-inhands.rsi
-    unequipDelay: 4
+    unequipDelay: 1
   - type: StaticPrice
     price: 2500
   - type: GunRequiresWield
@@ -296,14 +296,14 @@
     id: ExperimentalFactionWeapon
   - type: HeldSpeedModifier
   - type: ClothingSpeedModifier
-    sprintModifier: 0.9
-    walkModifier: 0.9
+    sprintModifier: 0.95
+    walkModifier: 0.95
   - type: SpeedModifiedOnWield
-    walkModifier: 0.6
-    sprintModifier: 0.5
+    walkModifier: 0.5
+    sprintModifier: 0.4
   - type: WieldDelay
-    baseDelay: 2
-    modifiedDelay: 2
+    baseDelay: 1.2
+    modifiedDelay: 1.2
     preventFiring: true
 
 - type: entity
@@ -333,7 +333,7 @@
     maxAngle: 40
     angleIncrease: 7
     angleDecay: 28
-    fireRate: 5 # 300 rpm
+    fireRate: 6 # 360 rpm
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -377,11 +377,15 @@
     price: 2500
   - type: SpeedModifiedOnWield
     walkModifier: 0.6
-    sprintModifier: 0.5 # lower firerate than grizzly but more accurate and more damage
+    sprintModifier: 0.5 # lower firerate than grizzly but more accurate and bit more damage
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 3
     pvsIncrease: 0.3
+  - type: WieldDelay
+    baseDelay: 0.8
+    modifiedDelay: 0.8
+    preventFiring: true
 
 - type: entity
   name: Cyborg minigun


### PR DESCRIPTION
## About the PR
Reduced the delays on majority of LMG actions (no more 4 second equip from clothing slot)
Grizzly should be more comparable to L6 now - higher accuracy & same firerate but higher slowdown w/ smaller mags
L6 min accuracy buffed by a few degrees, wield delay changed a bit - should be more of a magdump low-accuracy faster option now
Ratel has highest accuracy out of the 3 and slowdown inbetween Grizzly and L6, plus the lowest wield delay, but has 6 RPS compared to 8 - should be higher accuracy higher damage option now (36dmg/0.1 pen for 7.62x51mm compared to 25dmg/0.085 pen for 7.62x39mm)

## Why / Balance
current grizzly is really mid lol
LMGs can feel more like magdump slow moving dream now

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Tweaked L6/Grizzly/Ratel (slight accuracy buffs, faster wielding, etc) stats to be more useful compared to an actual rifle.
