### PR TITLE
Shipyard UI Description Boxes Things Whatever

### DIFF
--- a/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml
+++ b/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml
@@ -1,8 +1,8 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
                            xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                            xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                           SetSize="640 600"
-                           MinSize="640 450">
+                           SetSize="640 680"
+                           Resizable="False">
     <PanelContainer VerticalExpand="True" HorizontalExpand="True" Margin="0 8 0 2">
         <PanelContainer.PanelOverride>
             <gfx:StyleBoxFlat BorderThickness="7" BorderColor="#252525" BackgroundColor="#3d474d"/>

--- a/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml.cs
+++ b/Content.Client/_NF/Shipyard/UI/ShipyardConsoleMenu.xaml.cs
@@ -166,6 +166,7 @@ public sealed partial class ShipyardConsoleMenu : FancyWindow
             {
                 Vessel = prototype,
                 VesselName = { Text = prototype!.Name },
+                VesselDescription = { Text = prototype!.Description }, // Mono
                 Purchase = { Text = Loc.GetString("shipyard-console-purchase-available"), Disabled = !canPurchase },
                 Guidebook = { Disabled = prototype.GuidebookPage is null, TooltipDelay = 0.2f, ToolTip = prototype.Description },
                 Price = { Text = priceText },

--- a/Content.Client/_NF/Shipyard/UI/VesselRow.xaml
+++ b/Content.Client/_NF/Shipyard/UI/VesselRow.xaml
@@ -1,12 +1,17 @@
 <PanelContainer xmlns="https://spacestation14.io"
                 xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                 xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
-                HorizontalExpand="True">
+                HorizontalExpand="True"
+                SetHeight="130"
+                MaxWidth="590">
     <PanelContainer.PanelOverride>
         <gfx:StyleBoxFlat BorderThickness="3" BorderColor="#101010" BackgroundColor="#242424"/>
     </PanelContainer.PanelOverride>
-    <BoxContainer Orientation="Horizontal"
-                  HorizontalExpand="True">
+    <BoxContainer Orientation="Vertical"
+                  HorizontalExpand="True"
+                  VerticalExpand="False">
+        <BoxContainer Orientation="Horizontal"
+                      HorizontalExpand="True">
         <Label Name="VesselName"
             Access="Public"
             HorizontalExpand="True"
@@ -32,5 +37,25 @@
             StyleClasses="ButtonSquare"
             Margin="0 0 12 0"
             HorizontalAlignment="Right" /> <!-- Left margin only -->
+    </BoxContainer>
+        <PanelContainer VerticalExpand="True">
+        <PanelContainer.PanelOverride>
+            <gfx:StyleBoxFlat BorderThickness="3" BorderColor="#242424" BackgroundColor="#1a1b1c"/>
+        </PanelContainer.PanelOverride>
+            <ScrollContainer HScrollEnabled="False">
+            <BoxContainer Orientation="Vertical"
+                          HorizontalExpand="True"
+                          VerticalExpand="True">
+            <RichTextLabel Name="VesselDescription"
+                   Access="Public"
+                   HorizontalExpand="True"
+                   VerticalExpand="True"
+                   HorizontalAlignment="Left"
+                   VerticalAlignment="Top"
+                   Margin="5 0 2 0"
+                   Modulate="#999999"/>
+            </BoxContainer>
+            </ScrollContainer>
+        </PanelContainer>
     </BoxContainer>
 </PanelContainer>

--- a/Resources/Locale/en-US/_NF/shipyard/shipyard-console-component.ftl
+++ b/Resources/Locale/en-US/_NF/shipyard/shipyard-console-component.ftl
@@ -37,6 +37,7 @@ shipyard-console-menu-class-label = Class:{" "}
 shipyard-console-menu-engine-label = Engine:{" "}
 
 shipyard-console-purchase-available = Purchase
+shipyard-console-armament-default = Unspecified
 shipyard-console-guidebook = Manual
 shipyard-console-unassign-deed = Unassign
 shipyard-console-deed-unassigned = Deed unassigned from ID card successfully.


### PR DESCRIPTION
## About the PR
Look, the description is there instead of being hidden in the manual button tooltip.
Any concern about stupid-long descriptions interrupting scrolling can be answered with telling Unicorn to stop making ship descriptions 5 lines long.
Any concern about making it harder to see ships can be answered with The Filters And Search Bars Are Right There.

## Why / Balance
??? why was it in tooltip for manual button???? even more unreadable with stupid long descriptions

## Media
<img width="620" height="516" alt="image" src="https://github.com/user-attachments/assets/619c46ab-adc6-45be-adfb-9684c8bbbbe3" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Ship description visible in a simple text box outside of manual button tooltip, just like name and pricetag. Much more readable if you ask me.
