### PR TITLE
M92x Active Recharge Rate Buff

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
@@ -224,7 +224,7 @@
     startingCharge: 150
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 0.5
+    autoRechargeRate: 1.5
   - type: RechargeableBlocking
   - type: UseDelay
     delay: 10

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
@@ -224,7 +224,7 @@
     startingCharge: 150
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 0.15
+    autoRechargeRate: 0.5
   - type: RechargeableBlocking
   - type: UseDelay
     delay: 10


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Buffs active recharge of M92-X to 1.5 from 0.15

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is a noob trap.

Specifically, it recharges while off at 4 per second, and recharges while on at 0.15 a second

this means from 0 it'd take 1000 seconds or 16 minutes to recharge to full while its on. Meaning someone with a low health shield will probably never notice and leave it on and have it break almost immediately in a separate firefight like 3-4 minutes later.

This is not very well designed.

And if the intent that it should only recharge at a rate of 0.15 always, I like to mention the fact that

16 minutes for full recharge from 0.

Why.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: M92-X battery recharge rate while active buffed.

