### PR TITLE
Derelict Drillsite Buff

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/laser_drill.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/laser_drill.yml
@@ -74,7 +74,7 @@
   - type: Anchorable
     flags: None # 1984
   - type: ItemMiner
-    interval: 20
+    interval: 10 # previously 20
 
 - type: entity
   name: random ores


### PR DESCRIPTION
makes it do something


## About the PR

Changed the interval on the laser mines the drill site uses (not the normal ones, exclusively the drillsite ones) from 20 to 10

## Why / Balance

The derelict drillsite is hilariously useless - this makes it better than mining solo, i think

## Media

N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test

Check the file for Laser Drills to see the change - and view the derelict drillsite mine things ingame.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- The derelict drillsite now produces twice as much ore.


