### PR TITLE
Replaces Razor-N Nuke with Wyvern Varient

### DIFF
--- a/Resources/Maps/_Mono/ShuttleEvent/razorn.yml
+++ b/Resources/Maps/_Mono/ShuttleEvent/razorn.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 264.0.0
+  engineVersion: 271.2.0
   forkId: ""
   forkVersion: ""
-  time: 11/15/2025 15:28:11
+  time: 04/24/2026 00:58:36
   entityCount: 223
 maps: []
 grids:
@@ -33,14 +33,13 @@ entities:
     components:
     - type: MetaData
       name: ADS Razor-N
-    # bet
+    - type: Transform
+      parent: invalid
     - type: InitRepairSnapshot
     - type: ShipRepairRestrict
       toolWhitelist:
         tags:
         - ADSRepairTool
-    - type: Transform
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -70,6 +69,11 @@ entities:
       fixtures: {}
     - type: OccluderTree
     - type: SpreaderGrid
+      spreadQueues:
+        Puddle: []
+        Smoke: []
+        Kudzu: []
+        MetalFoam: []
     - type: Shuttle
       dampingModifier: 0.25
     - type: GridPathfinding
@@ -179,6 +183,7 @@ entities:
     - type: RadiationGridResistance
     - type: ShipGridLock
       locked: False
+    - type: ThermalSignature
 - proto: APCBasic
   entities:
   - uid: 4
@@ -1056,12 +1061,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
-- proto: ScuttleDeviceRazorN
+- proto: ScuttleDeviceWyvern
   entities:
   - uid: 125
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
 - proto: SpawnRedactedBorg


### PR DESCRIPTION
## About the PR

Title

## Why / Balance

instead of mald removal of the razor-N (https://github.com/Monolith-Station/Monolith/pull/3776)

this instead gives the targeted group/ship 300 seconds to GTFO/intercept the Razor N instead of 20 seconds (Why was it 20 seconds in the first place???)

## Media

everything the same, except the nuke change, which looks no different

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines. 
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test

spawn razor-n, arm nuke, see its 300 seconds instead of 20 seconds. 

## Breaking changes

sar its one thing being swapped

**Changelog**

:cl:
- tweak: Razor N antimatter bomb has had its detonation time increased from 20 seconds to 300 seconds, not like it will change anything due to faction skill issues. 


