### PR TITLE
Revert "Draupnir Nerf (#3960)"

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlight_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/standardlight_kinetic.yml
@@ -113,12 +113,6 @@
     ports:
     - Toggle
   - type: Gun
-    selectedMode: Burst
-    availableModes:
-    - Burst
-    burstFireRate: 25
-    shotsPerBurst: 25
-    burstCooldown: 3
     fireRate: 25
     recoil: 5 # 1/5x
     projectileSpeed: 180


### PR DESCRIPTION
## About the PR
i don't think it was at all needed, the changes kinda make it useless
draupnir was already okay, if you consider that it has terrible accuracy and range
plus the test shown in the PR showcases it being used in perfect conditions and still struggling; also, 4 of any other, even small, shipgun firing at one spot will shred it
i don't think draupnir at all needs a nerf, it's okay considering its hitrate and general spread in combat
however, there is an issue, but the issue is that mappers overuse draupnir, not that it's too strong

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reverted draupnir nerf.
