### PR TITLE
Funny Hristov

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/14.5x114mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/14.5x114mm.yml
@@ -9,7 +9,7 @@
       types:
         Piercing: 120
         Structural: 500
-    armorPenetration: 0.7
+    armorPenetration: 0.8
     penetrationThreshold: 500
     penetrationDamageTypeRequirement:
     - Structural

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/14.5x114mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/14.5x114mm.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 140
+        Piercing: 120
         Structural: 500
     armorPenetration: 0.7
     penetrationThreshold: 500

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/14.5x114mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/14.5x114mm.yml
@@ -7,9 +7,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 70
+        Piercing: 140
         Structural: 500
-    ignoreResistances: true # Goobstation
+    armorPenetration: 0.7
     penetrationThreshold: 500
     penetrationDamageTypeRequirement:
     - Structural

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/ranged_weapons.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Factions/ranged_weapons.yml
@@ -387,7 +387,7 @@
     Plasteel: 3000
     Plastic: 1000
     Silver: 2000
-    Uranium: 400
+    Plastitanium: 200
 
 # Ussp guns
 


### PR DESCRIPTION
## About the PR
Hristov damage increased to oneshot unarmored, but now only 80% AP instead of full. Also swaps 4 uranium in recipe for 2 plastitanium, I guess.

## Why / Balance
im awping it

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Hristov can now oneshot unarmored, but has AP reduced to 80% from full.