### PR TITLE
Freeport Comms

### DIFF
--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -18,6 +18,7 @@ chat-radio-supply = Supply
 chat-radio-syndicate = Syndicate
 chat-radio-freelance = Vanguard
 chat-radio-vanguard-command = Vanguard Command
+chat-radio-freeport = Freeport
 
 # not headset but whatever
 chat-radio-handheld = Handheld

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Ears/headsets.yml
@@ -95,12 +95,13 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyUssp
+      - EncryptionKeyFreeport
 
 - type: entity
   parent: ClothingHeadsetAlt
   id: ClothingHeadsetUSSP
   name: USSP headset
-  description: The standard-issue headset of the USSP Defensive Navy for decades. This headset will accept standard encryption keys and comes prefitted with a key for USSP Tactical Communications.
+  description: The standard-issue headset of the USSP Armed Forces for decades. This headset will accept standard encryption keys and comes prefitted with a key for USSP Tactical Communications.
   components:
   - type: Sprite
     sprite: Clothing/Ears/Headsets/security.rsi
@@ -111,6 +112,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyUssp
+      - EncryptionKeyFreeport
 
 #PDV
 - type: entity
@@ -161,6 +163,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyViper
+      - EncryptionKeyFreeport
 
 - type: entity
   parent: ClothingHeadsetViper

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/encryption_keys.yml
@@ -100,3 +100,20 @@
     - state: crypt_red
     - state: viper_label
 
+- type: entity
+  parent: EncryptionKey
+  id: EncryptionKeyFreeport
+  name: Freeport encryption key
+  description: A worn encryption key for Freeport communications, allowing the varied groups of Freeport to engage in diplomacy or yell insults, likely the latter.
+  components:
+  - type: EncryptionKey
+    channels:
+    - Freeport
+    defaultChannel: Freeport
+  - type: Item
+    sprite: Objects/Devices/encryption_keys.rsi
+  - type: Sprite
+    sprite: Objects/Devices/encryption_keys.rsi
+    layers:
+    - state: crypt_rusted
+    - state: cargo_label

--- a/Resources/Prototypes/_Mono/radio_channels.yml
+++ b/Resources/Prototypes/_Mono/radio_channels.yml
@@ -42,3 +42,11 @@
   frequency: 1753
   color: "#ff4242" #Brighter color used for visual clarity.
   longRange: true
+
+- type: radioChannel
+  id: Freeport
+  name: chat-radio-freeport
+  keycode: 'o'
+  frequency: 1761
+  color: "#b87333"
+  longRange: true


### PR DESCRIPTION
## About the PR
Adds a Freeport Encryption key. Why can't everyone get along?

The key has been added to USSP/VG headsets by default, all must yap.

Uses :o as the key.

Bit of a goida solution tbh.

## Why / Balance
Given communication has been raised as an issue, and that VG have paid off the HoA, it's in everyone's interest that both sides have shared comms.

## Media
<img width="589" height="389" alt="Screenshot 2026-06-25 193420" src="https://github.com/user-attachments/assets/7817ab23-35b1-4414-af06-a92a4b5ff70f" />

<img width="296" height="39" alt="Screenshot 2026-06-25 193504" src="https://github.com/user-attachments/assets/33cfe3c5-15fe-4c6b-bfb6-fd0662cdae68" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Spawn as VG/USSP, speak using :o 

## Breaking changes
Does not overlap with other channels it seems, but may happen I'm sure.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Freeport Comms, added to USSP/VG headsets by default
