### PR TITLE
POI Spawning Adjustments

### DIFF
--- a/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/hammeroftheunion.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/hammeroftheunion.yml
@@ -12,7 +12,7 @@
   parent: [BaseMobilePOI, BaseRepairablePOI]
   name: 'Hammer Of The Union'
   minimumDistance: 10000
-  maximumDistance: 15000
+  maximumDistance: 20000
   spawnGroup: Required
   gridPath: /Maps/_Mono/POI/Dungeons/hammeroftheunion.yml
   addComponents:

--- a/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/lancelot.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/lancelot.yml
@@ -12,7 +12,7 @@
   parent: BasePOI
   name: 'Lancelot Mining Outpost'
   minimumDistance: 10000
-  maximumDistance: 15000
+  maximumDistance: 20000
   spawnGroup: Optional
   gridPath: /Maps/_Mono/POI/Dungeons/lancelot.yml
   addComponents:

--- a/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/polaris.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/polaris.yml
@@ -12,7 +12,7 @@
   parent: BasePOI
   name: 'Polaris Bioresearch Center'
   minimumDistance: 10000
-  maximumDistance: 15000
+  maximumDistance: 20000
   spawnGroup: Optional
   gridPath: /Maps/_Mono/POI/Dungeons/polaris.yml
   addComponents:

--- a/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/ruin_tanker.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/ruin_tanker.yml
@@ -12,7 +12,7 @@
   parent: BaseMobilePOI
   name: 'Automated Inter Sector Tanker'
   minimumDistance: 10000
-  maximumDistance: 15000
+  maximumDistance: 20000
   spawnGroup: Optional
   gridPath: /Maps/_Mono/POI/Dungeons/ruin_tanker.yml
   addComponents:

--- a/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/zenith_poi.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/zenith_poi.yml
@@ -11,8 +11,8 @@
   id: Zenith
   parent: BaseMobilePOI
   name: 'ADS Zenith CK-395'
-  minimumDistance: 10000
-  maximumDistance: 15000
+  minimumDistance: 20000
+  maximumDistance: 25000
   spawnGroup: Optional
   gridPath: /Maps/_Mono/POI/Dungeons/zenith_poi.yml
   addComponents:

--- a/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/zvezda.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Dungeon/zvezda.yml
@@ -12,7 +12,7 @@
   parent: BasePOI
   name: 'Zvezda Orbital Habitation'
   minimumDistance: 10000
-  maximumDistance: 15000
+  maximumDistance: 20000
   spawnGroup: Optional
   gridPath: /Maps/_Mono/POI/Dungeons/zvezda.yml
   addComponents:

--- a/Resources/Prototypes/_Mono/PointsOfInterest/Supercapitals/jupiter.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Supercapitals/jupiter.yml
@@ -22,6 +22,13 @@
     color: "#d1bf58"
     flags: [HideLabel]
     readOnly: false
+  - type: WorldGenDistanceCarver
+    distanceThresholds:
+    # Dead zone
+    - maxDistance: 800
+      prob: 0.0
+    - maxDistance: 1500
+      prob: 0.3
 
 - type: gameMap
   id: Jupiter

--- a/Resources/Prototypes/_Mono/PointsOfInterest/derelictdrillsite.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/derelictdrillsite.yml
@@ -18,6 +18,13 @@
   addComponents:
   - type: IFF
     color: "#ccaa55"
+  - type: WorldGenDistanceCarver
+    distanceThresholds:
+    # Dead zone
+    - maxDistance: 800
+      prob: 0.0
+    - maxDistance: 1500
+      prob: 0.3
 
 - type: gameMap
   id: Mining

--- a/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
@@ -9,8 +9,8 @@
   id: HeliosFortress
   parent: [BasePOI, BaseRepairablePOI]
   name: 'PDV Helios Fortress'
-  minimumDistance: 7500
-  maximumDistance: 9500
+  minimumDistance: 8600
+  maximumDistance: 11500
   spawnGamePreset: [ NFAdventure, NFPirate, MonoStandard, MonoRogueTSF, MonoRogueUSSP, MonoADS, MonoChimera, MonoMixed, MonoAllAtOnce ]
   spawnGroup: Required
   gridPath: /Maps/_Mono/POI/pdvhelios.yml
@@ -18,6 +18,13 @@
   - type: IFF
     color: "#DE9E59"
     readOnly: true # mono
+  - type: WorldGenDistanceCarver
+    distanceThresholds:
+    # Dead zone
+    - maxDistance: 800
+      prob: 0.0
+    - maxDistance: 1500
+      prob: 0.3
 
 - type: gameMap
   id: HeliosFortress

--- a/Resources/Prototypes/_Mono/PointsOfInterest/tsfmchalcyon.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/tsfmchalcyon.yml
@@ -25,6 +25,13 @@
     readOnly: true
   - type: SolarPoweredGrid
     doNotCull: true
+  - type: WorldGenDistanceCarver
+    distanceThresholds:
+    # Dead zone
+    - maxDistance: 800
+      prob: 0.0
+    - maxDistance: 1500
+      prob: 0.3
 
 - type: gameMap
   id: TSFMCHalcyon

--- a/Resources/Prototypes/_Mono/PointsOfInterest/ussp.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/ussp.yml
@@ -20,6 +20,13 @@
   addComponents:
   - type: IFF
     color: "#ccaa55"
+  - type: WorldGenDistanceCarver
+    distanceThresholds:
+    # Dead zone
+    - maxDistance: 800
+      prob: 0.0
+    - maxDistance: 1500
+      prob: 0.3
 
 - type: gameMap
   id: USSPCamelot

--- a/Resources/Prototypes/_NF/PointsOfInterest/lpbravo.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/lpbravo.yml
@@ -12,8 +12,8 @@
   id: LPBravo
   parent: BasePOI
   name: 'Listening Point Bravo'
-  minimumDistance: 10000
-  maximumDistance: 13000
+  minimumDistance: 15000
+  maximumDistance: 17000
   spawnGroup: SyndicateFOB
   gridPath: /Maps/_NF/POI/lpbravo.yml
   hideWarp: true
@@ -26,6 +26,13 @@
   - type: SolarPoweredGrid
     trackOnInit: true
     doNotCull: true
+  - type: WorldGenDistanceCarver
+    distanceThresholds:
+    # Dead zone
+    - maxDistance: 800
+      prob: 0.0
+    - maxDistance: 1500
+      prob: 0.3
 
 - type: gameMap
   id: LPBravo

--- a/Resources/Prototypes/_NF/PointsOfInterest/medical.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/medical.yml
@@ -20,6 +20,13 @@
   - type: IFF
     color: "#00b7eb"
   - type: StationTransit
+  - type: WorldGenDistanceCarver
+    distanceThresholds:
+    # Dead zone
+    - maxDistance: 800
+      prob: 0.0
+    - maxDistance: 1500
+      prob: 0.3
 
 - type: gameMap
   id: Medical

--- a/Resources/Prototypes/_NF/PointsOfInterest/trademall.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/trademall.yml
@@ -27,11 +27,11 @@
     doNotCull: true
   - type: WorldGenDistanceCarver
     distanceThresholds:
-      # Dead zone
-      - maxDistance: 500
-        prob: 0.0
-      - maxDistance: 1000
-        prob: 0.3
+    # Dead zone
+    - maxDistance: 800
+      prob: 0.0
+    - maxDistance: 1500
+      prob: 0.3
 
 - type: gameMap
   id: TradeMall


### PR DESCRIPTION
## About the PR
Moves dungeon POIs further out and LBP a fuck ton further out, adds worldgen carvers to The Important Ones.

## Why / Balance
gg camelot getting fragged by AI turrets

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Important POIs have less asteroids/drones around them now.
- tweak: Changed dungeon POIs (like LBP) to spawn out further. Should help with camelot getting glassed by it.