### PR TITLE
USSP Language Implanter Fix

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Objects/Misc/translator_implanters.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Objects/Misc/translator_implanters.yml
@@ -126,14 +126,6 @@
   - type: Implanter
     implant: MarishTranslatorImplant
 
-- type: entity # Mono
-  id: NovaCygniTranslatorImplanter
-  parent: [ BaseTranslatorImplanter ]
-  name: Nova Cygni translator implant
-  components:
-  - type: Implanter
-    implant: NovaCygniTranslatorImplant
-
 - type: entity
   id: NewKinPidginTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Misc/translator_implanters.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Misc/translator_implanters.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: NovaCygniTranslatorImplanter
+  parent: [ BaseTranslatorImplanter ]
+  name: nova cygni translator implanter
+  components:
+  - type: Implanter
+    implant: NovaCygniTranslatorImplant
+
+- type: entity
+  id: GaryTranslatorImplanter
+  parent: [ BaseTranslatorImplanter ]
+  name: gary translator implanter
+  components:
+  - type: Implanter
+    implant: GaryTranslatorImplant

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/translator_implants.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/translator_implants.yml
@@ -16,7 +16,7 @@
 - type: entity
   parent: BaseSubdermalImplant
   id: NovaCygniTranslatorImplant
-  name: NovaCygni translator implant
+  name: nova cygni translator implant
   description: An implant that helps you speak and understand the language of the USSP.
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/language.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/language.yml
@@ -22,7 +22,7 @@
 # Implanters
 - type: latheRecipe
   id: GaryTranslatorImplanter
-  result: GaryTranslatorImplant
+  result: GaryTranslatorImplanter
   completetime: 2
   materials:
     Steel: 500
@@ -33,7 +33,7 @@
 
 - type: latheRecipe
   id: NovaCygniTranslatorImplanter
-  result: NovaCygniTranslatorImplant
+  result: NovaCygniTranslatorImplanter
   completetime: 2
   materials:
     Steel: 500


### PR DESCRIPTION
Fix to address https://discord.com/channels/1329292619834069034/1498004264830632026
Thanks to Hero_Swe for reporting this


## About the PR
Moved all Gary/USSP Language Implanters into Mono folders, implanters print correctly in Lathe now.

## Why / Balance
Makes USSP language implanters not useless

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Get a Prefac Language Tech Disk, print an implanter and jab yourself and speak space Russian.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: USSP Language Implanters now print correctly

