### PR TITLE
Fix ASM-220s From Blowing Themselves Up

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/Cartridge/trident_ammo.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/Cartridge/trident_ammo.yml
@@ -14,7 +14,7 @@
       projectile:
         shape:
           !type:PhysShapeCircle
-          radius: 1
+          radius: 0.3
         density: 1500
         layer:
         - WallLayer


### PR DESCRIPTION
## About the PR
lowers ASM-220 HE/ECM collision radius to be the same as LOSAT (0.3)

## Why / Balance
missile launchers adjacent to eachother (and other configurations but this is the most notable i think) would just blow up the launcher if you fired them, hitbox was way too big

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: ASM-220 torpedoes should be less likely to blow themselves or their own launcher up now.