### PR TITLE
Fix that One Turned Off Thruster on Ocelot and Also Add an Actual Suit Storage to It

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/Nfsd/ocelot.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/ocelot.yml
@@ -1,10 +1,10 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 271.2.0
+  engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/16/2026 18:45:37
+  time: 07/04/2026 15:14:41
   entityCount: 379
 maps: []
 grids:
@@ -219,10 +219,10 @@ entities:
             27: -1,4
     - type: SpreaderGrid
       spreadQueues:
-        Kudzu: []
-        MetalFoam: []
-        Puddle: []
         Smoke: []
+        Kudzu: []
+        Puddle: []
+        MetalFoam: []
     - type: GridAtmosphere
       version: 2
       data:
@@ -283,86 +283,28 @@ entities:
         uniqueMixes:
         - volume: 2500
           immutable: True
-          moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+          moles: {}
+        - volume: 2500
+          temperature: 293.15
+          moles: {}
         - volume: 2500
           temperature: 293.15
           moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
         - volume: 2500
           temperature: 293.14996
           moles:
-          - 20.078888
-          - 75.53487
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ShipGridLock
       locked: False
     - type: ThermalSignature
+    - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
 - proto: AirAlarm
   entities:
   - uid: 2
@@ -373,10 +315,10 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 175
-      - 178
-      - 213
-      - 218
+      - 171
+      - 174
+      - 209
+      - 214
   - uid: 3
     components:
     - type: Transform
@@ -385,12 +327,12 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 178
-      - 214
-      - 219
+      - 174
+      - 210
+      - 215
     - type: DeviceLinkSource
       linkedPorts:
-        241:
+        236:
         - - AirDanger
           - On
         - - AirNormal
@@ -402,26 +344,26 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 175
-      - 176
-      - 177
+      - 171
+      - 172
+      - 173
+      - 212
+      - 213
       - 216
-      - 217
-      - 220
-      - 215
+      - 211
     - type: DeviceLinkSource
       linkedPorts:
-        233:
+        229:
         - - AirDanger
           - Off
         - - AirNormal
           - On
-        237:
+        231:
         - - AirDanger
           - Off
         - - AirNormal
           - On
-        240:
+        235:
         - - AirDanger
           - On
         - - AirNormal
@@ -500,277 +442,317 @@ entities:
       parent: 1
 - proto: Bed
   entities:
-  - uid: 24
+  - uid: 16
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: BedsheetBlack
   entities:
-  - uid: 25
+  - uid: 17
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 26
+  - uid: 18
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 27
+  - uid: 19
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 28
+  - uid: 20
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 29
+  - uid: 21
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 30
+  - uid: 22
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 31
+  - uid: 23
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 32
+  - uid: 24
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 33
+  - uid: 25
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 34
+  - uid: 26
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 35
+  - uid: 27
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 36
+  - uid: 28
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 37
+  - uid: 29
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 38
+  - uid: 30
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 39
+  - uid: 31
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 40
+  - uid: 32
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 41
+  - uid: 33
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 42
+  - uid: 34
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 43
+  - uid: 35
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 44
+  - uid: 36
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 45
+  - uid: 37
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 46
+  - uid: 38
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 47
+  - uid: 39
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 48
+  - uid: 40
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 49
+  - uid: 41
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 50
+  - uid: 42
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 51
+  - uid: 43
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 52
+  - uid: 44
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 53
+  - uid: 45
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 54
+  - uid: 46
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 55
+  - uid: 47
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 56
+  - uid: 48
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 57
+  - uid: 49
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 58
+  - uid: 50
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 59
+  - uid: 51
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 60
+  - uid: 52
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 61
+  - uid: 53
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 62
+  - uid: 54
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 63
+  - uid: 55
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 64
+  - uid: 56
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 65
+  - uid: 57
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 66
+  - uid: 58
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 67
+  - uid: 59
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 68
+  - uid: 60
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 69
+  - uid: 61
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 70
+  - uid: 62
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 71
+  - uid: 63
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 72
+  - uid: 64
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 73
+  - uid: 65
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 74
+  - uid: 66
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 75
+  - uid: 67
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 76
+  - uid: 68
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
 - proto: CableHV
   entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
   - uid: 77
     components:
     - type: Transform
@@ -779,213 +761,173 @@ entities:
   - uid: 78
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: 0.5,-1.5
       parent: 1
   - uid: 79
     components:
     - type: Transform
-      pos: 0.5,-4.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 80
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: -0.5,-0.5
       parent: 1
   - uid: 81
     components:
     - type: Transform
-      pos: -0.5,-4.5
+      pos: -1.5,-0.5
       parent: 1
   - uid: 82
     components:
     - type: Transform
-      pos: -1.5,-4.5
+      pos: -2.5,-0.5
       parent: 1
   - uid: 83
     components:
     - type: Transform
-      pos: -2.5,-4.5
+      pos: -3.5,-0.5
       parent: 1
   - uid: 84
     components:
     - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
-  - uid: 85
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 86
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 87
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 88
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
-  - uid: 89
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 1
-  - uid: 90
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
-  - uid: 91
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
-      parent: 1
-  - uid: 92
-    components:
-    - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 93
+  - uid: 85
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 94
+  - uid: 86
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 95
+  - uid: 87
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 96
+  - uid: 88
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 97
+  - uid: 89
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 98
+  - uid: 90
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 99
+  - uid: 91
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 100
+  - uid: 92
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 101
+  - uid: 93
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 102
+  - uid: 94
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 103
+  - uid: 95
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 104
+  - uid: 96
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 105
+  - uid: 97
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 106
+  - uid: 98
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 107
+  - uid: 99
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 108
+  - uid: 100
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 109
+  - uid: 101
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 110
+  - uid: 102
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 111
+  - uid: 103
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 112
+  - uid: 104
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 113
+  - uid: 105
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 114
+  - uid: 106
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 115
+  - uid: 107
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 116
+  - uid: 108
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 117
+  - uid: 109
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 118
+  - uid: 110
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 119
+  - uid: 111
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -993,232 +935,232 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 120
+  - uid: 112
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 121
+  - uid: 113
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 122
+  - uid: 114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
-  - uid: 123
+  - uid: 115
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 124
+  - uid: 116
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 125
+  - uid: 117
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 126
+  - uid: 118
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 127
+  - uid: 119
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 128
+  - uid: 120
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 129
+  - uid: 121
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 130
+  - uid: 122
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1
-  - uid: 131
+  - uid: 123
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 132
+  - uid: 124
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 133
+  - uid: 125
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 134
+  - uid: 126
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 135
+  - uid: 127
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 136
+  - uid: 128
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 137
+  - uid: 129
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 138
+  - uid: 130
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 139
+  - uid: 131
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 140
+  - uid: 132
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 141
+  - uid: 133
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 142
+  - uid: 134
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 143
+  - uid: 135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 144
+  - uid: 136
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 145
+  - uid: 137
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 146
+  - uid: 138
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 147
+  - uid: 139
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 148
+  - uid: 140
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 149
+  - uid: 141
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 150
+  - uid: 142
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 151
+  - uid: 143
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 152
+  - uid: 144
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 153
+  - uid: 145
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 154
+  - uid: 146
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 155
+  - uid: 147
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 156
+  - uid: 148
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 157
+  - uid: 149
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 158
+  - uid: 150
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 159
+  - uid: 151
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 160
+  - uid: 152
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 368
+  - uid: 153
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 369
+  - uid: 154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 370
+  - uid: 155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,5.5
       parent: 1
-  - uid: 371
+  - uid: 156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1226,13 +1168,13 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 161
+  - uid: 157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-0.5
       parent: 1
-  - uid: 162
+  - uid: 158
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1240,7 +1182,7 @@ entities:
       parent: 1
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 163
+  - uid: 159
     components:
     - type: Transform
       pos: -1.5,0.5
@@ -1251,7 +1193,7 @@ entities:
       startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 164
+  - uid: 160
     components:
     - type: Transform
       pos: -3.5,0.5
@@ -1262,7 +1204,7 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttleTSFNVWS
   entities:
-  - uid: 165
+  - uid: 161
     components:
     - type: Transform
       pos: -2.5,0.5
@@ -1273,7 +1215,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopAdvancedRadar
   entities:
-  - uid: 166
+  - uid: 162
     components:
     - type: Transform
       pos: 1.5,0.5
@@ -1284,7 +1226,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopGunneryConsole
   entities:
-  - uid: 167
+  - uid: 163
     components:
     - type: Transform
       pos: 2.5,0.5
@@ -1295,7 +1237,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTabletopStationRecords
   entities:
-  - uid: 168
+  - uid: 164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1307,26 +1249,26 @@ entities:
       startingCharge: 0
 - proto: DarkCatwalkMono
   entities:
-  - uid: 169
+  - uid: 165
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 170
+  - uid: 166
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 171
+  - uid: 167
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
 - proto: FireAlarm
   entities:
-  - uid: 172
+  - uid: 168
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1334,9 +1276,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 175
-      - 178
-  - uid: 173
+      - 171
+      - 174
+  - uid: 169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1344,71 +1286,71 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 178
-  - uid: 174
+      - 174
+  - uid: 170
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
     - type: DeviceList
       devices:
-      - 175
-      - 176
-      - 177
+      - 171
+      - 172
+      - 173
 - proto: Firelock
   entities:
-  - uid: 175
+  - uid: 171
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 174
+      - 170
       - 4
-      - 172
+      - 168
       - 2
-  - uid: 176
+  - uid: 172
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 174
+      - 170
       - 4
-  - uid: 177
+  - uid: 173
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 174
+      - 170
       - 4
 - proto: FirelockGlass
   entities:
-  - uid: 178
+  - uid: 174
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 172
+      - 168
       - 2
-      - 173
+      - 169
       - 3
 - proto: FloorDrain
   entities:
-  - uid: 179
+  - uid: 175
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 180
+  - uid: 176
     components:
     - type: Transform
       pos: -2.5,3.5
@@ -1417,7 +1359,7 @@ entities:
       fixtures: {}
 - proto: GasMixerOnFlipped
   entities:
-  - uid: 181
+  - uid: 177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1432,7 +1374,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPassiveVent
   entities:
-  - uid: 182
+  - uid: 178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1444,7 +1386,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBendAlt1
   entities:
-  - uid: 183
+  - uid: 179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1452,7 +1394,7 @@ entities:
       parent: 1
 - proto: GasPipeBendAlt2
   entities:
-  - uid: 184
+  - uid: 180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1460,7 +1402,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 185
+  - uid: 181
     components:
     - type: Transform
       pos: 0.5,3.5
@@ -1469,7 +1411,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeFourwayAlt1
   entities:
-  - uid: 186
+  - uid: 182
     components:
     - type: Transform
       pos: 0.5,-3.5
@@ -1478,7 +1420,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeStraightAlt1
   entities:
-  - uid: 187
+  - uid: 183
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1486,7 +1428,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 188
+  - uid: 184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1494,7 +1436,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 189
+  - uid: 185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1502,42 +1444,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 190
+  - uid: 186
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 191
+  - uid: 187
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 192
+  - uid: 188
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 193
+  - uid: 189
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 194
+  - uid: 190
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 195
+  - uid: 191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1545,7 +1487,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 196
+  - uid: 192
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1555,14 +1497,14 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeStraightAlt2
   entities:
-  - uid: 197
+  - uid: 193
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 198
+  - uid: 194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1570,7 +1512,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 199
+  - uid: 195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1578,7 +1520,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 200
+  - uid: 196
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1586,7 +1528,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 201
+  - uid: 197
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1594,7 +1536,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 202
+  - uid: 198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1602,21 +1544,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 203
+  - uid: 199
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 204
+  - uid: 200
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 205
+  - uid: 201
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1624,7 +1566,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 206
+  - uid: 202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1634,7 +1576,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunctionAlt1
   entities:
-  - uid: 207
+  - uid: 203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1644,7 +1586,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeTJunctionAlt2
   entities:
-  - uid: 208
+  - uid: 204
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1652,14 +1594,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 209
+  - uid: 205
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 210
+  - uid: 206
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1669,14 +1611,14 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 211
+  - uid: 207
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
     - type: AtmosPipeLayers
       pipeLayer: Secondary
-  - uid: 212
+  - uid: 208
     components:
     - type: Transform
       pos: -4.5,-2.5
@@ -1685,7 +1627,7 @@ entities:
       pipeLayer: Secondary
 - proto: GasVentPump
   entities:
-  - uid: 213
+  - uid: 209
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1698,7 +1640,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 214
+  - uid: 210
     components:
     - type: Transform
       pos: 0.5,3.5
@@ -1710,7 +1652,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 215
+  - uid: 211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1723,7 +1665,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 216
+  - uid: 212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1738,7 +1680,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 217
+  - uid: 213
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1751,7 +1693,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 218
+  - uid: 214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1764,7 +1706,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 219
+  - uid: 215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1777,7 +1719,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 220
+  - uid: 216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1792,20 +1734,20 @@ entities:
       color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 221
+  - uid: 217
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 222
+  - uid: 218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 223
+  - uid: 219
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1813,7 +1755,7 @@ entities:
       parent: 1
 - proto: GunneryServerMedium
   entities:
-  - uid: 224
+  - uid: 220
     components:
     - type: Transform
       pos: 1.5,-1.5
@@ -1824,21 +1766,21 @@ entities:
       powerLoad: 10
 - proto: GyroscopeNfsd
   entities:
-  - uid: 225
+  - uid: 221
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 226
+  - uid: 222
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-- proto: LockerWallColorGenericBlack
+- proto: LockerWallEVAColorNfsdFilled
   entities:
-  - uid: 227
+  - uid: 223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1846,21 +1788,21 @@ entities:
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 228
+  - uid: 224
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 229
+  - uid: 225
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 230
+  - uid: 226
     components:
     - type: Transform
       anchored: True
@@ -1870,7 +1812,7 @@ entities:
       bodyType: Static
 - proto: OxygenCanister
   entities:
-  - uid: 231
+  - uid: 227
     components:
     - type: Transform
       anchored: True
@@ -1880,7 +1822,7 @@ entities:
       bodyType: Static
 - proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 232
+  - uid: 228
     components:
     - type: Transform
       pos: 0.5,-4.5
@@ -1889,7 +1831,7 @@ entities:
       targetPower: 50000
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 233
+  - uid: 229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1897,13 +1839,13 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 236
+  - uid: 230
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 237
+  - uid: 231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1913,13 +1855,13 @@ entities:
       invokeCounter: 1
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 234
+  - uid: 232
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 1
-  - uid: 238
+  - uid: 233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1927,14 +1869,14 @@ entities:
       parent: 1
 - proto: PoweredlightBlue
   entities:
-  - uid: 23
+  - uid: 234
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
 - proto: PoweredlightBlueAirAlarm
   entities:
-  - uid: 240
+  - uid: 235
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1942,7 +1884,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 241
+  - uid: 236
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1952,13 +1894,13 @@ entities:
       invokeCounter: 2
 - proto: RadarEdgeMarkerDiagonal
   entities:
-  - uid: 16
+  - uid: 237
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 22
+  - uid: 238
     components:
     - type: Transform
       pos: 4.5,-2.5
@@ -1968,18 +1910,18 @@ entities:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 372
+  - uid: 240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 373
+  - uid: 241
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 374
+  - uid: 242
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1987,37 +1929,37 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerHalftiltLeft
   entities:
-  - uid: 19
+  - uid: 243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-  - uid: 20
+  - uid: 244
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-4.5
       parent: 1
-  - uid: 362
+  - uid: 245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 363
+  - uid: 246
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 376
+  - uid: 247
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 1
-  - uid: 377
+  - uid: 248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2025,37 +1967,37 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerHalftiltRight
   entities:
-  - uid: 17
+  - uid: 249
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 18
+  - uid: 250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 235
+  - uid: 251
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-  - uid: 242
+  - uid: 252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,3.5
       parent: 1
-  - uid: 378
+  - uid: 253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 1
-  - uid: 379
+  - uid: 254
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2063,12 +2005,12 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 243
+  - uid: 255
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 244
+  - uid: 256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2076,69 +2018,69 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 245
+  - uid: 257
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 246
+  - uid: 258
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 247
+  - uid: 259
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 248
+  - uid: 260
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 249
+  - uid: 261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 250
+  - uid: 262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 251
+  - uid: 263
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 252
+  - uid: 264
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 253
+  - uid: 265
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
 - proto: ThrusterLargeNfsd
   entities:
-  - uid: 254
+  - uid: 266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-7.5
       parent: 1
-  - uid: 255
+  - uid: 267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2146,75 +2088,77 @@ entities:
       parent: 1
 - proto: ThrusterNfsd
   entities:
-  - uid: 256
+  - uid: 268
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 257
+  - uid: 269
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 258
+  - uid: 270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 259
+    - type: ApcPowerReceiver
+      powerLoad: 1
+  - uid: 271
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 260
+  - uid: 272
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 261
+  - uid: 273
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-    - type: Thruster
-      enabled: False
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 262
+  - uid: 274
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,5.5
       parent: 1
-  - uid: 263
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 264
+  - uid: 276
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 265
+  - uid: 277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 266
+  - uid: 278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 267
+    - type: ApcPowerReceiver
+      powerLoad: 1
+  - uid: 279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2222,7 +2166,7 @@ entities:
       parent: 1
 - proto: ToiletDirtyWater
   entities:
-  - uid: 268
+  - uid: 280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2230,285 +2174,285 @@ entities:
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 269
+  - uid: 281
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 270
+  - uid: 282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 1
-  - uid: 271
+  - uid: 283
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 272
+  - uid: 284
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 273
+  - uid: 285
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 274
+  - uid: 286
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 275
+  - uid: 287
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 276
+  - uid: 288
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 277
+  - uid: 289
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 278
+  - uid: 290
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 279
+  - uid: 291
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 280
+  - uid: 292
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 281
+  - uid: 293
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 282
+  - uid: 294
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 283
+  - uid: 295
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 284
+  - uid: 296
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 285
+  - uid: 297
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 286
+  - uid: 298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-0.5
       parent: 1
-  - uid: 287
+  - uid: 299
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 288
+  - uid: 300
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 289
+  - uid: 301
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 290
+  - uid: 302
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 291
+  - uid: 303
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 292
+  - uid: 304
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 293
+  - uid: 305
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 294
+  - uid: 306
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 295
+  - uid: 307
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 296
+  - uid: 308
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 297
+  - uid: 309
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 298
+  - uid: 310
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 299
+  - uid: 311
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 300
+  - uid: 312
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 301
+  - uid: 313
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 302
+  - uid: 314
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 303
+  - uid: 315
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 304
+  - uid: 316
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 305
+  - uid: 317
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 306
+  - uid: 318
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 307
+  - uid: 319
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 308
+  - uid: 320
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 309
+  - uid: 321
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 310
+  - uid: 322
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 311
+  - uid: 323
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 312
+  - uid: 324
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
-  - uid: 313
+  - uid: 325
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 314
+  - uid: 326
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-0.5
       parent: 1
-  - uid: 315
+  - uid: 327
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-0.5
       parent: 1
-  - uid: 316
+  - uid: 328
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 317
+  - uid: 329
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 318
+  - uid: 330
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 319
+  - uid: 331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
-  - uid: 320
+  - uid: 332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
-  - uid: 321
+  - uid: 333
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 322
+  - uid: 334
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 323
+  - uid: 335
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2516,25 +2460,25 @@ entities:
       parent: 1
 - proto: WallPlastitaniumDebug
   entities:
-  - uid: 324
+  - uid: 336
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-  - uid: 325
+  - uid: 337
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 326
+  - uid: 338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 327
+  - uid: 339
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2542,23 +2486,23 @@ entities:
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 328
+  - uid: 340
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 329
+  - uid: 341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 330
+  - uid: 342
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 331
+  - uid: 343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2566,97 +2510,97 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 332
+  - uid: 344
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-6.5
       parent: 1
-  - uid: 333
+  - uid: 345
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 334
+  - uid: 346
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-6.5
       parent: 1
-  - uid: 335
+  - uid: 347
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-5.5
       parent: 1
-  - uid: 336
+  - uid: 348
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 337
+  - uid: 349
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 338
+  - uid: 350
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 339
+  - uid: 351
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 340
+  - uid: 352
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 341
+  - uid: 353
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
-  - uid: 342
+  - uid: 354
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 343
+  - uid: 355
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 344
+  - uid: 356
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 345
+  - uid: 357
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 346
+  - uid: 358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 347
+  - uid: 359
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 348
+  - uid: 360
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 349
+  - uid: 361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2664,66 +2608,66 @@ entities:
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 350
+  - uid: 362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-  - uid: 351
+  - uid: 363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-  - uid: 352
+  - uid: 364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-7.5
       parent: 1
-  - uid: 353
+  - uid: 365
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 354
+  - uid: 366
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 355
+  - uid: 367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 356
+  - uid: 368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
       parent: 1
-  - uid: 357
+  - uid: 369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-1.5
       parent: 1
-  - uid: 358
+  - uid: 370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
-  - uid: 359
+  - uid: 371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-  - uid: 360
+  - uid: 372
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2731,14 +2675,14 @@ entities:
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 361
+  - uid: 373
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
 - proto: WeaponTurretCerberus
   entities:
-  - uid: 21
+  - uid: 374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2752,13 +2696,13 @@ entities:
       parent: 1
 - proto: WeaponTurretL85Autocannon
   entities:
-  - uid: 364
+  - uid: 376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 365
+  - uid: 377
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2766,13 +2710,13 @@ entities:
       parent: 1
 - proto: WeaponTurretType54
   entities:
-  - uid: 366
+  - uid: 378
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,0.5
       parent: 1
-  - uid: 367
+  - uid: 379
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/Maps/_Mono/Shuttles/Nfsd/ocelot.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/ocelot.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/04/2026 15:14:41
+  time: 07/04/2026 16:39:03
   entityCount: 379
 maps: []
 grids:
@@ -219,10 +219,10 @@ entities:
             27: -1,4
     - type: SpreaderGrid
       spreadQueues:
-        Smoke: []
         Kudzu: []
-        Puddle: []
         MetalFoam: []
+        Smoke: []
+        Puddle: []
     - type: GridAtmosphere
       version: 2
       data:
@@ -1778,14 +1778,6 @@ entities:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-- proto: LockerWallEVAColorNfsdFilled
-  entities:
-  - uid: 223
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,3.5
-      parent: 1
 - proto: MachineFTLDrive
   entities:
   - uid: 224
@@ -2042,6 +2034,14 @@ entities:
     components:
     - type: Transform
       pos: -3.5,1.5
+      parent: 1
+- proto: SuitStorageWallmountM82c
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
       parent: 1
 - proto: TableReinforced
   entities:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fix that one turned off thruster on ocelot and also add an actual suit storage to it
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
BECAUSE CORRUPT WONT DO IT SO I FUCKING HAVE TO I SUPPOSE
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Why do you need a screenshot of the THRUSTER BEING TURNED ON. GOOD FUCKING GOD.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

LOAD IN THE  OCELOT

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- fix: Highcommand stopped giving us budget cut and actually field a suit into the ocelot now.

