### PR TITLE
Faction Shipguns Are Now Restricted to Factions Again

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -125,7 +125,7 @@
   parent:
   - BallisticArtillery
   - BallisticArtilleryTier2HP
-  suffix: Medium, T2
+  suffix: Medium, T2, TSFMC ONLY
   description: A rapidly firing energy weapon, well known for its devastating burst followed by a constant stream of plasma.
   components:
   - type: StaticPrice
@@ -315,7 +315,7 @@
   parent:
   - BallisticArtilleryUnanchorable
   - BallisticArtilleryTier3HP
-  suffix: Large, T3
+  suffix: Large, T3, TSFMC ONLY
   description: A more specialized energy weapon, the Scylla fires a massive burst of plasma projectiles down range, in a huge spew to erase large and small targets alike.
   components:
   - type: StaticPrice
@@ -385,7 +385,7 @@
   parent:
   - BallisticArtilleryUnanchorable
   - BallisticArtilleryTier5HP
-  suffix: Station, T5
+  suffix: Station/Capital, T5, TSFMC ONLY
   description: Aetherion Dynamics' most iconic supercapital battery. Fires enormous ionized gas projectiles that melt through the toughest ship armor. Can be remotely activated or linked to a GCS.
   components:
   - type: StaticPrice

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/syndicate_kinetic.yml
@@ -6,7 +6,7 @@
 - type: entity
   id: WeaponTurretAdderScattercannon
   name: Adder scattercannon
-  suffix: Small, T1
+  suffix: Small, T1, PDV ONLY
   parent:
   - BallisticArtillery
   - BallisticArtilleryTier1HP
@@ -72,7 +72,7 @@
 - type: entity
   id: WeaponTurretFang
   name: Fang heavy 90mm autocannon
-  suffix: Medium, T3
+  suffix: Medium, T3, PDV ONLY
   parent:
   - BallisticArtillery
   - BallisticArtilleryTier3HP
@@ -152,7 +152,7 @@
 - type: entity
   id: WeaponTurretHydra
   name: Hydra 220mm battery
-  suffix: Large, T3
+  suffix: Large, T3, PDV ONLY
   parent: BallisticArtilleryUnanchorable
   description: A main cannonade of syndicate origin, the hydra is a monstrous tri-barreled battery of 220-millimeter pain, designed to shatter corpations' toughest vessels. Loads with a similar mechanism as the anaconda handgun.
   components:
@@ -247,7 +247,7 @@
 - type: entity
   id: WeaponTurretLeviathan
   name: LEVIATHAN 520mm howitzer
-  suffix: Capital, T5
+  suffix: Capital, T5, PDV ONLY
   parent:
   - BallisticArtilleryUnanchorable
   - BallisticArtilleryTier5HP

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/thantos_launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Kinetic/thantos_launcher.yml
@@ -6,7 +6,7 @@
   parent:
   - BallisticArtilleryUnanchorable
   - BallisticArtilleryTier5HP
-  suffix: Station, T5
+  suffix: STATION ONLY, T5
   description: The charon's mean older brother, the Thanatos is a force to be reckoned with. It can be remotely activated or linked up to a GCS. This one feeds from an autoloader somewhere, and doesn't need manual reloads.
   components:
   - type: StaticPrice


### PR DESCRIPTION
## About the PR
Civilians can't have their cake and eat it too.

## Why / Balance
Civilians and minor factions enjoy a greater gameplay freedom but in exchange they don't get access to the most powerful equipment and ships, while factions have those but they need to work towards their factions' goals.
These weapons were not intended for civilian use neither in terms of gameplay nor in terms of lore and our maintainers should not have to deal with the balance issues arising from having access to these on any ship (civilians already have roundstart access to some very over the top capitals like the Hammerhead or the Serkesh). 
This change would make it so that faction weapons being restricted is the norm and exceptions can be made on a case-by-case basis where they make sense (like LPB having syndicate weaponry despite not being PDV aligned).
Two non-faction ships already have faction guns mapped on them, attached in the media section below (if need be, I can remap those). 

## Media
<img width="480" height="1312" alt="wolfsnake-0" src="https://github.com/user-attachments/assets/de1e4a3b-a283-432e-849c-493f21ed479d" />

VG Wolfsnake (less egregious since the VG are supposed to be Syndicate larpers)


<img width="375" height="641" alt="605527849-210455ab-d1b3-42ca-89b8-0c38493c7e11" src="https://github.com/user-attachments/assets/c0625594-dfc5-4d7c-b8dd-722bd3f00b39" />

Skelraak (there's no reason for it to have a rare syndicate artillery piece)


## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Open a dev environment and look up faction shipguns in the entity spawn menu.

## Breaking changes
There shouldn't be any. It's just a few lines of yml.

**Changelog**
:cl:
- remove: Civilians no longer have access to faction shipguns for mapping. 

