### PR TITLE
Phosphorslop

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Eyes/glasses.yml
@@ -173,12 +173,12 @@
     isEquipment: true
     color: "#FFFFFFFF"
     lightRadius: 45
-  - type: NightVision # Gen 3 wide-quadtube
+  - type: NightVision # Gen 4 wide-quadtube
     relayOverlay: true
     goggleEffect: true
     viewCircleRadius: 450
     viewCircleCount: 4
     viewCircleSpacing: 280
     action: ActionToggleNightVision
-    phosphorColor: "#00FF00"
+    phosphorColor: "#41D7D9"
     lightingColor: "#FFFFFF32"

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/phaethon_dynasty.yml
@@ -9,14 +9,14 @@
     sprite: _Mono/Clothing/Head/Hardsuits/syndicate.rsi
   - type: Clothing
     sprite: _Mono/Clothing/Head/Hardsuits/syndicate.rsi
-  - type: NightVision # Gen 4 monotube
+  - type: NightVision # Amber monotube
     relayOverlay: true
     goggleEffect: true
     action: ActionToggleNightVision
     viewCircleRadius: 450
     viewCircleCount: 1
     viewCircleSpacing: 280
-    phosphorColor: "#41D7D9"
+    phosphorColor: "#FF3300"
     lightingColor: "#FFFFFF32"
 
 - type: entity
@@ -87,14 +87,14 @@
     sprite: _Mono/Clothing/Head/Hardsuits/pdv_vizier.rsi
   - type: Clothing
     sprite: _Mono/Clothing/Head/Hardsuits/pdv_vizier.rsi
-  - type: NightVision # Gen 4 dualtube
+  - type: NightVision # Amber 4 dualtube
     relayOverlay: true
     goggleEffect: true
     action: ActionToggleNightVision
     viewCircleRadius: 450
     viewCircleCount: 2
     viewCircleSpacing: 280
-    phosphorColor: "#41D7D9"
+    phosphorColor: "#FF3300"
     lightingColor: "#FFFFFF32"
 
 - type: entity
@@ -108,12 +108,12 @@
     sprite: _Mono/Clothing/Head/Hardsuits/basilisk.rsi
   - type: Clothing
     sprite: _Mono/Clothing/Head/Hardsuits/basilisk.rsi
-  - type: NightVision # Gen 4 quadtube
+  - type: NightVision # Gen 4 quadtube-wide
     relayOverlay: true
     goggleEffect: true
-    action: ActionToggleNightVision
-    viewCircleRadius: 400
+    viewCircleRadius: 450
     viewCircleCount: 4
-    viewCircleSpacing: 260
+    viewCircleSpacing: 280
+    action: ActionToggleNightVision
     phosphorColor: "#41D7D9"
     lightingColor: "#FFFFFF32"

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/tsfmc.yml
@@ -19,7 +19,7 @@
     viewCircleRadius: 400
     viewCircleCount: 2
     viewCircleSpacing: 280
-    phosphorColor: "#00FF00"
+    phosphorColor: "#00AACC"
     lightingColor: "#FFFFFF32"
   - type: Armor
     modifiers:
@@ -49,14 +49,14 @@
   - type: PressureProtection
     highPressureMultiplier: 0.08
     lowPressureMultiplier: 1000
-  - type: NightVision # Gen 3 quadtube-wide
+  - type: NightVision # Gen 4 quadtube-wide
     relayOverlay: true
     goggleEffect: true
     viewCircleRadius: 450
     viewCircleCount: 4
     viewCircleSpacing: 280
     action: ActionToggleNightVision
-    phosphorColor: "#00FF00"
+    phosphorColor: "#41D7D9"
     lightingColor: "#FFFFFF32"
   - type: Armor
     modifiers:
@@ -102,6 +102,15 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: NightVision # Gen 4 dual tube - It needs to be durable, after all.
+    relayOverlay: true
+    goggleEffect: true
+    action: ActionToggleNightVision
+    viewCircleRadius: 450
+    viewCircleCount: 2
+    viewCircleSpacing: 280
+    phosphorColor: "#41D7D9"
+    lightingColor: "#FFFFFF32"
   - type: EyeProtection
     protectionTime: 15
 
@@ -121,14 +130,14 @@
     lowPressureMultiplier: 1000
   - type: EyeProtection
     protectionTime: 15
-  - type: NightVision # Gen 3 dual tube - It needs to be durable, after all.
+  - type: NightVision # Gen 4 dual tube - It needs to be durable, after all.
     relayOverlay: true
     goggleEffect: true
     action: ActionToggleNightVision
     viewCircleRadius: 450
     viewCircleCount: 2
     viewCircleSpacing: 280
-    phosphorColor: "#00FF00"
+    phosphorColor: "#41D7D9"
     lightingColor: "#FFFFFF32"
   - type: Armor
     modifiers:


### PR DESCRIPTION
## About the PR
Neat. More amber phosphors for PDV. A little bit for TSF too.

## Why / Balance
Match CV-53 and M86

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed more NVG phosphors on TSF & PDV suits.
