### PR TITLE
Ship Combat Tweaks

### DIFF
--- a/Content.Shared/CCVar/CCVars.Shuttle.cs
+++ b/Content.Shared/CCVar/CCVars.Shuttle.cs
@@ -230,14 +230,14 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactDamageMultiplier =
-        CVarDef.Create("shuttle.impact.damage_multiplier", 0.00005f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.impact.damage_multiplier", 0.00001f, CVar.SERVERONLY);
 
     /// <summary>
     /// Multiplier of additional structural damage to do
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactStructuralDamage =
-        CVarDef.Create("shuttle.impact.structural_damage", 5f, CVar.SERVERONLY);
+        CVarDef.Create("shuttle.impact.structural_damage", 2f, CVar.SERVERONLY);
 
     /// <summary>
     /// Kinetic energy required to spawn sparks
@@ -258,7 +258,7 @@ public sealed partial class CCVars
     /// </summary>
     [CVarControl(AdminFlags.VarEdit)]
     public static readonly CVarDef<float> ImpactSlowdown =
-        CVarDef.Create("shuttle.impact.slowdown", 3.2f, CVar.SERVERONLY); //Previously: 1.6f
+        CVarDef.Create("shuttle.impact.slowdown", 4f, CVar.SERVERONLY); //Previously: 1.6f
 
     /// <summary>
     /// Minimum velocity change from impact for special throw effects (e.g. stuns, beakers breaking) to occur

--- a/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Mono/Damage/modifier_sets.yml
@@ -120,19 +120,19 @@
 - type: damageModifierSet
   id: MechArmorHeavy
   coefficients:
-    Blunt: 0.4
-    Slash: 0.4
+    Blunt: 0.5
+    Slash: 0.5
     Cold: 0
     Radiation: 0
-    Piercing: 0.5
+    Piercing: 0.6
     Shock: 2
-    Heat: 0.4
-    Structural: 0.6
+    Heat: 0.5
+    Structural: 0.7
   flatReductions:
-    Blunt: 7
-    Slash: 7
-    Piercing: 7
-    Heat: 4
+    Blunt: 5
+    Slash: 5
+    Piercing: 5
+    Heat: 3
     Structural: 1
 
 - type: damageModifierSet

--- a/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Specific/Mechs/mechs.yml
@@ -443,7 +443,7 @@
     criticalPowerStateSpeedPenalty: 0.85
     maxEquipmentAmount: 3
     airtight: true
-    maxIntegrity: 4000
+    maxIntegrity: 3000
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -460,7 +460,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 4000
+        damage: 6000
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -651,7 +651,7 @@
     criticalPowerStateSpeedPenalty: 0.95
     maxEquipmentAmount: 1
     airtight: true
-    maxIntegrity: 3000
+    maxIntegrity: 2000
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -660,7 +660,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 6000
+        damage: 4000
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -76,8 +76,8 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 10000
-    startingCharge: 10000
+    maxCharge: 40000
+    startingCharge: 40000
   - type: ExaminableBattery
   - type: WirelessNetworkConnection
     range: 500
@@ -94,16 +94,16 @@
       path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 500
+    autoRechargeRate: 350
   - type: SpaceArtillery
-    powerChargeRate: 500
+    powerChargeRate: 350
     powerUsePassive: 500
     powerUseActive: 0
   - type: FireControlRotate
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: CerberusSpread
-    fireCost: 1000
+    fireCost: 500
   - type: RadarBlip
     radarColor: "#C92BCC"
     scale: 2.5

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -27,7 +27,7 @@
     recoil: 5 # 1/5x
     minAngle: 0
     maxAngle: 0
-    projectileSpeed: 150
+    projectileSpeed: 180
     shootThermalSignature: 4000000 # ~2.8km with continuous fire
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon2.ogg
@@ -76,8 +76,8 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 40000
-    startingCharge: 40000
+    maxCharge: 10000
+    startingCharge: 10000
   - type: ExaminableBattery
   - type: WirelessNetworkConnection
     range: 500
@@ -86,7 +86,7 @@
     recoil: 8
     minAngle: 0
     maxAngle: 0
-    projectileSpeed: 150
+    projectileSpeed: 180
     shootThermalSignature: 4000000 # ~2.8km with continuous fire
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon2.ogg
@@ -94,16 +94,16 @@
       path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 350
+    autoRechargeRate: 500
   - type: SpaceArtillery
-    powerChargeRate: 350
+    powerChargeRate: 500
     powerUsePassive: 500
     powerUseActive: 0
   - type: FireControlRotate
   - type: Actions
   - type: ProjectileBatteryAmmoProvider
     proto: CerberusSpread
-    fireCost: 500
+    fireCost: 1000
   - type: RadarBlip
     radarColor: "#C92BCC"
     scale: 2.5
@@ -145,7 +145,7 @@
     recoil: 5 # 1/5x
     minAngle: 0
     maxAngle: 5
-    projectileSpeed: 185
+    projectileSpeed: 220
     shootThermalSignature: 500000 # ~5.6km with continuous fire
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/Gunshots/autopulse_laser_fire_01.ogg
@@ -275,7 +275,7 @@
     range: 500
   - type: Gun
     fireRate: 0.2
-    projectileSpeed: 140
+    projectileSpeed: 170
     shootThermalSignature: 2000000 # ~1414m after firing - relatively low
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon2.ogg
@@ -1056,7 +1056,7 @@
     range: 500
   - type: Gun
     recoil: 10 # 2/5x
-    projectileSpeed: 150
+    projectileSpeed: 180
     minAngle: 0
     maxAngle: 4
     burstCooldown: 2

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlight_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlight_kinetic.yml
@@ -27,7 +27,7 @@
   - type: Gun
     fireRate: 12
     recoil: 5 # 1/5x
-    projectileSpeed: 160
+    projectileSpeed: 192
     minAngle: 0
     maxAngle: 5
     shootThermalSignature: 10000 # relatively low for a shipgun, ~693m signature if firing continuously
@@ -113,7 +113,7 @@
   - type: Gun
     fireRate: 25
     recoil: 5 # 1/5x
-    projectileSpeed: 180
+    projectileSpeed: 216
     minAngle: 0
     maxAngle: 4
     shootThermalSignature: 100000 # ~4.5km if firing continuously

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardmedium_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardmedium_kinetic.yml
@@ -24,7 +24,7 @@
   - type: Gun
     fireRate: 3
     recoil: 10 # 2/5x
-    projectileSpeed: 170
+    projectileSpeed: 204
     minAngle: 0
     maxAngle: 3
     burstCooldown: 0.4
@@ -95,7 +95,7 @@
   - type: Gun
     fireRate: 1.5
     recoil: 10 # 2/5x
-    projectileSpeed: 250
+    projectileSpeed: 300
     minAngle: 0
     maxAngle: 2
     shootThermalSignature: 2000000 # ~3.5km signature if firing continuously

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
@@ -34,7 +34,7 @@
   - type: Gun
     fireRate: 5
     recoil: 10 # 2/5x
-    projectileSpeed: 200
+    projectileSpeed: 230
     minAngle: 0
     maxAngle: 5
     shootThermalSignature: 10000 # relatively low for a shipgun, ~693m signature if firing continuously


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
- Significantly nerfs ship ramming.
- Buffs projectile speeds of the following shipguns by ~20%:
	- Adder scattercannon: 200 -> 230
	- L85 20mm autocannon: 160 -> 192
	- RAC-30 Draupnir Autocannon: 180 -> 216
	- AK570 57mm autocannon: 170 -> 204
	- ADBP-7 DRAVON 90mm Autocannon: 250 -> 300
	- Type-35 MARAUDER-type plasma cannon: 150 -> 180 
		- Will be reworked in the near future
	- TPC Cerberus Plasma scattercannon: 150 -> 180
		- Will be reworked in the near future
	- Type-54C plasma autopulser: 185 -> 220 
		- Will be reworked in the near future
	- M220 RUBICON EMP launcher: 140 -> 170
	- Curio-1008 neutron repeater "Scythe": 150 -> 180
		- will be reworked in the near future
- ASF-59 "Flail" health decreased from `4000` -> `3000`
- ASF-59-B "Mace" health decreased from `3000` -> `2000`
- `MechArmorHeavy` provides less protection.

Ship Gunnery guidebook entries will be updated once pending reworks are in.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Significantly nerfed ship ramming.
- tweak: Nerfed ASF-59 "Flail" health.
- tweak: Nerfed ASF-59-B "Mace" health.
- tweak: Buffed projectile speeds of several shipguns.

