### PR TITLE
Makes Reactor Explosions Big and Strong

### DIFF
--- a/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
+++ b/Content.Server/_FarHorizons/Power/Generation/FissionGenerator/NuclearReactorSystem.cs
@@ -554,7 +554,7 @@ public sealed class NuclearReactorSystem : SharedNuclearReactorSystem
             _throwingSystem.TryThrow(Spawn("NuclearDebrisChunk", _transformSystem.GetMapCoordinates(uid)), _random.NextAngle().ToVec().Normalized(), _random.NextFloat(8, 16), uid);
 
         _audio.PlayPvs(new SoundPathSpecifier("/Audio/Effects/metal_break5.ogg"), uid);
-        _explosionSystem.QueueExplosion(ent.Owner, "Radioactive", Math.Max(100, MeltdownBadness * 5), 1, 5, 0, canCreateVacuum: false);
+        _explosionSystem.QueueExplosion(ent.Owner, "HardBombShipGun", Math.Max(1000, MeltdownBadness * 35), 1, 500, 1, canCreateVacuum: true); // Mono - buff size
 
         // Reset grids
         comp.ComponentGrid = new ReactorPartComponent[comp.ReactorGridWidth, comp.ReactorGridHeight]; // Not Array.Clear due to ammonia

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor.yml
@@ -127,6 +127,7 @@
   - type: PassiveThermalSignature # Mono
     signature: 5000000
   # Mono
+  - type: RequiresGrid
   - type: ShipRepairable
     repairTime: 45
     repairCost: 200

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/turbine.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/turbine.yml
@@ -104,6 +104,7 @@
     - NuclearReactor
     - Power
   # Mono
+  - type: RequiresGrid
   - type: ShipRepairable
     repairTime: 30
     repairCost: 75


### PR DESCRIPTION
## About the PR
Heavily buffs reactor explosions
Makes reactor parts delete off grid

## Why / Balance
They wouldn't even break directional windows

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Spawn the meltdown preset reactor, wait like 20 seconds

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed reactor explosions being too weak.