### PR TITLE
Kill Asakim

### DIFF
--- a/Resources/Prototypes/_Mono/GameRules/asakim.yml
+++ b/Resources/Prototypes/_Mono/GameRules/asakim.yml
@@ -2,8 +2,8 @@
   id: AsakimShipsTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-      - id: UnknownShuttleAsakimSmall
-      - id: UnknownShuttleAsakimMedium
+#      - id: UnknownShuttleAsakimSmall
+#      - id: UnknownShuttleAsakimMedium
 
 - type: entity
   parent: BaseRandomShuttleRule

--- a/Resources/Prototypes/_Mono/GameRules/asakim.yml
+++ b/Resources/Prototypes/_Mono/GameRules/asakim.yml
@@ -2,8 +2,8 @@
   id: AsakimShipsTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-#      - id: UnknownShuttleAsakimSmall
-#      - id: UnknownShuttleAsakimMedium
+      - id: UnknownShuttleAsakimSmall
+      - id: UnknownShuttleAsakimMedium
 
 - type: entity
   parent: BaseRandomShuttleRule

--- a/Resources/Prototypes/_Mono/GameRules/base.yml
+++ b/Resources/Prototypes/_Mono/GameRules/base.yml
@@ -29,7 +29,7 @@
   - type: BasicStationEventScheduler
     scheduledGameRules: !type:NestedSelector
       tableId: AsakimShipsTable
-    minimumTimeUntilFirstEvent: 3600 # 1 hour
+    minimumTimeUntilFirstEvent: 72000 # 20 hours (disabled)
     minMaxEventTiming:
       min: 3600 # 60 minutes between events
       max: 7200 # 120 minutes between events

--- a/Resources/Prototypes/_Mono/Guidebook/creatures.yml
+++ b/Resources/Prototypes/_Mono/Guidebook/creatures.yml
@@ -6,7 +6,7 @@
   children:
   - CorticalBorerGuide
   - Letoferol
-  - Asakim
+#  - Asakim
 
 - type: guideEntry
   id: CorticalBorerGuide


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Stopped Asakim shuttles from spawning and removed the guidebook entry.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is the fist step of the remnant rework I am planning. Asakim are at a weird place, nobody certainly knows what they are. A lot of people think they're NT made, others think they are from the prefracture war.
From a game-play perspective, Asakim are out of the box powergame antagonists which cannot talk to anyone but lizards. This encourages combat more than anything. The super limited interaction possibilities make it feel like a "no talk all frag" type of antagonist which is obviously bad for a MRP environment.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Sit alone in the dev env and wait (nothing will happen), open the guidebook and see that they're gone.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Asakim ghostroles will no longer appear

