### PR TITLE
E-Shipgun Rebalance/Tweaks

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -598,13 +598,13 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 75000 # 20 seconds of constant fire, 400rock walls destroyed per full mag. 2-3 mining pulsars needed to equal its output.
-    startingCharge: 75000
+    maxCharge: 56250 # 20 seconds of constant fire, 375 rock walls destroyed per full mag. 5 mining pulsers needed to equal its output.
+    startingCharge: 56250
   - type: BatterySelfRecharger
     autoRechargePause: true
     autoRechargePauseTime: 30
     autoRecharge: true
-    autoRechargeRate: 75000
+    autoRechargeRate: 56250
   - type: FireControlRotate
   - type: ExaminableBattery
   - type: WirelessNetworkConnection

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -126,7 +126,7 @@
   - BallisticArtillery
   - BallisticArtilleryTier2HP
   suffix: Medium, T2
-  description: A rapidly firing energy weapon, dealing a large amount of damage to its targets. Takes a long time to recharge.
+  description: A rapidly firing energy weapon, well known for its devastating burst followed by a constant stream of plasma.
   components:
   - type: StaticPrice
     price: 4000
@@ -137,8 +137,8 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 15500
-    startingCharge: 15500
+    maxCharge: 18000
+    startingCharge: 18000
   - type: ExaminableBattery
   - type: WirelessNetworkConnection
     range: 500
@@ -155,7 +155,7 @@
       path: /Audio/Weapons/click.ogg
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 220
+    autoRechargeRate: 2250
   - type: SpaceArtillery
     powerChargeRate: 700
     powerUsePassive: 100
@@ -198,8 +198,8 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 40000
-    startingCharge: 40000
+    maxCharge: 2250 # 15 seconds of constant fire, 75 rock walls destroyed per full mag
+    startingCharge: 3000
   - type: ExaminableBattery
   - type: WirelessNetworkConnection
     range: 500
@@ -338,9 +338,9 @@
     maxAngle: 8
     fireRate: 1
     recoil: 10 # 2/5x
-    burstCooldown: 16
-    burstFireRate: 50
-    shotsPerBurst: 50
+    burstCooldown: 4;
+    burstFireRate: 100
+    shotsPerBurst: 100
     selectedMode: Burst
     availableModes: Burst
     shootThermalSignature: 500000 # ~5.6km with continuous fire
@@ -350,7 +350,7 @@
       path: /Audio/Weapons/click.ogg
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 300
+    autoRechargeRate: 30000
   - type: SpaceArtillery
     powerChargeRate: 700
     powerUsePassive: 100
@@ -486,7 +486,7 @@
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
-    fireRate: 20
+    fireRate: 15
     recoil: 0
     minAngle: 0
     maxAngle: 0
@@ -541,7 +541,7 @@
   - type: WirelessNetworkConnection
     range: 500
   - type: Gun
-    fireRate: 0.15
+    fireRate: 0.3
     recoil: 5
     minAngle: 0
     maxAngle: 0
@@ -551,7 +551,7 @@
     soundEmpty:
       path: /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
   - type: SpaceArtillery
-    powerChargeRate: 200
+    powerChargeRate: 20000
     powerUsePassive: 300
     powerUseActive: 0
   - type: FireControlRotate
@@ -598,8 +598,8 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 50000
-    startingCharge: 50000
+    maxCharge: 100000 # 10 seconds of constant fire, 200 rock walls destroyed per full mag
+    startingCharge: 100000
   - type: BatterySelfRecharger
     autoRechargePause: true
     autoRechargePauseTime: 30

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -598,8 +598,8 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 100000 # 10 seconds of constant fire, 200 rock walls destroyed per full mag
-    startingCharge: 100000
+    maxCharge: 150000 # 15 seconds of constant fire, 250 rock walls destroyed per full mag. 2-3 mining pulsars needed to equal its output.
+    startingCharge: 150000
   - type: BatterySelfRecharger
     autoRechargePause: true
     autoRechargePauseTime: 30

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -335,10 +335,10 @@
   - type: Gun
     projectileSpeed: 240
     minAngle: 0
-    maxAngle: 8
+    maxAngle: 6
     fireRate: 1
     recoil: 10 # 2/5x
-    burstCooldown: 4;
+    burstCooldown: 5.5
     burstFireRate: 100
     shotsPerBurst: 100
     selectedMode: Burst
@@ -598,13 +598,13 @@
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
-    maxCharge: 150000 # 15 seconds of constant fire, 250 rock walls destroyed per full mag. 2-3 mining pulsars needed to equal its output.
-    startingCharge: 150000
+    maxCharge: 75000 # 20 seconds of constant fire, 400rock walls destroyed per full mag. 2-3 mining pulsars needed to equal its output.
+    startingCharge: 75000
   - type: BatterySelfRecharger
     autoRechargePause: true
     autoRechargePauseTime: 30
     autoRecharge: true
-    autoRechargeRate: 50000
+    autoRechargeRate: 75000
   - type: FireControlRotate
   - type: ExaminableBattery
   - type: WirelessNetworkConnection


### PR DESCRIPTION

## About the PR
<!-- What did you change? --> Rebalanced nearly every E-shipgun


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
## Energy shipguns:
- almost all of them were outclassed by ballistic counterparts

## Mining shipguns:
- Apollo was outclassed in nearly every way compared to the humble mining pulser. 
(1GP cost, Craftable,Anchorable,abile to fire constantly for minutes at a time)
- Now 5 mining pulsers equal 1 Apollo 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Spawn in all shipguns and start testing.

- Scylla was tested againtst longbow, other shipguns were tested againtst cerberus
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Rebalanced almost every Energy/mining shipgun:

L-20 Apollo Mining Laser Cannon:
- Max charge 50000 --> 56250 (20 seconds of fire, 375 rock walls)

M25 mining pulser: 
- Max charge 40000 --> 2250 (15 secs of constant fire, 75 rock walls)

Type-54C plasma autopulser:
- Max charge 15500 --> 18000 (60 rounds)
- Recharge rate 220 --> 2250 (12 seconds for full reload, 5 RPS recharge)

TPC Scylla plasma impulse driver:
- Burst firerate: 50 --> 100
- Burst shot count 50 --> 100
- Burst cooldown 16 --> 5.5
- Max angle 8 --> 6

TPC Prometheus Laser Cannon: 
- Firerate 0.15 --> 0.3

L-1 Phalanx: 
- Firerate 20 --> 15

