### PR TITLE
Cherrypicks some Nix-Related Commits From Wizard's Den

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737097711,
-        "narHash": "sha256-Zql7TDxEMAOASLSu0wBlfM5SIY+4Pz2R/k17O/asCYc=",
+        "lastModified": 1765890948,
+        "narHash": "sha256-Xe6fZzDS8uy9f17Pv6NEeBS9R6MFyuepbQUy6Xq/wH0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3cbc78cfa611511c04f47c4932509f9dbdf4381a",
+        "rev": "f92e917d0cefd3eca9d56ae25d689da841a989fd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.11",
+        "ref": "release-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,22 @@
 {
   description = "Development environment for Space Station 14";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      devShells.default = import ./shell.nix { inherit pkgs; };
-    });
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = import ./shell.nix { inherit pkgs; };
+      }
+    );
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,16 +1,20 @@
-{ pkgs ? (let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-in import (builtins.fetchTarball {
-  url =
-    "https://github.com/NixOS/nixpkgs/archive/${lock.nodes.nixpkgs.locked.rev}.tar.gz";
-  sha256 = lock.nodes.nixpkgs.locked.narHash;
-}) { }) }:
+{
+  pkgs ? (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/${lock.nodes.nixpkgs.locked.rev}.tar.gz";
+      sha256 = lock.nodes.nixpkgs.locked.narHash;
+    }) { }
+  ),
+}:
 
 let
   dependencies = with pkgs; [
     dotnetCorePackages.sdk_9_0
     icu
     glfw
-    SDL2
     libGL
     openal
     freetype
@@ -43,8 +47,11 @@ let
     at-spi2-core
     cups
     python3
+    wayland
+    nixfmt
   ];
-in pkgs.mkShell {
+in
+pkgs.mkShell {
   name = "space-station-14-devshell";
   buildInputs = [ pkgs.gtk3 ];
   packages = dependencies;

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,7 @@
 
 let
   dependencies = with pkgs; [
-    dotnetCorePackages.sdk_9_0
+    dotnet-sdk_10
     icu
     glfw
     libGL

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,7 @@ let
     libGL
     openal
     freetype
+    fontconfig
     fluidsynth
     soundfont-fluid
     gtk3
@@ -43,6 +44,7 @@ let
     xorg.libxshmfence
     mesa
     alsa-lib
+    pipewire
     dbus
     at-spi2-core
     cups


### PR DESCRIPTION
## About the PR
This PR cherrypicks all Nix-related commits from Wizard's Den. This fixes the SDK mismatch in `shell.nix` and... maybe some other problems I don't know. I don't understand the reasoning behind most of these changes, only that they are probably important

This is my first PR to Monolith, I believe. I'm on the Discord with the username `_mnva_`
I hope I did everything right

## Why / Balance
This is a bugfix for Nix support

`dotnetCorePackages.sdk_9_0` does not give version 10 of the SDK, which makes it yell at you when attempting to build using the shell

## Media
I load in fine after these changes
<img width="349" height="240" alt="image" src="https://github.com/user-attachments/assets/5f5ffb1d-2fd3-4723-926d-685bfdfeaa44" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
1. `nix-shell` or equivalent
2. `dotnet build`. You don't get a big warning yelling at you about the SDK version
3. Start a server. Join in for good measure. Everything should work