### PR TITLE
Mech Weapons Balance Pass

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -269,7 +269,7 @@
 - type: entity
   id: HeavyMechProjector
   name: RAVAGER-type Plasma Cannon
-  description: Based on the MARAUDER, the Ravager sacrifices range for portability. Extremely inaccurate, and subpar lensing causes the projectiles to dissipate only a few seconds away. Devastating up close. Fits on Large Hardpoints.
+  description: Based on the MARAUDER, the Ravager sacrifices range for firerate and portability. Extremely inaccurate, and subpar lensing causes the projectiles to dissipate only a few seconds away. Devastating up close. Fits on Large Hardpoints.
   suffix: Mech Weapon, Gun, Combat, EnergyCannon
   parent: [ BaseMechWeaponRange, HeavyMechMountEquipment ]
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -269,7 +269,7 @@
 - type: entity
   id: HeavyMechProjector
   name: RAVAGER-type Plasma Cannon
-  description: Based on the MARAUDER, the Ravager sacrifices range for rate of fire. Extremely inaccurate, and subpar lensing causes the projectiles to dissipate only a few seconds away. Devastating up close. Fits on Large Hardpoints.
+  description: Based on the MARAUDER, the Ravager sacrifices range for portability. Extremely inaccurate, and subpar lensing causes the projectiles to dissipate only a few seconds away. Devastating up close. Fits on Large Hardpoints.
   suffix: Mech Weapon, Gun, Combat, EnergyCannon
   parent: [ BaseMechWeaponRange, HeavyMechMountEquipment ]
   components:
@@ -279,7 +279,7 @@
     sprite: _Mono/Objects/Specific/Mech/tgmc_mecha_weapons.rsi
     state: flamer64x32
   - type: Gun
-    projectileSpeed: 80 # marauder is slow dingus... not inaccurate
+    projectileSpeed: 100 # marauder is slow dingus... not inaccurate
     minAngle: 0
     maxAngle: 15
     fireRate: 1.25

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -281,8 +281,8 @@
   - type: Gun
     projectileSpeed: 80 # marauder is slow dingus... not inaccurate
     minAngle: 0
-    maxAngle: 30
-    fireRate: 3
+    maxAngle: 15
+    fireRate: 1.25
     angleIncrease: 3
     angleDecay: 15
     selectedMode: FullAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -65,8 +65,8 @@
     state: smg64x32
   - type: Gun
     projectileSpeed: 55
-    fireRate: 12
-    minAngle: 3
+    fireRate: 14
+    minAngle: 0
     maxAngle: 35
     angleIncrease: 1
     angleDecay: 20
@@ -189,7 +189,7 @@
     state: tow64x32
   - type: Gun
     projectileSpeed: 50
-    fireRate: 0.7
+    fireRate: 1.25
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -161,7 +161,7 @@
     state: laserrifle64x32
   - type: Gun
     projectileSpeed: 150
-    fireRate: 1
+    fireRate: 0.15
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -65,8 +65,8 @@
     state: smg64x32
   - type: Gun
     projectileSpeed: 55
-    fireRate: 14
-    minAngle: 0
+    fireRate: 12
+    minAngle: 3
     maxAngle: 35
     angleIncrease: 1
     angleDecay: 20
@@ -189,7 +189,7 @@
     state: tow64x32
   - type: Gun
     projectileSpeed: 50
-    fireRate: 1.25
+    fireRate: 0.7
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -11,7 +11,7 @@
     damage:
       types:
         Piercing: 18
-        Structural: 50
+        Structural: 55
 
 - type: entity
   id: MechPelletShotgunSpread
@@ -32,11 +32,11 @@
   - type: Projectile
     damage:
       types:
-        Structural: 250
-        Piercing: 100
+        Structural: 550
+        Piercing: 150
         Shock: 0
   - type: EmpOnTrigger
-    range: 4
+    range: 5
     energyConsumption: 2700000
     disableDuration: 10
   - type: Sprite
@@ -97,7 +97,7 @@
       types:
         Piercing: 30
         Blunt: 20
-        Structural: 300
+        Structural: 350
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
@@ -278,8 +278,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
-        Structural: 60
+        Piercing: 50
+        Structural: 100
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/630_armorpiercing_shell_casing.rsi
     layers:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -95,8 +95,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 45
-        Structural: 225
+        Piercing: 35
+        Structural: 80
   - type: ShipWeaponProjectile
   - type: TimedDespawn
     lifetime: 3
@@ -117,16 +117,16 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 60
-        Blunt: 50
-        Structural: 250
+        Piercing: 30
+        Blunt: 20
+        Structural: 75
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    maxIntensity: 15
-    intensitySlope: 20
-    totalIntensity: 15
-    maxTileBreak: 1
+    totalIntensity: 30
+    intensitySlope: 2
+    maxIntensity: 4
+    maxTileBreak: 2
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/630_armorpiercing_shell_casing.rsi
     layers:
@@ -300,7 +300,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 70
+        Piercing: 30
+        Structural: 60
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/630_armorpiercing_shell_casing.rsi
     layers:
@@ -308,8 +309,8 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 12
-    intensitySlope: 4
+    totalIntensity: 27
+    intensitySlope: 3
     maxIntensity: 3
     maxTileBreak: 1
 
@@ -322,9 +323,9 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 25
-        Structural: 400
-        Heat: 50
+        Radiation: 10
+        Structural: 600
+        Heat: 40
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/plasmashot.rsi
     layers:
@@ -343,7 +344,7 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 25
-    intensitySlope: 12
-    maxIntensity: 15
+    totalIntensity: 40
+    intensitySlope: 4
+    maxIntensity: 6
     maxTileBreak: 1

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -10,7 +10,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
+        Piercing: 15
         Structural: 45
 
 - type: entity
@@ -32,13 +32,13 @@
   - type: Projectile
     damage:
       types:
-        Structural: 150
-        Piercing: 150
+        Structural: 250
+        Piercing: 50
         Shock: 0
   - type: EmpOnTrigger
     range: 4
     energyConsumption: 2700000
-    disableDuration: 30
+    disableDuration: 10
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
     layers:
@@ -66,28 +66,6 @@
     lifetime: 1
 
 - type: entity
-  id: 60mmMechShell
-  name: 60mm shell
-  parent: BaseBullet
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: Projectile
-    damage:
-      types:
-        Structural: 420
-        Blunt: 100
-        Piercing: 210
-  - type: RadarBlip
-    scale: 2.5
-    shape: triangle
-  - type: Explosive
-    explosionType: Default
-    totalIntensity: 10
-    intensitySlope: 5
-    maxIntensity: 25
-    maxTileBreak: 1
-
-- type: entity
   id: 35mmBullet
   parent: BaseBullet
   categories: [ HideSpawnMenu ]
@@ -96,7 +74,7 @@
     damage:
       types:
         Piercing: 35
-        Structural: 80
+        Structural: 70
   - type: ShipWeaponProjectile
   - type: TimedDespawn
     lifetime: 3

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -33,7 +33,7 @@
     damage:
       types:
         Structural: 250
-        Piercing: 50
+        Piercing: 100
         Shock: 0
   - type: EmpOnTrigger
     range: 4

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -10,8 +10,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
-        Structural: 45
+        Piercing: 18
+        Structural: 50
 
 - type: entity
   id: MechPelletShotgunSpread
@@ -73,8 +73,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
-        Structural: 70
+        Piercing: 45
+        Structural: 225
   - type: ShipWeaponProjectile
   - type: TimedDespawn
     lifetime: 3
@@ -97,7 +97,7 @@
       types:
         Piercing: 30
         Blunt: 20
-        Structural: 250
+        Structural: 300
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -97,7 +97,7 @@
       types:
         Piercing: 30
         Blunt: 20
-        Structural: 75
+        Structural: 150
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -148,7 +148,7 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 200
+    totalIntensity: 300
     intensitySlope: 4
     maxIntensity: 100
   - type: GatheringProjectile
@@ -156,10 +156,10 @@
   - type: MiningGatheringHard
   - type: TargetSeeking
     acceleration: 20
-    detectionRange: 100
-    scanArc: 5
-    launchSpeed: 10
-    maxSpeed: 64
+    detectionRange: 175
+    scanArc: 10
+    launchSpeed: 50
+    maxSpeed: 120
 
 - type: entity
   id: BlanketFlare

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -95,9 +95,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
-        Blunt: 20
-        Structural: 350
+        Piercing: 40
+        Blunt: 30
+        Structural: 300
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
@@ -278,8 +278,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 50
-        Structural: 100
+        Piercing: 45
+        Structural: 70
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/630_armorpiercing_shell_casing.rsi
     layers:
@@ -303,7 +303,7 @@
       types:
         Radiation: 10
         Structural: 600
-        Heat: 40
+        Heat: 45
   - type: Sprite
     sprite: _Mono/Objects/SpaceArtillery/plasmashot.rsi
     layers:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -10,8 +10,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 18
-        Structural: 55
+        Piercing: 30
+        Structural: 45
 
 - type: entity
   id: MechPelletShotgunSpread
@@ -21,7 +21,7 @@
   - type: ProjectileSpread
     proto: MechPelletShotgun
     count: 6
-    spread: 15
+    spread: 30
 
 - type: entity
   id: MechCoilgunSabot

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/Weapons/Gun/projectiles.yml
@@ -97,7 +97,7 @@
       types:
         Piercing: 30
         Blunt: 20
-        Structural: 150
+        Structural: 250
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Makes mechs less unbalanced

Nerfs coilgun. Now 0.15 RPS instead of 1 RPS (for a bloody coilgun btw). EMP disable now 10 seconds instead of 30 seconds (why was this like this) Damage against non-structures reduced.

Mech shotgun spread increased from 15 side to 30 side.

60mm removed (nothing used it)

220mm "Metronome" heavy burst autocannon non-structural damage nerfed, structural buffed to compensate. Explosion re-made to account for explosion changes, now has a large aoe.

DMR-90mm autocannon projectile explosion improved. Piercing reduced, structural buffed to compensate.

RAVAGER projectiles explosions improved and buffed somewhat. Non-structural damage reduced. RAVAGER Firerate reduced from 3 to 1.25, no longer equivalent to 6 marauders in one.

Buffs the Bazooka explosion and tracking/speed somewhat, it was seriously underperforming before.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

A lot of balance flaws.

Heavy mechs oneshotting people with basic weapons is really bad. Its one thing if you direct hit someone with a rocket, but the way things were balanced wasn't good. A lot of mech weapons just have stupid amounts of damage.

Shipgun EMPs should not be 50 years. 30 seconds is absurd for a shipgun EMP. Our shipguns don't have that long of EMP either. It had 1 RPS btw.

Hot take alert: Mech weapons don't need to be that much stronger than non-mech weapons (against organics). You are in a giant tank. You are basically unkillable. Mechs don't need to do absurd amounts of damage (to the point of oneshotting people) on top of that.

Updates mech weapon explosions similar to ship explosions. Aka, less shitty explosions.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Rebalanced and updated S2/S4 mech weapons to current standards and updated explosions for explosion fix. As well as to do somewhat less damage against non-structures.
- tweak: Mech coilgun RPS reduced massively, Emp duration lowered, EMP range increased, direct damage increased.
- tweak: Mech shotgun spread increased.
- tweak: Ravager firerate decreased from 3 to 1.25 RPS. Damage/explosion increased slightly and improved.
- tweak: Bazooka explosion intensity buffed. Missile launch speed and tracking increased.
