### PR TITLE
Fix Typo in Rules Xml

### DIFF
--- a/Resources/ServerInfo/_Mono/Guidebook/Rules/MonolithRuleset.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Rules/MonolithRuleset.xml
@@ -27,7 +27,7 @@ These are the core rules of Monolith:
 - 4. [textlink="Do not use alternative accounts." link="MonolithRuleCoreFourAlternativeAccounts"]
 - 5. [textlink="All communication must be in English." link="MonolithRuleCoreFiveLanguages"]
 - 6. [textlink="Do not abuse the Admin Help System." link="MonolithRuleCoreSixAhelp"]
-- 7. [textlink="Do not threaten to report a player." link="MonolithRuleCoreSevenThreatenReport"]
+- 7. [textlink="Do not threaten to report a player." link="MonolithRuleCoreSevenThreatenToReport"]
 
 ## Roleplay Rules
 These are the roleplay rules of Monolith:


### PR DESCRIPTION
<img width="1083" height="30" alt="image" src="https://github.com/user-attachments/assets/33df9444-5b49-4b2b-be60-15f95a8f3113" />
oooooooops

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.