### PR TITLE
Medchem Tweak 

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -80,7 +80,7 @@ reagent-name-tranexamic-acid = tranexamic acid
 reagent-desc-tranexamic-acid = A blood-clotting medicine used to prevent profuse bleeding. Causes heavier bleeding on overdose. Commonly found in small doses within emergency medipens.
 
 reagent-name-tricordrazine = tricordrazine
-reagent-desc-tricordrazine = A wide-spectrum stimulant, originally derived from cordrazine. Treats damage of all basic health types, but is most effective on minor wounds. Best used as an additive to other chemicals and is very dangerous to overdose.
+reagent-desc-tricordrazine = A wide-spectrum stimulant, originally derived from cordrazine. Treats damage of all basic health types, but is most effective on minor wounds. Best used as an additive to other chemicals.
 
 reagent-name-lipozine = lipozine
 reagent-desc-lipozine = A chemical that accelerates metabolism, causing the user to hunger faster.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -920,7 +920,7 @@
         - !type:ReagentThreshold
           min: 15
         reagent: Tricordrazine
-        amount: -0.3
+        amount: -0.8
         
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -711,7 +711,7 @@
       effects:
       - !type:EvenHealthChange
         damage:
-          Brute: -2 #Mono -1.75 >> -2
+          Brute: -2.5 #Mono -1.75 >> -2.5
           Airloss: -1
       - !type:HealthChange
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -151,11 +151,13 @@
   color: "#ffaa00"
   metabolisms:
     Medicine:
-      metabolismRate: 0.2 # Mono 0.5 >> 0.2
+      metabolismRate: 0.2 # Mono 1.5 >> 1
       effects:
       - !type:EvenHealthChange
         damage:
-          Brute: -1 #Mono 1.5 >> 1
+          Brute: -1
+      - !type:ModifyBleedAmount # Mono: buff to differentiate more from trico
+        amount: -0.25
       - !type:HealthChange
         conditions:
         - !type:OrganType # Goobstation - Yowie
@@ -871,6 +873,7 @@
   color: "#ba7d7d"
   metabolisms:
     Medicine:
+      metabolismRate: 0.2 #Mono: Slower metabolism rate
       effects:
       # Medium-large quantities can hurt you instead,
       # but still technically stop your bleeding.
@@ -898,9 +901,6 @@
       effects:
       - !type:EvenHealthChange #Mono: Low damage healing
         conditions:
-        - !type:ReagentThreshold
-          min: 0
-          max: 15
         - !type:TotalDamage
           max: 50
         damage:
@@ -909,27 +909,18 @@
           Toxin: -0.5
       - !type:EvenHealthChange #Mono: High damage healing
         conditions:
-        - !type:ReagentThreshold
-          min: 0
-          max: 15
         - !type:TotalDamage
           min: 50
         damage:
           Brute: -0.25
           Burn: -0.25
           Toxin: -0.12
-      - !type:HealthChange # Mono: Overdose, low rate compounded by slow metabolism
+      - !type:AdjustReagent # Mono: Overdose, penalize metabolism
         conditions:
         - !type:ReagentThreshold
           min: 15
-        damage:
-          types:
-            Poison: 1
-      - !type:ModifyBleedAmount # Mono: Causes bleeding in OD
-        conditions:
-        - !type:ReagentThreshold
-          min: 15
-        amount: 0.5
+        reagent: Tricordrazine
+        amount: -0.3
         
 
 - type: reagent
@@ -959,26 +950,19 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:EvenHealthChange # Mono - Overdose
+      - !type:EvenHealthChange
         conditions:
-        - !type:ReagentThreshold
-          min: 0
-          max: 100
         damage:
           Burn: -1.5
           Toxin: -1.5
           Airloss: -1.5
           Brute: -1.5   
-      - !type:HealthChange # Mono - Added overdose
+      - !type:AdjustReagent # Mono: Overdose, penalize metabolism
         conditions:
         - !type:ReagentThreshold
-          min: 100
-        damage:
-          groups:
-            Burn: 1
-            Toxin: 1
-            Airloss: 1
-            Brute: 1
+          min: 60
+        reagent: Omnizine
+        amount: -1.0
 
 - type: reagent
   id: Ultravasculine


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adjustments in the spirit of https://github.com/Monolith-Station/Monolith/pull/3576

Trico OD 1poison/tick past 15u >> Replaced with 1 metabolism past 15u
Omni OD damage/tick past 100u >> Replaced with 2 metabolism past 60u. 
Bicar >> Add 0.25 bleed reduction/tick
Tranexamic >> Given 0.2 metabolism
Oligmers >> Match bicar's effective brute healing per u

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Trico: Immigrants from other forks will invariably kill themselves on trico when they treat it the same way as they did from their origin fork. This new overdose effect basically disincentivizes treating it as a "buff" chem while avoiding excessive knowledge check punishments.

Omnizine: Same principal as trico. Technically a buff with tradeoffs: foaming 250u of omni on yourself is no longer suicide, and it lasts ~246 seconds. This is 46 seconds longer than the hypothetical max of the old overdose mechanic, at a steep penalty of 190 more omnizine. If you have a good botanist on hand, you'll afford it and 60u of omni is still 120 seconds of regen, which isn't something to scoff at.

Bicar: Significant performance overlap with trico. The bleed reduction gives an additional edge without being rigged (gauze wins anyway)

Tranex: Enables lower proportions of tranexamic to be useful, freeing up space in your custom chem mixes.

Oligomers: Bicar heals 5 brute per 1u, so I matched oligomers to that. The change basically makes oligomers a fast-burn version version of bicar with a superior OD condition ft. airloss restoration. A decent upgrade.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Small beans

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Trico and Omni no longer kill you on OD, but instead consume more per metabolism (less severe knowledge check punishment). Omni OD threshold reduced to 60
- tweak: Bicar now reduces bleeding slightly. Tranexamic now has 0.2 metabolism. Oligomers buffed 2 brute/u >> 2.5 to match bicar's per u healing
