### PR TITLE
USSP Faction Bounty Tags

### DIFF
--- a/Resources/Prototypes/_Mono/Catalogs/Bounties/ussp_bounties.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Bounties/ussp_bounties.yml
@@ -100,18 +100,6 @@
       - BiomassBounty
 
 - type: cargoBounty
-  id: USSPRogueHardsuit
-  reward: 32000
-  description: ussp-bounty-desc-rogue-hardsuit
-  idPrefix: NC # nova cygni fyi
-  entries:
-  - name: ussp-bounty-name-rogue-hardsuit
-    amount: 1
-    whitelist:
-      tags:
-      - RogueHardsuit
-
-- type: cargoBounty
   id: USSPBountyMilitaryMech
   reward: 100000
   description: ussp-bounty-desc-military-mech

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Back/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Back/modsuit.yml
@@ -12,8 +12,6 @@
       gloves: ClothingModsuitGauntletsUSSPVaryag
       outerClothing: ClothingModsuitChestplateUSSPVaryag
       shoes: ClothingModsuitBootsUSSPVaryag
-  - type: PirateBountyItem # Mono
-    id: ClothingOuterHardsuitTacsuit
 
 - type: entity
   parent: ClothingModsuitUSSPVaryag
@@ -43,8 +41,6 @@
       gloves: ClothingModsuitGauntletsUSSPZastavnik
       outerClothing: ClothingModsuitChestplateUSSPZastavnik
       shoes: ClothingModsuitBootsUSSPZastavnik
-  - type: PirateBountyItem # Mono
-    id: ClothingOuterHardsuitTacsuitHighValue
 
 - type: entity
   parent: ClothingModsuitUSSPZastavnik

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ussp.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT2 ]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitUsspL27
   name: USSP L-27 tacsuit
   description: The standard combat suit of USSP naval operations.
@@ -41,11 +41,9 @@
   - type: StaticPrice
     price: 1250
     vendPrice: 7500
-  - type: PirateBountyItem # Mono
-    id: ClothingOuterHardsuitTacsuit
 
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT0 ]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitUsspL10
   name: USSP L-10 lightsuit
   description: An old USSP model of combat suit that is still in use in the frontlines.
@@ -87,11 +85,9 @@
   - type: StaticPrice
     price: 420
     vendPrice: 2500
-  - type: PirateBountyItem # Mono
-    id: ClothingOuterHardsuitTacsuit
 
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT0 ]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitUsspL10A
   name: USSP L-10-A lightsuit
   description: An old USSP model of combat suit that is still in use in the frontlines.
@@ -133,11 +129,9 @@
   - type: StaticPrice
     price: 500
     vendPrice: 3000
-  - type: PirateBountyItem # Mono
-    id: ClothingOuterHardsuitTacsuit
 
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT0 ]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitUsspM10
   name: USSP M-10 scoutsuit
   description: A new prototype of combat suit using the old L-10 as a baseline. It has a integrated mass scanner in his helmet.
@@ -178,11 +172,9 @@
   - type: StaticPrice
     price: 1350
     vendPrice: 8000
-  - type: PirateBountyItem # Mono
-    id: ClothingOuterHardsuitTacsuitHighValue
 
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT2 ]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitUsspL30
   name: USSP L-30 Naval Commissar parade hardsuit.
   description: A highly decorated hardsuit with upgraded mobility and higher quality lighter armor plates to quickly convey orders on the frontline. (or not be sweaty in a parade)
@@ -224,11 +216,9 @@
   - type: StaticPrice
     price: 3300
     vendPrice: 20000
-  - type: PirateBountyItem # Mono
-    id: ClothingOuterHardsuitTacsuitHighValue
 
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseFactionGearOtherFactionT3 ]
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitOfficerCombat
   name: USSP UF-16 "Voenkom" commissar tacsuit
   description: Developed by Union armament manufacturers for use by members of the commissariat on the frontlines. Features enhanced plating for survivability, allowing commanders to continue to give orders even while under heavy fire.
@@ -270,5 +260,4 @@
   - type: StaticPrice
     price: 4200
     vendPrice: 25000
-  - type: PirateBountyItem # Mono
-    id: ClothingOuterHardsuitTacsuitHighValue
+

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/encryption_keys.yml
@@ -15,8 +15,6 @@
     layers:
     - state: crypt_rusted
     - state: sec_label
-  - type: PirateBountyItem
-    id: EncryptionKeyFaction
 
 - type: entity
   parent: EncryptionKey
@@ -35,8 +33,6 @@
     layers:
     - state: crypt_blue
     - state: sec_label
-  - type: PirateBountyItem
-    id: EncryptionKeyFaction
 
 - type: entity
   parent: EncryptionKey
@@ -103,5 +99,4 @@
     layers:
     - state: crypt_red
     - state: viper_label
-  #- type: PirateBountyItem
-  #  id: EncryptionKeyFaction > Unsure if these should stay as the USSP minor faction/company has it.
+

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -63,8 +63,6 @@
     walkModifier: 0.8
     sprintModifier: 0.65
   - type: GunRequiresWield
-  - type: PirateBountyItem # Mono
-    id: ExperimentalFactionWeapon
 
 - type: entity
   name: VFD MR-8B LWMMG (8x65mm SKR)
@@ -207,8 +205,6 @@
     walkModifier: 0.65
     sprintModifier: 0.65
   - type: GunRequiresWield
-  - type: PirateBountyItem # Mono
-    id: ExperimentalFactionWeapon
 
 - type: entity
   name: TCA MMG-68 "Grizzly" (6.8x52mm caseless)

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -202,8 +202,6 @@
   - type: Appearance
   - type: StaticPrice
     price: 1200
-  - type: PirateBountyItem
-    id: StandardFactionLongarm
   # Attachment slop
   - type: ESAttachableGun
     slots:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -76,8 +76,6 @@
   - type: SpeedModifiedOnWield
     walkModifier: 0.85
     sprintModifier: 0.85
-  - type: PirateBountyItem
-    id: StandardFactionLongarm
   # Attachment slop
   - type: ESAttachableGun
     slots:


### PR DESCRIPTION
## About the PR
USSP gear no longer shows as a faction or pirate bounty, confusingly, the examine text reads as showing as belonging to a _major faction_.
Rogue suit removed from USSP bounties because VG are our dubious lore friends.
VG Encryption key comment removed as no longer relevant.

## Why / Balance
Holdover from the good ol days, no longer relevant.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Use shift click to examine things. I give really good gaming advice.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: USSP gear no longer has tags for faction turn-ins/Bounties

