### PR TITLE
Research Tech Position Test Mogging

### DIFF
--- a/Content.IntegrationTests/Tests/_NF/TechnologyTreeTests.cs
+++ b/Content.IntegrationTests/Tests/_NF/TechnologyTreeTests.cs
@@ -16,7 +16,7 @@ public sealed class TechnologyTreeTests
 
         var protoManager = server.ResolveDependency<IPrototypeManager>();
 
-        Dictionary<Vector2i, string> techNamesByPosition = new();
+        // Dictionary<Vector2i, string> techNamesByPosition = new(); // Mono: Commented out since duplicate-position techs are normal (we hide techs if the server can't research them)
 
         await server.WaitPost(() =>
         {
@@ -24,8 +24,8 @@ public sealed class TechnologyTreeTests
             {
                 foreach (var tech in protoManager.EnumeratePrototypes<TechnologyPrototype>())
                 {
-                    Assert.That(techNamesByPosition.TryGetValue(tech.Position, out var techName), Is.False, $"Tech {tech.ID} has a duplicate position {tech.Position} with {techName}.");
-                    techNamesByPosition[tech.Position] = tech.ID;
+                    //Assert.That(techNamesByPosition.TryGetValue(tech.Position, out var techName), Is.False, $"Tech {tech.ID} has a duplicate position {tech.Position} with {techName}."); // Mono: Commented out since duplicate-position techs are normal (we hide techs if the server can't research them)
+                    //techNamesByPosition[tech.Position] = tech.ID;
 
                     foreach (var recipe in tech.RecipeUnlocks)
                     {


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Comments out the tech tree test that checks if researches have duplicate positions on the tech tree.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Since we hide techs that a server cannot research, faction techs can overlap for less confusion between factions. This test screams when we do that which is mean, so I shot it in the back of the head.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
not player facing
