### PR TITLE
Adds the Jaguar to the T0 Tsfmc Voucher

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
@@ -67,6 +67,7 @@
     - Shiv
     - Syringe
     - Ocelot
+    - Jaguar
     - Tumour
 
 # start T1


### PR DESCRIPTION
## About the PR
1 line of yml to do exactly what the title says

## Why / Balance
It should have been added to the t0 voucher when it was originally added.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Get a tsfmc T0 voucher and use it to get a Jaguar.

## Breaking changes
hopefully none

**Changelog**
:cl:
- add: Added the Jaguar to the TSFMC T0 voucher
