### PR TITLE
2 Minor Fixes Im Too Lazy to Make Separate PRs For

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/134x92mm.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Ammunition/Boxes/134x92mm.yml
@@ -39,7 +39,7 @@
   name: ammunition box (13.4x92mm DU-APFSDS caseless)
   components:
   - type: BallisticAmmoProvider
-    proto: Cartridge145x114mm
+    proto: CartridgeShenzhen
   - type: Sprite
     layers:
     - state: base
@@ -58,7 +58,7 @@
     - 0,0,1,1
   - type: BallisticAmmoProvider
     capacity: 30
-    proto: Cartridge145x114mm
+    proto: CartridgeShenzhen
   - type: Sprite
     sprite: _Mono/Objects/Weapons/Guns/Ammunition/Boxes/14.5x114mm.rsi
     layers:

--- a/Resources/Prototypes/_Mono/Loadouts/TSFMC/Specifics/Ranks/ranks_tsfn_cn.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/TSFMC/Specifics/Ranks/ranks_tsfn_cn.yml
@@ -3,6 +3,9 @@
 - type: loadout
   id: TsfnCNRankE1
   name: TSFN HJ1 (HJ1-LNG)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e1-cn
@@ -10,6 +13,9 @@
 - type: loadout
   id: TsfnCNRankE2
   name: TSFN HJ2 (HJ2-SHW)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e2-cn
@@ -17,6 +23,9 @@
 - type: loadout
   id: TsfnCNRankE3
   name: TSFN HJ3 (HJ3-ZW)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e3-cn
@@ -24,6 +33,9 @@
 - type: loadout
   id: TsfnCNRankE4
   name: TSFN HJ4 (HJ4-SW)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e4-cn
@@ -33,6 +45,9 @@
 - type: loadout
   id: TsfnCNRankE5
   name: TSFN HJ5 (HJ5-SHX)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e5-cn
@@ -40,6 +55,9 @@
 - type: loadout
   id: TsfnCNRankE6
   name: TSFN HJ6 (HJ6-ZX)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e6-cn
@@ -47,6 +65,9 @@
 - type: loadout
   id: TsfnCNRankE7
   name: TSFN HJ7 (HJ7-SX)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e7-cn
@@ -54,6 +75,9 @@
 - type: loadout
   id: TsfnCNRankE8
   name: TSFN HJ8 (HJ8-DX)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e8-cn
@@ -63,6 +87,9 @@
 - type: loadout
   id: TsfnCNRankE9
   name: TSFN HJ9 (HJ9-SHJ)
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: TsfnCNRanking
   components:
   - type: ChatRank
     rank: tsfn-e9-cn


### PR DESCRIPTION
## About the PR
Fixes TSF naval ranks not requiring any timelock. Fixes 13.4x92mm boxes having 14.5 in them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Shenzhen ammo boxes having the wrong bullets.
- fix: Fixed TSF naval ranks not requiring any time to unlock.
