### PR TITLE
Stop Debug Crash On Lathe Menu

### DIFF
--- a/Content.Client/_ES/Storage/ItemMapper/ESItemMapperSystem.cs
+++ b/Content.Client/_ES/Storage/ItemMapper/ESItemMapperSystem.cs
@@ -23,7 +23,9 @@ public sealed class ESItemMapperSystem : ESSharedItemMapperSystem
 
         if (!Appearance.TryGetData(ent, ESItemMapperVisuals.Layers, out Dictionary<string, string?> layers, args.Component))
         {
-            throw new Exception($"Couldn't find the necessary {nameof(ESItemMapperVisuals.Layers)} layer on {ToPrettyString(ent)}.");
+            //throw new Exception($"Couldn't find the necessary {nameof(ESItemMapperVisuals.Layers)} layer on {ToPrettyString(ent)}.");
+            //Mono: Stopgap. Prevents crash in debug mode when looking at lathe menu. Someone more competent can come up with a more comprehensive fix.
+            return;
         }
 
         foreach (var (key, state) in layers)

--- a/Content.Client/_ES/Storage/ItemMapper/ESItemMapperSystem.cs
+++ b/Content.Client/_ES/Storage/ItemMapper/ESItemMapperSystem.cs
@@ -23,8 +23,9 @@ public sealed class ESItemMapperSystem : ESSharedItemMapperSystem
 
         if (!Appearance.TryGetData(ent, ESItemMapperVisuals.Layers, out Dictionary<string, string?> layers, args.Component))
         {
-            //throw new Exception($"Couldn't find the necessary {nameof(ESItemMapperVisuals.Layers)} layer on {ToPrettyString(ent)}.");
-            //Mono: Stopgap. Prevents crash in debug mode when looking at lathe menu. Someone more competent can come up with a more comprehensive fix.
+            //Stopgap, throw replaced with Log.Warning and return. Prevents crash in debug mode when looking at lathe menu.
+            //Someone more competent can come up with a more comprehensive fix.
+            Log.Warning($"Couldn't find the necessary {nameof(ESItemMapperVisuals.Layers)} layer on {ToPrettyString(ent)}.");
             return;
         }
 

--- a/Content.Client/_ES/Storage/ItemMapper/ESItemMapperSystem.cs
+++ b/Content.Client/_ES/Storage/ItemMapper/ESItemMapperSystem.cs
@@ -24,7 +24,7 @@ public sealed class ESItemMapperSystem : ESSharedItemMapperSystem
         if (!Appearance.TryGetData(ent, ESItemMapperVisuals.Layers, out Dictionary<string, string?> layers, args.Component))
         {
             //throw new Exception($"Couldn't find the necessary {nameof(ESItemMapperVisuals.Layers)} layer on {ToPrettyString(ent)}.");
-            //Mono: Stopgap. Prevents crash in debug mode when looking at lathe menu. Someone more competent can come up with a more comprehensive fix.
+            //Mono: Stopgap, replaced throw with return. Prevents crash in debug mode when looking at lathe menu. Someone more competent can come up with a more comprehensive fix.
             return;
         }
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The single throw I commented out in this PR was causing debug mode to crash when it triggered

I don't know why it triggers considering no visual issues occur with the associated troublemakers (weapons with attachments when viewing them in lathes), but replacing it with a return doesn't seem to cause any issues

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Crash annoying

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Check How to test


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

Try replicating this screenshot in debug mode and see what happens

<img width="831" height="328" alt="image" src="https://github.com/user-attachments/assets/a52857b4-9553-49b7-80d6-93b9a584a644" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

Hopefully it's more fix than break

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

not really player facing
