### PR TITLE
Buffs the Grizzly by Deleting the Unequip Delay.

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -284,7 +284,6 @@
   - type: Appearance
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/LMGs/grizzly/Grizzly-inhands.rsi
-    unequipDelay: 0.5
   - type: StaticPrice
     price: 2500
   - type: GunRequiresWield


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
* Removes one line of code, allowing you to instantly draw the Grizzly. (But not wield.)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* Getting hit-stunned out of pulling your gun out is not fun.
* I personally don't believe it'd affect balance too badly, as you still need to wait to wield and shoot.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The osmium based parts in the Grizzly have been replaced with lighter plastic parts. You don't need to wait to draw the gun. 
