### PR TITLE
Fix Not Being Able to Unassign Normal Deeds

### DIFF
--- a/Content.Server/_NF/Shipyard/Components/ShipyardVoucherComponent.cs
+++ b/Content.Server/_NF/Shipyard/Components/ShipyardVoucherComponent.cs
@@ -60,4 +60,10 @@ public sealed partial class ShipyardVoucherComponent : Component
     /// </summary>
     [DataField, AutoPausedField]
     public TimeSpan NextBuyAt = TimeSpan.FromSeconds(0);
+
+    /// <summary>
+    ///     Mono: Whether this voucher is allowed to have its deed unassigned.
+    /// </summary>
+    [DataField]
+    public bool CanBeUnassigned = true;
 }

--- a/Content.Server/_NF/Shipyard/Components/ShipyardVoucherComponent.cs
+++ b/Content.Server/_NF/Shipyard/Components/ShipyardVoucherComponent.cs
@@ -60,10 +60,4 @@ public sealed partial class ShipyardVoucherComponent : Component
     /// </summary>
     [DataField, AutoPausedField]
     public TimeSpan NextBuyAt = TimeSpan.FromSeconds(0);
-
-    /// <summary>
-    ///     Mono: Whether this voucher is allowed to have its deed unassigned.
-    /// </summary>
-    [DataField]
-    public bool CanBeUnassigned = true;
 }

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -1102,7 +1102,7 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
-        if (!TryComp<ShipyardVoucherComponent>(targetId, out var voucher) || voucher.CanBeUnassigned != true) // Mono: If voucher is not allowed to unassign deeds, fail.
+        if (TryComp<ShipyardVoucherComponent>(targetId, out var voucher) && voucher.CanBeUnassigned != true) // Mono: If voucher is not allowed to unassign deeds, fail.
         {
             ConsolePopup(player, Loc.GetString("shipyard-console-no-unassign"));
             PlayDenySound(player, uid, component);

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -1102,6 +1102,13 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
+        if (!TryComp<ShipyardVoucherComponent>(targetId, out var voucher) || voucher.CanBeUnassigned != true) // Mono: If voucher is not allowed to unassign deeds, fail.
+        {
+            ConsolePopup(player, Loc.GetString("shipyard-console-no-unassign"));
+            PlayDenySound(player, uid, component);
+            return;
+        } // end mono
+
         // Check if the player is on cooldown
         var cooldown = EnsureComp<ShipyardUnassignCooldownComponent>(player);
         var currentTime = _timing.CurTime;

--- a/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
+++ b/Content.Server/_NF/Shipyard/Systems/ShipyardSystem.Consoles.cs
@@ -1102,13 +1102,6 @@ public sealed partial class ShipyardSystem : SharedShipyardSystem
             return;
         }
 
-        if (!TryComp<ShipyardVoucherComponent>(targetId, out var voucher) || voucher.CanBeUnassigned != true) // Mono: If voucher is not allowed to unassign deeds, fail.
-        {
-            ConsolePopup(player, Loc.GetString("shipyard-console-no-unassign"));
-            PlayDenySound(player, uid, component);
-            return;
-        } // end mono
-
         // Check if the player is on cooldown
         var cooldown = EnsureComp<ShipyardUnassignCooldownComponent>(player);
         var currentTime = _timing.CurTime;

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
@@ -10,7 +10,6 @@
     sprite: _Mono/Objects/Misc/newlpc.rsi
     state: icon
   - type: ShipyardVoucher
-    canBeUnassigned: false
     destroyOnEmpty: false
     cooldown: 1800 # thirty minutes
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
@@ -10,6 +10,7 @@
     sprite: _Mono/Objects/Misc/newlpc.rsi
     state: icon
   - type: ShipyardVoucher
+    canBeUnassigned: false
     destroyOnEmpty: false
     cooldown: 1800 # thirty minutes
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Tried to make LPCs not be able to unassign their deeds, but this bled into normal deeds (EVEN THOUGH IT WORKED IN TESTING...) so reverting
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
broken
shouldn't make LPCs unbalanced but whatever its a test merge
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="500" height="119" alt="image" src="https://github.com/user-attachments/assets/d06e2ce2-7805-4103-96b4-23795611d92a" />
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- fix: Fixed deeds not being able to unassign ships.
