### PR TITLE
USSP Loadout Tweaks

### DIFF
--- a/Resources/Prototypes/_Mono/Loadouts/USSP/bags.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/USSP/bags.yml
@@ -18,9 +18,3 @@
   price: 75000
   equipment:
     back: ClothingModsuitUSSPZastavnikPowerCell
-  
-- type: loadout
-  id: USSPModsuitUSSPVaryag
-  price: 50000
-  equipment:
-    back: ClothingModsuitUSSPVaryagPowerCell

--- a/Resources/Prototypes/_Mono/Loadouts/USSP/role_loadouts_ussp.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/USSP/role_loadouts_ussp.yml
@@ -23,6 +23,7 @@
   - ContractorTrinkets
   - USSPBureaucracy
   - NfsdSpeciesSpecific
+  - ContractorArmorPlates
   - UsspFirearm
   - UsspMag
 
@@ -33,7 +34,7 @@
   - USSPJumpsuitOfficer
   - USSPNeck
   - USSPGloves
-  - USSPBackpackSergeant
+  - USSPBackpack
   - USSPOuterClothingOfficer
   - TsfmcShoes
   - TsfmcFace
@@ -51,6 +52,7 @@
   - ContractorTrinkets
   - USSPBureaucracy
   - NfsdSpeciesSpecific
+  - ContractorArmorPlates
   - UsspFirearm
   - UsspMag
 
@@ -61,7 +63,7 @@
   - USSPJumpsuitOfficer
   - USSPNeck
   - USSPCommissarGloves
-  - USSPBackpackSergeant
+  - USSPBackpack
   - USSPOuterClothingOfficer
   - TsfmcShoes
   - TsfmcFace
@@ -79,5 +81,6 @@
   - ContractorTrinkets
   - USSPBureaucracy
   - NfsdSpeciesSpecific
+  - ContractorArmorPlates
   - UsspFirearm
   - UsspMag

--- a/Resources/Prototypes/_Mono/Loadouts/USSP/universal_groups.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/USSP/universal_groups.yml
@@ -10,17 +10,6 @@
   - USSPBackpack
 
 - type: loadoutGroup
-  id: USSPBackpackSergeant
-  name: loadout-group-contractor-backpack
-  minLimit: 1
-  loadouts:
-  - USSPModsuitUSSPVaryag
-  fallbacks:
-  - USSPBackpack
-  subgroups:
-  - USSPBackpack
-
-- type: loadoutGroup
   id: USSPBelt
   name: loadout-group-contractor-belt
   minLimit: 1
@@ -138,7 +127,6 @@
   name: loadout-group-contractor-head
   loadouts:
   - USSPOfficerCap
-  - ContractorClothingHeadHatUshanka
   subgroups:
   - USSPHead
 

--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/commissar.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/commissar.yml
@@ -23,7 +23,7 @@
   displayWeight: 40
   special:
   - !type:AddImplantSpecial
-    implants: UsspTrackingImplant
+    implants: [ UsspTrackingImplant ]
   - !type:AddComponentSpecial
     components:
     - type: MailDisabled

--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/commissar.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/commissar.yml
@@ -23,7 +23,7 @@
   displayWeight: 40
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, UsspTrackingImplant ]
+    implants: UsspTrackingImplant
   - !type:AddComponentSpecial
     components:
     - type: MailDisabled

--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/rifleman.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/rifleman.yml
@@ -17,7 +17,7 @@
   displayWeight: 10
   special:
   - !type:AddImplantSpecial
-    implants: UsspTrackingImplant
+    implants: [ UsspTrackingImplant ]
   - !type:AddComponentSpecial
     components:
     - type: MailDisabled

--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/rifleman.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/rifleman.yml
@@ -17,7 +17,7 @@
   displayWeight: 10
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, UsspTrackingImplant ]
+    implants: UsspTrackingImplant
   - !type:AddComponentSpecial
     components:
     - type: MailDisabled

--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/sergeant.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/sergeant.yml
@@ -20,7 +20,7 @@
   displayWeight: 30
   special:
   - !type:AddImplantSpecial
-    implants: UsspTrackingImplant
+    implants: [ UsspTrackingImplant ]
   - !type:AddComponentSpecial
     components:
     - type: MailDisabled

--- a/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/sergeant.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/UnionOfSovietSocialistPlanets/sergeant.yml
@@ -20,7 +20,7 @@
   displayWeight: 30
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, UsspTrackingImplant ]
+    implants: UsspTrackingImplant
   - !type:AddComponentSpecial
     components:
     - type: MailDisabled


### PR DESCRIPTION
## About the PR
Removes Modsuit from loadouts, only collective labour will save you, All roles get armor plates as an option instead. Fixes Serzhant hat loadout weirdness, owning multiple ushankas is the first step on the path to reverting to a TSF shill. Mindshields are also dead now.


## Why / Balance
Modsuit change requested by @Corrupt142, everything else is just QC and standardising 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Look at the loadouts, it's just that easy. Check for a mindshield on your 2d spess commie.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: USSP Loadouts tweaked, modsuits swapped for plates, lore accurate

