### PR TITLE
Viewport Bounds Check for Shield Drawing

### DIFF
--- a/Content.Client/_Crescent/ShipShields/ShipShieldOverlay.cs
+++ b/Content.Client/_Crescent/ShipShields/ShipShieldOverlay.cs
@@ -16,7 +16,6 @@ namespace Content.Client._Crescent.ShipShields;
 
 public sealed class ShipShieldOverlay : Overlay
 {
-    [Dependency] private readonly SharedTransformSystem _transform = default!;
     private readonly FixtureSystem _fixture;
     private readonly SharedPhysicsSystem _physics;
     private readonly IResourceCache _resourceCache;

--- a/Content.Client/_Crescent/ShipShields/ShipShieldOverlay.cs
+++ b/Content.Client/_Crescent/ShipShields/ShipShieldOverlay.cs
@@ -10,11 +10,13 @@ using Content.Client.Resources;
 using Robust.Client.Physics;
 using Robust.Shared.Prototypes;
 using System.Runtime.InteropServices;
+using Robust.Client.GameObjects;
 
 namespace Content.Client._Crescent.ShipShields;
 
 public sealed class ShipShieldOverlay : Overlay
 {
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
     private readonly FixtureSystem _fixture;
     private readonly SharedPhysicsSystem _physics;
     private readonly IResourceCache _resourceCache;
@@ -22,6 +24,7 @@ public sealed class ShipShieldOverlay : Overlay
     private readonly ShaderInstance _unshadedShader;
     private readonly List<DrawVertexUV2D> _verts = new(128); // Mono
     private readonly Texture _shieldTexture;
+    private readonly Box2 _bounds = new(-16, -16, 16, 16);
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowWorld;
 
@@ -51,7 +54,8 @@ public sealed class ShipShieldOverlay : Overlay
             if (xform.MapID != args.MapId)
                 continue;
 
-            // TODO: We can probably at least test its parent grid is in PVS range...?
+            if (!_bounds.Contains(_transform.GetWorldPosition(xform)))
+                continue;
 
             var fixture = _fixture.GetFixtureOrNull(uid, "shield", fixtures);
 

--- a/Content.Client/_Crescent/ShipShields/ShipShieldOverlay.cs
+++ b/Content.Client/_Crescent/ShipShields/ShipShieldOverlay.cs
@@ -24,7 +24,6 @@ public sealed class ShipShieldOverlay : Overlay
     private readonly ShaderInstance _unshadedShader;
     private readonly List<DrawVertexUV2D> _verts = new(128); // Mono
     private readonly Texture _shieldTexture;
-    private readonly Box2 _bounds = new(-16, -16, 16, 16);
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowWorld;
 
@@ -54,34 +53,40 @@ public sealed class ShipShieldOverlay : Overlay
             if (xform.MapID != args.MapId)
                 continue;
 
-            if (!_bounds.Contains(_transform.GetWorldPosition(xform)))
-                continue;
-
             var fixture = _fixture.GetFixtureOrNull(uid, "shield", fixtures);
 
             if (fixture is not { Shape: ChainShape chain })
                 continue;
 
-            DrawShield(handle, uid, chain, xform, _shieldTexture, visuals.ShieldColor, _verts);
+            // Mono: No need to draw the shield locally if its out of range.
+            var transform = _physics.GetPhysicsTransform(uid, xform);
+            var worldBounds = new Box2();
+            foreach (var vertex in chain.Vertices)
+            {
+                var worldPos = VertexToWorldPos(vertex, transform);
+                worldBounds = worldBounds.ExtendToContain(worldPos);
+            }
+            if (!args.WorldAABB.Intersects(worldBounds))
+                continue;
+
+            DrawShield(handle, chain, transform, _shieldTexture, visuals.ShieldColor, _verts);
             _verts.Clear(); // Clear for next shield - Mono
         }
     }
 
     private void DrawShield(
         DrawingHandleWorld handle,
-        EntityUid uid,
         ChainShape chain,
-        TransformComponent xform,
+        Transform transform,
         Texture tex,
         Color color,
         List<DrawVertexUV2D> verts)
     {
         // The vertices of this fixture are defined relative to local position,
         // so we'll have to add them to this and then use the matrix to put them back in world position.
-        var localPos = xform.LocalPosition;
-
         // If "Transforms" ever get deprecated go ahead and check how DebugPHysicsSystem is drawing chains in this hellworld future
-        var transform = _physics.GetPhysicsTransform(uid);
+
+        // Mono Update: Just use transform.Position for world position already for corners
 
         for (int i = 1; i < chain.Count; i++)
         {
@@ -92,10 +97,10 @@ public sealed class ShipShieldOverlay : Overlay
             var rightVertex = VertexToWorldPos(chain.Vertices[i], transform);
 
             // bottom left corner
-            var leftCorner = Corner(localPos, leftVertex, transform);
+            var leftCorner = Corner(leftVertex, transform);
 
             // bottom right corner
-            var rightCorner = Corner(localPos, rightVertex, transform);
+            var rightCorner = Corner(rightVertex, transform);
 
             // Assemble 2 triangles.
 
@@ -118,10 +123,9 @@ public sealed class ShipShieldOverlay : Overlay
         return Transform.Mul(transform, vertexPos);
     }
 
-    private static Vector2 Corner(Vector2 localPos, Vector2 vertexPos, Transform transform, float radius = 1.3f)
+    private static Vector2 Corner(Vector2 vertexPos, Transform transform, float radius = 1.3f)
     {
-        var localXform = Transform.Mul(transform, localPos);
-        var cornerPos = Vector2.Subtract(vertexPos, localXform);
+        var cornerPos = Vector2.Subtract(vertexPos, transform.Position);
         cornerPos.Normalize();
         cornerPos *= radius;
 


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Checks to see if the shield is in range so the client doesn't spend effort drawing shields outside of its viewport range. Also updates the code a bit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Mild optimization.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

not player facing

