### PR TITLE
Sale Price Test and Material Upprice

### DIFF
--- a/Content.IntegrationTests/Tests/_Mono/ManufacturePriceTest.cs
+++ b/Content.IntegrationTests/Tests/_Mono/ManufacturePriceTest.cs
@@ -1,0 +1,88 @@
+using Content.Server.Cargo.Systems;
+using Content.Shared.Lathe;
+using Content.Shared.Lathe.Prototypes;
+using Content.Shared.Materials;
+using Content.Shared.Research.Prototypes;
+using Robust.Server.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Log;
+using Robust.Shared.Prototypes;
+using System;
+using System.Collections.Generic;
+
+namespace Content.IntegrationTests.Tests._Mono;
+
+[TestFixture]
+public sealed class ManufacturePriceTest
+{
+    private const float _pricingThreshold = 2f;
+
+    [Test]
+    public async Task CheckAllShuttleGrids()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entSysManager = server.ResolveDependency<IEntitySystemManager>();
+        var entManager = server.ResolveDependency<IEntityManager>();
+        var proto = server.ResolveDependency<IPrototypeManager>();
+        var factory = server.ResolveDependency<IComponentFactory>();
+        var pricing = entSysManager.GetEntitySystem<PricingSystem>();
+
+        var count = 0;
+        await server.WaitPost(() =>
+        {
+            var matPrices = new Dictionary<ProtoId<MaterialPrototype>, float>();
+            foreach (var mat in proto.EnumeratePrototypes<MaterialPrototype>())
+            {
+                matPrices[mat.ID] = (float)mat.Price;
+            }
+
+            foreach (var latheProto in proto.EnumeratePrototypes<EntityPrototype>())
+            {
+                if (!latheProto.TryGetComponent<LatheComponent>(out var lathe, factory))
+                    continue;
+
+                var allPacks = new List<ProtoId<LatheRecipePackPrototype>>();
+                allPacks.AddRange(lathe.DynamicPacks);
+                allPacks.AddRange(lathe.StaticPacks);
+                foreach (var pack in allPacks)
+                {
+                    var packProto = proto.Index(pack);
+                    foreach (var recipe in packProto.Recipes)
+                    {
+                        var recipeProto = proto.Index(recipe);
+
+                        var price = 0f;
+                        foreach (var (id, count) in recipeProto.Materials)
+                            price += matPrices[id] * count;
+
+                        var worth = 0f;
+                        if (proto.TryIndex(recipeProto.Result, out var resultProto))
+                            worth += (float)pricing.GetEstimatedPrice(resultProto) * (lathe.ProductValueModifier ?? 1f);
+                        foreach (var (id, count) in recipeProto.MaterialResult)
+                            worth += matPrices[id] * count;
+
+                        if (worth == 0f || price == 0f)
+                            continue;
+
+                        var ratio = worth / price;
+                        if (ratio > _pricingThreshold)
+                        {
+                            count++;
+                            var reasons = new List<string>();
+                            foreach (var (id, count) in recipeProto.Materials)
+                                reasons.Add($"material {id}: priced at {matPrices[id]}, we need {count}, total ${matPrices[id] * count}");
+                            Logger.Warning($"Overpriced recipe prototype {recipe} in pack {pack} on lathe {latheProto.ID}: material sale price {price}, product sale price (1x) {worth}, ratio {ratio}, manufacture cost breakdown: [{string.Join("], [", reasons)}]");
+                        }
+                    }
+                }
+            }
+        });
+        if (count > 0)
+            Assert.Fail($"Found {count} overpriced items");
+
+        await server.WaitRunTicks(1);
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/_Mono/ManufacturePriceTest.cs
+++ b/Content.IntegrationTests/Tests/_Mono/ManufacturePriceTest.cs
@@ -15,7 +15,7 @@ namespace Content.IntegrationTests.Tests._Mono;
 [TestFixture]
 public sealed class ManufacturePriceTest
 {
-    private const float _pricingThreshold = 2f;
+    private const float _pricingThreshold = 4f;
 
     [Test]
     public async Task CheckAllShuttleGrids()

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -92,7 +92,7 @@
     sprite: Objects/Devices/flatpack.rsi
     state: solar-assembly-part
   product: CrateEngineeringSolar
-  cost: 1500 # Frontier: 525<1500
+  cost: 3000 # Mono
   category: cargoproduct-category-name-engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -38,7 +38,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: brass_3
   product: CrateMaterialBrass
-  cost: 5000 # Frontier: 3000<5000
+  cost: 31000 # Mono
   category: cargoproduct-category-name-materials
   group: market
 
@@ -92,7 +92,7 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: paper_3
   product: CrateMaterialPaper
-  cost: 1000
+  cost: 16000 # Mono
   category: cargoproduct-category-name-materials
   group: market
 

--- a/Resources/Prototypes/Nyanotrasen/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Nyanotrasen/Reagents/Materials/materials.yml
@@ -5,4 +5,4 @@
   icon: { sprite: /Textures/Nyanotrasen/Objects/Materials/materials.rsi, state: bluespace }
   color: "#53a9ff"
   stackEntity: MaterialBluespace
-  price: 15
+  price: 30

--- a/Resources/Prototypes/Reagents/Materials/glass.yml
+++ b/Resources/Prototypes/Reagents/Materials/glass.yml
@@ -4,7 +4,7 @@
   name: materials-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: glass }
   color: "#a8ccd7"
-  price: 0.075 # $15 for one unit # FRONTIER: 0.15<0.075 - TODO: review material values
+  price: 1 # Mono
 
 - type: material
   id: ReinforcedGlass
@@ -12,7 +12,7 @@
   name: materials-reinforced-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: rglass }
   color: "#549bb0"
-  price: 0.0836 # 1-0.5 mix of glass and metal. # FRONTIER: 0.225<0.0836 (80% of 0.1045) - TODO: review material values
+  price: 1.5 # Mono - 1+0.5 glass:steel
 
 - type: material
   id: PlasmaGlass
@@ -20,7 +20,7 @@
   name: materials-plasma-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: pglass }
   color: "#b35989"
-  price: 0.22 # 1-1 mix of plasma and glass. # FRONTIER: 0.50<0.22 (80% of 0.275) - TODO: review material values
+  price: 3 # Mono - 1+1 glass:plasma
 
 - type: material
   id: ReinforcedPlasmaGlass
@@ -28,7 +28,7 @@
   name: materials-reinforced-plasma-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: rpglass }
   color: "#8c4069"
-  price: 0.2436 # 1-1-0.5 mix of plasma, glass, and metal. # FRONTIER: 0.575<0.2436 (80% of 0.3045) - TODO: review material values
+  price: 3.5 # Mono - 1+1+0.5 glass:plasma:steel
 
 - type: material
   id: BrassGlass
@@ -36,7 +36,7 @@
   name: materials-clockwork-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: cglass }
   color: "#9b6f07"
-  price: 0.0875 # average of glass and brass. # FRONTIER: 0.225<0.0875 - TODO: review material values
+  price: 3 # Mono - 1+1 glass:brass
 
 - type: material
   id: UraniumGlass
@@ -44,7 +44,7 @@
   name: materials-uranium-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: uglass }
   color: "#3cab38"
-  price: 0.22 # 1-1 mix of uranium and glass. # FRONTIER: 1.0<0.22 (80% of 0.275) - TODO: review material values
+  price: 4 # Mono - 1+1 uranium:glass
 
 - type: material
   id: ReinforcedUraniumGlass
@@ -52,4 +52,4 @@
   name: materials-reinforced-uranium-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: ruglass }
   color: "#2d872a"
-  price: 0.2436 # 2-2-1 mix of uranium, glass, and metal. # Frontier: 0.7<0.2436 (80% of 0.3045) (materials balance)
+  price: 4.5 # Mono - 1+1+0.5 uranium:glass:steel

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -5,7 +5,7 @@
   unit: materials-unit-piece
   icon: { sprite: /Textures/Objects/Misc/monkeycube.rsi, state: cube }
   color: "#8A9A5B"
-  price: 0.1
+  price: 500 # Mono - 500/unit since integer stacks
 
 - type: material
   id: Cardboard
@@ -13,7 +13,7 @@
   name: materials-cardboard
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cardboard }
   color: "#70736c"
-  price: 0.005 # Frontier: 0.025<0.005 TODO - materials rebalance
+  price: 1 # Mono
 
 - type: material
   id: Cloth
@@ -22,7 +22,7 @@
   unit: materials-unit-roll
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: cloth }
   color: "#e7e7de"
-  price: 0.05
+  price: 1 # Mono
 
 - type: material
   id: Durathread
@@ -32,7 +32,7 @@
   unit: materials-unit-sheet
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: durathread }
   color: "#8291a1"
-  price: 0.15 # 1-1 mix of plastic and cloth. # Frontier: 0.35<0.15 TODO - materials rebalance
+  price: 2 # 1-1 mix of plastic and cloth. # Mono
 
 - type: material
   id: Paper
@@ -40,7 +40,7 @@
   name: materials-paper
   icon: { sprite: Objects/Materials/Sheets/other.rsi, state: paper }
   color: "#d9d9d9"
-  price: 0.01 # it's paper bro what do you expect?
+  price: 1 # it's paper bro what do you expect? # Mono
 
 - type: material
   id: Plasma
@@ -48,7 +48,7 @@
   name: materials-plasma
   icon: { sprite: Objects/Materials/Sheets/other.rsi, state: plasma }
   color: "#7e009e"
-  price: 0.2 # $35 for 1 unit # Frontier: 0.35<0.2 TODO - materials rebalance
+  price: 2 # $35 for 1 unit # Frontier: 0.35<0.2 TODO - materials rebalance # Mono
 
 - type: material
   id: Plastic
@@ -56,7 +56,7 @@
   name: materials-plastic
   icon: { sprite: Objects/Materials/Sheets/other.rsi, state: plastic }
   color: "#d9d9d9"
-  price: 0.1 # $20 for 1 unit # Frontier: 0.2<0.1 TODO - materials rebalance
+  price: 1 # Mono
 
 - type: material
   id: Wood
@@ -65,7 +65,7 @@
   unit: materials-unit-plank
   icon: { sprite: Objects/Materials/materials.rsi, state: wood }
   color: "#966F33"
-  price: 0.10 # $10 for 1 unit
+  price: 2 # Mono - wood is rare in space
 
 - type: material
   id: Uranium
@@ -73,7 +73,7 @@
   name: materials-uranium
   icon: { sprite: Objects/Materials/Sheets/other.rsi, state: uranium }
   color: "#32a852"
-  price: 0.2 # $85 for 1 unit # Frontier: 0.85<0.2 TODO - materials rebalance
+  price: 3 # Mono
 
 - type: material
   id: Bananium
@@ -82,7 +82,7 @@
   unit: materials-unit-bunch
   icon: { sprite: Objects/Materials/materials.rsi, state: bananium }
   color: "#32a852"
-  price: 0.2 # $100 for 1 unit # Frontier: 1.0<0.2 TODO - materials rebalance
+  price: 10 # Mono
 
 - type: material
   id: Meaterial # you can't take this pun from me
@@ -115,7 +115,7 @@
   unit: materials-unit-piece
   icon: { sprite: Objects/Materials/ore.rsi, state: coal }
   color: "#404040"
-  price: 0.03 # Frontier: 0.1<0.03 TODO - material rebalance
+  price: 0.2 # Mono
 
 - type: material
   id: Gunpowder
@@ -123,7 +123,7 @@
   unit: materials-unit-piece
   icon: { sprite: Objects/Misc/reagent_fillings.rsi, state: powderpile }
   color: "#A9A9A9"
-  price: 0.005 # Frontier: 0<0.005 - same value as cardboard
+  price: 1 # Mono
 
 - type: material
   id: Diamond

--- a/Resources/Prototypes/Reagents/Materials/metals.yml
+++ b/Resources/Prototypes/Reagents/Materials/metals.yml
@@ -3,7 +3,7 @@
   stackEntity: SheetSteel1
   name: materials-steel
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: steel }
-  price: 0.059 # Frontier: 0.15<0.059 tweaked per recipe (coal value)
+  price: 1 # Mono - 3 coal + 1 iron
 
 - type: material
   id: Gold
@@ -12,7 +12,7 @@
   unit: materials-unit-bar
   icon: { sprite: Objects/Materials/ingots.rsi, state: gold }
   color: "#FFD700"
-  price: 0.2 # $75 for 1 unit # Frontier: 0.75<0.2 - TODO: material rework
+  price: 2 # Mono
 
 - type: material
   id: Silver
@@ -21,7 +21,7 @@
   unit: materials-unit-bar
   icon: { sprite: Objects/Materials/ingots.rsi, state: silver }
   color: "#C0C0C0"
-  price: 0.15 # $60 for 1 unit # Frontier: 0.6<0.15 - TODO: material rework
+  price: 2 # Mono
 
 - type: material
   id: Brass
@@ -29,7 +29,7 @@
   name: materials-brass
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: brass }
   color: "#b18b25"
-  price: 0.1 # $30 for 1 unit # Frontier: 0.30<0.1 - TODO: material rework
+  price: 2 # Mono
 
 - type: material
   id: Plasteel
@@ -37,4 +37,4 @@
   name: materials-plasteel
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: plasteel }
   color: "#696969" #Okay, this is epic
-  price: 0.2544 # 1-1 mix of plasma and steel. # Frontier: 0.5<0.2544 (80% of 0.318) (tweaked per recipe)
+  price: 5 # Mono - 1+2 plasma and steel

--- a/Resources/Prototypes/Reagents/Materials/ores.yml
+++ b/Resources/Prototypes/Reagents/Materials/ores.yml
@@ -4,7 +4,7 @@
   name: materials-raw-iron
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: iron }
-  price: 0.05
+  price: 0.2 # Mono - half of processed
 
 - type: material
   id: RawQuartz
@@ -13,7 +13,7 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: spacequartz }
   color: "#a8ccd7"
-  price: 0.075
+  price: 0.5 # Mono - half of processed
 
 - type: material
   id: RawGold
@@ -22,7 +22,7 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: gold }
   color: "#FFD700"
-  price: 0.2
+  price: 1 # Mono - half of processed
 
 - type: material
   id: RawDiamond
@@ -31,7 +31,7 @@
   unit: materials-unit-piece
   icon: { sprite: Objects/Materials/ore.rsi, state: diamond }
   color: "#C9D8F2"
-  price: 0.5
+  price: 10 # Mono - half of processed
 
 - type: material
   id: RawSilver
@@ -40,7 +40,7 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: silver }
   color: "#C0C0C0"
-  price: 0.15
+  price: 1 # Mono - half of processed
 
 - type: material
   id: RawPlasma
@@ -49,7 +49,7 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: plasma }
   color: "#7e009e"
-  price: 0.2
+  price: 1 # Mono - half of processed
 
 - type: material
   id: RawUranium
@@ -58,7 +58,7 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: uranium }
   color: "#32a852"
-  price: 0.2
+  price: 1.5 # Mono - half of processed
 
 - type: material
   id: RawBananium
@@ -67,7 +67,7 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: bananium }
   color: "#32a852"
-  price: 0.2
+  price: 5 # Mono - half of processed
 
 - type: material
   id: RawSalt
@@ -76,4 +76,4 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: salt }
   color: "#f5e7d7"
-  price: 0.075
+  price: 0.5 # Mono

--- a/Resources/Prototypes/_NF/Entities/Materials/ore.yml
+++ b/Resources/Prototypes/_NF/Entities/Materials/ore.yml
@@ -99,7 +99,7 @@
   unit: materials-unit-chunk
   icon: { sprite: /Textures/_NF/Objects/Materials/ore.rsi, state: scrapore }
   color: "#FFD700"
-  price: 0.1
+  price: 2.5 # Mono - based off steel + 2x ore discount
 
 # Spawner for lathe: yield random mats if processed in ore processor
 - type: entity


### PR DESCRIPTION
## About the PR
- adds test to see if any recipe does not multiply the sale price of its inputs by more than 4x
- upprices every material because they were laughably cheap

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Materials and ore sell for significantly more now.
