### PR TITLE
T2-T5 Rad Blocking Stats

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/walls.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/walls.yml
@@ -47,6 +47,8 @@
     tags:
     - Wall
     - WallT1
+  - type: RadiationBlocker
+    resistance: 2
 
 - type: entity
   abstract: true
@@ -95,6 +97,8 @@
     tags:
     - Wall
     - WallT2
+  - type: RadiationBlocker
+    resistance: 3
 
 - type: entity
   abstract: true
@@ -143,6 +147,8 @@
     tags:
     - Wall
     - WallT3
+  - type: RadiationBlocker
+    resistance: 4
 
 - type: entity
   abstract: true
@@ -191,6 +197,8 @@
     tags:
     - Wall
     - WallT4
+  - type: RadiationBlocker
+    resistance: 5
 
 - type: entity
   abstract: true
@@ -233,6 +241,8 @@
     price: 75
   - type: ArmorThickness
     thickness: 20
+  - type: RadiationBlocker
+    resistance: 5
 
 - type: entity
   parent: WallReinforced


### PR DESCRIPTION
## About the PR
Gives T2-5 radblocker stats
Starts at 3 w/ T2, increases by 1 up to 5 w/ T4, doesnt increase from there

## Why / Balance
Shuttle walls & reinforced uranium/plasma windows already have 4-5 resistance; A reinforced plastitanium wall should be able to block radiation as well as a window lol

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
see the rads

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: More rad resistance for walls.
