### PR TITLE
Fix Loadout Window Title

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1452,7 +1452,7 @@ namespace Content.Client.Lobby.UI
 
             _loadoutWindow = new LoadoutWindow(Profile, roleLoadout, roleLoadoutProto, _playerManager.LocalSession, collection)
             {
-                Title = jobProto?.ID + "-loadout",
+                Title = jobProto?.LocalizedName + " loadout", // Mono - replace the "-" with a space in "-loadout", change to LocalizedName from ID
             };
 
             // Refresh the buttons etc.


### PR DESCRIPTION
## About the PR
Fixes title of loadout windows showing the wrong name (eg Sheriff-loadout)
Closes https://github.com/Monolith-Station/Monolith/issues/3758

## Why / Balance
Was showing ID for window title for some reason? (shouldn't be doing that + showed the old frontier ID lol)

## Media
<img width="201" height="35" alt="image" src="https://github.com/user-attachments/assets/fb2c8f86-d9b1-4ac9-a9ee-6002ec30d37e" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Fixed loadout UI windows having the wrong title.
