### PR TITLE
Nuke Separate Iconsmooth for Walls

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -55,7 +55,7 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: IconSmooth
-    key: solidwalls # Mono
+    key: walls
     mode: NoSprite
   - type: Occluder
   - type: ContainerFill

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -88,7 +88,7 @@
     graph: ClockworkGirder
     node: clockworkWall
   - type: IconSmooth
-    key: clockwalls # Mono
+    key: walls
     base: clock
   - type: RCDDeconstructable # Frontier
     cost: 6 # Frontier
@@ -117,7 +117,7 @@
     delay: 8
     fx: EffectRCDDeconstruct8
   - type: IconSmooth
-    key: clownwalls # Mono
+    key: walls
     base: clown
   - type: Fixtures
     fixtures:
@@ -149,7 +149,7 @@
     graph: Girder
     node: meatWall
   - type: IconSmooth
-    key: meatwalls # Mono
+    key: walls
     base: meat
 
 - type: entity
@@ -165,7 +165,7 @@
   - type: Icon
     sprite: Structures/Walls/cult.rsi
   - type: IconSmooth
-    key: cultwalls # Mono
+    key: walls
     base: cult
 
 - type: entity
@@ -203,7 +203,7 @@
     delay: 8
     fx: EffectRCDDeconstruct8
   - type: IconSmooth
-    key: diamondwalls # Mono
+    key: walls
     base: diamond
 
 - type: entity
@@ -237,7 +237,7 @@
         - WallLayer
         density: 4000
   - type: IconSmooth
-    key: goldwalls # Mono
+    key: walls
     base: gold
 
 - type: entity
@@ -253,7 +253,7 @@
   - type: Icon
     sprite: Structures/Walls/ice.rsi
   - type: IconSmooth
-    key: icewalls # Mono
+    key: walls
     base: ice
 
 - type: entity
@@ -276,7 +276,7 @@
     delay: 8
     fx: EffectRCDDeconstruct8
   - type: IconSmooth
-    key: plasmawalls # Mono
+    key: walls
     base: plasma
   - type: RadiationBlocker
     resistance: 5
@@ -301,7 +301,7 @@
     delay: 8
     fx: EffectRCDDeconstruct8
   - type: IconSmooth
-    key: plasticwalls # Mono
+    key: walls
     base: plastic
 
 - type: entity
@@ -319,7 +319,7 @@
   - type: Icon
     sprite: Structures/Walls/plastitanium.rsi
   - type: IconSmooth
-    key: plastitaniumwalls # Mono
+    key: walls
     base: plastitanium
   - type: Fixtures
     fixtures:
@@ -399,7 +399,7 @@
     state: state0
   - type: IconSmooth
     mode: Diagonal
-    key: plastitaniumwalls
+    key: walls
     base: state
   - type: Icon
     sprite: Structures/Walls/plastitanium_diagonal.rsi
@@ -443,7 +443,7 @@
     graph: Girder
     node: reinforcedWall
   - type: IconSmooth
-    key: reinforcedwalls # Mono
+    key: walls
     base: reinf_over
   - type: Appearance
   - type: GenericVisualizer
@@ -494,7 +494,7 @@
     graph: Girder
     node: reinforcedWallRust
   - type: IconSmooth
-    key: reinforcedwalls # Mono
+    key: walls
     base: reinf_over
   - type: RCDDeconstructable #Frontier
     cost: 6 #Frontier
@@ -520,7 +520,7 @@
     state: state0
   - type: IconSmooth
     mode: Diagonal
-    key: reinforcedwalls # Mono
+    key: walls
     base: state
   - type: Icon
     sprite: Structures/Walls/reinforced_diagonal.rsi
@@ -566,7 +566,7 @@
   - type: Icon
     sprite: Structures/Walls/riveted.rsi
   - type: IconSmooth
-    key: rivetedwalls # Mono
+    key: walls
     base: riveted
   - type: StaticPrice
     price: 70 # Frontier: 150<115
@@ -592,7 +592,7 @@
     delay: 8
     fx: EffectRCDDeconstruct8
   - type: IconSmooth
-    key: sandstonewalls # Mono
+    key: walls
     base: sandstone
 
 - type: entity
@@ -615,7 +615,7 @@
     delay: 8
     fx: EffectRCDDeconstruct8
   - type: IconSmooth
-    key: silverwalls # Mono
+    key: walls
     base: silver
 
 #shuttle walls
@@ -643,7 +643,7 @@
     state: state0
   - type: IconSmooth
     mode: Diagonal
-    key: exteriorshuttlewalls # Mono
+    key: walls
     base: state
   - type: Icon
     sprite: Structures/Walls/shuttle_diagonal.rsi
@@ -701,7 +701,7 @@
     graph: Girder
     node: shuttleWall
   - type: IconSmooth
-    key: exteriorshuttlewalls # Mono
+    key: walls
     base: state
   - type: Appearance
   - type: GenericVisualizer
@@ -753,7 +753,7 @@
     graph: Girder
     node: shuttleInteriorWall
   - type: IconSmooth
-    key: interiorshuttlewalls # Mono
+    key: walls
     base: state
 #  - type: Reflect # Frontier
 #    reflectProb: 1 # Frontier
@@ -779,7 +779,7 @@
     delay: 8
     fx: EffectRCDDeconstruct8
   - type: IconSmooth
-    key: solidwalls # Mono
+    key: walls
     base: solid
 
 - type: entity
@@ -798,7 +798,7 @@
     state: state0
   - type: IconSmooth
     mode: Diagonal
-    key: solidwalls # Mono
+    key: walls
     base: state
   - type: Icon
     sprite: Structures/Walls/solid_diagonal.rsi
@@ -845,7 +845,7 @@
     graph: Girder
     node: wallrust
   - type: IconSmooth
-    key: solidwalls # Mono
+    key: walls
     base: solid
 
 - type: entity
@@ -931,7 +931,7 @@
         - WallLayer
         density: 6000
   - type: IconSmooth
-    key: uraniumwalls # Mono
+    key: walls
     base: uranium
   - type: RadiationBlocker
     resistance: 6
@@ -1031,7 +1031,7 @@
   - type: Icon
     sprite: Structures/Walls/necropolis.rsi
   - type: IconSmooth
-    key: necropoliswalls # Mono
+    key: walls
     base: necropolis
 
 - type: entity
@@ -1047,7 +1047,7 @@
   - type: Icon
     sprite: Structures/Walls/mining.rsi
   - type: IconSmooth
-    key: miningwalls # Mono
+    key: walls
     base: mining
   - type: RandomIconSmooth
     randomStates:
@@ -1071,7 +1071,7 @@
     state: state0
   - type: IconSmooth
     mode: Diagonal
-    key: miningwalls # Mono
+    key: walls
     base: state
   - type: Icon
     sprite: Structures/Walls/mining_diagonal.rsi

--- a/Resources/Prototypes/_Mono/Entities/Structures/walls.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/walls.yml
@@ -250,7 +250,7 @@
   suffix: OUTPOST ONLY
   components:
   - type: IconSmooth
-    key: reinforcedwalls # Mono
+    key: walls
     base: reinf_over
   - type: Destructible
     thresholds:
@@ -316,7 +316,7 @@
         acts: ["Destruction"]
   - type: IconSmooth
     mode: Diagonal
-    key: reinforcedwalls # Mono
+    key: walls
     base: state
   - type: Icon
     sprite: Structures/Walls/reinforced_diagonal.rsi

--- a/Resources/Prototypes/_NF/Entities/Structures/Specific/bloodcult.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Specific/bloodcult.yml
@@ -75,7 +75,7 @@
   - type: Icon
     sprite: _NF/Structures/Specific/BloodCult/wall.rsi
   - type: IconSmooth
-    key: cultwalls # Mono
+    key: walls
     base: cult
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Structures/Walls/diagonal_walls.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Walls/diagonal_walls.yml
@@ -96,7 +96,7 @@
     state: state0
   - type: IconSmooth
     mode: DiagonalNF
-    key: uraniumwalls # Mono
+    key: walls
     base: state
   - type: Icon
     sprite: _NF/Structures/Walls/uranium_diagonal.rsi

--- a/Resources/Prototypes/_Shitmed/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Structures/Walls/walls.yml
@@ -22,7 +22,7 @@
     state: state0
   - type: IconSmooth
     mode: Diagonal
-    key: nanolaminatewalls # Mono
+    key: walls
     base: state
   - type: Icon
     sprite: _Shitmed/Structures/Walls/abductor_diagonal.rsi
@@ -99,7 +99,7 @@
     graph: Girder
     node: shuttleWall
   - type: IconSmooth
-    key: nanolaminatewalls # Mono
+    key: walls
     base: state
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
## About the PR
Brings back iconsmooth for all wall types instead of having it be separate for each type
Some are excluded intentionally (like asteroid rock)

## Why / Balance
Its ugly as shit!!! Also discord poll was 78% in favor of bringing back (57 votes)

## Media
<img width="60" height="102" alt="image" src="https://github.com/user-attachments/assets/81a2e8ad-dd0b-4333-98c1-6515df69982a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Brought back walls of different types having iconsmooth.
