### PR TITLE
Flatpack Opening Uses Collision of Flatpacked Entity

### DIFF
--- a/Content.Shared/Construction/Components/FlatpackComponent.cs
+++ b/Content.Shared/Construction/Components/FlatpackComponent.cs
@@ -40,21 +40,6 @@ public sealed partial class FlatpackComponent : Component
     /// </summary>
     [DataField]
     public Dictionary<string, Color> BoardColors = new();
-
-
-    /// <summary>
-    /// Collision layer assumption of the unflatpacked object. Used for checking if unpackable.
-    /// </summary>
-    [ViewVariables]
-    [DataField("layer", customTypeSerializer: typeof(FlagSerializer<CollisionLayer>))]
-    public int CollisionLayer = (int)CollisionGroup.MachineLayer;
-
-    /// <summary>
-    /// Collision mask assumption of the unflatpacked object. Used for checking if unpackable.
-    /// </summary>
-    [ViewVariables]
-    [DataField("mask", customTypeSerializer: typeof(FlagSerializer<CollisionMask>))]
-    public int CollisionMask = (int)CollisionGroup.MachineMask;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -14,6 +14,8 @@ using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Content.Shared.Construction.EntitySystems;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Physics;
 
 namespace Content.Shared.Construction;
 
@@ -79,13 +81,18 @@ public abstract class SharedFlatpackSystem : EntitySystem
             return;
         }
 
+        if (!PrototypeManager.Resolve(comp.Entity, out var proto) ||
+            !proto.TryGetComponent<FixturesComponent>(out var fixture, EntityManager.ComponentFactory))
+        {
+            return;
+        }
+
+        var (layer, mask) = SharedPhysicsSystem.GetHardCollision(fixture);
         var buildPos = _map.TileIndicesFor(grid, gridComp, xform.Coordinates);
 
-        // Mono fix - makes this logic smarter using existing anchorable logic.
-        // Could be made better by getting the actual collison layers and mask of the spawned entity, but that's kind of complicated before its spawned.
-        if (!_anchorable.TileFree(gridComp, buildPos, ent.Comp.CollisionLayer, ent.Comp.CollisionMask))
+        if (!_anchorable.TileFree(gridComp, buildPos, layer, mask))
         {
-            _popup.PopupPredicted(Loc.GetString("flatpack-unpack-no-room"), uid, args.User); // Mono, predict the popup
+            _popup.PopupPredicted(Loc.GetString("flatpack-unpack-no-room"), uid, args.User);
             return;
         }
 


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

ports https://github.com/space-wizards/space-station-14/pull/41849

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

They did it first and better

I almost did it like this but then gave up, oops.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
fix: Flatpacks now use the collision of the flatpacked entity, so they can be opened on tables and aren't blocked by ghosts.
