### PR TITLE
Crystallizer GUI Fix

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Atmospherics/crystallizer.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Atmospherics/crystallizer.yml
@@ -83,6 +83,7 @@
   - type: ActivatableUI
     key: enum.CrystallizerUiKey.Key
     requiresComplex: false
+    blockSpectators: true
   - type: PointLight
     color: "#3a807f"
     radius: 2


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes the Crystallizer GUI being accessible to normal Ghosts. Closes https://github.com/Monolith-Station/Monolith/issues/3830

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixing an issue.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Try to do RMB -> Toggle UI as Ghost, nothing pops up. Fantastic!

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None to my knowledge.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Ark
- fix: Crystallizer GUI can no longer be accessed by Ghosts.
