### PR TITLE
Adaptive Raycasting

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -1,20 +1,13 @@
 using Content.Server.Destructible;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
-using Content.Shared.Physics;
 using Content.Shared.Projectiles;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics; // Mono;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
-using System.Linq;
-using System.Numerics;
-using Content.Server.Gatherable.Components;
-using Robust.Shared.Configuration;
-using Content.Shared._Mono.CCVar;
 
 namespace Content.Server.Projectiles;
 
@@ -22,21 +15,13 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 {
     [Dependency] private readonly DestructibleSystem _destructibleSystem = default!;
 
-    [Dependency] private readonly IMapManager _mapMan = default!; // Mono
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
-    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     // <Mono>
     private EntityQuery<PhysicsComponent> _physQuery;
     private EntityQuery<FixturesComponent> _fixQuery;
 
-    /// <summary>
-    /// Minimum velocity for a projectile to be considered for raycast hit detection.
-    /// Projectiles slower than this will rely on standard StartCollideEvent.
-    /// </summary>
-    private float _minRaycastVelocity;
-    private bool _adaptiveRaycasting;
 
     public override void Initialize()
     {
@@ -65,7 +50,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             damageRequired -= damageableComponent.TotalDamage;
             damageRequired = FixedPoint2.Max(damageRequired, FixedPoint2.Zero);
         }
-        var deleted = Deleted(target);
+        // var deleted = Deleted(target); // Mono: Unused
 
         // Call base implementation to handle damage application and other effects
         var modifiedDamage = base.ProjectileCollide(projectile, target, collisionCoordinates, predicted);

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -13,6 +13,8 @@ using Robust.Shared.Physics.Systems;
 using System.Linq;
 using System.Numerics;
 using Content.Server.Gatherable.Components;
+using Robust.Shared.Configuration;
+using Content.Shared._Mono.CCVar;
 
 namespace Content.Server.Projectiles;
 
@@ -23,6 +25,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
     [Dependency] private readonly IMapManager _mapMan = default!; // Mono
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     // <Mono>
     private EntityQuery<PhysicsComponent> _physQuery;
@@ -32,8 +35,8 @@ public sealed class ProjectileSystem : SharedProjectileSystem
     /// Minimum velocity for a projectile to be considered for raycast hit detection.
     /// Projectiles slower than this will rely on standard StartCollideEvent.
     /// </summary>
-    private const float MinRaycastVelocity = 75f;
-    // </Mono>
+    private float _minRaycastVelocity;
+    private bool _adaptiveRaycasting;
 
     public override void Initialize()
     {
@@ -42,7 +45,6 @@ public sealed class ProjectileSystem : SharedProjectileSystem
         // Mono
         _physQuery = GetEntityQuery<PhysicsComponent>();
         _fixQuery = GetEntityQuery<FixturesComponent>();
-
         // Mono
         UpdatesBefore.Add(typeof(SharedPhysicsSystem));
     }
@@ -150,7 +152,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             var xform = Transform(uid);
             var currentVelocity = projectileComp.RaycastResetVelocity ?? _physics.GetMapLinearVelocity(uid, physicsComp, xform);
             var velLen = currentVelocity.Length();
-            if (velLen < MinRaycastVelocity && projectileComp.RaycastResetVelocity == null)
+            if (!ShouldRaycastProjectile(velLen) && projectileComp.RaycastResetVelocity == null)
                 continue;
 
             var lastMap = _transformSystem.GetMapCoordinates(xform);

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -122,9 +122,9 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     // Mono
     public bool ShouldRaycastProjectile(float speed)
     {
-        if (_adaptiveRaycasting && speed >= _minRaycastVelocity * (_physicsTickrate / BasePhysicsTickrate))
+        if (_adaptiveRaycasting && speed > _minRaycastVelocity * (_physicsTickrate / BasePhysicsTickrate))
             return true;
-        else if (speed >= _minRaycastVelocity)
+        else if (speed > _minRaycastVelocity)
             return true;
 
         return false;

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -70,7 +70,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     private float _minRaycastVelocity; // Mono
     private bool _adaptiveRaycasting; // Mono
     private const int BasePhysicsTickrate = 60; // Mono
-    private int _physicsTickrate;
+    private int _physicsTickrate; // Mono
 
     public override void Initialize()
     {
@@ -96,6 +96,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         Subs.CVar(_cfg, MonoCVars.ProjectileRaycastSpeedThreshold, value => _minRaycastVelocity = value, true);
         Subs.CVar(_cfg, MonoCVars.ProjectileAdaptiveRaycastThreshold, value => _adaptiveRaycasting = value, true);
         Subs.CVar(_cfg, CVars.TargetMinimumTickrate, value => _physicsTickrate = value, true);
+        // Mono End
     }
 
     /// <summary>
@@ -119,7 +120,11 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         EnsureComp<MetaDataComponent>(uid);
     }
 
-    // Mono
+    /// <summary>
+    /// Mono: Handles whether a projectile is raycasted based off projectile speed.
+    /// </summary>
+    /// <param name="speed"></param>
+    /// <returns></returns>
     public bool ShouldRaycastProjectile(float speed)
     {
         if (_adaptiveRaycasting && speed > _minRaycastVelocity * (_physicsTickrate / BasePhysicsTickrate))

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -33,6 +33,9 @@ using System.Collections.Concurrent;
 using Robust.Shared.Timing;
 using Content.Shared._Mono;
 using Content.Shared.Tag;
+using Robust.Shared.Configuration;
+using Content.Shared._Mono.CCVar;
+using Robust.Shared;
 
 namespace Content.Shared.Projectiles;
 
@@ -54,6 +57,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     [Dependency] private readonly IParallelManager _parallel = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // Mono
 
     // Cache of projectiles waiting for collision checks
     private readonly ConcurrentQueue<(EntityUid Uid, ProjectileComponent Component, EntityUid Target)> _pendingCollisionChecks = new();
@@ -62,6 +66,11 @@ public abstract partial class SharedProjectileSystem : EntitySystem
     private const int ProjectileBatchSize = 16;
     private TimeSpan _lastBatchProcess;
     private readonly TimeSpan _processingInterval = TimeSpan.FromMilliseconds(16); // ~60Hz
+
+    private float _minRaycastVelocity; // Mono
+    private bool _adaptiveRaycasting; // Mono
+    private const int BasePhysicsTickrate = 60; // Mono
+    private int _physicsTickrate;
 
     public override void Initialize()
     {
@@ -83,6 +92,10 @@ public abstract partial class SharedProjectileSystem : EntitySystem
 
         // Mono
         SubscribeLocalEvent<ProjectileComponent, TileFrictionEvent>(OnTileFriction);
+
+        Subs.CVar(_cfg, MonoCVars.ProjectileRaycastSpeedThreshold, value => _minRaycastVelocity = value, true);
+        Subs.CVar(_cfg, MonoCVars.ProjectileAdaptiveRaycastThreshold, value => _adaptiveRaycasting = value, true);
+        Subs.CVar(_cfg, CVars.TargetMinimumTickrate, value => _physicsTickrate = value, true);
     }
 
     /// <summary>
@@ -104,6 +117,17 @@ public abstract partial class SharedProjectileSystem : EntitySystem
             return;
 
         EnsureComp<MetaDataComponent>(uid);
+    }
+
+    // Mono
+    public bool ShouldRaycastProjectile(float speed)
+    {
+        if (_adaptiveRaycasting && speed >= _minRaycastVelocity * (_physicsTickrate / BasePhysicsTickrate))
+            return true;
+        else if (speed >= _minRaycastVelocity)
+            return true;
+
+        return false;
     }
 
     private void OnStartCollide(EntityUid uid, ProjectileComponent component, ref StartCollideEvent args)

--- a/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
+++ b/Content.Shared/_Mono/CCVar/CCVars.Mono.cs
@@ -182,6 +182,24 @@ public sealed partial class MonoCVars
 
     #endregion
 
+    #region Projectile Raycasting
+
+    /// <summary>
+    ///     Speed threshold for projectiles to be calculated by raycast instead of normal collision.
+    /// </summary>
+    public static readonly CVarDef<float> ProjectileRaycastSpeedThreshold =
+        CVarDef.Create("mono.projectile.raycast_speed_threshold", 75f, CVar.ARCHIVE | CVar.REPLICATED);
+
+    /// <summary>
+    ///     Do we automatically adapt our raycast threshold based off the set tickrate?
+    ///     I.e. half the tickrate would mean a halved speed threshold.
+    ///     Should probably be disabled for replays, if we ever have them.
+    /// </summary>
+    public static readonly CVarDef<bool> ProjectileAdaptiveRaycastThreshold =
+        CVarDef.Create("mono.projectile.adaptive_raycast_threshold", true, CVar.ARCHIVE | CVar.REPLICATED);
+
+    #endregion
+
     #region Misc
 
     public static readonly CVarDef<bool> CompanyWhitelist =


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

implements projectile raycasting speed threshold as a CVar

implements adaptive raycasting CVar, if true, will raycast lower/raise speed projectiles to account for lowered physics tickrate CVar based off the tickrate ratio. By default set to true.

cleans up unused stuff

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Should fix projectiles clipping through walls.

If too laggy, just disable via CVar.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Projectiles are now adapted for lower tickrates, and don't phase.
