### PR TITLE
Ban Mikusss From Contributing to IPC Code

### DIFF
--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -352,6 +352,7 @@
   chatMessages: ["chat-emote-msg-buzz"]
   whitelist: # Mono
     components:
+    - Silicon
     - BorgChassis
   chatTriggers:
     - buzzing

--- a/Resources/Prototypes/_EinsteinEngines/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Voice/speech_emote_sounds.yml
@@ -45,6 +45,8 @@
         variation: 0.125
     Beep: # normal
       path: /Audio/_EinsteinEngines/Voice/IPC/beep_2000.ogg
+    Boop:
+      path: /Audio/_EinsteinEngines/Voice/IPC/beep_500.ogg
     Buzz:
       path: /Audio/Machines/buzz-sigh.ogg
     Honk:

--- a/Resources/Prototypes/_EinsteinEngines/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Voice/speech_emotes.yml
@@ -11,7 +11,7 @@
   - sdeathgasp
 
 - type: emote
-  id: Whirr # uncategorized as it is generic - Mono, youre an idiot.
+  id: Whirr
   name: chat-emote-name-whirr
   category: Vocal
   chatMessages: [ whirrs ]
@@ -21,13 +21,14 @@
     - BorgChassis
   chatTriggers:
     - whirrs
+    - rattles
 
 - type: emote
   id: Boop
   name: chat-emote-name-boop
   category: Vocal
-  chatMessages: [ boops. ]
-  whitelist:
+  chatMessages: [ boops ]
+  whitelist: # Mono - IPC's, borgs, protogens
     components:
     - Silicon
     - BorgChassis


### PR DESCRIPTION
## About the PR
i fixed ipc emotes now WHERE THE FUCK IS MY MONEY

## Why / Balance
idiot contributes to code, another idiot reverts

## Media
no

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
already did

## Breaking changes
your bones will break

**Changelog**
:cl: router
- fix: IPCs can now boop and buzz. This was supposed to be possible all the time.