### PR TITLE
GS-004 Canisters Are Now Large.

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/4_gauge.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Magazines/4_gauge.yml
@@ -17,7 +17,7 @@
     soundRack:
       path: /Audio/Weapons/Guns/Cock/smg_cock.ogg
   - type: Item
-    size: Small # Probably needs tweaking.
+    size: Large # Probably needs tweaking. NO SHIT, ME.
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
* 4 gauge ammo canisters Small > Large
* They now occupy a 2x4 space. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* Whoops...
* They're no longer more efficient than just carrying ammo boxes 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: 4 gauge canisters are no longer small items due to infringing on a MACo patent.

