### PR TITLE
Make All EMP Shipguns Unanchorable AKA I Hate Fun

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -256,7 +256,7 @@
   id: WeaponTurretM220
   name: M220 RUBICON EMP launcher
   parent:
-  - BallisticArtillery
+  - BallisticArtilleryUnanchorable
   - BallisticArtilleryTier2HP
   suffix: Medium, T2
   description: Launches EMP projectiles at ships, disabling systems with powerful electromagnetic pulses. Ideal for non-lethal engagements and can be remotely activated or linked to a GCS.

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/tovek_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/tovek_launcher.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: WeaponTurretTovek
   name: ADMX-250 TOVEK Missile Pod
-  parent: BallisticArtilleryCartridge
+  parent: BallisticArtilleryUnanchorableCartridge
   description: A 250mm missile pod created by Aetherion Dynamics. Fires 250mm warheads to devastate enemy ships at long range. Can be remotely activated or linked to a GCS.
   components:
   - type: StaticPrice


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
emp shitguns are now unanchorable
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
emp shipguns are supposed to be specialized, like artillery. Them being anchorable is pure hell for balancing them properly
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: RUBICONs and Toveks are no longer anchorable.
