### PR TITLE
Fix an Issue with VHS Filter

### DIFF
--- a/Content.Client/_SCP/RetroMonitor/RetroMonitorOverlay.cs
+++ b/Content.Client/_SCP/RetroMonitor/RetroMonitorOverlay.cs
@@ -1,6 +1,6 @@
-using Content.Shared._Scp.RetroMonitor;
+using Content.Shared._Scp.RetroMonitor; // Mono
 using Robust.Client.Graphics;
-using Robust.Client.Player;
+using Robust.Client.Player; // Mono
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 

--- a/Content.Client/_SCP/RetroMonitor/RetroMonitorOverlay.cs
+++ b/Content.Client/_SCP/RetroMonitor/RetroMonitorOverlay.cs
@@ -1,4 +1,6 @@
+using Content.Shared._Scp.RetroMonitor;
 using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 
@@ -7,6 +9,8 @@ namespace Content.Client._Scp.RetroMonitor;
 public sealed class RetroMonitorOverlay : Overlay
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!; // Mono
+    [Dependency] IEntityManager _entityManager = default!; // Mono
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     public override bool RequestScreenTexture => true; // Запрашиваем ScreenTexture
@@ -18,6 +22,19 @@ public sealed class RetroMonitorOverlay : Overlay
         IoCManager.InjectDependencies(this);
         _retroShader = _prototypeManager.Index<ShaderPrototype>("crt_vhs").InstanceUnique();
     }
+
+    // Mono start
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (_playerManager.LocalEntity is not { Valid: true } player
+            || !_entityManager.HasComponent<RetroMonitorViewComponent>(player))
+        {
+            return false;
+        }
+
+        return base.BeforeDraw(in args);
+    }
+    // Mono end
 
     protected override void Draw(in OverlayDrawArgs args)
     {

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -38,7 +38,7 @@ public sealed class DCCVars
     /// Disables all vision filters for species like Vulpkanin or Harpies. There are good reasons someone might want to disable these.
     /// </summary>
     public static readonly CVarDef<bool> NoVisionFilters =
-        CVarDef.Create("accessibility.no_vision_filters", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("accessibility.no_vision_filters", false, CVar.CLIENTONLY | CVar.ARCHIVE); // Mono - false by default
 
     /// <summary>
     /// Whether the Shipyard is enabled.


### PR DESCRIPTION
## About the PR
Fixes an issue with #3902 where the ccvar toggle didn't actually check if you had the component in any way

## Why / Balance
Would give you the filter even if you werent supposed to

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed an issue where the retro-monitor overlay would be applied when it shouldn't be.
- tweak: Species vision filters are now on by default.
