### PR TITLE
Make Credits Moth-Edible

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -65,6 +65,29 @@
   - type: ShipyardSellCondition # Frontier: Teleport to shipyard console on sale
     preserveOnSale: true
 
+  # Moths can eat credits #
+  - type: Food
+    solution: food
+    delay: 0.5
+    forceFeedDelay: 0.5
+    requiresSpecialDigestion: true
+  - type: FlavorProfile
+    flavors:
+    - paper
+  - type: BadFood
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 1
+  - type: Tag
+    tags:
+    - ClothMade
+    - Paper
+  - type: MothFood
+
 - type: material
   id: Credit
   name: credit


### PR DESCRIPTION
## About the PR
Added food, mothfood, and badfood components to space_cash.yml to make credits moth-edible. 

## Why / Balance
We need more reasons to hate moths.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x ] I have added media to this PR or it does not require an ingame showcase.
- [ x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Pick up credits as a moth and press z. Tested locally on moths, working as intended. Not edible by humans.

## Breaking changes
None

**Changelog**

:cl:
- add: Moths eat your spessos

-->
