### PR TITLE
Slight NVG Buffs

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -375,7 +375,7 @@
   description: Toggles the night vision on and off.
   components:
   - type: InstantAction
-    useDelay: 2
+    useDelay: 0.25
     icon:
       sprite: Interface/Actions/night_vision.rsi
       state: icon

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -188,7 +188,7 @@
     relayOverlay: true
     goggleEffect: true
     action: ActionToggleNightVision
-    viewCircleRadius: 300
+    viewCircleRadius: 400
     viewCircleCount: 1
     viewCircleSpacing: 280
     phosphorColor: "#00FF00"

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/phaethon_dynasty.yml
@@ -9,14 +9,14 @@
     sprite: _Mono/Clothing/Head/Hardsuits/syndicate.rsi
   - type: Clothing
     sprite: _Mono/Clothing/Head/Hardsuits/syndicate.rsi
-  - type: NightVision # Gen 2 monotubee
+  - type: NightVision # Gen 4 monotube
     relayOverlay: true
     goggleEffect: true
     action: ActionToggleNightVision
-    viewCircleRadius: 400
-    viewCircleCount: 2
+    viewCircleRadius: 450
+    viewCircleCount: 1
     viewCircleSpacing: 280
-    phosphorColor: "#00FF00"
+    phosphorColor: "#41D7D9"
     lightingColor: "#FFFFFF32"
 
 - type: entity
@@ -87,12 +87,12 @@
     sprite: _Mono/Clothing/Head/Hardsuits/pdv_vizier.rsi
   - type: Clothing
     sprite: _Mono/Clothing/Head/Hardsuits/pdv_vizier.rsi
-  - type: NightVision # Gen 2 monotubee
+  - type: NightVision # Gen 4 dualtube
     relayOverlay: true
     goggleEffect: true
     action: ActionToggleNightVision
-    viewCircleRadius: 400
+    viewCircleRadius: 450
     viewCircleCount: 2
     viewCircleSpacing: 280
-    phosphorColor: "#00FF00"
+    phosphorColor: "#41D7D9"
     lightingColor: "#FFFFFF32"

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/tsfmc.yml
@@ -12,12 +12,12 @@
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
-  - type: NightVision # Gen 1 monotube
+  - type: NightVision # Gen 1 dualtube
     relayOverlay: true
     goggleEffect: true
     action: ActionToggleNightVision
     viewCircleRadius: 400
-    viewCircleCount: 1
+    viewCircleCount: 2
     viewCircleSpacing: 280
     phosphorColor: "#00FF00"
     lightingColor: "#FFFFFF32"

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ui.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/ui.yml
@@ -108,7 +108,7 @@
     relayOverlay: true
     goggleEffect: true
     action: ActionToggleNightVision
-    viewCircleRadius: 400
+    viewCircleRadius: 430
     viewCircleCount: 1
     viewCircleSpacing: 280
     phosphorColor: "#00FF00"


### PR DESCRIPTION
## About the PR
Buffs radius of basic monotube all hardsuits get, buffs PDV suit NVGs, buffs M82c NVGs, reduces action delay

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reduced the delay on the toggle NVGs action.
- tweak: Buffed radius on basic hardsuit NVGs, buffed NVGs on M82c, CV-32, CV-67, and U.I. engineering suits.
