### PR TITLE
Fixes and Improves Flatpacks

### DIFF
--- a/Content.Shared/Construction/Components/FlatpackComponent.cs
+++ b/Content.Shared/Construction/Components/FlatpackComponent.cs
@@ -1,8 +1,11 @@
+using Content.Shared.Physics;
 using Content.Shared.Tools;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Construction.Components;
 
@@ -37,6 +40,21 @@ public sealed partial class FlatpackComponent : Component
     /// </summary>
     [DataField]
     public Dictionary<string, Color> BoardColors = new();
+
+
+    /// <summary>
+    /// Collision layer assumption of the unflatpacked object. Used for checking if unpackable.
+    /// </summary>
+    [ViewVariables]
+    [DataField("layer", customTypeSerializer: typeof(FlagSerializer<CollisionLayer>))]
+    public int CollisionLayer = (int)CollisionGroup.MachineLayer;
+
+    /// <summary>
+    /// Collision mask assumption of the unflatpacked object. Used for checking if unpackable.
+    /// </summary>
+    [ViewVariables]
+    [DataField("mask", customTypeSerializer: typeof(FlagSerializer<CollisionMask>))]
+    public int CollisionMask = (int)CollisionGroup.MachineMask;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -30,9 +30,9 @@ public sealed partial class AnchorableSystem : EntitySystem
     [Dependency] private readonly PullingSystem _pulling = default!;
     [Dependency] private readonly SharedToolSystem _tool = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
-    [Dependency] private   readonly TagSystem _tagSystem = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-
+    [Dependency] private readonly SharedMapSystem _map = default!;
     private EntityQuery<PhysicsComponent> _physicsQuery;
 
     public readonly ProtoId<TagPrototype> Unstackable = "Unstackable";
@@ -280,12 +280,19 @@ public sealed partial class AnchorableSystem : EntitySystem
     private bool TileFree(EntityCoordinates coordinates, PhysicsComponent anchorBody)
     {
         // Probably ignore CanCollide on the anchoring body?
-        var gridUid = coordinates.GetGridUid(EntityManager);
-
-        if (!TryComp<MapGridComponent>(gridUid, out var grid))
+        if (_transformSystem.GetGrid(coordinates) is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
             return false;
 
-        var tileIndices = grid.TileIndicesFor(coordinates);
+        var tileIndices = _map.TileIndicesFor(gridUid, grid, coordinates);
+        return TileFree(grid, tileIndices, anchorBody.CollisionLayer, anchorBody.CollisionMask);
+    }
+
+    public bool TileFree(EntityCoordinates coordinates, PhysicsComponent anchorBody, EntityUid gridUid, MapGridComponent? grid) // Mono: Alternate method
+    {
+        if (!Resolve(gridUid, ref grid))
+            return false;
+
+        var tileIndices = _map.TileIndicesFor(gridUid, grid, coordinates);
         return TileFree(grid, tileIndices, anchorBody.CollisionLayer, anchorBody.CollisionMask);
     }
 
@@ -295,7 +302,7 @@ public sealed partial class AnchorableSystem : EntitySystem
     /// <param name="grid"></param>
     public bool TileFree(MapGridComponent grid, Vector2i gridIndices, int collisionLayer = 0, int collisionMask = 0)
     {
-        var enumerator = grid.GetAnchoredEntitiesEnumerator(gridIndices);
+        var enumerator = _map.GetAnchoredEntitiesEnumerator(grid.Owner, grid, gridIndices);
 
         while (enumerator.MoveNext(out var ent))
         {

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -287,15 +287,6 @@ public sealed partial class AnchorableSystem : EntitySystem
         return TileFree(grid, tileIndices, anchorBody.CollisionLayer, anchorBody.CollisionMask);
     }
 
-    public bool TileFree(EntityCoordinates coordinates, PhysicsComponent anchorBody, EntityUid gridUid, MapGridComponent? grid) // Mono: Alternate method
-    {
-        if (!Resolve(gridUid, ref grid))
-            return false;
-
-        var tileIndices = _map.TileIndicesFor(gridUid, grid, coordinates);
-        return TileFree(grid, tileIndices, anchorBody.CollisionLayer, anchorBody.CollisionMask);
-    }
-
     /// <summary>
     /// Returns true if no hard anchored entities match the collision layer or mask specified.
     /// </summary>
@@ -336,7 +327,7 @@ public sealed partial class AnchorableSystem : EntitySystem
 
     public bool AnyUnstackablesAnchoredAt(EntityCoordinates location)
     {
-        var gridUid = location.GetGridUid(EntityManager);
+        var gridUid = _transformSystem.GetGrid(location);
 
         if (!TryComp<MapGridComponent>(gridUid, out var grid))
             return false;

--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -12,6 +12,8 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
+using Content.Shared.Construction.EntitySystems;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.Construction;
 
@@ -30,6 +32,7 @@ public abstract class SharedFlatpackSystem : EntitySystem
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedToolSystem _tool = default!;
+    [Dependency] private readonly AnchorableSystem _anchorable = default!; // Mono
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -79,14 +82,10 @@ public abstract class SharedFlatpackSystem : EntitySystem
         var buildPos = _map.TileIndicesFor(grid, gridComp, xform.Coordinates);
         var coords = _map.ToCenterCoordinates(grid, buildPos);
 
-        // TODO FLATPAK
-        // Make this logic smarter. This should eventually allow for shit like building microwaves on tables and such.
-        // Also: make it ignore ghosts
-        if (_entityLookup.AnyEntitiesIntersecting(coords, LookupFlags.Dynamic | LookupFlags.Static))
+        // Mono fix - makes this logic smarter using existing anchorable logic
+        if (TryComp<PhysicsComponent>(uid, out var anchorBody) && !_anchorable.TileFree(coords, anchorBody, grid, gridComp))
         {
-            // this popup is on the server because the predicts on the intersection is crazy
-            if (_net.IsServer)
-                _popup.PopupEntity(Loc.GetString("flatpack-unpack-no-room"), uid, args.User);
+            _popup.PopupPredicted(Loc.GetString("flatpack-unpack-no-room"), uid, args.User); // Mono, predict the popup
             return;
         }
 

--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -70,7 +70,7 @@ public abstract class SharedFlatpackSystem : EntitySystem
 
         args.Handled = true;
 
-        if (comp.Entity == null)
+        if (comp.Entity is not { } flatpackEntity)
         {
             Log.Error($"No entity prototype present for flatpack {ToPrettyString(ent)}.");
 
@@ -80,10 +80,9 @@ public abstract class SharedFlatpackSystem : EntitySystem
         }
 
         var buildPos = _map.TileIndicesFor(grid, gridComp, xform.Coordinates);
-        var coords = _map.ToCenterCoordinates(grid, buildPos);
 
         // Mono fix - makes this logic smarter using existing anchorable logic
-        if (TryComp<PhysicsComponent>(uid, out var anchorBody) && !_anchorable.TileFree(coords, anchorBody, grid, gridComp))
+        if (!_anchorable.TileFree(gridComp, buildPos, ent.Comp.CollisionLayer, ent.Comp.CollisionMask))
         {
             _popup.PopupPredicted(Loc.GetString("flatpack-unpack-no-room"), uid, args.User); // Mono, predict the popup
             return;
@@ -91,7 +90,7 @@ public abstract class SharedFlatpackSystem : EntitySystem
 
         if (_net.IsServer)
         {
-            var spawn = Spawn(comp.Entity, _map.GridTileToLocal(grid, gridComp, buildPos));
+            var spawn = Spawn(flatpackEntity, _map.GridTileToLocal(grid, gridComp, buildPos));
             if (TryComp(spawn, out TransformComponent? spawnXform)) // Frontier: rotatable flatpacks
                 spawnXform.LocalRotation = xform.LocalRotation.GetCardinalDir().ToAngle(); // Frontier: rotatable flatpacks
             _adminLogger.Add(LogType.Construction,

--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -81,7 +81,8 @@ public abstract class SharedFlatpackSystem : EntitySystem
 
         var buildPos = _map.TileIndicesFor(grid, gridComp, xform.Coordinates);
 
-        // Mono fix - makes this logic smarter using existing anchorable logic
+        // Mono fix - makes this logic smarter using existing anchorable logic.
+        // Could be made better by getting the actual collison layers and mask of the spawned entity, but that's kind of complicated before its spawned.
         if (!_anchorable.TileFree(gridComp, buildPos, ent.Comp.CollisionLayer, ent.Comp.CollisionMask))
         {
             _popup.PopupPredicted(Loc.GetString("flatpack-unpack-no-room"), uid, args.User); // Mono, predict the popup


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Flatpacks now properly respect collision layers similar to anchoring.

This means they can be unpacked where normal machines can be anchored, and within shields.

Makes an assumption of MachineLayer and MachineMask for default as actually fetching the Physics component of the unspawned prototype is a bit too much for me.

also fixes some warns

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Code improvement and fix.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Flatpacks now can be unpacked in shields, in railings, etc.
