### PR TITLE
AP/HP/RIP for 6.8x52mm STANAG

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/68x52mm.yml
@@ -81,6 +81,53 @@
       map: ["enum.GunVisualLayers.Mag"]
     - state: rubber
 
+# Mono AP syst
+#anti-flesh:
+- type: entity
+  parent: BaseAmmoBox68x52mmCaseless
+  id: AmmoBox68x52mmCaselessHP
+  name: ammunition box (6.8x52mm STANAG Caseless HP)
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge68x52mmCaselessHP
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  parent: BaseAmmoBox68x52mmCaseless
+  id: AmmoBox68x52mmCaselessRIP
+  name: ammunition box (6.8x52mm STANAG Caseless RIP)
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge68x52mmCaselessRIP
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+#armor-piercing:
+
+- type: entity
+  parent: BaseAmmoBox68x52mmCaseless
+  id: AmmoBox68x52mmCaselessPlasteelAP
+  name: ammunition box (6.8x52mm STANAG Caseless AP)
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge68x52mmCaselessPlasteelAP
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+#big ammo boxes
 - type: entity
   parent: BaseAmmoBox68x52mmCaseless
   id: AmmoBox68x52mmCaselessBig

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/68x52mm.yml
@@ -56,7 +56,7 @@
 # Mono AP syst
 #anti-flesh:
 - type: entity
-  id: Cartridge68x52mmHP
+  id: Cartridge68x52mmCaselessHP
   name: cartridge (6.8x52mm STANAG Caseless HP)
   parent: BaseCartridge68x52mmCaseless
   components:
@@ -71,7 +71,7 @@
       color: "#90EE90"
 
 - type: entity
-  id: Cartridge68x52mmRIP
+  id: Cartridge68x52mmCaselessRIP
   name: cartridge (6.8x52mm STANAG Caseless RIP)
   parent: BaseCartridge68x52mmCaseless
   components:
@@ -88,7 +88,7 @@
 #armor-piercing:
 
 - type: entity
-  id: Cartridge68x52mmPlasteelAP
+  id: Cartridge68x52mmCaselessPlasteelAP
   name: cartridge (6.8x52mm STANAG Caseless AP)
   parent: BaseCartridge68x52mmCaseless
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/68x52mm.yml
@@ -53,3 +53,52 @@
         map: [ "enum.AmmoVisualLayers.Tip" ]
         color: "#dbdbdb"
 
+# Mono AP syst
+#anti-flesh:
+- type: entity
+  id: Cartridge68x52mmHP
+  name: cartridge (6.8x52mm STANAG Caseless HP)
+  parent: BaseCartridge68x52mm
+  components:
+  - type: CartridgeAmmo
+    proto: Bullet68x52mmCaselessHP
+  - type: Sprite
+    layers:
+    - state: base
+      map: [ "enum.AmmoVisualLayers.Base" ]
+    - state: tip
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      color: "#90EE90"
+
+- type: entity
+  id: Cartridge68x52mmRIP
+  name: cartridge (6.8x52mm STANAG Caseless RIP)
+  parent: BaseCartridge68x52mm
+  components:
+  - type: CartridgeAmmo
+    proto: Bullet68x52mmCaselessRIP
+  - type: Sprite
+    layers:
+    - state: base
+      map: [ "enum.AmmoVisualLayers.Base" ]
+    - state: tip
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      color: "#C04000"
+
+#armor-piercing:
+
+- type: entity
+  id: Cartridge68x52mmPlasteelAP
+  name: cartridge (6.8x52mm STANAG Caseless AP)
+  parent: BaseCartridge68x52mm
+  components:
+  - type: CartridgeAmmo
+    proto: Bullet68x52mmCaselessPlasteelAP
+  - type: Sprite
+    layers:
+    - state: base
+      map: [ "enum.AmmoVisualLayers.Base" ]
+    - state: tip
+      map: [ "enum.AmmoVisualLayers.Tip" ]
+      color: "#888888"
+

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/68x52mm.yml
@@ -58,7 +58,7 @@
 - type: entity
   id: Cartridge68x52mmHP
   name: cartridge (6.8x52mm STANAG Caseless HP)
-  parent: BaseCartridge68x52mm
+  parent: BaseCartridge68x52mmCaseless
   components:
   - type: CartridgeAmmo
     proto: Bullet68x52mmCaselessHP
@@ -73,7 +73,7 @@
 - type: entity
   id: Cartridge68x52mmRIP
   name: cartridge (6.8x52mm STANAG Caseless RIP)
-  parent: BaseCartridge68x52mm
+  parent: BaseCartridge68x52mmCaseless
   components:
   - type: CartridgeAmmo
     proto: Bullet68x52mmCaselessRIP
@@ -90,7 +90,7 @@
 - type: entity
   id: Cartridge68x52mmPlasteelAP
   name: cartridge (6.8x52mm STANAG Caseless AP)
-  parent: BaseCartridge68x52mm
+  parent: BaseCartridge68x52mmCaseless
   components:
   - type: CartridgeAmmo
     proto: Bullet68x52mmCaselessPlasteelAP

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/68x52mm.yml
@@ -151,3 +151,50 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+
+# Mono AP syst
+#anti-flesh:
+
+- type: entity
+  id: Magazine68x52mmCaselessHP
+  name: "magazine (6.8x52mm STANAG Caseless HP)"
+  parent: BaseMagazine68x52mmCaseless
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge68x52mmCaselessHP
+  - type: Sprite
+    layers:
+    - state: red
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: Magazine68x52mmCaselessRIP
+  name: "magazine (6.8x52mm STANAG Caseless RIP)"
+  parent: BaseMagazine68x52mmCaseless
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge68x52mmCaselessRIP
+  - type: Sprite
+    layers:
+    - state: red
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+#armor-piercing:
+
+- type: entity
+  id: Magazine68x52mmCaselessPlasteelAP
+  name: "magazine (6.8x52mm STANAG Caseless AP)"
+  parent: BaseMagazine68x52mmCaseless
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge68x52mmCaselessPlasteelAP
+  - type: Sprite
+    layers:
+    - state: red
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/68x52mm.yml
@@ -31,3 +31,47 @@
     damage:
       types:
         Blunt: 3
+
+# Mono AP syst
+# + 0.05 base AP
+#anti-flesh:
+- type: entity
+  id: Bullet68x52mmCaselessHP
+  parent: BaseBullet
+  name: bullet (6.8x52mm Caseless HP)
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Slash: 4
+        Piercing: 29
+    armorPenetration: -0.525
+
+- type: entity
+  id: Bullet68x52mmCaselessRIP
+  parent: BaseBullet
+  name: bullet (6.8x52mm Caseless RIP)
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Slash: 6
+        Piercing: 35
+    armorPenetration: -0.8
+
+#armor-piercing:
+
+- type: entity
+  id: Bullet68x52mmCaselessPlasteelAP
+  parent: BaseBullet
+  name: bullet (6.8x52mm Caseless AP)
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 11
+        Structural: 35
+    armorPenetration: 0.65

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_68x52mm.yml
@@ -6,6 +6,11 @@
   result: Magazine68x52mmCaseless
 
 - type: latheRecipe
+  parent: BaseAmmoPlasteelAPIntermediateMagazineRecipe
+  id: Magazine68x52mmPlasteelAP
+  result: Magazine68x52mmPlasteelAP
+
+- type: latheRecipe
   parent: BaseAmmoRubberIntermediateMagazineRecipe
   id: Magazine68x52mmRubber
   result: Magazine68x52mmCaselessRubber
@@ -20,12 +25,27 @@
   id: Magazine68x52mmEmpty
   result: Magazine68x52mmCaselessEmpty
 
+- type: latheRecipe
+  parent: BaseAmmoHPIntermediateMagazineRecipe
+  id: Magazine68x52mmHP
+  result: Magazine68x52mmHP
+
+- type: latheRecipe
+  parent: BaseAmmoRIPIntermediateMagazineRecipe
+  id: Magazine68x52mmRIP
+  result: Magazine68x52mmRIP
+
 #Boxes
 
 - type: latheRecipe
   parent: BaseAmmoFMJIntermediateAmmoBoxRecipe
   id: AmmoBox68x52mmFMJ
   result: AmmoBox68x52mmCaseless
+
+- type: latheRecipe
+  parent: BaseAmmoPlasteelAPIntermediateAmmoBoxRecipe
+  id: AmmoBox68x52mmPlasteelAP
+  result: AmmoBox68x52mmPlasteelAP
 
 - type: latheRecipe
   parent: BaseAmmoRubberIntermediateAmmoBoxRecipe
@@ -36,6 +56,16 @@
   parent: BaseAmmoPracticeIntermediateAmmoBoxRecipe
   id: AmmoBox68x52mmPractice
   result: AmmoBox68x52mmCaselessPractice
+
+- type: latheRecipe
+  parent: BaseAmmoHPIntermediateAmmoBoxRecipe
+  id: AmmoBox68x52mmHP
+  result: AmmoBox68x52mmHP
+
+- type: latheRecipe
+  parent: BaseAmmoRIPIntermediateAmmoBoxRecipe
+  id: AmmoBox68x52mmRIP
+  result: AmmoBox68x52mmRIP
 
 #big box
 - type: latheRecipe

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_68x52mm.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Ammo/Intermediate_68x52mm.yml
@@ -8,7 +8,7 @@
 - type: latheRecipe
   parent: BaseAmmoPlasteelAPIntermediateMagazineRecipe
   id: Magazine68x52mmPlasteelAP
-  result: Magazine68x52mmPlasteelAP
+  result: Magazine68x52mmCaselessPlasteelAP
 
 - type: latheRecipe
   parent: BaseAmmoRubberIntermediateMagazineRecipe
@@ -28,12 +28,12 @@
 - type: latheRecipe
   parent: BaseAmmoHPIntermediateMagazineRecipe
   id: Magazine68x52mmHP
-  result: Magazine68x52mmHP
+  result: Magazine68x52mmCaselessHP
 
 - type: latheRecipe
   parent: BaseAmmoRIPIntermediateMagazineRecipe
   id: Magazine68x52mmRIP
-  result: Magazine68x52mmRIP
+  result: Magazine68x52mmCaselessRIP
 
 #Boxes
 
@@ -45,7 +45,7 @@
 - type: latheRecipe
   parent: BaseAmmoPlasteelAPIntermediateAmmoBoxRecipe
   id: AmmoBox68x52mmPlasteelAP
-  result: AmmoBox68x52mmPlasteelAP
+  result: AmmoBox68x52mmCaselessPlasteelAP
 
 - type: latheRecipe
   parent: BaseAmmoRubberIntermediateAmmoBoxRecipe
@@ -60,12 +60,12 @@
 - type: latheRecipe
   parent: BaseAmmoHPIntermediateAmmoBoxRecipe
   id: AmmoBox68x52mmHP
-  result: AmmoBox68x52mmHP
+  result: AmmoBox68x52mmCaselessHP
 
 - type: latheRecipe
   parent: BaseAmmoRIPIntermediateAmmoBoxRecipe
   id: AmmoBox68x52mmRIP
-  result: AmmoBox68x52mmRIP
+  result: AmmoBox68x52mmCaselessRIP
 
 #big box
 - type: latheRecipe

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
@@ -504,6 +504,8 @@
   - AmmoBox762x39mmPlasteelAP
   - Magazine45_magnumPistolPlasteelAP
   - AmmoBox45_magnumPlasteelAP
+  - Magazine68x52mmPlasteelAP
+  - AmmoBox68x52mmPlasteelAP
   - SpeedLoader45_magnumPlasteelAP
   - Magazine46x30mmPistolPlasteelAP
   - Magazine46x30mmSubMachineGunPlasteelAP
@@ -537,6 +539,8 @@
   - Magazine45_magnumPistolHP
   - SpeedLoader45_magnumHP
   - AmmoBox45_magnumHP
+  - Magazine68x52mmHP
+  - AmmoBox68x52mmHP
   - Magazine46x30mmPistolHP
   - Magazine46x30mmSubMachineGunHP
   - AmmoBox46x30mmHP
@@ -566,6 +570,8 @@
   - Magazine45_magnumPistolRIP
   - SpeedLoader45_magnumRIP
   - AmmoBox45_magnumRIP
+  - Magazine68x52mmPlasteelRIP
+  - AmmoBox68x52mmPlasteelRIP
   - Magazine46x30mmPistolRIP
   - Magazine46x30mmSubMachineGunRIP
   - AmmoBox46x30mmRIP
@@ -756,6 +762,8 @@
   - Magazine45_ACPPistolHP
   - Magazine45_ACPSubMachineGunHP
   - AmmoBox45_ACPHP
+  - Magazine68x52mmHP
+  - AmmoBox68x52mmHP
 
 # Energy
   - Magazine700Thz
@@ -846,6 +854,8 @@
   - Magazine45_magnumPistolPlasteelAP
   - AmmoBox45_magnumPlasteelAP
   - SpeedLoader45_magnumPlasteelAP
+  - Magazine68x52mmPlasteelAP
+  - AmmoBox68x52mmPlasteelAP
   - Magazine46x30mmPistolPlasteelAP
   - Magazine46x30mmSubMachineGunPlasteelAP
   - AmmoBox46x30mmPlasteelAP
@@ -881,6 +891,8 @@
   - Magazine45_magnumPistolRIP
   - SpeedLoader45_magnumRIP
   - AmmoBox45_magnumRIP
+  - Magazine68x52mmRIP
+  - AmmoBox68x52mmRIP
   - Magazine46x30mmPistolRIP
   - Magazine46x30mmSubMachineGunRIP
   - AmmoBox46x30mmRIP
@@ -920,7 +932,7 @@
   - AmmoBox10Phz
   - LargePowerCell400Thz
   - LargePowerCell700Thz
-  
+
 #Big Ammo Boxes
   - AmmoBox762x39mmBigFMJ
   - AmmoBox762x51mmBigFMJ

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/ammo.yml
@@ -570,8 +570,8 @@
   - Magazine45_magnumPistolRIP
   - SpeedLoader45_magnumRIP
   - AmmoBox45_magnumRIP
-  - Magazine68x52mmPlasteelRIP
-  - AmmoBox68x52mmPlasteelRIP
+  - Magazine68x52mmRIP
+  - AmmoBox68x52mmRIP
   - Magazine46x30mmPistolRIP
   - Magazine46x30mmSubMachineGunRIP
   - AmmoBox46x30mmRIP

--- a/Resources/Prototypes/_Mono/Research/Universal/smallarms.yml
+++ b/Resources/Prototypes/_Mono/Research/Universal/smallarms.yml
@@ -20,6 +20,8 @@
   - Magazine45_magnumPistolPlasteelAP
   - AmmoBox45_magnumPlasteelAP
   - SpeedLoader45_magnumPlasteelAP
+  - Magazine68x52mmPlasteelAP
+  - AmmoBox68x52mmPlasteelAP
   - Magazine46x30mmPistolPlasteelAP
   - Magazine46x30mmSubMachineGunPlasteelAP
   - AmmoBox46x30mmPlasteelAP
@@ -100,6 +102,8 @@
   - Magazine45_magnumPistolRIP
   - SpeedLoader45_magnumRIP
   - AmmoBox45_magnumRIP
+  - Magazine68x52mmRIP
+  - AmmoBox68x52mmRIP
   - Magazine46x30mmPistolRIP
   - Magazine46x30mmSubMachineGunRIP
   - AmmoBox46x30mmRIP


### PR DESCRIPTION
## About the PR
Adds Mono AP system ammo variants for 6.8x52mm

## Why / Balance
Consistency w/ other ammo types
Based off 5.56x45mm stats w/ slightly more damage & slightly less pen.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added AP/HP/RIP for 6.8x52mm finally.