### PR TITLE
Fix 4 Letter Ship Designations Being Fully Renamable

### DIFF
--- a/Content.Shared/_NF/Shipyard/Components/ShuttleDeedComponent.cs
+++ b/Content.Shared/_NF/Shipyard/Components/ShuttleDeedComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._NF.Shipyard.Components;
 public sealed partial class ShuttleDeedComponent : Component
 {
     public const int MaxNameLength = 30;
-    public const int MaxSuffixLength = 3 + 1 + 4; // 3 digits, dash, up to 4 letters - should be enough
+    public const int MaxSuffixLength = 4 + 1 + 4; // 3 digits, dash, up to 4 letters - should be enough
 
     [DataField]
     public EntityUid? ShuttleUid = null;

--- a/Content.Shared/_NF/Shipyard/Components/ShuttleDeedComponent.cs
+++ b/Content.Shared/_NF/Shipyard/Components/ShuttleDeedComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._NF.Shipyard.Components;
 public sealed partial class ShuttleDeedComponent : Component
 {
     public const int MaxNameLength = 30;
-    public const int MaxSuffixLength = 4 + 1 + 4; // 3 digits, dash, up to 4 letters - should be enough
+    public const int MaxSuffixLength = 4 + 1 + 4; // 4 digits, dash, up to 4 letters - should be enough
 
     [DataField]
     public EntityUid? ShuttleUid = null;


### PR DESCRIPTION

<img width="253" height="161" alt="image" src="https://github.com/user-attachments/assets/dac84649-b7f5-40c9-a148-89f1c47189e5" />

:cl:
- fix: Fixed ships with 4 letter designation suffixes (such as TSFN/USSP) being fully renamable.