### PR TITLE
Make 250mm EMPHE Less Ass

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Missile/projectiles.yml
@@ -230,10 +230,10 @@
     muzzleFlash: MuzzleFlashEffectSmall
   - type: RadarBlip
     radarColor: "#FB00FF"
-    scale: 1
+    scale: 2
     shape: hexagon
   - type: TimedDespawn
-    lifetime: 8
+    lifetime: 7
   - type: PointLight
     radius: 3.5
     color: orange
@@ -253,11 +253,11 @@
   - type: MiningGatheringSoft
   - type: MiningGatheringHard
   - type: TargetSeeking
-    acceleration: 25
+    acceleration: 60
     detectionRange: 600
     scanArc: 45
-    launchSpeed: 30
-    maxSpeed: 300
+    launchSpeed: 60
+    maxSpeed: 400
     trackDelay: 0.6
 
 # Serpent Torpedo


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
buffed EMPHE missiles to be faster and more manouverable

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
they coudnt catch up to the smaller shielded ships so i decided to buff them!

Balance:

EMPHE can still be dodged with a very agile ship, although now it is abile to fill the shieldcracker role for the paladin.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: buffed 250mm EMPHE missiles to be faster, more agile 


