### PR TITLE
Gunnery Server Anchorage and Gp Limiting

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -142,7 +142,7 @@
   - type: Machine
     board: MachineGCSUltraCircuitboard
   - type: FireControlServer
-    processingPower: 500
+    processingPower: 300
   - type: Battery
     maxCharge: 2000
     startingCharge: 2000

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/FireControl/gunnery.yml
@@ -112,7 +112,7 @@
 
 - type: entity
   id: GunneryServerUltra
-  parent: [GunneryServerBase] # removed BaseStructureDisableToolUse
+  parent: [BaseStructureDisableToolUse, GunneryServerBase]
   name: ultra-high-power gunnery control server
   components:
   - type: Machine
@@ -128,8 +128,8 @@
     idleLoad: 50
     batteryRechargeRate: 2400
     batteryRechargeEfficiency: 0.95
-#  - type: Anchorable # Sorry Tunguska, but I am NOT risking this being used for a missile bus. - "what could go wrong" says redrover
-#    flags: Anchorable
+  - type: Anchorable # Sorry Tunguska, but I am NOT risking this being used for a missile bus. - "what could go wrong" says redrover -- It turns out, a lot could and did.
+    flags: Anchorable
   - type: ShipRepairable
     repairTime: 25
     repairCost: 100


### PR DESCRIPTION
## About the PR
Makes Ultra-High-Gunnery servers are no longer unanchorable or deconstruct-able.
Omega server GP power down from 500 --> 300

## Why / Balance
Believe it or not, we can do game balance better than this. 
<img width="1691" height="539" alt="image" src="https://github.com/user-attachments/assets/a99ceefc-46af-432e-821c-56d5ac80632e" />
<img width="379" height="200" alt="image" src="https://github.com/user-attachments/assets/8e0cea67-0635-46c1-8384-e1c92e373d2b" />
Saturn has 162 gp
Flyssa has 180 gp

180 is already double that of an ultra-high gunnery server which is now no longer going to be the norm existing capitals have some wiggleroom for modding but realistically, the base armaments of the capital ships should just be enough on their own mapping wise. I would make the limit 180 but the wyvern is a weird edge case because the ADS exists solely to torment me with a 282 gp behemoth so whatever, I guess this doesn't actually fix capitals. At least there's only ever one per side.


As for the ultra-high server...
The current state of affairs for ship combat is rather bleak as players homogenize every single ship design into the same brick with 90gp worth of guns they spent an hour building instead of playing the game. When they finally do play the game, it either trivializes fights against others who do not rush the same power-gaming time sink as them making the fight unfun for both parties. In the event they DO meet their match, both pilots end up flying with an unreasonable level of fear as they do not want their real life time investment of the past hour to suddenly go up in flames, leading to these upgraded ship fights being avoided and ran from more often than stock ship fights, leading to more unsatisfying engagements and outcomes.

Ultra-high gunnery servers are not researchable so it stands to reason that they should not be so easily acquired. Instead of simply buying and selling a ship to acquire, they can be rare drops at POI's or rewards for engaging in ship combat in the first place, literally anything would be better than this, including nothing. Which is the stopgap measure I'm offering here.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Spawn ultra-high-gunnery server, try to unwrench or deconstruct. 
Spawn flyssa, wyvern or saturn, observe that all their guns still work

**Changelog**
:cl:
- tweak: Ultra-high-gunnery servers no longer unanchorable.
- tweak: Omega-high-gunnery server GP down from 500 --> 300
