### PR TITLE
TSFN Polaris Small Touchups

### DIFF
--- a/Resources/SharedMaps/_Mono/Shuttles/Nfsd/polaris.yml
+++ b/Resources/SharedMaps/_Mono/Shuttles/Nfsd/polaris.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 06/30/2026 11:16:24
-  entityCount: 2199
+  time: 07/16/2026 11:24:56
+  entityCount: 2242
 maps: []
 grids:
 - 1
@@ -25,6 +25,7 @@ tilemap:
   6: FloorTechMaint2
   15: FloorTechMaint3
   7: FloorTechMaintAlt
+  32: FloorTechMaintDark
   8: FloorTechMaintSterile
   10: FloorWhite
   13: FloorWhiteMono
@@ -59,7 +60,7 @@ entities:
       chunks:
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAgACAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAABgAAAAAAAAEAAAAAAAAHAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAACAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAAAGAAAAAAAAAQAAAAAAAAgAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAAAQAAAAAAAAEAAAAAAAAFAAAAAAAABQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAAJAAAAAAMAAQAAAAAAAAAAAAAAAAAAAAAAAAAAEgAAAAAAAAEAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAIABAAAAAACAAEAAAAAAAABAAAAAAAABwAAAAAAAAgAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAABAAAAAAAACAAAAAAAAAkAAAAAAwAIAAAAAAAABwAAAAAAAAQAAAAAAgABAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAACAFkAAAAAAABZAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAABZAAAAAAAACQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAkAAAAAAAAEAAAAAAEAWQAAAAADAFkAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAAAAAAQAAAAAAAAoAAAAAAwAKAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAACQAAAAABAAkAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAAAAAAQAAAAAAAAQAAAAAAgAEAAAAAAIABAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAEAAAAAAEACwAAAAADAAsAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAABAAAAAAAABQAAAAAAAAUAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAcAAAAAAAADAAAAAAAAAwAAAAAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAABQAAAAAAAAUAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAgACAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAHAAAAAAAABwAAAAAAAAEAAAAAAAAHAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAACAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAgAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAARAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAAJAAAAAAMAAQAAAAAAAAAAAAAAAAAAAAAAAAAAEgAAAAAAAAEAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAIABAAAAAACAAEAAAAAAAABAAAAAAAABwAAAAAAAAgAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAABAAAAAAAACAAAAAAAAAkAAAAAAwAIAAAAAAAABwAAAAAAAAQAAAAAAgABAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAACAFkAAAAAAABZAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAQAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAIAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAABZAAAAAAAACQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAkAAAAAAAAEAAAAAAEAWQAAAAADAFkAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAAAAAAQAAAAAAAAoAAAAAAwAKAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAACQAAAAABAAkAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAAAAAAQAAAAAAAAQAAAAAAgAEAAAAAAIABAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAEAAAAAAEACwAAAAADAAsAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAABAAAAAAAABQAAAAAAAAUAAAAAAAAAQAAAAAAACAAAAAAAAAHAAAAAAAAAQAAAAAAAAcAAAAAAAADAAAAAAAAAwAAAAAAAA==
           version: 7
         -1,0:
           ind: -1,0
@@ -71,7 +72,7 @@ entities:
           version: 7
         0,-1:
           ind: 0,-1
-          tiles: AQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAABAAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAcAAAAAAAABAAAAAAAABgAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAAIAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAACAAAAAAAAAEAAAAAAAAGAAAAAAAABgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABQAAAAAAAAUAAAAAAAABAAAAAAAAAQAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAADAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAACAAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAwAJAAAAAAIAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABZAAAAAAIABAAAAAABAAQAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAAJAAAAAAEACQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAADAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkAAAAAAAAEAAAAAAAACQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAACQAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAADQAAAAABAAoAAAAAAwAKAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAALAAAAAAMACwAAAAADAA4AAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAcAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAACwAAAAADAAsAAAAAAAAOAAAAAAEAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: AQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAAFAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAABAAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAcAAAAAAAABAAAAAAAABwAAAAAAAAcAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAAIAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAACAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAADAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAACAAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAwAJAAAAAAIAAQAAAAAAACAAAAAAAAAHAAAAAAAAAQAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABZAAAAAAIABAAAAAABAAQAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAAJAAAAAAEACQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAADAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAIAAAAAAAAAcAAAAAAAABAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkAAAAAAAAEAAAAAAAACQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAACQAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAABAAAAAAAADQAAAAABAAoAAAAAAwAKAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAALAAAAAAMACwAAAAADAA4AAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAcAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAACwAAAAADAAsAAAAAAAAOAAAAAAEAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
           version: 7
         0,1:
           ind: 0,1
@@ -112,10 +113,34 @@ entities:
         version: 2
         nodes:
         - node:
+            color: '#F1B223FF'
+            id: Bot
+          decals:
+            300: -7,-14
+            301: -6,-14
+            302: 5,-14
+            303: 4,-14
+            304: 10,-7
+            305: 10,-9
+            315: -4,18
+            316: 2,18
+        - node:
+            color: '#FFFFFFFF'
+            id: BotGreyscale
+          decals:
+            299: 6,-8
+        - node:
             color: '#D69949FF'
             id: Box
           decals:
             265: -1,-11
+        - node:
+            color: '#F1B223FF'
+            id: Box
+          decals:
+            306: 10,-8
+            307: 4,-11
+            308: -6,-11
         - node:
             color: '#5FA1E7FF'
             id: BoxGreyscale
@@ -216,8 +241,6 @@ entities:
           decals:
             7: -2,-18
             8: 0,-18
-            68: -6,-14
-            69: 4,-14
             140: -9,-3
             141: -8,-3
             201: -1,-8
@@ -228,10 +251,6 @@ entities:
           decals:
             5: 0,-13
             6: -2,-13
-            72: 5,-12
-            73: 4,-12
-            74: -6,-12
-            75: -7,-12
             178: -6,4
             179: 4,4
             199: -1,-6
@@ -255,12 +274,6 @@ entities:
             color: '#D69949FF'
             id: Delivery
           decals:
-            1: -4,18
-            2: 2,18
-            47: -6,-11
-            48: -7,-11
-            49: 4,-11
-            50: 5,-11
             110: -4,-6
             111: -3,-5
             112: -2,-5
@@ -278,11 +291,6 @@ entities:
             206: -1,-7
             263: 0,-10
             264: -2,-10
-        - node:
-            color: '#4593A5FF'
-            id: DeliveryGreyscale
-          decals:
-            262: 6,-8
         - node:
             color: '#545454FF'
             id: ShiptestFullTileOverlayGreyscale
@@ -354,6 +362,7 @@ entities:
             282: 0,-20
             283: 0,-21
             284: 0,-22
+            313: -6,-7
         - node:
             color: '#FFFFFFFF'
             id: TechN
@@ -363,10 +372,6 @@ entities:
             43: 0,-13
             45: 2,-15
             46: -4,-15
-            80: 4,-12
-            81: 5,-12
-            84: -7,-12
-            85: -6,-12
             86: -4,-8
             89: 2,-8
             187: -5,4
@@ -376,6 +381,7 @@ entities:
             247: -4,-9
             250: -4,-12
             251: 2,-12
+            311: -7,-6
         - node:
             color: '#FFFFFFFF'
             id: TechNE
@@ -399,8 +405,6 @@ entities:
             37: -2,-18
             38: -1,-18
             39: 0,-18
-            82: 4,-14
-            83: -6,-14
             92: -1,-5
             145: -9,-3
             151: -8,-3
@@ -437,6 +441,9 @@ entities:
             279: -2,-20
             280: -2,-21
             281: -2,-22
+            309: 9,-7
+            310: 9,-9
+            314: -6,-1
         - node:
             color: '#355A7396'
             id: TrimlineNorthEast
@@ -517,18 +524,12 @@ entities:
           decals:
             19: 0,-18
             20: -2,-18
-            70: 4,-14
-            71: -6,-14
         - node:
             color: '#D69949FF'
             id: WarnLineGreyscaleS
           decals:
             15: -2,-13
             16: 0,-13
-            76: -6,-12
-            77: -7,-12
-            78: 4,-12
-            79: 5,-12
             182: -6,4
             183: 4,4
         - node:
@@ -593,10 +594,10 @@ entities:
             122: 6,-1
     - type: SpreaderGrid
       spreadQueues:
-        Kudzu: []
         Smoke: []
-        Puddle: []
+        Kudzu: []
         MetalFoam: []
+        Puddle: []
     - type: GridAtmosphere
       version: 2
       data:
@@ -604,16 +605,15 @@ entities:
           -4,-3:
             0: 17544
           -4,-2:
-            0: 32772
-            1: 64
+            1: 68
+            0: 32768
           -3,-3:
-            2: 61440
-            0: 192
+            2: 61644
           -3,-2:
             2: 24703
           -3,-4:
-            0: 256
-            2: 52416
+            0: 268
+            2: 49152
           -3,-1:
             0: 16
             2: 52416
@@ -621,9 +621,9 @@ entities:
             0: 8204
             1: 2176
           -2,-4:
-            2: 63248
+            2: 62976
           -2,-3:
-            2: 53350
+            2: 53367
           -2,-2:
             2: 18385
           -2,-1:
@@ -740,21 +740,21 @@ entities:
             0: 68
             1: 2048
           1,-4:
-            2: 65472
+            2: 62208
+            0: 8
           1,-3:
-            2: 53299
-            0: 128
+            2: 53503
           1,-2:
             2: 8028
           1,-5:
             1: 16320
             0: 40
           2,-4:
-            2: 4368
-            0: 1024
+            0: 1025
+            2: 4096
           2,-3:
-            0: 152
-            2: 24576
+            2: 24593
+            0: 136
           2,-2:
             2: 870
             0: 32768
@@ -763,8 +763,7 @@ entities:
           3,-3:
             0: 4352
           3,-2:
-            0: 1
-            1: 16
+            1: 17
           0,5:
             1: 52497
             0: 8192
@@ -842,17 +841,20 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1135
+      - 1120
+      - 1339
+      - 1353
+      - 60
       - 1356
-      - 1371
+      - 58
     - type: DeviceLinkSource
       linkedPorts:
-        1429:
+        1440:
         - - AirDanger
           - On
         - - AirNormal
           - Off
-        1410:
+        1414:
         - - AirDanger
           - Off
         - - AirNormal
@@ -865,17 +867,20 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1134
-      - 1370
-      - 1355
+      - 1119
+      - 1352
+      - 1338
+      - 1357
+      - 62
+      - 61
     - type: DeviceLinkSource
       linkedPorts:
-        1430:
+        1441:
         - - AirDanger
           - On
         - - AirNormal
           - Off
-        1409:
+        1413:
         - - AirDanger
           - Off
         - - AirNormal
@@ -888,19 +893,20 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1135
-      - 1131
-      - 1132
-      - 1353
-      - 1368
+      - 1120
+      - 1116
+      - 1117
+      - 1336
+      - 1350
+      - 59
     - type: DeviceLinkSource
       linkedPorts:
-        1431:
+        1442:
         - - AirDanger
           - On
         - - AirNormal
           - Off
-        1418:
+        1430:
         - - AirDanger
           - Off
         - - AirNormal
@@ -913,19 +919,20 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1124
-      - 1133
-      - 1134
-      - 1354
-      - 1369
+      - 1109
+      - 1118
+      - 1119
+      - 1337
+      - 1351
+      - 55
     - type: DeviceLinkSource
       linkedPorts:
-        1432:
+        1443:
         - - AirDanger
           - On
         - - AirNormal
           - Off
-        1417:
+        1429:
         - - AirDanger
           - Off
         - - AirNormal
@@ -938,17 +945,17 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1132
-      - 1367
-      - 1352
+      - 1117
+      - 1349
+      - 1335
     - type: DeviceLinkSource
       linkedPorts:
-        1451:
+        1461:
         - - AirDanger
           - Off
         - - AirNormal
           - On
-        1433:
+        1444:
         - - AirDanger
           - On
         - - AirNormal
@@ -961,17 +968,18 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1133
-      - 1351
-      - 1366
+      - 1118
+      - 1334
+      - 1348
+      - 63
     - type: DeviceLinkSource
       linkedPorts:
-        1450:
+        1460:
         - - AirDanger
           - Off
         - - AirNormal
           - On
-        1434:
+        1445:
         - - AirDanger
           - On
         - - AirNormal
@@ -984,25 +992,16 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1123
-      - 1125
-      - 1127
-      - 1129
-      - 1346
-      - 1361
+      - 1108
+      - 1110
+      - 1112
+      - 1114
+      - 1331
+      - 1344
+      - 65
     - type: DeviceLinkSource
       linkedPorts:
-        1443:
-        - - AirDanger
-          - Off
-        - - AirNormal
-          - On
-        1444:
-        - - AirDanger
-          - Off
-        - - AirNormal
-          - On
-        1435:
+        1446:
         - - AirDanger
           - On
         - - AirNormal
@@ -1014,19 +1013,19 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1131
-      - 1129
-      - 1130
-      - 1372
-      - 1358
+      - 1116
+      - 1114
+      - 1115
+      - 1354
+      - 1341
     - type: DeviceLinkSource
       linkedPorts:
-        1436:
+        1447:
         - - AirDanger
           - On
         - - AirNormal
           - Off
-        1423:
+        1435:
         - - AirDanger
           - Off
         - - AirNormal
@@ -1038,20 +1037,21 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1121
-      - 1122
-      - 1124
-      - 1123
-      - 1373
-      - 1357
+      - 1106
+      - 1107
+      - 1108
+      - 1109
+      - 1340
+      - 1355
+      - 64
     - type: DeviceLinkSource
       linkedPorts:
-        1437:
+        1448:
         - - AirDanger
           - On
         - - AirNormal
           - Off
-        1422:
+        1434:
         - - AirDanger
           - Off
         - - AirNormal
@@ -1063,17 +1063,17 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1130
-      - 1350
-      - 1365
+      - 1115
+      - 1333
+      - 1347
     - type: DeviceLinkSource
       linkedPorts:
-        1425:
+        1437:
         - - AirDanger
           - Off
         - - AirNormal
           - On
-        1439:
+        1450:
         - - AirDanger
           - On
         - - AirNormal
@@ -1086,17 +1086,17 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 1122
-      - 1345
-      - 1360
+      - 1107
+      - 1330
+      - 1343
     - type: DeviceLinkSource
       linkedPorts:
-        1438:
+        1449:
         - - AirDanger
           - On
         - - AirNormal
           - Off
-        1426:
+        1438:
         - - AirDanger
           - Off
         - - AirNormal
@@ -1104,22 +1104,25 @@ entities:
   - uid: 13
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-11.5
+      pos: -2.5,-11.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1363
-      - 1348
-      - 1126
+      - 1111
+      - 1113
+      - 1112
+      - 1110
+      - 1332
+      - 1345
+      - 54
     - type: DeviceLinkSource
       linkedPorts:
-        1440:
+        1451:
         - - AirDanger
           - On
         - - AirNormal
           - Off
-        1427:
+        1452:
         - - AirDanger
           - Off
         - - AirNormal
@@ -1127,61 +1130,30 @@ entities:
   - uid: 14
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-11.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,-14.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1128
-      - 1349
-      - 1364
-    - type: DeviceLinkSource
-      linkedPorts:
-        1441:
-        - - AirDanger
-          - On
-        - - AirNormal
-          - Off
-        1428:
-        - - AirDanger
-          - Off
-        - - AirNormal
-          - On
+      - 1327
+      - 1358
+      - 52
+      - 1111
   - uid: 15
     components:
     - type: Transform
-      pos: -2.5,-11.5
+      rot: 3.141592653589793 rad
+      pos: -5.5,-14.5
       parent: 1
     - type: DeviceList
       devices:
-      - 1126
-      - 1128
-      - 1127
-      - 1125
-      - 1347
-      - 1362
-    - type: DeviceLinkSource
-      linkedPorts:
-        1442:
-        - - AirDanger
-          - On
-        - - AirNormal
-          - Off
-        1445:
-        - - AirDanger
-          - Off
-        - - AirNormal
-          - On
-- proto: AirlockCaptainLocked
-  entities:
-  - uid: 16
-    components:
-    - type: Transform
-      pos: 5.5,-1.5
-      parent: 1
+      - 1328
+      - 1346
+      - 53
+      - 1113
 - proto: AirlockExternalGlassNfsdLocked
   entities:
-  - uid: 17
+  - uid: 16
     components:
     - type: Transform
       pos: 1.5,15.5
@@ -1190,10 +1162,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        18:
+        17:
         - - DoorStatus
           - DoorBolt
-  - uid: 18
+  - uid: 17
     components:
     - type: Transform
       pos: 2.5,13.5
@@ -1202,10 +1174,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        17:
+        16:
         - - DoorStatus
           - DoorBolt
-  - uid: 19
+  - uid: 18
     components:
     - type: Transform
       pos: -2.5,-0.5
@@ -1214,10 +1186,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        20:
+        19:
         - - DoorStatus
           - DoorBolt
-  - uid: 20
+  - uid: 19
     components:
     - type: Transform
       pos: -4.5,-0.5
@@ -1226,10 +1198,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        19:
+        18:
         - - DoorStatus
           - DoorBolt
-  - uid: 21
+  - uid: 20
     components:
     - type: Transform
       pos: 1.5,-0.5
@@ -1238,10 +1210,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        22:
+        21:
         - - DoorStatus
           - DoorBolt
-  - uid: 22
+  - uid: 21
     components:
     - type: Transform
       pos: 3.5,-0.5
@@ -1250,25 +1222,25 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        21:
+        20:
         - - DoorStatus
           - DoorBolt
-  - uid: 23
+  - uid: 22
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
-  - uid: 24
+  - uid: 23
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 1
-  - uid: 25
+  - uid: 24
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 1
-  - uid: 26
+  - uid: 25
     components:
     - type: Transform
       pos: -2.5,15.5
@@ -1277,10 +1249,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        27:
+        26:
         - - DoorStatus
           - DoorBolt
-  - uid: 27
+  - uid: 26
     components:
     - type: Transform
       pos: -3.5,13.5
@@ -1289,77 +1261,89 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        26:
+        25:
         - - DoorStatus
           - DoorBolt
 - proto: AirlockHatch
   entities:
-  - uid: 28
+  - uid: 27
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 1
-  - uid: 29
+  - uid: 28
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 1
-  - uid: 30
+  - uid: 29
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 31
+  - uid: 30
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
-- proto: AirlockNfsdLocked
+- proto: AirlockHeavyTSFMCLocked
   entities:
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
   - uid: 32
     components:
     - type: Transform
-      pos: -3.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
       parent: 1
   - uid: 33
     components:
     - type: Transform
-      pos: 4.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-10.5
       parent: 1
   - uid: 34
     components:
     - type: Transform
-      pos: -5.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-6.5
       parent: 1
+- proto: AirlockNfsdLocked
+  entities:
   - uid: 35
     components:
     - type: Transform
-      pos: -6.5,-1.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-1.5
       parent: 1
   - uid: 36
     components:
     - type: Transform
-      pos: 3.5,-6.5
+      pos: -3.5,5.5
       parent: 1
   - uid: 37
     components:
     - type: Transform
-      pos: -3.5,-10.5
+      pos: 4.5,-3.5
       parent: 1
   - uid: 38
     components:
     - type: Transform
-      pos: -0.5,-11.5
+      pos: -5.5,-3.5
       parent: 1
   - uid: 39
     components:
     - type: Transform
-      pos: 2.5,-10.5
+      pos: -6.5,-1.5
       parent: 1
   - uid: 40
     components:
     - type: Transform
-      pos: -4.5,-6.5
+      pos: -0.5,-11.5
       parent: 1
   - uid: 41
     components:
@@ -1415,149 +1399,239 @@ entities:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-- proto: AmeController
-  entities:
   - uid: 51
     components:
     - type: Transform
-      pos: 5.5,-13.5
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-7.5
       parent: 1
-    - type: AmeController
-      injecting: True
-    - type: ContainerContainer
-      containers:
-        fuelSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 52
-  - uid: 53
-    components:
-    - type: Transform
-      pos: -6.5,-13.5
-      parent: 1
-    - type: AmeController
-      injecting: True
-    - type: ContainerContainer
-      containers:
-        fuelSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 54
-- proto: AmeJar
-  entities:
   - uid: 52
     components:
     - type: Transform
-      parent: 51
-    - type: Physics
-      canCollide: False
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-12.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+  - uid: 53
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 15
   - uid: 54
     components:
     - type: Transform
-      parent: 53
-    - type: Physics
-      canCollide: False
-- proto: AmeShielding
-  entities:
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-14.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 13
   - uid: 55
     components:
     - type: Transform
-      pos: 6.5,-14.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
   - uid: 56
     components:
     - type: Transform
-      pos: 6.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-7.5
       parent: 1
   - uid: 57
     components:
     - type: Transform
-      pos: 6.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-0.5
       parent: 1
   - uid: 58
     components:
     - type: Transform
-      pos: 7.5,-14.5
+      rot: -1.5707963267948966 rad
+      pos: -3.5,9.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
   - uid: 59
     components:
     - type: Transform
-      pos: 7.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
       parent: 1
-    - type: PointLight
-      radius: 2
-      enabled: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
   - uid: 60
     components:
     - type: Transform
-      pos: 7.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: -3.5,16.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
   - uid: 61
     components:
     - type: Transform
-      pos: 8.5,-14.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,9.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
   - uid: 62
     components:
     - type: Transform
-      pos: 8.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,16.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
   - uid: 63
     components:
     - type: Transform
-      pos: 8.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-1.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
   - uid: 64
     components:
     - type: Transform
-      pos: -7.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 10
   - uid: 65
     components:
     - type: Transform
-      pos: -7.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 8
+- proto: AmeController
+  entities:
   - uid: 66
     components:
     - type: Transform
-      pos: -7.5,-14.5
+      pos: -6.5,-10.5
       parent: 1
   - uid: 67
     components:
     - type: Transform
-      pos: -8.5,-12.5
+      pos: 5.5,-10.5
       parent: 1
+- proto: AmeShielding
+  entities:
   - uid: 68
     components:
     - type: Transform
-      pos: -8.5,-13.5
+      pos: 8.5,-11.5
       parent: 1
-    - type: PointLight
-      radius: 2
-      enabled: True
   - uid: 69
     components:
     - type: Transform
-      pos: -8.5,-14.5
+      pos: 8.5,-12.5
       parent: 1
   - uid: 70
     components:
     - type: Transform
-      pos: -9.5,-12.5
+      pos: 6.5,-10.5
       parent: 1
   - uid: 71
     components:
     - type: Transform
-      pos: -9.5,-13.5
+      pos: 7.5,-10.5
       parent: 1
   - uid: 72
     components:
     - type: Transform
-      pos: -9.5,-14.5
+      pos: 8.5,-10.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -9.5,-10.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -7.5,-12.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -8.5,-10.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
       parent: 1
 - proto: AmmoLoader
   entities:
-  - uid: 73
+  - uid: 86
     components:
     - type: MetaData
       name: ammo loader (port AK820s)
@@ -1566,20 +1640,20 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1917:
+        2185:
         - - AmmoLoaderLoad
           - SpaceArtilleryLoad
-        1915:
+        2183:
         - - AmmoLoaderLoad
           - SpaceArtilleryLoad
-        1913:
+        2181:
         - - AmmoLoaderLoad
           - SpaceArtilleryLoad
     - type: Label
       currentLabel: port AK820s
     - type: NameModifier
       baseName: ammo loader
-  - uid: 74
+  - uid: 87
     components:
     - type: MetaData
       name: ammo loader (starboard AK820s)
@@ -1588,13 +1662,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1912:
+        2180:
         - - AmmoLoaderLoad
           - SpaceArtilleryLoad
-        1914:
+        2182:
         - - AmmoLoaderLoad
           - SpaceArtilleryLoad
-        1916:
+        2184:
         - - AmmoLoaderLoad
           - SpaceArtilleryLoad
     - type: Label
@@ -1603,1177 +1677,1187 @@ entities:
       baseName: ammo loader
 - proto: APCBasic
   entities:
-  - uid: 75
+  - uid: 88
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,9.5
       parent: 1
-  - uid: 76
+  - uid: 89
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,9.5
       parent: 1
-  - uid: 77
+  - uid: 90
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 1
-  - uid: 78
+  - uid: 91
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,14.5
       parent: 1
-  - uid: 79
+  - uid: 92
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 80
+  - uid: 93
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 81
+  - uid: 94
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 82
+  - uid: 95
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 1
-  - uid: 83
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-7.5
       parent: 1
-  - uid: 84
+  - uid: 97
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-7.5
       parent: 1
-  - uid: 85
+  - uid: 98
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-14.5
       parent: 1
-  - uid: 86
+  - uid: 99
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-14.5
       parent: 1
-  - uid: 87
+  - uid: 100
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 88
+  - uid: 101
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 89
+  - uid: 102
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 90
+  - uid: 103
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 91
+  - uid: 106
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 92
+  - uid: 107
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 93
+  - uid: 108
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 1
-  - uid: 94
+  - uid: 109
     components:
     - type: Transform
       pos: -0.5,-22.5
       parent: 1
-  - uid: 95
+  - uid: 110
     components:
     - type: Transform
       pos: -1.5,-22.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 96
+  - uid: 111
     components:
     - type: Transform
       pos: 12.5,-6.5
       parent: 1
-  - uid: 97
+  - uid: 112
     components:
     - type: Transform
       pos: 12.5,-7.5
       parent: 1
-  - uid: 98
+  - uid: 113
     components:
     - type: Transform
       pos: 11.5,-4.5
       parent: 1
-  - uid: 99
+  - uid: 114
     components:
     - type: Transform
       pos: -12.5,-11.5
       parent: 1
-  - uid: 100
-    components:
-    - type: Transform
-      pos: 8.5,-10.5
-      parent: 1
-  - uid: 101
-    components:
-    - type: Transform
-      pos: 7.5,-10.5
-      parent: 1
-  - uid: 102
+  - uid: 115
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 1
-  - uid: 103
+  - uid: 116
     components:
     - type: Transform
       pos: 9.5,-16.5
       parent: 1
-  - uid: 104
+  - uid: 117
     components:
     - type: Transform
       pos: 8.5,-19.5
       parent: 1
-  - uid: 105
+  - uid: 118
     components:
     - type: Transform
       pos: 7.5,-18.5
       parent: 1
-  - uid: 106
+  - uid: 119
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 1
-  - uid: 107
+  - uid: 120
     components:
     - type: Transform
       pos: 6.5,-18.5
       parent: 1
-  - uid: 108
+  - uid: 121
     components:
     - type: Transform
       pos: 6.5,-17.5
       parent: 1
-  - uid: 109
+  - uid: 122
     components:
     - type: Transform
       pos: 5.5,-17.5
       parent: 1
-  - uid: 110
+  - uid: 123
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 111
+  - uid: 124
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1
-  - uid: 112
+  - uid: 125
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 113
+  - uid: 126
     components:
     - type: Transform
       pos: 11.5,-11.5
       parent: 1
-  - uid: 114
+  - uid: 127
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 1
-  - uid: 115
+  - uid: 128
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 1
-  - uid: 116
+  - uid: 129
     components:
     - type: Transform
       pos: 12.5,-9.5
       parent: 1
-  - uid: 117
+  - uid: 130
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 1
-  - uid: 118
+  - uid: 131
     components:
     - type: Transform
       pos: -5.5,-17.5
       parent: 1
-  - uid: 119
+  - uid: 132
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 120
+  - uid: 133
     components:
     - type: Transform
       pos: -6.5,-17.5
       parent: 1
-  - uid: 121
+  - uid: 134
     components:
     - type: Transform
       pos: -7.5,-17.5
       parent: 1
-  - uid: 122
+  - uid: 135
     components:
     - type: Transform
       pos: -7.5,-18.5
       parent: 1
-  - uid: 123
+  - uid: 136
     components:
     - type: Transform
       pos: -8.5,-17.5
       parent: 1
-  - uid: 124
+  - uid: 137
     components:
     - type: Transform
       pos: -8.5,-18.5
       parent: 1
-  - uid: 125
+  - uid: 138
     components:
     - type: Transform
       pos: -9.5,-19.5
       parent: 1
-  - uid: 126
+  - uid: 139
     components:
     - type: Transform
       pos: -10.5,-16.5
       parent: 1
-  - uid: 127
+  - uid: 140
     components:
     - type: Transform
       pos: -11.5,-13.5
       parent: 1
-  - uid: 128
-    components:
-    - type: Transform
-      pos: -9.5,-10.5
-      parent: 1
-  - uid: 129
-    components:
-    - type: Transform
-      pos: -8.5,-10.5
-      parent: 1
-  - uid: 131
+  - uid: 141
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 1
-  - uid: 132
+  - uid: 142
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 1
-  - uid: 133
+  - uid: 143
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 1
-  - uid: 134
+  - uid: 144
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 1
-  - uid: 135
+  - uid: 145
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 1
-  - uid: 136
+  - uid: 146
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 1
-  - uid: 137
+  - uid: 147
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 138
+  - uid: 148
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 139
+  - uid: 149
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 140
+  - uid: 150
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 141
+  - uid: 151
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 142
+  - uid: 152
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 143
+  - uid: 153
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 144
+  - uid: 154
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 145
+  - uid: 155
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 146
+  - uid: 156
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 1
-  - uid: 147
+  - uid: 157
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 1
-  - uid: 148
+  - uid: 158
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 1
-  - uid: 149
+  - uid: 159
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 1
-  - uid: 150
+  - uid: 160
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 1
-  - uid: 151
+  - uid: 161
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 1
-  - uid: 152
+  - uid: 162
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 1
-  - uid: 153
+  - uid: 163
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
-  - uid: 154
+  - uid: 164
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
-  - uid: 155
+  - uid: 165
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 1
-  - uid: 156
+  - uid: 166
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 1
-  - uid: 157
+  - uid: 167
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 1
-  - uid: 158
+  - uid: 168
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 159
+  - uid: 169
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
-  - uid: 160
+  - uid: 170
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 1
-  - uid: 161
+  - uid: 171
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 162
+  - uid: 172
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 163
+  - uid: 173
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 164
+  - uid: 174
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 165
+  - uid: 175
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 166
+  - uid: 176
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 167
+  - uid: 177
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-  - uid: 168
+  - uid: 178
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 1
-  - uid: 169
+  - uid: 179
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 1
-  - uid: 170
+  - uid: 180
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
-  - uid: 171
+  - uid: 181
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
-  - uid: 172
+  - uid: 182
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 173
+  - uid: 183
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 174
+  - uid: 184
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 175
+  - uid: 185
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 176
+  - uid: 186
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 177
+  - uid: 187
     components:
     - type: Transform
       pos: -5.5,12.5
       parent: 1
-  - uid: 178
+  - uid: 188
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
-  - uid: 179
+  - uid: 189
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 1
-  - uid: 180
+  - uid: 190
     components:
     - type: Transform
       pos: -6.5,12.5
       parent: 1
-  - uid: 181
+  - uid: 191
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 1
-  - uid: 182
+  - uid: 192
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 1
-  - uid: 183
+  - uid: 193
     components:
     - type: Transform
       pos: -7.5,12.5
       parent: 1
-  - uid: 184
+  - uid: 194
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 1
-  - uid: 185
+  - uid: 195
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 1
-  - uid: 186
+  - uid: 196
     components:
     - type: Transform
       pos: -8.5,9.5
       parent: 1
-  - uid: 187
+  - uid: 197
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 1
-  - uid: 188
+  - uid: 198
     components:
     - type: Transform
       pos: -8.5,7.5
       parent: 1
-  - uid: 189
+  - uid: 199
     components:
     - type: Transform
       pos: -8.5,6.5
       parent: 1
-  - uid: 190
+  - uid: 200
     components:
     - type: Transform
       pos: -7.5,8.5
       parent: 1
-  - uid: 191
+  - uid: 201
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 1
-  - uid: 192
+  - uid: 202
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 1
-  - uid: 193
+  - uid: 203
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 1
-  - uid: 194
+  - uid: 204
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 1
-  - uid: 195
+  - uid: 205
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-  - uid: 196
+  - uid: 206
     components:
     - type: Transform
       pos: -7.5,15.5
       parent: 1
-  - uid: 197
+  - uid: 207
     components:
     - type: Transform
       pos: -7.5,14.5
       parent: 1
-  - uid: 198
+  - uid: 208
     components:
     - type: Transform
       pos: -6.5,15.5
       parent: 1
-  - uid: 199
+  - uid: 209
     components:
     - type: Transform
       pos: -6.5,14.5
       parent: 1
-  - uid: 200
+  - uid: 210
     components:
     - type: Transform
       pos: 5.5,15.5
       parent: 1
-  - uid: 201
+  - uid: 211
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 1
-  - uid: 202
+  - uid: 212
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 203
+  - uid: 213
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 1
-  - uid: 204
+  - uid: 214
     components:
     - type: Transform
       pos: 6.5,17.5
       parent: 1
-  - uid: 205
+  - uid: 215
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 1
-  - uid: 206
+  - uid: 216
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 1
-  - uid: 207
+  - uid: 217
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 208
+  - uid: 218
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 209
+  - uid: 219
     components:
     - type: Transform
       pos: 5.5,21.5
       parent: 1
-  - uid: 212
+  - uid: 220
     components:
     - type: Transform
       pos: -6.5,21.5
       parent: 1
-  - uid: 213
+  - uid: 221
     components:
     - type: Transform
       pos: -6.5,19.5
       parent: 1
-  - uid: 214
+  - uid: 222
     components:
     - type: Transform
       pos: -6.5,18.5
       parent: 1
-  - uid: 215
+  - uid: 223
     components:
     - type: Transform
       pos: -5.5,19.5
       parent: 1
-  - uid: 216
+  - uid: 224
     components:
     - type: Transform
       pos: -5.5,18.5
       parent: 1
-  - uid: 217
+  - uid: 225
     components:
     - type: Transform
       pos: -7.5,17.5
       parent: 1
-  - uid: 218
+  - uid: 226
     components:
     - type: Transform
       pos: -4.5,24.5
       parent: 1
-  - uid: 219
+  - uid: 227
     components:
     - type: Transform
       pos: -4.5,23.5
       parent: 1
-  - uid: 220
+  - uid: 228
     components:
     - type: Transform
       pos: -4.5,22.5
       parent: 1
-  - uid: 221
+  - uid: 229
     components:
     - type: Transform
       pos: -3.5,24.5
       parent: 1
-  - uid: 222
+  - uid: 230
     components:
     - type: Transform
       pos: -3.5,23.5
       parent: 1
-  - uid: 223
+  - uid: 231
     components:
     - type: Transform
       pos: -3.5,22.5
       parent: 1
-  - uid: 224
+  - uid: 232
     components:
     - type: Transform
       pos: -2.5,24.5
       parent: 1
-  - uid: 225
+  - uid: 233
     components:
     - type: Transform
       pos: -5.5,24.5
       parent: 1
-  - uid: 226
+  - uid: 234
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 1
-  - uid: 227
+  - uid: 235
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 1
-  - uid: 228
+  - uid: 236
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
-  - uid: 229
+  - uid: 237
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 1
-  - uid: 230
+  - uid: 238
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 231
+  - uid: 239
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
-  - uid: 232
+  - uid: 240
     components:
     - type: Transform
       pos: 3.5,22.5
       parent: 1
-  - uid: 233
+  - uid: 241
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 1
-  - uid: 234
+  - uid: 242
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 1
-  - uid: 235
+  - uid: 243
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 236
+  - uid: 244
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
-  - uid: 237
+  - uid: 245
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
-  - uid: 238
+  - uid: 246
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 1
-  - uid: 239
+  - uid: 247
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 240
+  - uid: 248
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 241
+  - uid: 249
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 242
+  - uid: 250
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 243
+  - uid: 251
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 244
+  - uid: 252
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 245
+  - uid: 253
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 246
+  - uid: 254
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 247
+  - uid: 255
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 248
+  - uid: 256
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 249
+  - uid: 257
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 250
+  - uid: 258
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 251
+  - uid: 259
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 252
+  - uid: 260
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 253
+  - uid: 261
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 254
+  - uid: 262
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 255
+  - uid: 263
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 256
+  - uid: 264
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 257
+  - uid: 265
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 258
+  - uid: 266
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 259
+  - uid: 267
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 260
+  - uid: 268
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 261
+  - uid: 269
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 262
+  - uid: 270
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 263
+  - uid: 271
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 264
+  - uid: 272
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 265
+  - uid: 273
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 266
+  - uid: 274
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 267
+  - uid: 275
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 1
-  - uid: 268
+  - uid: 276
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 1
-  - uid: 269
+  - uid: 277
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 270
+  - uid: 278
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 1
-  - uid: 271
+  - uid: 279
     components:
     - type: Transform
       pos: -1.5,18.5
       parent: 1
-  - uid: 272
+  - uid: 280
     components:
     - type: Transform
       pos: -1.5,19.5
       parent: 1
-  - uid: 273
+  - uid: 281
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 274
+  - uid: 282
     components:
     - type: Transform
       pos: -1.5,20.5
       parent: 1
-  - uid: 275
+  - uid: 283
     components:
     - type: Transform
       pos: -1.5,21.5
       parent: 1
-  - uid: 276
+  - uid: 284
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1
-  - uid: 277
+  - uid: 285
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 1
-  - uid: 278
+  - uid: 286
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 1
-  - uid: 279
+  - uid: 287
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 280
+  - uid: 288
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 281
+  - uid: 289
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 282
+  - uid: 290
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 283
+  - uid: 291
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 284
+  - uid: 292
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 285
+  - uid: 293
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 286
+  - uid: 294
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 287
+  - uid: 295
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 288
+  - uid: 296
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 289
+  - uid: 297
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 290
+  - uid: 298
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 291
+  - uid: 299
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 292
+  - uid: 300
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 2020
+  - uid: 301
     components:
     - type: Transform
       pos: -4.5,-17.5
       parent: 1
-  - uid: 2021
+  - uid: 302
     components:
     - type: Transform
       pos: 3.5,-17.5
       parent: 1
-  - uid: 2022
+  - uid: 303
     components:
     - type: Transform
       pos: -13.5,-9.5
       parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -8.5,-15.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -9.5,-15.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 7.5,-15.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 8.5,-15.5
+      parent: 1
 - proto: Autolathe
   entities:
-  - uid: 293
+  - uid: 308
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 294
+  - uid: 309
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
 - proto: BedsheetBlack
   entities:
-  - uid: 298
+  - uid: 310
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 302
+  - uid: 311
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 303
+  - uid: 312
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 304
+  - uid: 313
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
 - proto: BunkBottom
   entities:
-  - uid: 297
+  - uid: 314
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 299
+  - uid: 315
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
 - proto: BunkTop
   entities:
-  - uid: 295
+  - uid: 316
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 300
+  - uid: 317
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
 - proto: ButtonFrameCaution
   entities:
-  - uid: 305
+  - uid: 318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2781,2615 +2865,2523 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 306
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 1
-  - uid: 307
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 308
-    components:
-    - type: Transform
-      pos: -3.5,18.5
-      parent: 1
-  - uid: 309
-    components:
-    - type: Transform
-      pos: -3.5,17.5
-      parent: 1
-  - uid: 310
-    components:
-    - type: Transform
-      pos: -3.5,16.5
-      parent: 1
-  - uid: 311
-    components:
-    - type: Transform
-      pos: -3.5,15.5
-      parent: 1
-  - uid: 312
-    components:
-    - type: Transform
-      pos: -3.5,14.5
-      parent: 1
-  - uid: 313
-    components:
-    - type: Transform
-      pos: -3.5,13.5
-      parent: 1
-  - uid: 314
-    components:
-    - type: Transform
-      pos: -3.5,12.5
-      parent: 1
-  - uid: 315
-    components:
-    - type: Transform
-      pos: -3.5,11.5
-      parent: 1
-  - uid: 316
-    components:
-    - type: Transform
-      pos: -3.5,10.5
-      parent: 1
-  - uid: 317
-    components:
-    - type: Transform
-      pos: -3.5,9.5
-      parent: 1
-  - uid: 318
-    components:
-    - type: Transform
-      pos: -3.5,8.5
-      parent: 1
   - uid: 319
     components:
     - type: Transform
-      pos: -3.5,7.5
+      pos: 2.5,5.5
       parent: 1
   - uid: 320
     components:
     - type: Transform
-      pos: -3.5,6.5
+      pos: -1.5,0.5
       parent: 1
   - uid: 321
     components:
     - type: Transform
-      pos: -3.5,5.5
+      pos: -3.5,18.5
       parent: 1
   - uid: 322
     components:
     - type: Transform
-      pos: -3.5,4.5
+      pos: -3.5,17.5
       parent: 1
   - uid: 323
     components:
     - type: Transform
-      pos: -3.5,3.5
+      pos: -3.5,16.5
       parent: 1
   - uid: 324
     components:
     - type: Transform
-      pos: -3.5,2.5
+      pos: -3.5,15.5
       parent: 1
   - uid: 325
     components:
     - type: Transform
-      pos: -3.5,1.5
+      pos: -3.5,14.5
       parent: 1
   - uid: 326
     components:
     - type: Transform
-      pos: 2.5,1.5
+      pos: -3.5,13.5
       parent: 1
   - uid: 327
     components:
     - type: Transform
-      pos: 2.5,2.5
+      pos: -3.5,12.5
       parent: 1
   - uid: 328
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: -3.5,11.5
       parent: 1
   - uid: 329
     components:
     - type: Transform
-      pos: 2.5,4.5
+      pos: -3.5,10.5
       parent: 1
   - uid: 330
     components:
     - type: Transform
-      pos: 2.5,6.5
+      pos: -3.5,9.5
       parent: 1
   - uid: 331
     components:
     - type: Transform
-      pos: 2.5,7.5
+      pos: -3.5,8.5
       parent: 1
   - uid: 332
     components:
     - type: Transform
-      pos: 2.5,8.5
+      pos: -3.5,7.5
       parent: 1
   - uid: 333
     components:
     - type: Transform
-      pos: 2.5,9.5
+      pos: -3.5,6.5
       parent: 1
   - uid: 334
     components:
     - type: Transform
-      pos: 2.5,10.5
+      pos: -3.5,5.5
       parent: 1
   - uid: 335
     components:
     - type: Transform
-      pos: 2.5,11.5
+      pos: -3.5,4.5
       parent: 1
   - uid: 336
     components:
     - type: Transform
-      pos: 2.5,12.5
+      pos: -3.5,3.5
       parent: 1
   - uid: 337
     components:
     - type: Transform
-      pos: 2.5,13.5
+      pos: -3.5,2.5
       parent: 1
   - uid: 338
     components:
     - type: Transform
-      pos: 2.5,14.5
+      pos: -3.5,1.5
       parent: 1
   - uid: 339
     components:
     - type: Transform
-      pos: 2.5,15.5
+      pos: 2.5,1.5
       parent: 1
   - uid: 340
     components:
     - type: Transform
-      pos: 2.5,16.5
+      pos: 2.5,2.5
       parent: 1
   - uid: 341
     components:
     - type: Transform
-      pos: 2.5,17.5
+      pos: 2.5,3.5
       parent: 1
   - uid: 342
     components:
     - type: Transform
-      pos: 2.5,18.5
+      pos: 2.5,4.5
       parent: 1
   - uid: 343
     components:
     - type: Transform
-      pos: -3.5,19.5
+      pos: 2.5,6.5
       parent: 1
   - uid: 344
     components:
     - type: Transform
-      pos: -3.5,20.5
+      pos: 2.5,7.5
       parent: 1
   - uid: 345
     components:
     - type: Transform
-      pos: -3.5,21.5
+      pos: 2.5,8.5
       parent: 1
   - uid: 346
     components:
     - type: Transform
-      pos: 2.5,21.5
+      pos: 2.5,9.5
       parent: 1
   - uid: 347
     components:
     - type: Transform
-      pos: 2.5,20.5
+      pos: 2.5,10.5
       parent: 1
   - uid: 348
     components:
     - type: Transform
-      pos: 2.5,19.5
+      pos: 2.5,11.5
       parent: 1
   - uid: 349
     components:
     - type: Transform
-      pos: 3.5,14.5
+      pos: 2.5,12.5
       parent: 1
   - uid: 350
     components:
     - type: Transform
-      pos: 4.5,14.5
+      pos: 2.5,13.5
       parent: 1
   - uid: 351
     components:
     - type: Transform
-      pos: 5.5,14.5
+      pos: 2.5,14.5
       parent: 1
   - uid: 352
     components:
     - type: Transform
-      pos: 6.5,14.5
+      pos: 2.5,15.5
       parent: 1
   - uid: 353
     components:
     - type: Transform
-      pos: -4.5,14.5
+      pos: 2.5,16.5
       parent: 1
   - uid: 354
     components:
     - type: Transform
-      pos: -5.5,14.5
+      pos: 2.5,17.5
       parent: 1
   - uid: 355
     components:
     - type: Transform
-      pos: -6.5,14.5
+      pos: 2.5,18.5
       parent: 1
   - uid: 356
     components:
     - type: Transform
-      pos: -7.5,14.5
+      pos: -3.5,19.5
       parent: 1
   - uid: 357
     components:
     - type: Transform
-      pos: -4.5,7.5
+      pos: -3.5,20.5
       parent: 1
   - uid: 358
     components:
     - type: Transform
-      pos: -5.5,7.5
+      pos: -3.5,21.5
       parent: 1
   - uid: 359
     components:
     - type: Transform
-      pos: -6.5,7.5
+      pos: 2.5,21.5
       parent: 1
   - uid: 360
     components:
     - type: Transform
-      pos: -7.5,7.5
+      pos: 2.5,20.5
       parent: 1
   - uid: 361
     components:
     - type: Transform
-      pos: -8.5,7.5
+      pos: 2.5,19.5
       parent: 1
   - uid: 362
     components:
     - type: Transform
-      pos: 3.5,7.5
+      pos: 3.5,14.5
       parent: 1
   - uid: 363
     components:
     - type: Transform
-      pos: 4.5,7.5
+      pos: 4.5,14.5
       parent: 1
   - uid: 364
     components:
     - type: Transform
-      pos: 5.5,7.5
+      pos: 5.5,14.5
       parent: 1
   - uid: 365
     components:
     - type: Transform
-      pos: 6.5,7.5
+      pos: 6.5,14.5
       parent: 1
   - uid: 366
     components:
     - type: Transform
-      pos: 7.5,7.5
+      pos: -4.5,14.5
       parent: 1
   - uid: 367
     components:
     - type: Transform
-      pos: 3.5,8.5
+      pos: -5.5,14.5
       parent: 1
   - uid: 368
     components:
     - type: Transform
-      pos: -4.5,8.5
+      pos: -6.5,14.5
       parent: 1
   - uid: 369
     components:
     - type: Transform
-      pos: 3.5,9.5
+      pos: -7.5,14.5
       parent: 1
   - uid: 370
     components:
     - type: Transform
-      pos: -4.5,9.5
+      pos: -4.5,7.5
       parent: 1
   - uid: 371
     components:
     - type: Transform
-      pos: -4.5,1.5
+      pos: -5.5,7.5
       parent: 1
   - uid: 372
     components:
     - type: Transform
-      pos: -5.5,1.5
+      pos: -6.5,7.5
       parent: 1
   - uid: 373
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: -7.5,7.5
       parent: 1
   - uid: 374
     components:
     - type: Transform
-      pos: 4.5,1.5
+      pos: -8.5,7.5
       parent: 1
   - uid: 375
     components:
     - type: Transform
-      pos: 4.5,0.5
+      pos: 3.5,7.5
       parent: 1
   - uid: 376
     components:
     - type: Transform
-      pos: 4.5,-0.5
+      pos: 4.5,7.5
       parent: 1
   - uid: 377
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      pos: 5.5,7.5
       parent: 1
   - uid: 378
     components:
     - type: Transform
-      pos: 4.5,-2.5
+      pos: 6.5,7.5
       parent: 1
   - uid: 379
     components:
     - type: Transform
-      pos: -5.5,0.5
+      pos: 7.5,7.5
       parent: 1
   - uid: 380
     components:
     - type: Transform
-      pos: -5.5,-0.5
+      pos: 3.5,8.5
       parent: 1
   - uid: 381
     components:
     - type: Transform
-      pos: -5.5,-1.5
+      pos: -4.5,8.5
       parent: 1
   - uid: 382
     components:
     - type: Transform
-      pos: -5.5,-2.5
+      pos: 3.5,9.5
       parent: 1
   - uid: 383
     components:
     - type: Transform
-      pos: 3.5,-0.5
+      pos: -4.5,9.5
       parent: 1
   - uid: 384
     components:
     - type: Transform
-      pos: 2.5,-0.5
+      pos: -4.5,1.5
       parent: 1
   - uid: 385
     components:
     - type: Transform
-      pos: 1.5,-0.5
+      pos: -5.5,1.5
       parent: 1
   - uid: 386
     components:
     - type: Transform
-      pos: 0.5,-0.5
+      pos: 3.5,1.5
       parent: 1
   - uid: 387
     components:
     - type: Transform
-      pos: -0.5,-0.5
+      pos: 4.5,1.5
       parent: 1
   - uid: 388
     components:
     - type: Transform
-      pos: -1.5,-0.5
+      pos: 4.5,0.5
       parent: 1
   - uid: 389
     components:
     - type: Transform
-      pos: -2.5,-0.5
+      pos: 4.5,-0.5
       parent: 1
   - uid: 390
     components:
     - type: Transform
-      pos: -3.5,-0.5
+      pos: 4.5,-1.5
       parent: 1
   - uid: 391
     components:
     - type: Transform
-      pos: -4.5,-0.5
+      pos: 4.5,-2.5
       parent: 1
   - uid: 392
     components:
     - type: Transform
-      pos: -1.5,1.5
+      pos: -5.5,0.5
       parent: 1
   - uid: 393
     components:
     - type: Transform
-      pos: -1.5,2.5
+      pos: -5.5,-0.5
       parent: 1
   - uid: 394
     components:
     - type: Transform
-      pos: -1.5,3.5
+      pos: -5.5,-1.5
       parent: 1
   - uid: 395
     components:
     - type: Transform
-      pos: -1.5,4.5
+      pos: -5.5,-2.5
       parent: 1
   - uid: 396
     components:
     - type: Transform
-      pos: -1.5,5.5
+      pos: 3.5,-0.5
       parent: 1
   - uid: 397
     components:
     - type: Transform
-      pos: -1.5,6.5
+      pos: 2.5,-0.5
       parent: 1
   - uid: 398
     components:
     - type: Transform
-      pos: -1.5,7.5
+      pos: 1.5,-0.5
       parent: 1
   - uid: 399
     components:
     - type: Transform
-      pos: -1.5,8.5
+      pos: 0.5,-0.5
       parent: 1
   - uid: 400
     components:
     - type: Transform
-      pos: -1.5,9.5
+      pos: -0.5,-0.5
       parent: 1
   - uid: 401
     components:
     - type: Transform
-      pos: -1.5,10.5
+      pos: -1.5,-0.5
       parent: 1
   - uid: 402
     components:
     - type: Transform
-      pos: -1.5,11.5
+      pos: -2.5,-0.5
       parent: 1
   - uid: 403
     components:
     - type: Transform
-      pos: -1.5,12.5
+      pos: -3.5,-0.5
       parent: 1
   - uid: 404
     components:
     - type: Transform
-      pos: -1.5,13.5
+      pos: -4.5,-0.5
       parent: 1
   - uid: 405
     components:
     - type: Transform
-      pos: -1.5,14.5
+      pos: -1.5,1.5
       parent: 1
   - uid: 406
     components:
     - type: Transform
-      pos: -1.5,15.5
+      pos: -1.5,2.5
       parent: 1
   - uid: 407
     components:
     - type: Transform
-      pos: -1.5,16.5
+      pos: -1.5,3.5
       parent: 1
   - uid: 408
     components:
     - type: Transform
-      pos: -1.5,19.5
+      pos: -1.5,4.5
       parent: 1
   - uid: 409
     components:
     - type: Transform
-      pos: -1.5,18.5
+      pos: -1.5,5.5
       parent: 1
   - uid: 410
     components:
     - type: Transform
-      pos: -1.5,20.5
+      pos: -1.5,6.5
       parent: 1
   - uid: 411
     components:
     - type: Transform
-      pos: -1.5,21.5
+      pos: -1.5,7.5
       parent: 1
   - uid: 412
     components:
     - type: Transform
-      pos: -1.5,22.5
+      pos: -1.5,8.5
       parent: 1
   - uid: 413
     components:
     - type: Transform
-      pos: -1.5,17.5
+      pos: -1.5,9.5
       parent: 1
   - uid: 414
     components:
     - type: Transform
-      pos: 0.5,22.5
+      pos: -1.5,10.5
       parent: 1
   - uid: 415
     components:
     - type: Transform
-      pos: 0.5,21.5
+      pos: -1.5,11.5
       parent: 1
   - uid: 416
     components:
     - type: Transform
-      pos: 0.5,20.5
+      pos: -1.5,12.5
       parent: 1
   - uid: 417
     components:
     - type: Transform
-      pos: 0.5,19.5
+      pos: -1.5,13.5
       parent: 1
   - uid: 418
     components:
     - type: Transform
-      pos: 0.5,18.5
+      pos: -1.5,14.5
       parent: 1
   - uid: 419
     components:
     - type: Transform
-      pos: 0.5,17.5
+      pos: -1.5,15.5
       parent: 1
   - uid: 420
     components:
     - type: Transform
-      pos: 0.5,16.5
+      pos: -1.5,16.5
       parent: 1
   - uid: 421
     components:
     - type: Transform
-      pos: 0.5,15.5
+      pos: -1.5,19.5
       parent: 1
   - uid: 422
     components:
     - type: Transform
-      pos: 0.5,14.5
+      pos: -1.5,18.5
       parent: 1
   - uid: 423
     components:
     - type: Transform
-      pos: 0.5,13.5
+      pos: -1.5,20.5
       parent: 1
   - uid: 424
     components:
     - type: Transform
-      pos: 0.5,12.5
+      pos: -1.5,21.5
       parent: 1
   - uid: 425
     components:
     - type: Transform
-      pos: 0.5,11.5
+      pos: -1.5,22.5
       parent: 1
   - uid: 426
     components:
     - type: Transform
-      pos: 0.5,10.5
+      pos: -1.5,17.5
       parent: 1
   - uid: 427
     components:
     - type: Transform
-      pos: 0.5,9.5
+      pos: 0.5,22.5
       parent: 1
   - uid: 428
     components:
     - type: Transform
-      pos: 0.5,8.5
+      pos: 0.5,21.5
       parent: 1
   - uid: 429
     components:
     - type: Transform
-      pos: 0.5,7.5
+      pos: 0.5,20.5
       parent: 1
   - uid: 430
     components:
     - type: Transform
-      pos: 0.5,6.5
+      pos: 0.5,19.5
       parent: 1
   - uid: 431
     components:
     - type: Transform
-      pos: 0.5,5.5
+      pos: 0.5,18.5
       parent: 1
   - uid: 432
     components:
     - type: Transform
-      pos: 0.5,4.5
+      pos: 0.5,17.5
       parent: 1
   - uid: 433
     components:
     - type: Transform
-      pos: 0.5,3.5
+      pos: 0.5,16.5
       parent: 1
   - uid: 434
     components:
     - type: Transform
-      pos: 0.5,2.5
+      pos: 0.5,15.5
       parent: 1
   - uid: 435
     components:
     - type: Transform
-      pos: 0.5,0.5
+      pos: 0.5,14.5
       parent: 1
   - uid: 436
     components:
     - type: Transform
-      pos: 0.5,1.5
+      pos: 0.5,13.5
       parent: 1
   - uid: 437
     components:
     - type: Transform
-      pos: -6.5,-1.5
+      pos: 0.5,12.5
       parent: 1
   - uid: 438
     components:
     - type: Transform
-      pos: -7.5,-1.5
+      pos: 0.5,11.5
       parent: 1
   - uid: 439
     components:
     - type: Transform
-      pos: -8.5,-1.5
+      pos: 0.5,10.5
       parent: 1
   - uid: 440
     components:
     - type: Transform
-      pos: -9.5,-1.5
+      pos: 0.5,9.5
       parent: 1
   - uid: 441
     components:
     - type: Transform
-      pos: 5.5,-1.5
+      pos: 0.5,8.5
       parent: 1
   - uid: 442
     components:
     - type: Transform
-      pos: 6.5,-1.5
+      pos: 0.5,7.5
       parent: 1
   - uid: 443
     components:
     - type: Transform
-      pos: 7.5,-1.5
+      pos: 0.5,6.5
       parent: 1
   - uid: 444
     components:
     - type: Transform
-      pos: 8.5,-1.5
+      pos: 0.5,5.5
       parent: 1
   - uid: 445
     components:
     - type: Transform
-      pos: 7.5,-0.5
+      pos: 0.5,4.5
       parent: 1
   - uid: 446
     components:
     - type: Transform
-      pos: 7.5,0.5
+      pos: 0.5,3.5
       parent: 1
   - uid: 447
     components:
     - type: Transform
-      pos: 7.5,-2.5
+      pos: 0.5,2.5
       parent: 1
   - uid: 448
     components:
     - type: Transform
-      pos: 7.5,-3.5
+      pos: 0.5,0.5
       parent: 1
   - uid: 449
     components:
     - type: Transform
-      pos: -8.5,-2.5
+      pos: 0.5,1.5
       parent: 1
   - uid: 450
     components:
     - type: Transform
-      pos: -8.5,-3.5
+      pos: -6.5,-1.5
       parent: 1
   - uid: 451
     components:
     - type: Transform
-      pos: -8.5,-0.5
+      pos: -7.5,-1.5
       parent: 1
   - uid: 452
     components:
     - type: Transform
-      pos: -8.5,0.5
+      pos: -8.5,-1.5
       parent: 1
   - uid: 453
     components:
     - type: Transform
-      pos: -7.5,-5.5
+      pos: -9.5,-1.5
       parent: 1
   - uid: 454
     components:
     - type: Transform
-      pos: -6.5,-5.5
+      pos: 5.5,-1.5
       parent: 1
   - uid: 455
     components:
     - type: Transform
-      pos: -5.5,-5.5
+      pos: 6.5,-1.5
       parent: 1
   - uid: 456
     components:
     - type: Transform
-      pos: 6.5,-5.5
+      pos: 7.5,-1.5
       parent: 1
   - uid: 457
     components:
     - type: Transform
-      pos: 5.5,-5.5
+      pos: 8.5,-1.5
       parent: 1
   - uid: 458
     components:
     - type: Transform
-      pos: 4.5,-5.5
+      pos: 7.5,-0.5
       parent: 1
   - uid: 459
     components:
     - type: Transform
-      pos: 4.5,-6.5
+      pos: 7.5,0.5
       parent: 1
   - uid: 460
     components:
     - type: Transform
-      pos: 4.5,-4.5
+      pos: 7.5,-2.5
       parent: 1
   - uid: 461
     components:
     - type: Transform
-      pos: -5.5,-4.5
+      pos: 7.5,-3.5
       parent: 1
   - uid: 462
     components:
     - type: Transform
-      pos: -5.5,-6.5
+      pos: -8.5,-2.5
       parent: 1
   - uid: 463
     components:
     - type: Transform
-      pos: -5.5,-3.5
+      pos: -8.5,-3.5
       parent: 1
   - uid: 464
     components:
     - type: Transform
-      pos: 4.5,-3.5
+      pos: -8.5,-0.5
       parent: 1
   - uid: 465
     components:
     - type: Transform
-      pos: 3.5,-6.5
+      pos: -8.5,0.5
       parent: 1
   - uid: 466
     components:
     - type: Transform
-      pos: 2.5,-6.5
+      pos: -7.5,-5.5
       parent: 1
   - uid: 467
     components:
     - type: Transform
-      pos: 1.5,-6.5
+      pos: -6.5,-5.5
       parent: 1
   - uid: 468
     components:
     - type: Transform
-      pos: 0.5,-6.5
+      pos: -5.5,-5.5
       parent: 1
   - uid: 469
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: 6.5,-5.5
       parent: 1
   - uid: 470
     components:
     - type: Transform
-      pos: -1.5,-6.5
+      pos: 5.5,-5.5
       parent: 1
   - uid: 471
     components:
     - type: Transform
-      pos: -2.5,-6.5
+      pos: 4.5,-5.5
       parent: 1
   - uid: 472
     components:
     - type: Transform
-      pos: -3.5,-6.5
+      pos: 4.5,-6.5
       parent: 1
   - uid: 473
     components:
     - type: Transform
-      pos: -4.5,-6.5
+      pos: 4.5,-4.5
       parent: 1
   - uid: 474
     components:
     - type: Transform
-      pos: -3.5,-7.5
+      pos: -5.5,-4.5
       parent: 1
   - uid: 475
     components:
     - type: Transform
-      pos: -3.5,-8.5
+      pos: -5.5,-6.5
       parent: 1
   - uid: 476
     components:
     - type: Transform
-      pos: -3.5,-9.5
+      pos: -5.5,-3.5
       parent: 1
   - uid: 477
     components:
     - type: Transform
-      pos: -3.5,-10.5
+      pos: 4.5,-3.5
       parent: 1
   - uid: 478
     components:
     - type: Transform
-      pos: -3.5,-11.5
+      pos: 3.5,-6.5
       parent: 1
   - uid: 479
     components:
     - type: Transform
-      pos: -3.5,-12.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 480
     components:
     - type: Transform
-      pos: -3.5,-13.5
+      pos: 1.5,-6.5
       parent: 1
   - uid: 481
     components:
     - type: Transform
-      pos: 2.5,-13.5
+      pos: 0.5,-6.5
       parent: 1
   - uid: 482
     components:
     - type: Transform
-      pos: 2.5,-12.5
+      pos: -0.5,-6.5
       parent: 1
   - uid: 483
     components:
     - type: Transform
-      pos: 2.5,-11.5
+      pos: -1.5,-6.5
       parent: 1
   - uid: 484
     components:
     - type: Transform
-      pos: 2.5,-10.5
+      pos: -2.5,-6.5
       parent: 1
   - uid: 485
     components:
     - type: Transform
-      pos: 2.5,-9.5
+      pos: -3.5,-6.5
       parent: 1
   - uid: 486
     components:
     - type: Transform
-      pos: 2.5,-8.5
+      pos: -4.5,-6.5
       parent: 1
   - uid: 487
     components:
     - type: Transform
-      pos: 2.5,-7.5
+      pos: -3.5,-7.5
       parent: 1
   - uid: 488
     components:
     - type: Transform
-      pos: 1.5,-13.5
+      pos: -3.5,-8.5
       parent: 1
   - uid: 489
     components:
     - type: Transform
-      pos: 0.5,-13.5
+      pos: -3.5,-9.5
       parent: 1
   - uid: 490
     components:
     - type: Transform
-      pos: -0.5,-13.5
+      pos: -3.5,-10.5
       parent: 1
   - uid: 491
     components:
     - type: Transform
-      pos: -1.5,-13.5
+      pos: -3.5,-11.5
       parent: 1
   - uid: 492
     components:
     - type: Transform
-      pos: -2.5,-13.5
+      pos: -3.5,-12.5
       parent: 1
   - uid: 493
     components:
     - type: Transform
-      pos: -0.5,-12.5
+      pos: -3.5,-13.5
       parent: 1
   - uid: 494
     components:
     - type: Transform
-      pos: -1.5,-11.5
+      pos: 2.5,-13.5
       parent: 1
   - uid: 495
     components:
     - type: Transform
-      pos: 0.5,-11.5
+      pos: 2.5,-12.5
       parent: 1
   - uid: 496
     components:
     - type: Transform
-      pos: -0.5,-11.5
+      pos: 2.5,-11.5
       parent: 1
   - uid: 497
     components:
     - type: Transform
-      pos: -0.5,-10.5
+      pos: 2.5,-10.5
       parent: 1
   - uid: 498
     components:
     - type: Transform
-      pos: -0.5,-9.5
+      pos: 2.5,-9.5
       parent: 1
   - uid: 499
     components:
     - type: Transform
-      pos: -0.5,-8.5
+      pos: 2.5,-8.5
       parent: 1
   - uid: 500
     components:
     - type: Transform
-      pos: -0.5,-7.5
+      pos: 2.5,-7.5
       parent: 1
   - uid: 501
     components:
     - type: Transform
-      pos: -0.5,-5.5
+      pos: 1.5,-13.5
       parent: 1
   - uid: 502
     components:
     - type: Transform
-      pos: -0.5,-4.5
+      pos: 0.5,-13.5
       parent: 1
   - uid: 503
     components:
     - type: Transform
-      pos: -0.5,-14.5
+      pos: -0.5,-13.5
       parent: 1
   - uid: 504
     components:
     - type: Transform
-      pos: -0.5,-15.5
+      pos: -1.5,-13.5
       parent: 1
   - uid: 505
     components:
     - type: Transform
-      pos: -0.5,-16.5
+      pos: -2.5,-13.5
       parent: 1
   - uid: 506
     components:
     - type: Transform
-      pos: -0.5,-17.5
+      pos: -0.5,-12.5
       parent: 1
   - uid: 507
     components:
     - type: Transform
-      pos: -0.5,-18.5
+      pos: -1.5,-11.5
       parent: 1
   - uid: 508
     components:
     - type: Transform
-      pos: -0.5,-19.5
+      pos: 0.5,-11.5
       parent: 1
   - uid: 509
     components:
     - type: Transform
-      pos: -0.5,-20.5
+      pos: -0.5,-11.5
       parent: 1
   - uid: 510
     components:
     - type: Transform
-      pos: -0.5,-21.5
+      pos: -0.5,-10.5
       parent: 1
   - uid: 511
     components:
     - type: Transform
-      pos: -0.5,-22.5
+      pos: -0.5,-9.5
       parent: 1
   - uid: 512
     components:
     - type: Transform
-      pos: -4.5,-12.5
+      pos: -0.5,-8.5
       parent: 1
   - uid: 513
     components:
     - type: Transform
-      pos: -5.5,-12.5
+      pos: -0.5,-7.5
       parent: 1
   - uid: 514
     components:
     - type: Transform
-      pos: -6.5,-12.5
+      pos: -0.5,-5.5
       parent: 1
   - uid: 515
     components:
     - type: Transform
-      pos: -7.5,-12.5
+      pos: -0.5,-4.5
       parent: 1
   - uid: 516
     components:
     - type: Transform
-      pos: -8.5,-12.5
+      pos: -0.5,-14.5
       parent: 1
   - uid: 517
     components:
     - type: Transform
-      pos: -9.5,-12.5
+      pos: -0.5,-15.5
       parent: 1
   - uid: 518
     components:
     - type: Transform
-      pos: 3.5,-12.5
+      pos: -0.5,-16.5
       parent: 1
   - uid: 519
     components:
     - type: Transform
-      pos: 4.5,-12.5
+      pos: -0.5,-17.5
       parent: 1
   - uid: 520
     components:
     - type: Transform
-      pos: 5.5,-12.5
+      pos: -0.5,-18.5
       parent: 1
   - uid: 521
     components:
     - type: Transform
-      pos: 6.5,-12.5
+      pos: -0.5,-19.5
       parent: 1
   - uid: 522
     components:
     - type: Transform
-      pos: 7.5,-12.5
+      pos: -0.5,-20.5
       parent: 1
   - uid: 523
     components:
     - type: Transform
-      pos: 8.5,-12.5
+      pos: -0.5,-21.5
       parent: 1
   - uid: 524
     components:
     - type: Transform
-      pos: 7.5,-5.5
+      pos: -0.5,-22.5
       parent: 1
   - uid: 525
     components:
     - type: Transform
-      pos: 8.5,-5.5
+      pos: -4.5,-12.5
       parent: 1
   - uid: 526
     components:
     - type: Transform
-      pos: 9.5,-5.5
+      pos: 3.5,-12.5
       parent: 1
   - uid: 527
     components:
     - type: Transform
-      pos: -8.5,-5.5
+      pos: 7.5,-5.5
       parent: 1
   - uid: 528
     components:
     - type: Transform
-      pos: -9.5,-5.5
+      pos: 8.5,-5.5
       parent: 1
   - uid: 529
     components:
     - type: Transform
-      pos: -10.5,-5.5
+      pos: 9.5,-5.5
       parent: 1
   - uid: 530
     components:
     - type: Transform
-      pos: -10.5,-6.5
+      pos: -8.5,-5.5
       parent: 1
   - uid: 531
     components:
     - type: Transform
-      pos: -10.5,-7.5
+      pos: -9.5,-5.5
       parent: 1
   - uid: 532
     components:
     - type: Transform
-      pos: -10.5,-8.5
+      pos: -10.5,-5.5
       parent: 1
   - uid: 533
     components:
     - type: Transform
-      pos: 9.5,-6.5
+      pos: -10.5,-6.5
       parent: 1
   - uid: 534
     components:
     - type: Transform
-      pos: 9.5,-7.5
+      pos: -10.5,-7.5
       parent: 1
   - uid: 535
     components:
     - type: Transform
-      pos: 9.5,-8.5
+      pos: -10.5,-8.5
       parent: 1
   - uid: 536
     components:
     - type: Transform
-      pos: 6.5,-6.5
+      pos: 9.5,-6.5
       parent: 1
   - uid: 537
     components:
     - type: Transform
-      pos: 6.5,-7.5
+      pos: 9.5,-7.5
       parent: 1
   - uid: 538
     components:
     - type: Transform
-      pos: 6.5,-8.5
+      pos: 9.5,-8.5
       parent: 1
   - uid: 539
     components:
     - type: Transform
-      pos: -7.5,-6.5
+      pos: 6.5,-6.5
       parent: 1
   - uid: 540
     components:
     - type: Transform
-      pos: -7.5,-7.5
+      pos: 6.5,-7.5
       parent: 1
   - uid: 541
     components:
     - type: Transform
-      pos: -7.5,-8.5
+      pos: 6.5,-8.5
       parent: 1
   - uid: 542
     components:
     - type: Transform
-      pos: 7.5,-4.5
+      pos: -7.5,-6.5
       parent: 1
   - uid: 543
     components:
     - type: Transform
-      pos: 1.5,14.5
+      pos: -7.5,-7.5
       parent: 1
   - uid: 544
     components:
     - type: Transform
-      pos: -8.5,-4.5
+      pos: -7.5,-8.5
       parent: 1
   - uid: 545
     components:
     - type: Transform
-      pos: -2.5,14.5
+      pos: 7.5,-4.5
       parent: 1
   - uid: 546
     components:
     - type: Transform
-      pos: -4.5,-2.5
+      pos: 1.5,14.5
       parent: 1
   - uid: 547
     components:
     - type: Transform
-      pos: 3.5,-2.5
+      pos: -8.5,-4.5
       parent: 1
   - uid: 548
     components:
     - type: Transform
-      pos: 4.5,-7.5
+      pos: -2.5,14.5
       parent: 1
   - uid: 549
     components:
     - type: Transform
-      pos: -5.5,-7.5
+      pos: -4.5,-2.5
       parent: 1
   - uid: 550
     components:
     - type: Transform
-      pos: -4.5,-14.5
+      pos: 3.5,-2.5
       parent: 1
   - uid: 551
     components:
     - type: Transform
-      pos: 3.5,-14.5
+      pos: 4.5,-7.5
       parent: 1
   - uid: 552
     components:
     - type: Transform
-      pos: 2.5,-14.5
+      pos: -5.5,-7.5
       parent: 1
   - uid: 553
     components:
     - type: Transform
-      pos: -3.5,-14.5
+      pos: -4.5,-14.5
       parent: 1
   - uid: 554
     components:
     - type: Transform
-      pos: 7.5,-16.5
+      pos: 3.5,-14.5
       parent: 1
   - uid: 555
     components:
     - type: Transform
-      pos: 6.5,-16.5
+      pos: 2.5,-14.5
       parent: 1
   - uid: 556
     components:
     - type: Transform
-      pos: 6.5,-15.5
+      pos: -3.5,-14.5
       parent: 1
   - uid: 557
     components:
     - type: Transform
-      pos: 5.5,-15.5
+      pos: 7.5,-16.5
       parent: 1
   - uid: 558
     components:
     - type: Transform
-      pos: 4.5,-15.5
+      pos: 6.5,-16.5
       parent: 1
   - uid: 559
     components:
     - type: Transform
-      pos: 3.5,-15.5
+      pos: 6.5,-15.5
       parent: 1
   - uid: 560
     components:
     - type: Transform
-      pos: -4.5,-15.5
+      pos: 5.5,-15.5
       parent: 1
   - uid: 561
     components:
     - type: Transform
-      pos: -5.5,-15.5
+      pos: 4.5,-15.5
       parent: 1
   - uid: 562
     components:
     - type: Transform
-      pos: -6.5,-15.5
+      pos: 3.5,-15.5
       parent: 1
   - uid: 563
     components:
     - type: Transform
-      pos: -7.5,-15.5
+      pos: -4.5,-15.5
       parent: 1
   - uid: 564
     components:
     - type: Transform
-      pos: -7.5,-16.5
+      pos: -5.5,-15.5
       parent: 1
   - uid: 565
     components:
     - type: Transform
-      pos: -8.5,-16.5
+      pos: -6.5,-15.5
       parent: 1
   - uid: 566
     components:
     - type: Transform
-      pos: -7.5,-14.5
+      pos: -7.5,-15.5
       parent: 1
   - uid: 567
     components:
     - type: Transform
-      pos: -7.5,-13.5
+      pos: -7.5,-16.5
       parent: 1
   - uid: 568
     components:
     - type: Transform
-      pos: 6.5,-13.5
+      pos: -8.5,-16.5
       parent: 1
   - uid: 569
     components:
     - type: Transform
-      pos: 6.5,-14.5
+      pos: 0.5,-16.5
       parent: 1
   - uid: 570
     components:
     - type: Transform
-      pos: 0.5,-16.5
+      pos: 1.5,-16.5
       parent: 1
   - uid: 571
     components:
     - type: Transform
-      pos: 1.5,-16.5
+      pos: 1.5,-15.5
       parent: 1
   - uid: 572
     components:
     - type: Transform
-      pos: 1.5,-15.5
+      pos: 1.5,-17.5
       parent: 1
   - uid: 573
     components:
     - type: Transform
-      pos: 1.5,-17.5
+      pos: -2.5,-15.5
       parent: 1
   - uid: 574
     components:
     - type: Transform
-      pos: -2.5,-15.5
+      pos: -2.5,-16.5
       parent: 1
   - uid: 575
     components:
     - type: Transform
-      pos: -2.5,-16.5
+      pos: -2.5,-17.5
       parent: 1
   - uid: 576
     components:
     - type: Transform
-      pos: -2.5,-17.5
+      pos: -1.5,-16.5
       parent: 1
   - uid: 577
     components:
     - type: Transform
-      pos: -1.5,-16.5
+      pos: -0.5,-3.5
       parent: 1
   - uid: 578
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: -0.5,-2.5
       parent: 1
   - uid: 579
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: -0.5,-1.5
       parent: 1
   - uid: 580
     components:
     - type: Transform
-      pos: -0.5,-1.5
+      pos: 0.5,-3.5
       parent: 1
   - uid: 581
     components:
     - type: Transform
-      pos: 0.5,-3.5
+      pos: -1.5,-3.5
       parent: 1
   - uid: 582
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: 6.5,-4.5
       parent: 1
   - uid: 583
     components:
     - type: Transform
-      pos: 6.5,-4.5
+      pos: -7.5,-4.5
       parent: 1
   - uid: 584
     components:
     - type: Transform
-      pos: -7.5,-4.5
+      pos: 4.5,-9.5
       parent: 1
-- proto: CableHV
-  entities:
   - uid: 585
     components:
     - type: Transform
-      pos: 0.5,-10.5
+      pos: -5.5,-9.5
       parent: 1
   - uid: 586
     components:
     - type: Transform
-      pos: 0.5,-9.5
+      pos: -5.5,-10.5
       parent: 1
   - uid: 587
     components:
     - type: Transform
-      pos: -5.5,1.5
+      pos: -5.5,-11.5
       parent: 1
   - uid: 588
     components:
     - type: Transform
-      pos: -1.5,-10.5
+      pos: -5.5,-12.5
       parent: 1
   - uid: 589
     components:
     - type: Transform
-      pos: -1.5,-9.5
+      pos: 4.5,-10.5
       parent: 1
   - uid: 590
     components:
     - type: Transform
-      pos: -1.5,-8.5
+      pos: 4.5,-11.5
       parent: 1
   - uid: 591
     components:
     - type: Transform
-      pos: 0.5,-8.5
+      pos: 4.5,-12.5
       parent: 1
   - uid: 592
     components:
     - type: Transform
-      pos: -0.5,-8.5
+      pos: 5.5,-11.5
       parent: 1
   - uid: 593
     components:
     - type: Transform
-      pos: -0.5,-11.5
+      pos: 6.5,-11.5
       parent: 1
   - uid: 594
     components:
     - type: Transform
-      pos: -0.5,-12.5
+      pos: 7.5,-11.5
       parent: 1
   - uid: 595
     components:
     - type: Transform
-      pos: -1.5,-12.5
+      pos: 8.5,-11.5
       parent: 1
   - uid: 596
     components:
     - type: Transform
-      pos: -2.5,-12.5
+      pos: -6.5,-11.5
       parent: 1
   - uid: 597
     components:
     - type: Transform
-      pos: 0.5,-12.5
+      pos: -7.5,-11.5
       parent: 1
   - uid: 598
     components:
     - type: Transform
-      pos: 1.5,-12.5
+      pos: -8.5,-11.5
       parent: 1
   - uid: 599
     components:
     - type: Transform
-      pos: 2.5,-12.5
+      pos: -9.5,-11.5
       parent: 1
+- proto: CableHV
+  entities:
   - uid: 600
     components:
     - type: Transform
-      pos: 3.5,-12.5
+      pos: 0.5,-10.5
       parent: 1
   - uid: 601
     components:
     - type: Transform
-      pos: -5.5,-13.5
+      pos: 0.5,-9.5
       parent: 1
   - uid: 602
     components:
     - type: Transform
-      pos: 5.5,-12.5
+      pos: -5.5,1.5
       parent: 1
   - uid: 603
     components:
     - type: Transform
-      pos: 5.5,-13.5
+      pos: -1.5,-10.5
       parent: 1
   - uid: 604
     components:
     - type: Transform
-      pos: -3.5,-12.5
+      pos: -1.5,-9.5
       parent: 1
   - uid: 605
     components:
     - type: Transform
-      pos: -4.5,-12.5
+      pos: -1.5,-8.5
       parent: 1
   - uid: 606
     components:
     - type: Transform
-      pos: -4.5,-13.5
+      pos: 0.5,-8.5
       parent: 1
   - uid: 607
     components:
     - type: Transform
-      pos: -6.5,-12.5
+      pos: -0.5,-8.5
       parent: 1
   - uid: 608
     components:
     - type: Transform
-      pos: -6.5,-13.5
+      pos: -0.5,-11.5
       parent: 1
   - uid: 609
     components:
     - type: Transform
-      pos: 4.5,-13.5
+      pos: -0.5,-12.5
       parent: 1
   - uid: 610
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: -1.5,-12.5
       parent: 1
   - uid: 611
     components:
     - type: Transform
-      pos: -1.5,-6.5
+      pos: -2.5,-12.5
       parent: 1
   - uid: 612
     components:
     - type: Transform
-      pos: -2.5,-6.5
+      pos: 0.5,-12.5
       parent: 1
   - uid: 613
     components:
     - type: Transform
-      pos: -3.5,-6.5
+      pos: 1.5,-12.5
       parent: 1
   - uid: 614
     components:
     - type: Transform
-      pos: -4.5,-6.5
+      pos: 2.5,-12.5
       parent: 1
   - uid: 615
     components:
     - type: Transform
-      pos: -5.5,-6.5
+      pos: -3.5,-12.5
       parent: 1
   - uid: 616
     components:
     - type: Transform
-      pos: 0.5,-6.5
+      pos: -0.5,-6.5
       parent: 1
   - uid: 617
     components:
     - type: Transform
-      pos: 1.5,-6.5
+      pos: -1.5,-6.5
       parent: 1
   - uid: 618
     components:
     - type: Transform
-      pos: 2.5,-6.5
+      pos: -2.5,-6.5
       parent: 1
   - uid: 619
     components:
     - type: Transform
-      pos: 3.5,-6.5
+      pos: -3.5,-6.5
       parent: 1
   - uid: 620
     components:
     - type: Transform
-      pos: 4.5,-6.5
+      pos: -4.5,-6.5
       parent: 1
   - uid: 621
     components:
     - type: Transform
-      pos: 4.5,-5.5
+      pos: -5.5,-6.5
       parent: 1
   - uid: 622
     components:
     - type: Transform
-      pos: 4.5,-4.5
+      pos: 0.5,-6.5
       parent: 1
   - uid: 623
     components:
     - type: Transform
-      pos: 4.5,-3.5
+      pos: 1.5,-6.5
       parent: 1
   - uid: 624
     components:
     - type: Transform
-      pos: 4.5,-2.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 625
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      pos: 3.5,-6.5
       parent: 1
   - uid: 626
     components:
     - type: Transform
-      pos: 4.5,-0.5
+      pos: 4.5,-6.5
       parent: 1
   - uid: 627
     components:
     - type: Transform
-      pos: 4.5,0.5
+      pos: 4.5,-5.5
       parent: 1
   - uid: 628
     components:
     - type: Transform
-      pos: -5.5,0.5
+      pos: 4.5,-4.5
       parent: 1
   - uid: 629
     components:
     - type: Transform
-      pos: -5.5,-0.5
+      pos: 4.5,-3.5
       parent: 1
   - uid: 630
     components:
     - type: Transform
-      pos: -5.5,-1.5
+      pos: 4.5,-2.5
       parent: 1
   - uid: 631
     components:
     - type: Transform
-      pos: -5.5,-2.5
+      pos: 4.5,-1.5
       parent: 1
   - uid: 632
     components:
     - type: Transform
-      pos: -5.5,-3.5
+      pos: 4.5,-0.5
       parent: 1
   - uid: 633
     components:
     - type: Transform
-      pos: -5.5,-4.5
+      pos: 4.5,0.5
       parent: 1
   - uid: 634
     components:
     - type: Transform
-      pos: -5.5,-5.5
+      pos: -5.5,0.5
       parent: 1
   - uid: 635
     components:
     - type: Transform
-      pos: -5.5,2.5
+      pos: -5.5,-0.5
       parent: 1
   - uid: 636
     components:
     - type: Transform
-      pos: -4.5,2.5
+      pos: -5.5,-1.5
       parent: 1
   - uid: 637
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: -5.5,-2.5
       parent: 1
   - uid: 638
     components:
     - type: Transform
-      pos: 4.5,1.5
+      pos: -5.5,-3.5
       parent: 1
   - uid: 639
     components:
     - type: Transform
-      pos: 2.5,1.5
+      pos: -5.5,-4.5
       parent: 1
   - uid: 640
     components:
     - type: Transform
-      pos: -6.5,6.5
+      pos: -5.5,-5.5
       parent: 1
   - uid: 641
     components:
     - type: Transform
-      pos: -7.5,6.5
+      pos: -5.5,2.5
       parent: 1
   - uid: 642
     components:
     - type: Transform
-      pos: -5.5,6.5
+      pos: -4.5,2.5
       parent: 1
   - uid: 643
     components:
     - type: Transform
-      pos: -4.5,3.5
+      pos: 3.5,1.5
       parent: 1
   - uid: 644
     components:
     - type: Transform
-      pos: 4.5,6.5
+      pos: 4.5,1.5
       parent: 1
   - uid: 645
     components:
     - type: Transform
-      pos: -5.5,3.5
+      pos: 2.5,1.5
       parent: 1
   - uid: 646
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: -6.5,6.5
       parent: 1
   - uid: 647
     components:
     - type: Transform
-      pos: 3.5,6.5
+      pos: -7.5,6.5
       parent: 1
   - uid: 648
     components:
     - type: Transform
-      pos: 3.5,7.5
+      pos: -5.5,6.5
       parent: 1
   - uid: 649
     components:
     - type: Transform
-      pos: 3.5,8.5
+      pos: -4.5,3.5
       parent: 1
   - uid: 650
     components:
     - type: Transform
-      pos: -4.5,8.5
+      pos: 2.5,4.5
       parent: 1
   - uid: 651
     components:
     - type: Transform
-      pos: -4.5,7.5
+      pos: -5.5,3.5
       parent: 1
   - uid: 652
     components:
     - type: Transform
-      pos: -4.5,6.5
+      pos: 2.5,3.5
       parent: 1
   - uid: 653
     components:
     - type: Transform
-      pos: -3.5,3.5
+      pos: 3.5,6.5
       parent: 1
   - uid: 654
     components:
     - type: Transform
-      pos: -6.5,-10.5
+      pos: 3.5,7.5
       parent: 1
   - uid: 655
     components:
     - type: Transform
-      pos: -6.5,-11.5
+      pos: 3.5,8.5
       parent: 1
   - uid: 656
     components:
     - type: Transform
-      pos: -2.5,3.5
+      pos: -4.5,8.5
       parent: 1
   - uid: 657
     components:
     - type: Transform
-      pos: 5.5,6.5
+      pos: -4.5,7.5
       parent: 1
   - uid: 658
     components:
     - type: Transform
-      pos: 5.5,-11.5
+      pos: -4.5,6.5
       parent: 1
   - uid: 659
     components:
     - type: Transform
-      pos: -6.5,-9.5
+      pos: -3.5,3.5
       parent: 1
   - uid: 660
     components:
     - type: Transform
-      pos: 1.5,3.5
+      pos: -2.5,3.5
       parent: 1
   - uid: 661
     components:
     - type: Transform
-      pos: 3.5,-13.5
+      pos: 2.5,5.5
       parent: 1
   - uid: 662
     components:
     - type: Transform
-      pos: 5.5,-10.5
+      pos: 1.5,3.5
       parent: 1
   - uid: 663
     components:
     - type: Transform
-      pos: 5.5,-9.5
+      pos: 2.5,-11.5
       parent: 1
   - uid: 664
     components:
     - type: Transform
-      pos: 2.5,-11.5
+      pos: 2.5,-10.5
       parent: 1
   - uid: 665
     components:
     - type: Transform
-      pos: 2.5,-10.5
+      pos: 2.5,-9.5
       parent: 1
   - uid: 666
     components:
     - type: Transform
-      pos: 2.5,-9.5
+      pos: 2.5,-8.5
       parent: 1
   - uid: 667
     components:
     - type: Transform
-      pos: 2.5,-8.5
+      pos: 2.5,-7.5
       parent: 1
   - uid: 668
     components:
     - type: Transform
-      pos: 2.5,-7.5
+      pos: -3.5,-7.5
       parent: 1
   - uid: 669
     components:
     - type: Transform
-      pos: -3.5,-7.5
+      pos: -3.5,-8.5
       parent: 1
   - uid: 670
     components:
     - type: Transform
-      pos: -3.5,-8.5
+      pos: -3.5,-9.5
       parent: 1
   - uid: 671
     components:
     - type: Transform
-      pos: -3.5,-9.5
+      pos: -3.5,-10.5
       parent: 1
   - uid: 672
     components:
     - type: Transform
-      pos: -3.5,-10.5
+      pos: -3.5,-11.5
       parent: 1
   - uid: 673
     components:
     - type: Transform
-      pos: -3.5,-11.5
+      pos: 2.5,6.5
       parent: 1
   - uid: 674
     components:
     - type: Transform
-      pos: 6.5,6.5
+      pos: -7.5,1.5
       parent: 1
   - uid: 675
     components:
     - type: Transform
-      pos: -7.5,1.5
+      pos: -6.5,1.5
       parent: 1
   - uid: 676
     components:
     - type: Transform
-      pos: 6.5,5.5
+      pos: -7.5,2.5
       parent: 1
   - uid: 677
     components:
     - type: Transform
-      pos: 6.5,4.5
+      pos: -7.5,3.5
       parent: 1
   - uid: 678
     components:
     - type: Transform
-      pos: 6.5,3.5
+      pos: -7.5,4.5
       parent: 1
   - uid: 679
     components:
     - type: Transform
-      pos: 6.5,2.5
+      pos: -7.5,5.5
       parent: 1
   - uid: 680
     components:
     - type: Transform
-      pos: 6.5,1.5
+      pos: -0.5,-10.5
       parent: 1
   - uid: 681
     components:
     - type: Transform
-      pos: 5.5,1.5
+      pos: -4.5,4.5
       parent: 1
   - uid: 682
     components:
     - type: Transform
-      pos: -6.5,1.5
+      pos: -5.5,4.5
       parent: 1
   - uid: 683
     components:
     - type: Transform
-      pos: -7.5,2.5
+      pos: 2.5,2.5
       parent: 1
   - uid: 684
     components:
     - type: Transform
-      pos: -7.5,3.5
+      pos: -6.5,-10.5
       parent: 1
   - uid: 685
     components:
     - type: Transform
-      pos: -7.5,4.5
+      pos: 5.5,-10.5
       parent: 1
   - uid: 686
     components:
     - type: Transform
-      pos: -7.5,5.5
+      pos: -5.5,-10.5
       parent: 1
   - uid: 687
     components:
     - type: Transform
-      pos: -0.5,-10.5
+      pos: 4.5,-10.5
       parent: 1
   - uid: 688
     components:
     - type: Transform
-      pos: -4.5,4.5
+      pos: 3.5,-10.5
       parent: 1
   - uid: 689
     components:
     - type: Transform
-      pos: -5.5,4.5
-      parent: 1
-  - uid: 690
-    components:
-    - type: Transform
-      pos: 2.5,2.5
+      pos: -4.5,-10.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 691
+  - uid: 690
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 692
+  - uid: 691
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 693
+  - uid: 692
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 694
+  - uid: 693
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 695
+  - uid: 694
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 696
+  - uid: 695
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 697
+  - uid: 696
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 698
+  - uid: 697
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 699
+  - uid: 698
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 700
+  - uid: 699
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 701
+  - uid: 700
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
-  - uid: 702
+  - uid: 701
     components:
     - type: Transform
       pos: -3.5,14.5
       parent: 1
-  - uid: 703
+  - uid: 702
     components:
     - type: Transform
       pos: -2.5,14.5
       parent: 1
-  - uid: 704
+  - uid: 703
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 705
+  - uid: 704
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 706
+  - uid: 705
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-  - uid: 707
+  - uid: 706
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 708
+  - uid: 707
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 709
+  - uid: 708
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 710
+  - uid: 709
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 711
+  - uid: 710
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 712
+  - uid: 711
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 713
+  - uid: 712
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 714
+  - uid: 713
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 715
+  - uid: 714
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 1
-  - uid: 716
+  - uid: 715
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 717
+  - uid: 716
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 718
+  - uid: 717
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 719
+  - uid: 718
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 720
+  - uid: 719
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 721
+  - uid: 720
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 722
+  - uid: 721
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 723
+  - uid: 722
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 724
+  - uid: 723
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 725
+  - uid: 724
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 726
+  - uid: 725
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 727
+  - uid: 726
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 1
-  - uid: 728
+  - uid: 727
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 1
-  - uid: 729
+  - uid: 728
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 730
+  - uid: 729
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 731
+  - uid: 730
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 732
+  - uid: 731
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 733
+  - uid: 732
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 734
+  - uid: 733
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 735
+  - uid: 734
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 736
+  - uid: 735
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 737
+  - uid: 736
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 738
+  - uid: 737
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 739
+  - uid: 738
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 740
+  - uid: 739
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 741
+  - uid: 740
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 742
+  - uid: 741
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 743
+  - uid: 742
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 744
+  - uid: 743
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 745
+  - uid: 744
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 746
+  - uid: 745
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 747
+  - uid: 746
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 748
+  - uid: 747
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 749
+  - uid: 748
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 750
+  - uid: 749
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 751
+  - uid: 750
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 752
+  - uid: 751
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 753
+  - uid: 752
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 754
+  - uid: 753
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 755
+  - uid: 754
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 756
+  - uid: 755
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 757
+  - uid: 756
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 758
+  - uid: 757
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 759
+  - uid: 758
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 760
+  - uid: 759
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 761
+  - uid: 760
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 762
+  - uid: 761
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 763
+  - uid: 762
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
-  - uid: 764
+  - uid: 763
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
-  - uid: 765
+  - uid: 764
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 766
+  - uid: 765
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 1
-  - uid: 767
+  - uid: 766
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 768
+  - uid: 767
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
-  - uid: 769
+  - uid: 768
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 1
-  - uid: 770
+  - uid: 769
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 771
+  - uid: 770
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 772
+  - uid: 771
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 773
+  - uid: 772
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 774
+  - uid: 773
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 775
+  - uid: 774
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 776
+  - uid: 775
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 777
+  - uid: 776
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 778
+  - uid: 777
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 779
+  - uid: 778
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 780
+  - uid: 779
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 1
-  - uid: 781
+  - uid: 780
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 782
+  - uid: 781
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 783
+  - uid: 782
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 784
+  - uid: 783
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 785
+  - uid: 784
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 786
+  - uid: 785
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 787
+  - uid: 786
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 788
+  - uid: 787
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 789
+  - uid: 788
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 790
+  - uid: 789
     components:
     - type: Transform
       pos: -4.5,-14.5
       parent: 1
-  - uid: 791
+  - uid: 790
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 792
+  - uid: 791
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 793
+  - uid: 792
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 794
+  - uid: 793
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 795
+  - uid: 794
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 796
+  - uid: 795
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 797
+  - uid: 796
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 798
+  - uid: 797
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 799
+  - uid: 798
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 800
+  - uid: 799
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 801
+  - uid: 800
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 802
+  - uid: 801
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
-  - uid: 803
+  - uid: 802
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 1
-  - uid: 804
+  - uid: 803
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 805
+  - uid: 804
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 806
-    components:
-    - type: Transform
-      pos: 5.5,-9.5
-      parent: 1
-  - uid: 807
-    components:
-    - type: Transform
-      pos: 5.5,-10.5
-      parent: 1
-  - uid: 808
-    components:
-    - type: Transform
-      pos: 5.5,-11.5
-      parent: 1
-  - uid: 809
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 1
-  - uid: 810
-    components:
-    - type: Transform
-      pos: -6.5,-10.5
-      parent: 1
-  - uid: 811
-    components:
-    - type: Transform
-      pos: -6.5,-11.5
-      parent: 1
-  - uid: 812
-    components:
-    - type: Transform
-      pos: -5.5,-11.5
-      parent: 1
-  - uid: 813
-    components:
-    - type: Transform
-      pos: -5.5,-12.5
-      parent: 1
-  - uid: 814
+  - uid: 805
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 815
+  - uid: 806
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 816
+  - uid: 807
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 810
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 1
+  - uid: 811
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 817
+  - uid: 812
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
+  - uid: 813
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 814
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 818
+  - uid: 815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 819
+  - uid: 816
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 1
-  - uid: 820
+  - uid: 817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-10.5
       parent: 1
-  - uid: 821
+  - uid: 818
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-10.5
       parent: 1
-  - uid: 822
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-13.5
-      parent: 1
-  - uid: 823
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-13.5
-      parent: 1
-  - uid: 824
+  - uid: 819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 825
+  - uid: 820
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5397,1157 +5389,1141 @@ entities:
       parent: 1
 - proto: CarpetBlue
   entities:
-  - uid: 981
+  - uid: 821
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 1910
+  - uid: 822
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 1919
+  - uid: 823
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 1920
+  - uid: 824
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 826
+  - uid: 825
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 827
+  - uid: 826
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 829
+  - uid: 827
     components:
     - type: Transform
       pos: -7.5,15.5
       parent: 1
-  - uid: 831
+  - uid: 828
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 1
-  - uid: 832
+  - uid: 829
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 1
-  - uid: 833
+  - uid: 830
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 834
+  - uid: 831
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 1
-  - uid: 835
+  - uid: 832
     components:
     - type: Transform
       pos: -8.5,6.5
       parent: 1
-  - uid: 836
+  - uid: 833
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 1
-  - uid: 837
+  - uid: 834
     components:
     - type: Transform
       pos: -8.5,7.5
       parent: 1
-  - uid: 838
+  - uid: 835
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
-  - uid: 839
+  - uid: 836
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 840
+  - uid: 837
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 841
+  - uid: 838
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 842
+  - uid: 839
     components:
     - type: Transform
       pos: -7.5,8.5
       parent: 1
-  - uid: 843
+  - uid: 840
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 844
+  - uid: 841
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 845
+  - uid: 842
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 846
+  - uid: 843
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 847
+  - uid: 844
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 848
+  - uid: 845
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 849
+  - uid: 846
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 850
+  - uid: 847
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 851
+  - uid: 848
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 852
+  - uid: 849
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 853
+  - uid: 850
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 854
+  - uid: 851
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 855
+  - uid: 852
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 856
+  - uid: 853
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
-  - uid: 857
+  - uid: 854
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 858
+  - uid: 855
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 859
+  - uid: 856
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 860
+  - uid: 857
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 861
+  - uid: 858
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 862
+  - uid: 859
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 863
+  - uid: 860
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 864
+  - uid: 861
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 865
+  - uid: 862
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 1
-  - uid: 866
+  - uid: 863
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 1
-  - uid: 867
+  - uid: 864
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 868
+  - uid: 865
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
-  - uid: 869
+  - uid: 866
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 1
-  - uid: 870
+  - uid: 867
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 1
-  - uid: 871
+  - uid: 868
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 1
-  - uid: 872
+  - uid: 869
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 1
-  - uid: 873
+  - uid: 870
     components:
     - type: Transform
       pos: -1.5,21.5
       parent: 1
-  - uid: 874
+  - uid: 871
     components:
     - type: Transform
       pos: -1.5,20.5
       parent: 1
-  - uid: 875
+  - uid: 872
     components:
     - type: Transform
       pos: -1.5,19.5
       parent: 1
-  - uid: 876
+  - uid: 873
     components:
     - type: Transform
       pos: -1.5,18.5
       parent: 1
-  - uid: 877
+  - uid: 874
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 1
-  - uid: 878
+  - uid: 875
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 879
+  - uid: 876
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 1
-  - uid: 880
+  - uid: 877
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 881
+  - uid: 878
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 882
+  - uid: 879
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 883
+  - uid: 880
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 884
+  - uid: 881
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 885
+  - uid: 882
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 886
+  - uid: 883
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 887
+  - uid: 884
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 888
+  - uid: 885
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 889
+  - uid: 886
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 890
+  - uid: 887
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 891
+  - uid: 888
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 1
-  - uid: 892
+  - uid: 889
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 1
-  - uid: 893
+  - uid: 890
     components:
     - type: Transform
       pos: 7.5,-18.5
       parent: 1
-  - uid: 894
+  - uid: 891
     components:
     - type: Transform
       pos: 6.5,-17.5
       parent: 1
-  - uid: 895
+  - uid: 892
     components:
     - type: Transform
       pos: 6.5,-18.5
       parent: 1
-  - uid: 896
+  - uid: 893
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 1
-  - uid: 897
+  - uid: 894
     components:
     - type: Transform
       pos: 5.5,-17.5
       parent: 1
-  - uid: 898
+  - uid: 895
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 899
+  - uid: 896
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1
-  - uid: 901
+  - uid: 897
     components:
     - type: Transform
       pos: 3.5,-17.5
       parent: 1
-  - uid: 902
+  - uid: 898
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 1
-  - uid: 903
+  - uid: 899
     components:
     - type: Transform
       pos: -5.5,-17.5
       parent: 1
-  - uid: 904
+  - uid: 900
     components:
     - type: Transform
       pos: -6.5,-16.5
       parent: 1
-  - uid: 905
+  - uid: 901
     components:
     - type: Transform
       pos: -6.5,-17.5
       parent: 1
-  - uid: 906
+  - uid: 902
     components:
     - type: Transform
       pos: -7.5,-17.5
       parent: 1
-  - uid: 907
+  - uid: 903
     components:
     - type: Transform
       pos: -7.5,-18.5
       parent: 1
-  - uid: 908
+  - uid: 904
     components:
     - type: Transform
       pos: -8.5,-17.5
       parent: 1
-  - uid: 909
+  - uid: 905
     components:
     - type: Transform
       pos: -8.5,-18.5
       parent: 1
-  - uid: 910
+  - uid: 906
     components:
     - type: Transform
       pos: -7.5,14.5
       parent: 1
-  - uid: 911
+  - uid: 907
     components:
     - type: Transform
       pos: -6.5,15.5
       parent: 1
-  - uid: 912
+  - uid: 908
     components:
     - type: Transform
       pos: -6.5,14.5
       parent: 1
-  - uid: 913
+  - uid: 909
     components:
     - type: Transform
       pos: -6.5,19.5
       parent: 1
-  - uid: 914
+  - uid: 910
     components:
     - type: Transform
       pos: -6.5,18.5
       parent: 1
-  - uid: 915
+  - uid: 911
     components:
     - type: Transform
       pos: -5.5,19.5
       parent: 1
-  - uid: 916
+  - uid: 912
     components:
     - type: Transform
       pos: -5.5,18.5
       parent: 1
-  - uid: 917
+  - uid: 913
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 1
-  - uid: 918
+  - uid: 914
     components:
     - type: Transform
       pos: 4.5,18.5
       parent: 1
-  - uid: 919
+  - uid: 915
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 1
-  - uid: 920
+  - uid: 916
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 1
-  - uid: 921
+  - uid: 917
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 922
+  - uid: 918
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 1
-  - uid: 923
+  - uid: 919
     components:
     - type: Transform
       pos: 5.5,15.5
       parent: 1
-  - uid: 924
+  - uid: 920
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 1
-  - uid: 925
+  - uid: 921
     components:
     - type: Transform
       pos: 3.5,23.5
       parent: 1
-  - uid: 926
+  - uid: 922
     components:
     - type: Transform
       pos: 3.5,22.5
       parent: 1
-  - uid: 927
+  - uid: 923
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
-  - uid: 928
+  - uid: 924
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 1
-  - uid: 929
+  - uid: 925
     components:
     - type: Transform
       pos: -3.5,23.5
       parent: 1
-  - uid: 930
+  - uid: 926
     components:
     - type: Transform
       pos: -3.5,22.5
       parent: 1
-  - uid: 931
+  - uid: 927
     components:
     - type: Transform
       pos: -4.5,23.5
       parent: 1
-  - uid: 932
+  - uid: 928
     components:
     - type: Transform
       pos: -4.5,22.5
       parent: 1
-  - uid: 933
+  - uid: 929
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 934
+  - uid: 930
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 1
-  - uid: 935
+  - uid: 931
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 936
+  - uid: 932
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 937
+  - uid: 933
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 938
+  - uid: 934
     components:
     - type: Transform
       pos: -5.5,12.5
       parent: 1
-  - uid: 939
+  - uid: 935
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
-  - uid: 940
+  - uid: 936
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 1
-  - uid: 941
+  - uid: 937
     components:
     - type: Transform
       pos: -6.5,12.5
       parent: 1
-  - uid: 942
+  - uid: 938
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 1
-  - uid: 943
+  - uid: 939
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 1
-  - uid: 944
+  - uid: 940
     components:
     - type: Transform
       pos: -7.5,12.5
       parent: 1
-  - uid: 945
+  - uid: 941
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 1
-  - uid: 946
+  - uid: 942
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 1
-  - uid: 947
+  - uid: 943
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 1
-  - uid: 948
+  - uid: 944
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 1
-  - uid: 949
+  - uid: 945
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 1
-  - uid: 950
+  - uid: 946
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-  - uid: 951
+  - uid: 947
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 1
-  - uid: 952
+  - uid: 948
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 953
+  - uid: 949
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 954
+  - uid: 950
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 955
+  - uid: 951
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 956
+  - uid: 952
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
-  - uid: 957
+  - uid: 953
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 958
+  - uid: 954
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 1
-  - uid: 959
+  - uid: 955
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
-  - uid: 960
+  - uid: 956
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 961
+  - uid: 957
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 962
+  - uid: 958
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 963
+  - uid: 959
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
-  - uid: 964
+  - uid: 960
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 965
+  - uid: 961
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 966
+  - uid: 962
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
-  - uid: 967
+  - uid: 963
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
-  - uid: 968
+  - uid: 964
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 1
-  - uid: 969
+  - uid: 965
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 1
-  - uid: 970
+  - uid: 966
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 1
-  - uid: 971
+  - uid: 967
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 1
-  - uid: 972
+  - uid: 968
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 1
-  - uid: 973
+  - uid: 969
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 1
-  - uid: 974
+  - uid: 970
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 1
-  - uid: 975
+  - uid: 971
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 976
+  - uid: 972
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 977
+  - uid: 973
     components:
     - type: Transform
       pos: 12.5,-6.5
       parent: 1
-  - uid: 978
+  - uid: 974
     components:
     - type: Transform
       pos: 12.5,-7.5
       parent: 1
-  - uid: 979
+  - uid: 975
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 1
-  - uid: 980
+  - uid: 976
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 1
-  - uid: 983
+  - uid: 977
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
-  - uid: 984
+  - uid: 978
     components:
     - type: Transform
       pos: -3.5,14.5
       parent: 1
-  - uid: 985
+  - uid: 979
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
-  - uid: 986
+  - uid: 980
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 987
+  - uid: 981
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 988
+  - uid: 982
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
-  - uid: 989
+  - uid: 983
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 990
+  - uid: 984
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 991
+  - uid: 985
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 992
+  - uid: 986
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
-  - uid: 993
+  - uid: 987
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 994
+  - uid: 988
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 995
+  - uid: 989
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 996
+  - uid: 990
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 997
+  - uid: 991
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 998
+  - uid: 992
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 999
+  - uid: 993
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 1
-  - uid: 1000
+  - uid: 994
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 1001
-    components:
-    - type: Transform
-      pos: -0.5,-14.5
-      parent: 1
-  - uid: 1002
-    components:
-    - type: Transform
-      pos: -0.5,-15.5
-      parent: 1
-  - uid: 1003
-    components:
-    - type: Transform
-      pos: -0.5,-16.5
-      parent: 1
-  - uid: 1004
-    components:
-    - type: Transform
-      pos: -1.5,-13.5
-      parent: 1
-  - uid: 1005
-    components:
-    - type: Transform
-      pos: -1.5,-14.5
-      parent: 1
-  - uid: 1006
+  - uid: 995
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 1007
+  - uid: 996
+    components:
+    - type: Transform
+      pos: -0.5,-16.5
+      parent: 1
+  - uid: 997
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 1
+  - uid: 998
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 999
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
-  - uid: 1008
-    components:
-    - type: Transform
-      pos: -6.5,-12.5
-      parent: 1
-  - uid: 1009
-    components:
-    - type: Transform
-      pos: -6.5,-13.5
-      parent: 1
-  - uid: 1010
-    components:
-    - type: Transform
-      pos: 5.5,-12.5
-      parent: 1
-  - uid: 1011
-    components:
-    - type: Transform
-      pos: 5.5,-13.5
-      parent: 1
-  - uid: 1012
-    components:
-    - type: Transform
-      pos: 4.5,-12.5
-      parent: 1
-  - uid: 1013
-    components:
-    - type: Transform
-      pos: -5.5,-12.5
-      parent: 1
-  - uid: 1014
+  - uid: 1000
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 1015
+  - uid: 1001
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 1016
+  - uid: 1002
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 1017
+  - uid: 1003
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 1018
+  - uid: 1004
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 1019
+  - uid: 1005
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 1020
+  - uid: 1006
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 1021
+  - uid: 1007
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 1022
+  - uid: 1008
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 1023
+  - uid: 1009
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 1024
+  - uid: 1010
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 1025
+  - uid: 1011
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 1026
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 1
-  - uid: 1027
+  - uid: 1012
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 1028
+  - uid: 1013
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 1
-  - uid: 1029
+  - uid: 1014
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 1030
-    components:
-    - type: Transform
-      pos: -5.5,-6.5
-      parent: 1
-  - uid: 1031
+  - uid: 1015
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 1032
+  - uid: 1016
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 1033
+  - uid: 1017
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
-  - uid: 1034
+  - uid: 1018
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 1035
-    components:
-    - type: Transform
-      pos: 9.5,-6.5
-      parent: 1
-  - uid: 1036
-    components:
-    - type: Transform
-      pos: 9.5,-7.5
-      parent: 1
-  - uid: 1037
-    components:
-    - type: Transform
-      pos: 9.5,-8.5
-      parent: 1
-  - uid: 1038
+  - uid: 1019
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
-  - uid: 1039
+  - uid: 1020
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 1040
+  - uid: 1021
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 1041
+  - uid: 1022
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 1042
+  - uid: 1023
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 1043
+  - uid: 1024
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
-  - uid: 1044
+  - uid: 1025
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 1045
+  - uid: 1026
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 1046
-    components:
-    - type: Transform
-      pos: -6.5,-5.5
-      parent: 1
-  - uid: 1047
+  - uid: 1027
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 1048
+  - uid: 1028
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 1049
+  - uid: 1029
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 1050
+  - uid: 1030
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 1051
+  - uid: 1031
     components:
     - type: Transform
       pos: -0.5,-19.5
       parent: 1
-  - uid: 1052
+  - uid: 1032
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 1
-  - uid: 1053
+  - uid: 1033
     components:
     - type: Transform
       pos: -0.5,-21.5
       parent: 1
-  - uid: 1507
+  - uid: 1034
     components:
     - type: Transform
       pos: -4.5,-17.5
       parent: 1
+  - uid: 1035
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 1
+  - uid: 1036
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 1037
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 1038
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 1039
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 1040
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+- proto: CatwalkMono
+  entities:
+  - uid: 1041
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 1
+  - uid: 1042
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,15.5
+      parent: 1
+  - uid: 1043
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 1044
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 1054
+  - uid: 1045
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 1055
+  - uid: 1046
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6555,80 +6531,292 @@ entities:
       parent: 1
 - proto: CharonSlugAmmo
   entities:
-  - uid: 1056
+  - uid: 1047
     components:
     - type: Transform
       pos: 2.5073252,-1.2488098
       parent: 1
-  - uid: 1057
+  - uid: 1048
     components:
     - type: Transform
       pos: 2.5073252,-1.3846122
       parent: 1
-  - uid: 1058
+  - uid: 1049
     components:
     - type: Transform
       pos: 2.5073252,-1.508069
       parent: 1
-  - uid: 1059
+  - uid: 1050
     components:
     - type: Transform
       pos: 2.5011482,-1.631526
       parent: 1
-  - uid: 1060
+  - uid: 1051
     components:
     - type: Transform
       pos: 2.5011482,-1.7117728
       parent: 1
-  - uid: 1061
+  - uid: 1052
     components:
     - type: Transform
       pos: -3.500505,-1.236464
       parent: 1
-  - uid: 1062
+  - uid: 1053
     components:
     - type: Transform
       pos: -3.506682,-1.359921
       parent: 1
-  - uid: 1063
+  - uid: 1054
     components:
     - type: Transform
       pos: -3.506682,-1.4710321
       parent: 1
-  - uid: 1064
+  - uid: 1055
     components:
     - type: Transform
       pos: -3.506682,-1.588316
       parent: 1
-  - uid: 1065
+  - uid: 1056
     components:
     - type: Transform
       pos: -3.5128589,-1.6932542
       parent: 1
 - proto: ClosetWallO2N2Filled
   entities:
-  - uid: 1948
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-15.5
-      parent: 1
-  - uid: 1950
+  - uid: 1057
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,-15.5
+      pos: -3.5,-16.5
+      parent: 1
+- proto: CMSemioticAirlock
+  entities:
+  - uid: 2207
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 2208
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 2237
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 1
+  - uid: 2238
+    components:
+    - type: Transform
+      pos: -2.5,-21.5
+      parent: 1
+- proto: CMSemioticAmmunition
+  entities:
+  - uid: 2240
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 2241
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 2242
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+- proto: CMSemioticBathunisex
+  entities:
+  - uid: 2231
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 1
+  - uid: 2232
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+- proto: CMSemioticBridge
+  entities:
+  - uid: 2223
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+- proto: CMSemioticDistribution_pipes
+  entities:
+  - uid: 2227
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+- proto: CMSemioticElectronics
+  entities:
+  - uid: 2210
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 2211
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+- proto: CMSemioticExhaust
+  entities:
+  - uid: 2209
+    components:
+    - type: Transform
+      pos: 2.5,21.5
+      parent: 1
+  - uid: 2212
+    components:
+    - type: Transform
+      pos: 3.5,-16.5
+      parent: 1
+  - uid: 2213
+    components:
+    - type: Transform
+      pos: 7.5,-16.5
+      parent: 1
+  - uid: 2214
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 1
+  - uid: 2215
+    components:
+    - type: Transform
+      pos: -8.5,-16.5
+      parent: 1
+  - uid: 2216
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 2217
+    components:
+    - type: Transform
+      pos: -4.5,19.5
+      parent: 1
+  - uid: 2218
+    components:
+    - type: Transform
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 2219
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 2220
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 2221
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 2222
+    components:
+    - type: Transform
+      pos: -3.5,21.5
+      parent: 1
+- proto: CMSemioticHazard
+  entities:
+  - uid: 2225
+    components:
+    - type: Transform
+      pos: -2.5,23.5
+      parent: 1
+  - uid: 2226
+    components:
+    - type: Transform
+      pos: 1.5,23.5
+      parent: 1
+- proto: CMSemioticHigh_voltage
+  entities:
+  - uid: 2234
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 2235
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 2236
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+- proto: CMSemioticLife_support
+  entities:
+  - uid: 2228
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 1
+- proto: CMSemioticMaint
+  entities:
+  - uid: 1102
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 1103
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: CMSemioticNonpress_0g
+  entities:
+  - uid: 2198
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 2206
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+- proto: CMSemioticStorage
+  entities:
+  - uid: 2239
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 1
+- proto: CMSemioticSuit_storage
+  entities:
+  - uid: 2224
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 2229
+    components:
+    - type: Transform
+      pos: -4.5,16.5
       parent: 1
 - proto: ComfyChair
   entities:
-  - uid: 1066
+  - uid: 1058
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
 - proto: ComputerEliteRadar
   entities:
-  - uid: 1067
+  - uid: 1059
     components:
     - type: Transform
       pos: 0.5,-4.5
@@ -6637,7 +6825,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1068
+  - uid: 1060
     components:
     - type: Transform
       pos: -1.5,-4.5
@@ -6648,7 +6836,7 @@ entities:
       startingCharge: 0
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 1069
+  - uid: 1061
     components:
     - type: Transform
       pos: 1.5,-4.5
@@ -6659,7 +6847,7 @@ entities:
       startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 1070
+  - uid: 1062
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6671,23 +6859,23 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttleTSFNVWS
   entities:
-  - uid: 1071
+  - uid: 1063
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        1911:
+        2186:
         - - device-button-1
           - SpaceArtilleryFire
-        302:
+        311:
         - - device-button-2
           - Toggle
-        303:
+        312:
         - - device-button-2
           - Toggle
-        304:
+        313:
         - - device-button-2
           - Toggle
     - type: ApcPowerReceiver
@@ -6696,7 +6884,7 @@ entities:
       startingCharge: 0
 - proto: ComputerStationRecords
   entities:
-  - uid: 1072
+  - uid: 1064
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6708,7 +6896,7 @@ entities:
       startingCharge: 0
 - proto: ComputerTelevision
   entities:
-  - uid: 296
+  - uid: 1065
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6718,7 +6906,7 @@ entities:
       powerLoad: 5
     - type: Battery
       startingCharge: 0
-  - uid: 1074
+  - uid: 1066
     components:
     - type: Transform
       pos: 8.5,-1.5
@@ -6729,165 +6917,173 @@ entities:
       startingCharge: 0
 - proto: DarkCatwalkMono
   entities:
-  - uid: 1075
+  - uid: 1067
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 1068
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-7.5
+      parent: 1
+  - uid: 1069
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 1076
+  - uid: 1070
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 1077
+  - uid: 1071
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 1078
+  - uid: 1072
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
-  - uid: 1079
+  - uid: 1073
     components:
     - type: Transform
       pos: -3.5,15.5
       parent: 1
-  - uid: 1080
+  - uid: 1074
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 1081
+  - uid: 1075
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 1082
+  - uid: 1076
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 1083
-    components:
-    - type: Transform
-      pos: 4.5,-10.5
-      parent: 1
-  - uid: 1084
-    components:
-    - type: Transform
-      pos: 5.5,-10.5
-      parent: 1
-  - uid: 1085
-    components:
-    - type: Transform
-      pos: -5.5,-10.5
-      parent: 1
-  - uid: 1086
-    components:
-    - type: Transform
-      pos: -6.5,-10.5
-      parent: 1
-  - uid: 1087
+  - uid: 1077
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 1088
+  - uid: 1078
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 1089
+  - uid: 1079
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 1090
+  - uid: 1080
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 1091
+  - uid: 1081
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 1092
+  - uid: 1082
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 1093
+  - uid: 1083
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 1094
+  - uid: 1084
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 1095
+  - uid: 1085
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 1096
+  - uid: 1086
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 1097
+  - uid: 1087
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 1098
+  - uid: 1088
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 1
-  - uid: 1099
+  - uid: 1089
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 1100
+  - uid: 1090
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 1101
+  - uid: 1091
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 1
-  - uid: 1102
+  - uid: 1092
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 1103
+  - uid: 1093
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 1104
+  - uid: 1094
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
+  - uid: 1095
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 1096
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 982
+  - uid: 1098
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 1909
+  - uid: 1099
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6895,359 +7091,188 @@ entities:
       parent: 1
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 1951
+  - uid: 1100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 1952
+  - uid: 1101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 1953
+  - uid: 2230
     components:
     - type: Transform
-      pos: 3.5,5.5
+      pos: -5.5,5.5
       parent: 1
-  - uid: 1954
+  - uid: 2233
     components:
     - type: Transform
-      pos: -4.5,5.5
+      pos: 4.5,5.5
       parent: 1
 - proto: FactionLathe
   entities:
-  - uid: 1105
+  - uid: 1104
     components:
     - type: Transform
       pos: 10.5,-7.5
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 1106
+  - uid: 1105
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-- proto: FireAlarm
-  entities:
-  - uid: 1107
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,10.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1135
-  - uid: 1108
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,10.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1134
-  - uid: 1109
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,1.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1124
-      - 1133
-      - 1134
-  - uid: 1110
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,1.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1135
-      - 1131
-      - 1132
-  - uid: 1111
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-2.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1133
-  - uid: 1112
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,-3.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1132
-  - uid: 1113
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-8.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1123
-      - 1125
-      - 1127
-      - 1129
-  - uid: 1114
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-6.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1121
-      - 1122
-      - 1124
-      - 1123
-  - uid: 1115
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-6.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1131
-      - 1129
-      - 1130
-  - uid: 1116
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-6.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1122
-  - uid: 1117
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-8.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1130
-  - uid: 1118
-    components:
-    - type: Transform
-      pos: 1.5,-11.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1126
-      - 1128
-      - 1127
-      - 1125
-  - uid: 1119
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-11.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1128
-  - uid: 1120
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-11.5
-      parent: 1
-    - type: DeviceList
-      devices:
-      - 1126
 - proto: Firelock
   entities:
-  - uid: 1121
+  - uid: 1106
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1114
       - 10
-  - uid: 1122
+  - uid: 1107
     components:
     - type: Transform
       pos: 8.5,-5.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1114
       - 10
-      - 1116
       - 12
-  - uid: 1123
+  - uid: 1108
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1113
       - 8
-      - 1114
       - 10
-  - uid: 1124
+  - uid: 1109
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1109
       - 5
-      - 1114
       - 10
-  - uid: 1125
+  - uid: 1110
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1113
       - 8
-      - 1118
-      - 15
-  - uid: 1126
+      - 13
+  - uid: 1111
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1120
-      - 1118
-      - 15
       - 13
-  - uid: 1127
+      - 14
+  - uid: 1112
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1113
       - 8
-      - 1118
-      - 15
-  - uid: 1128
+      - 13
+  - uid: 1113
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1118
+      - 13
       - 15
-      - 1119
-      - 14
-  - uid: 1129
+  - uid: 1114
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1113
       - 8
-      - 1115
       - 9
-  - uid: 1130
+  - uid: 1115
     components:
     - type: Transform
       pos: -7.5,-6.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1115
       - 9
-      - 1117
       - 11
-  - uid: 1131
+  - uid: 1116
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1110
       - 4
-      - 1115
       - 9
-  - uid: 1132
+  - uid: 1117
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1110
       - 4
-      - 1112
       - 6
-  - uid: 1133
+  - uid: 1118
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1109
       - 5
-      - 1111
       - 7
-  - uid: 1134
+  - uid: 1119
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1108
       - 3
-      - 1109
       - 5
-  - uid: 1135
+  - uid: 1120
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 1107
       - 2
-      - 1110
       - 4
 - proto: FloorDrain
   entities:
-  - uid: 1136
+  - uid: 1121
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 1137
+  - uid: 1122
     components:
     - type: Transform
       pos: -10.5,-7.5
@@ -7256,7 +7281,7 @@ entities:
       fixtures: {}
 - proto: GasMixerOn
   entities:
-  - uid: 1138
+  - uid: 1123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7269,22 +7294,22 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#0055CCFF'
 - proto: GasPassiveVent
   entities:
-  - uid: 1139
+  - uid: 1124
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-10.5
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-15.5
       parent: 1
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 1140
+  - uid: 1125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7294,1345 +7319,1463 @@ entities:
       pipeLayer: Secondary
 - proto: GasPipeBendAlt1
   entities:
-  - uid: 1141
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1142
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1143
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1144
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1145
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1146
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1147
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1148
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1150
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1151
+  - uid: 1126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1152
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1153
-    components:
-    - type: Transform
-      pos: 4.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1154
-    components:
-    - type: Transform
-      pos: 9.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1155
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1156
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1157
-    components:
-    - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-- proto: GasPipeBendAlt2
-  entities:
-  - uid: 1158
-    components:
-    - type: Transform
-      pos: 7.5,-8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1159
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1160
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1161
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1162
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1163
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1164
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1165
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1166
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1167
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1168
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1169
-    components:
-    - type: Transform
-      pos: -1.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1170
+      color: '#0055CCFF'
+  - uid: 1127
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1171
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1172
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1173
-    components:
-    - type: Transform
-      pos: 4.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1174
-    components:
-    - type: Transform
-      pos: 9.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1175
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1176
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1177
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1178
+      color: '#0055CCFF'
+  - uid: 1128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,8.5
+      pos: -6.5,-4.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1179
+      color: '#0055CCFF'
+  - uid: 1129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,8.5
+      pos: 4.5,-6.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1180
+      color: '#0055CCFF'
+  - uid: 1130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,8.5
+      pos: -5.5,-6.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1181
-    components:
-    - type: Transform
-      pos: 3.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-- proto: GasPipeStraightAlt1
-  entities:
-  - uid: 1182
-    components:
-    - type: Transform
-      pos: -0.5,-11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1183
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1184
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1185
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1186
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1187
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1188
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1189
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1190
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1191
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1192
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1193
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1194
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1195
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1196
+      color: '#0055CCFF'
+  - uid: 1131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,1.5
+      pos: -5.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1197
+      color: '#0055CCFF'
+  - uid: 1132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,-1.5
+      pos: -3.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1198
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1199
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1200
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1201
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1202
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1203
-    components:
-    - type: Transform
-      pos: 2.5,-8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1204
-    components:
-    - type: Transform
-      pos: 2.5,-9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1205
-    components:
-    - type: Transform
-      pos: 2.5,-10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1206
-    components:
-    - type: Transform
-      pos: 2.5,-11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1207
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1208
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1209
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1210
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1211
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1212
+      color: '#0055CCFF'
+  - uid: 1133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-12.5
+      pos: -9.5,-1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1213
+      color: '#0055CCFF'
+  - uid: 1134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-12.5
+      pos: -7.5,-5.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1214
-    components:
-    - type: Transform
-      pos: 0.5,-13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1215
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1216
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1217
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1218
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1219
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1220
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1221
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1222
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1223
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1224
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1225
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1226
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1227
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1228
-    components:
-    - type: Transform
-      pos: 2.5,6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1229
-    components:
-    - type: Transform
-      pos: -3.5,6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1230
-    components:
-    - type: Transform
-      pos: -3.5,7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1231
-    components:
-    - type: Transform
-      pos: -3.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1232
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1233
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1234
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1235
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-- proto: GasPipeStraightAlt2
-  entities:
-  - uid: 1236
+      color: '#0055CCFF'
+  - uid: 1135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1237
+      color: '#0055CCFF'
+  - uid: 1136
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,4.5
+      pos: -0.5,-12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1238
-    components:
-    - type: Transform
-      pos: 7.5,-9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1239
-    components:
-    - type: Transform
-      pos: 6.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1240
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1241
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1242
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1243
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1244
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1245
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1246
+      color: '#0055CCFF'
+  - uid: 1137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-2.5
+      pos: 2.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1247
+      color: '#0055CCFF'
+  - uid: 1138
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-3.5
+      pos: 4.5,1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1248
+      color: '#0055CCFF'
+  - uid: 1139
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-4.5
+      pos: 9.5,-5.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1249
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1250
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1251
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1252
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1253
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1254
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1255
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1256
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1257
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1258
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1259
-    components:
-    - type: Transform
-      pos: 2.5,-11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1260
-    components:
-    - type: Transform
-      pos: 2.5,-10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1261
-    components:
-    - type: Transform
-      pos: 2.5,-9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1262
-    components:
-    - type: Transform
-      pos: 2.5,-8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1263
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1264
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1265
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1266
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-9.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1267
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1268
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1269
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1270
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1271
-    components:
-    - type: Transform
-      pos: -1.5,-13.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1272
-    components:
-    - type: Transform
-      pos: -1.5,-14.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1273
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1274
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1275
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1276
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1277
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1278
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1279
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1280
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1281
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1282
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1283
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1284
-    components:
-    - type: Transform
-      pos: 2.5,6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1285
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1286
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1287
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1288
-    components:
-    - type: Transform
-      pos: -3.5,5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1289
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1290
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1291
-    components:
-    - type: Transform
-      pos: 9.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1292
-    components:
-    - type: Transform
-      pos: 9.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1293
-    components:
-    - type: Transform
-      pos: -0.5,-11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1294
-    components:
-    - type: Transform
-      pos: -0.5,-10.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1295
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1296
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1297
+      color: '#0055CCFF'
+  - uid: 1140
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1298
+      color: '#0055CCFF'
+  - uid: 1141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1142
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 1143
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1147
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1148
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1151
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1152
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1153
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1155
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1156
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1157
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1158
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1159
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1161
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1163
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1164
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraightAlt1
+  entities:
+  - uid: 1165
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1166
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1169
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1174
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1176
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1177
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1178
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1179
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1183
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1186
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1187
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1188
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1189
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1190
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1191
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1192
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1193
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1194
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1195
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1197
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1198
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1199
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1202
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1203
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1205
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1207
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1208
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1209
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1212
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1213
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1214
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1215
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1216
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 1220
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1222
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1224
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1226
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1228
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1229
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1230
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1231
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1232
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1233
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1234
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1235
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1236
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1239
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1242
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1244
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1245
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1246
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1247
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1249
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1251
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1252
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1254
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1255
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1257
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1258
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1259
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1260
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1261
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1262
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1267
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1268
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1270
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1271
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1272
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1273
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1274
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1275
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1277
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1278
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1299
+      color: '#990000FF'
+  - uid: 1279
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1300
+      color: '#990000FF'
+  - uid: 1280
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1301
+      color: '#990000FF'
+  - uid: 1281
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1302
+      color: '#990000FF'
+  - uid: 1282
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1303
+      color: '#990000FF'
+  - uid: 1283
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1304
+      color: '#990000FF'
+  - uid: 1284
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1305
+      color: '#990000FF'
+  - uid: 1285
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1306
+      color: '#990000FF'
+  - uid: 1286
     components:
     - type: Transform
       pos: -3.5,14.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1307
+      color: '#990000FF'
+  - uid: 1287
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1308
+      color: '#990000FF'
+  - uid: 1288
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1309
+      color: '#990000FF'
+  - uid: 1289
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1310
+      color: '#990000FF'
+  - uid: 1290
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1311
+      color: '#990000FF'
+  - uid: 1291
     components:
     - type: Transform
-      anchored: False
-      pos: -3.5,9.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-5.5
       parent: 1
-    - type: Physics
-      canCollide: True
-      bodyType: Dynamic
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1292
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1293
+    components:
+    - type: Transform
+      pos: -6.5,-14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeTJunctionAlt1
   entities:
-  - uid: 1312
+  - uid: 1295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1313
+      color: '#0055CCFF'
+  - uid: 1296
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#0055CCFF'
+  - uid: 1297
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1298
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1299
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1300
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1302
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1304
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1305
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1306
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1307
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1308
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunctionAlt2
+  entities:
+  - uid: 1309
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1310
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1312
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1313
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 1314
     components:
     - type: Transform
@@ -8640,29 +8783,29 @@ entities:
       pos: 4.5,-5.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#990000FF'
   - uid: 1315
     components:
     - type: Transform
-      pos: 2.5,-6.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,-6.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#990000FF'
   - uid: 1316
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#990000FF'
   - uid: 1317
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-6.5
+      pos: 2.5,-6.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#990000FF'
   - uid: 1318
     components:
     - type: Transform
@@ -8670,191 +8813,58 @@ entities:
       pos: -5.5,-5.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#990000FF'
   - uid: 1319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,4.5
+      pos: -5.5,-1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#990000FF'
   - uid: 1320
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,-12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#990000FF'
   - uid: 1321
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1322
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1323
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1324
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1325
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-- proto: GasPipeTJunctionAlt2
-  entities:
-  - uid: 1326
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1327
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1328
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1329
-    components:
-    - type: Transform
-      pos: 6.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1330
-    components:
-    - type: Transform
-      pos: -6.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1331
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1332
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1333
-    components:
-    - type: Transform
-      pos: -3.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1334
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1335
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1336
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1337
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-12.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-12.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1339
+      color: '#990000FF'
+  - uid: 1322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1340
+      color: '#990000FF'
+  - uid: 1323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1341
+      color: '#990000FF'
+  - uid: 1324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,6.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 1342
+  - uid: 1325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8862,7 +8872,7 @@ entities:
       parent: 1
     - type: AtmosPipeLayers
       pipeLayer: Secondary
-  - uid: 1343
+  - uid: 1326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8872,7 +8882,31 @@ entities:
       pipeLayer: Secondary
 - proto: GasVentPump
   entities:
-  - uid: 1344
+  - uid: 1327
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 1328
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 15
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 1329
     components:
     - type: Transform
       pos: -0.5,-10.5
@@ -8880,8 +8914,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1345
+      color: '#0055CCFF'
+  - uid: 1330
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8893,8 +8927,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1346
+      color: '#0055CCFF'
+  - uid: 1331
     components:
     - type: Transform
       pos: 0.5,-5.5
@@ -8905,8 +8939,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1347
+      color: '#0055CCFF'
+  - uid: 1332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8914,36 +8948,12 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 15
-    - type: AtmosPipeLayers
-      pipeLayer: Secondary
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1348
-    components:
-    - type: Transform
-      pos: 4.5,-11.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
       - 13
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1349
-    components:
-    - type: Transform
-      pos: -5.5,-11.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 14
-    - type: AtmosPipeLayers
-      pipeLayer: Secondary
-    - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1350
+      color: '#0055CCFF'
+  - uid: 1333
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8955,8 +8965,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1351
+      color: '#0055CCFF'
+  - uid: 1334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8968,8 +8978,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1352
+      color: '#0055CCFF'
+  - uid: 1335
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8981,8 +8991,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1353
+      color: '#0055CCFF'
+  - uid: 1336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8994,8 +9004,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1354
+      color: '#0055CCFF'
+  - uid: 1337
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9007,8 +9017,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1355
+      color: '#0055CCFF'
+  - uid: 1338
     components:
     - type: Transform
       pos: 2.5,7.5
@@ -9019,8 +9029,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1356
+      color: '#0055CCFF'
+  - uid: 1339
     components:
     - type: Transform
       pos: -3.5,8.5
@@ -9031,8 +9041,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1357
+      color: '#0055CCFF'
+  - uid: 1340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9044,8 +9054,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
-  - uid: 1358
+      color: '#0055CCFF'
+  - uid: 1341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9057,10 +9067,10 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
-      color: '#00AACCFF'
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 1359
+  - uid: 1342
     components:
     - type: Transform
       pos: -0.5,-9.5
@@ -9068,8 +9078,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1360
+      color: '#990000FF'
+  - uid: 1343
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9081,8 +9091,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1361
+      color: '#990000FF'
+  - uid: 1344
     components:
     - type: Transform
       pos: -1.5,-5.5
@@ -9093,8 +9103,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1362
+      color: '#990000FF'
+  - uid: 1345
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9102,36 +9112,24 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 15
-    - type: AtmosPipeLayers
-      pipeLayer: Tertiary
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1363
-    components:
-    - type: Transform
-      pos: 5.5,-11.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
       - 13
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1364
+      color: '#990000FF'
+  - uid: 1346
     components:
     - type: Transform
       pos: -6.5,-11.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 14
+      - 15
+    - type: AtmosPipeColor
+      color: '#990000FF'
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
-    - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1365
+  - uid: 1347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9143,8 +9141,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1366
+      color: '#990000FF'
+  - uid: 1348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9156,8 +9154,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1367
+      color: '#990000FF'
+  - uid: 1349
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9169,8 +9167,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1368
+      color: '#990000FF'
+  - uid: 1350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9182,8 +9180,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1369
+      color: '#990000FF'
+  - uid: 1351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9195,8 +9193,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1370
+      color: '#990000FF'
+  - uid: 1352
     components:
     - type: Transform
       pos: 2.5,8.5
@@ -9207,8 +9205,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1371
+      color: '#990000FF'
+  - uid: 1353
     components:
     - type: Transform
       pos: -3.5,7.5
@@ -9222,8 +9220,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1372
+      color: '#990000FF'
+  - uid: 1354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9235,8 +9233,8 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1373
+      color: '#990000FF'
+  - uid: 1355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9248,35 +9246,55 @@ entities:
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1374
+      color: '#990000FF'
+  - uid: 1356
     components:
     - type: Transform
       pos: -3.5,15.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
-  - uid: 1375
+      color: '#990000FF'
+  - uid: 1357
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
-      color: '#DD0075FF'
+      color: '#990000FF'
+- proto: GasVentScrubberFreezer
+  entities:
+  - uid: 1358
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+    - type: AtmosPipeColor
+      color: '#990000FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
 - proto: GravityGeneratorMini
   entities:
-  - uid: 1376
+  - uid: 1359
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
 - proto: GreebleAntenna1
   entities:
-  - uid: 1998
+  - uid: 1360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9284,7 +9302,7 @@ entities:
       parent: 1
 - proto: GreebleAntenna2
   entities:
-  - uid: 2002
+  - uid: 1361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9292,13 +9310,13 @@ entities:
       parent: 1
 - proto: GreebleElint1
   entities:
-  - uid: 1999
+  - uid: 1362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-8.5
       parent: 1
-  - uid: 2000
+  - uid: 1363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9306,12 +9324,12 @@ entities:
       parent: 1
 - proto: GreebleRadarpanel2
   entities:
-  - uid: 1918
+  - uid: 1364
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 1
-  - uid: 2001
+  - uid: 1365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9319,49 +9337,49 @@ entities:
       parent: 1
 - proto: Grille
   entities:
-  - uid: 1377
+  - uid: 1366
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 1
-  - uid: 1378
+  - uid: 1367
     components:
     - type: Transform
       pos: 3.5,24.5
       parent: 1
-  - uid: 1379
+  - uid: 1368
     components:
     - type: Transform
       pos: -3.5,24.5
       parent: 1
-  - uid: 1380
+  - uid: 1369
     components:
     - type: Transform
       pos: -4.5,24.5
       parent: 1
-  - uid: 1936
+  - uid: 1370
     components:
     - type: Transform
-      pos: 8.5,-10.5
+      pos: -9.5,-15.5
       parent: 1
-  - uid: 1937
+  - uid: 1371
     components:
     - type: Transform
-      pos: 7.5,-10.5
+      pos: 7.5,-15.5
       parent: 1
-  - uid: 1938
+  - uid: 1372
     components:
     - type: Transform
-      pos: -8.5,-10.5
+      pos: -8.5,-15.5
       parent: 1
-  - uid: 1940
+  - uid: 1373
     components:
     - type: Transform
-      pos: -9.5,-10.5
+      pos: 8.5,-15.5
       parent: 1
 - proto: GunneryServerUltra
   entities:
-  - uid: 1381
+  - uid: 1374
     components:
     - type: Transform
       pos: 0.5,-9.5
@@ -9372,93 +9390,97 @@ entities:
       powerLoad: 50
 - proto: GyroscopeNfsd
   entities:
-  - uid: 1382
+  - uid: 1375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 1376
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-13.5
+      parent: 1
+  - uid: 1377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 1378
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-13.5
+      parent: 1
+  - uid: 1379
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 1
-  - uid: 1383
+  - uid: 1380
     components:
     - type: Transform
       pos: -3.5,18.5
       parent: 1
-  - uid: 1384
-    components:
-    - type: Transform
-      pos: 4.5,-10.5
-      parent: 1
-  - uid: 1385
-    components:
-    - type: Transform
-      pos: 5.5,-10.5
-      parent: 1
-  - uid: 1386
-    components:
-    - type: Transform
-      pos: -6.5,-10.5
-      parent: 1
-  - uid: 1387
-    components:
-    - type: Transform
-      pos: -5.5,-10.5
-      parent: 1
 - proto: Handrail
   entities:
-  - uid: 301
+  - uid: 1381
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 1939
+  - uid: 1382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 1941
+  - uid: 1383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-14.5
       parent: 1
-  - uid: 1942
+  - uid: 1384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-14.5
       parent: 1
-  - uid: 1943
+  - uid: 1385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
-  - uid: 1944
+  - uid: 1386
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 1945
+  - uid: 1387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,9.5
       parent: 1
-  - uid: 1946
+  - uid: 1388
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
-  - uid: 1947
+  - uid: 1389
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-20.5
       parent: 1
-  - uid: 1949
+  - uid: 1390
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9466,42 +9488,42 @@ entities:
       parent: 1
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 1388
+  - uid: 1391
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
 - proto: KitchenElectricGrill
   entities:
-  - uid: 1389
+  - uid: 1392
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 1
 - proto: KitchenElectricRange
   entities:
-  - uid: 1390
+  - uid: 1393
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 1391
+  - uid: 1394
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 1392
+  - uid: 1395
     components:
     - type: Transform
       pos: -11.5,-6.5
       parent: 1
 - proto: LockableButtonSecurity
   entities:
-  - uid: 1393
+  - uid: 1396
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9509,84 +9531,82 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        304:
+        313:
         - - Pressed
           - Toggle
-        303:
+        312:
         - - Pressed
           - Toggle
-        302:
+        311:
         - - Pressed
           - Toggle
 - proto: LockerCaptain
   entities:
-  - uid: 1394
+  - uid: 1397
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
 - proto: LockerFreezerBase
   entities:
-  - uid: 1395
+  - uid: 1398
     components:
     - type: Transform
       pos: -11.5,-8.5
       parent: 1
 - proto: LockerSteel
   entities:
-  - uid: 1073
+  - uid: 1399
     components:
     - type: Transform
       pos: -9.5,-1.5
       parent: 1
-  - uid: 1396
+  - uid: 1400
     components:
     - type: Transform
       pos: -9.5,-0.5
       parent: 1
-  - uid: 1397
+  - uid: 1401
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 1
 - proto: LockerWallMaterialsFuelAmeJarFilled
   entities:
-  - uid: 1398
+  - uid: 1402
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-14.5
+      pos: -6.5,-9.5
       parent: 1
-  - uid: 1399
+  - uid: 1403
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-14.5
+      pos: 5.5,-9.5
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 1400
+  - uid: 1404
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
 - proto: MachineMaterialSilo
   entities:
-  - uid: 1401
+  - uid: 1405
     components:
     - type: Transform
       pos: 10.5,-8.5
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 1402
+  - uid: 1406
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 1403
+  - uid: 1407
     components:
     - type: Transform
       anchored: True
@@ -9596,7 +9616,7 @@ entities:
       bodyType: Static
 - proto: OxygenCanister
   entities:
-  - uid: 1404
+  - uid: 1408
     components:
     - type: Transform
       anchored: True
@@ -9606,26 +9626,26 @@ entities:
       bodyType: Static
 - proto: PaperBin20
   entities:
-  - uid: 1405
+  - uid: 1409
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
 - proto: PaperDoor
   entities:
-  - uid: 1406
+  - uid: 1410
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 1
-  - uid: 1407
+  - uid: 1411
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
 - proto: PaperOffice
   entities:
-  - uid: 1408
+  - uid: 1412
     components:
     - type: Transform
       pos: -2.5582623,-4.4744544
@@ -9637,7 +9657,7 @@ entities:
         PORT 2 BUTTON IS LINKED TO CHARON BLAST DOORS
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 1409
+  - uid: 1413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9645,7 +9665,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1410
+  - uid: 1414
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9653,70 +9673,118 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1411
+  - uid: 1415
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 1412
+  - uid: 1416
     components:
     - type: Transform
       pos: -4.5,15.5
       parent: 1
-  - uid: 1413
+  - uid: 1417
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 1
-  - uid: 1414
+  - uid: 1418
     components:
     - type: Transform
       pos: -3.5,18.5
       parent: 1
-  - uid: 1415
+  - uid: 1419
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 1416
+  - uid: 1420
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
+  - uid: 1421
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 1422
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 1423
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 1424
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 1425
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 1426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 1427
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 1428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 1417
+  - uid: 1429
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1418
+  - uid: 1430
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1419
+  - uid: 1431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 1420
+  - uid: 1432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-3.5
       parent: 1
-  - uid: 1421
+  - uid: 1433
     components:
     - type: Transform
       pos: -10.5,-4.5
       parent: 1
-  - uid: 1422
+  - uid: 1434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9724,7 +9792,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1423
+  - uid: 1435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9732,13 +9800,13 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1424
+  - uid: 1436
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-8.5
       parent: 1
-  - uid: 1425
+  - uid: 1437
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9746,7 +9814,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1426
+  - uid: 1438
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9754,25 +9822,16 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1427
+- proto: PoweredlightBlue
+  entities:
+  - uid: 1439
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-11.5
+      pos: -0.5,-4.5
       parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
-  - uid: 1428
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-11.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
 - proto: PoweredlightBlueAirAlarm
   entities:
-  - uid: 1429
+  - uid: 1440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9780,7 +9839,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1430
+  - uid: 1441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9788,7 +9847,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1431
+  - uid: 1442
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9796,7 +9855,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1432
+  - uid: 1443
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9804,7 +9863,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1433
+  - uid: 1444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9812,7 +9871,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1434
+  - uid: 1445
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9820,7 +9879,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1435
+  - uid: 1446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9828,7 +9887,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1436
+  - uid: 1447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9836,7 +9895,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1437
+  - uid: 1448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9844,7 +9903,7 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1438
+  - uid: 1449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9852,30 +9911,14 @@ entities:
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1439
+  - uid: 1450
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 1440
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-11.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 2
-  - uid: 1441
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-11.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 2
-  - uid: 1442
+  - uid: 1451
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9885,23 +9928,7 @@ entities:
       invokeCounter: 2
 - proto: PoweredlightLED
   entities:
-  - uid: 1443
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-5.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
-  - uid: 1444
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-5.5
-      parent: 1
-    - type: DeviceLinkSink
-      invokeCounter: 1
-  - uid: 1445
+  - uid: 1452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9911,61 +9938,198 @@ entities:
       invokeCounter: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 1446
+  - uid: 1453
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,9.5
       parent: 1
-  - uid: 1447
+  - uid: 1454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
-  - uid: 1448
+  - uid: 1455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,19.5
       parent: 1
-  - uid: 1449
+  - uid: 1456
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,19.5
       parent: 1
+  - uid: 1457
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 1458
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 1
+- proto: PoweredStrobeGreenEnabled
+  entities:
+  - uid: 2187
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 2195
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,22.5
+      parent: 1
+  - uid: 2196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,18.5
+      parent: 1
+  - uid: 2197
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 2199
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 2200
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 2201
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-6.5
+      parent: 1
+- proto: PoweredStrobeLedEnabled
+  entities:
+  - uid: 2202
+    components:
+    - type: Transform
+      pos: -8.5,-17.5
+      parent: 1
+  - uid: 2203
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 2204
+    components:
+    - type: Transform
+      pos: 3.5,-17.5
+      parent: 1
+  - uid: 2205
+    components:
+    - type: Transform
+      pos: 7.5,-17.5
+      parent: 1
+- proto: PoweredStrobeRedEnabled
+  entities:
+  - uid: 2188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 2189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 2190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 2191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-6.5
+      parent: 1
+  - uid: 2192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 2193
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,18.5
+      parent: 1
+  - uid: 2194
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,22.5
+      parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 1450
+  - uid: 1459
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 1460
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 1451
+  - uid: 1461
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
+  - uid: 1462
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 1463
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
 - proto: Rack
   entities:
-  - uid: 1452
+  - uid: 1464
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 1453
+  - uid: 1465
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
 - proto: RadarEdgeMarkerCenter
   entities:
-  - uid: 1974
+  - uid: 1466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9973,185 +10137,185 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerDiagonal
   entities:
-  - uid: 130
+  - uid: 1467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,8.5
       parent: 1
-  - uid: 1975
+  - uid: 1468
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 1
-  - uid: 1976
+  - uid: 1469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
-  - uid: 1977
+  - uid: 1470
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 1
-  - uid: 1978
+  - uid: 1471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-  - uid: 1979
+  - uid: 1472
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 1980
+  - uid: 1473
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 1993
+  - uid: 1474
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-10.5
       parent: 1
-  - uid: 1994
+  - uid: 1475
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-10.5
       parent: 1
-  - uid: 2023
+  - uid: 1476
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 2024
+  - uid: 1477
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 2025
+  - uid: 1478
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 2026
+  - uid: 1479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,12.5
       parent: 1
-  - uid: 2027
+  - uid: 1480
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 2055
+  - uid: 1481
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,6.5
       parent: 1
-  - uid: 2056
+  - uid: 1482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 1
-  - uid: 2057
+  - uid: 1483
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 1
-  - uid: 2058
+  - uid: 1484
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 1
-  - uid: 2059
+  - uid: 1485
     components:
     - type: Transform
       pos: -5.5,12.5
       parent: 1
-  - uid: 2060
+  - uid: 1486
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,10.5
       parent: 1
-  - uid: 2088
+  - uid: 1487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 1
-  - uid: 2089
+  - uid: 1488
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-11.5
       parent: 1
-  - uid: 2093
+  - uid: 1489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-10.5
       parent: 1
-  - uid: 2094
+  - uid: 1490
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-11.5
       parent: 1
-  - uid: 2126
+  - uid: 1491
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-5.5
       parent: 1
-  - uid: 2135
+  - uid: 1492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-5.5
       parent: 1
-  - uid: 2156
+  - uid: 1493
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-  - uid: 2157
+  - uid: 1494
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-10.5
       parent: 1
-  - uid: 2158
+  - uid: 1495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-11.5
       parent: 1
-  - uid: 2159
+  - uid: 1496
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-10.5
       parent: 1
-  - uid: 2198
+  - uid: 1497
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,4.5
       parent: 1
-  - uid: 2199
+  - uid: 1498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10159,225 +10323,225 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerHalftiltLeft
   entities:
-  - uid: 1921
+  - uid: 1499
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,21.5
       parent: 1
-  - uid: 1922
+  - uid: 1500
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,18.5
       parent: 1
-  - uid: 1923
+  - uid: 1501
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,15.5
       parent: 1
-  - uid: 1924
+  - uid: 1502
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,12.5
       parent: 1
-  - uid: 1925
+  - uid: 1503
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
-  - uid: 1926
+  - uid: 1504
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 1
-  - uid: 1927
+  - uid: 1505
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-  - uid: 1928
+  - uid: 1506
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 1963
+  - uid: 1507
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,20.5
       parent: 1
-  - uid: 1964
+  - uid: 1508
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,17.5
       parent: 1
-  - uid: 1965
+  - uid: 1509
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 1
-  - uid: 1966
+  - uid: 1510
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,11.5
       parent: 1
-  - uid: 1967
+  - uid: 1511
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 1968
+  - uid: 1512
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-  - uid: 1969
+  - uid: 1513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 1970
+  - uid: 1514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 1973
+  - uid: 1515
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 1989
+  - uid: 1516
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
       parent: 1
-  - uid: 1990
+  - uid: 1517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-9.5
       parent: 1
-  - uid: 2008
+  - uid: 1518
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-16.5
       parent: 1
-  - uid: 2009
+  - uid: 1519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-17.5
       parent: 1
-  - uid: 2010
+  - uid: 1520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-18.5
       parent: 1
-  - uid: 2011
+  - uid: 1521
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-17.5
       parent: 1
-  - uid: 2018
+  - uid: 1522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-17.5
       parent: 1
-  - uid: 2019
+  - uid: 1523
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-16.5
       parent: 1
-  - uid: 2063
+  - uid: 1524
     components:
     - type: Transform
       pos: -7.5,15.5
       parent: 1
-  - uid: 2064
+  - uid: 1525
     components:
     - type: Transform
       pos: -6.5,19.5
       parent: 1
-  - uid: 2065
+  - uid: 1526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,15.5
       parent: 1
-  - uid: 2066
+  - uid: 1527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,19.5
       parent: 1
-  - uid: 2071
+  - uid: 1528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 2072
+  - uid: 1529
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 2076
+  - uid: 1530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 1
-  - uid: 2085
+  - uid: 1531
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-13.5
       parent: 1
-  - uid: 2086
+  - uid: 1532
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-12.5
       parent: 1
-  - uid: 2100
+  - uid: 1533
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,0.5
       parent: 1
-  - uid: 2101
+  - uid: 1534
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-0.5
       parent: 1
-  - uid: 2160
+  - uid: 1535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-  - uid: 2161
+  - uid: 1536
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10385,225 +10549,225 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerHalftiltRight
   entities:
-  - uid: 1671
+  - uid: 1537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,19.5
       parent: 1
-  - uid: 1929
+  - uid: 1538
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,21.5
       parent: 1
-  - uid: 1930
+  - uid: 1539
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,18.5
       parent: 1
-  - uid: 1931
+  - uid: 1540
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,15.5
       parent: 1
-  - uid: 1932
+  - uid: 1541
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,12.5
       parent: 1
-  - uid: 1933
+  - uid: 1542
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 1934
+  - uid: 1543
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 1935
+  - uid: 1544
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 1955
+  - uid: 1545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 1956
+  - uid: 1546
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 1957
+  - uid: 1547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 1958
+  - uid: 1548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 1959
+  - uid: 1549
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,8.5
       parent: 1
-  - uid: 1960
+  - uid: 1550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 1961
+  - uid: 1551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,17.5
       parent: 1
-  - uid: 1962
+  - uid: 1552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,20.5
       parent: 1
-  - uid: 1971
+  - uid: 1553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,14.5
       parent: 1
-  - uid: 1972
+  - uid: 1554
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 1991
+  - uid: 1555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
-  - uid: 1992
+  - uid: 1556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-9.5
       parent: 1
-  - uid: 2004
+  - uid: 1557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-18.5
       parent: 1
-  - uid: 2005
+  - uid: 1558
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-17.5
       parent: 1
-  - uid: 2006
+  - uid: 1559
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-16.5
       parent: 1
-  - uid: 2007
+  - uid: 1560
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-17.5
       parent: 1
-  - uid: 2016
+  - uid: 1561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-17.5
       parent: 1
-  - uid: 2017
+  - uid: 1562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-16.5
       parent: 1
-  - uid: 2068
+  - uid: 1563
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 1
-  - uid: 2069
+  - uid: 1564
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,15.5
       parent: 1
-  - uid: 2070
+  - uid: 1565
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 1
-  - uid: 2073
+  - uid: 1566
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-4.5
       parent: 1
-  - uid: 2074
+  - uid: 1567
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 2075
+  - uid: 1568
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-5.5
       parent: 1
-  - uid: 2079
+  - uid: 1569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-13.5
       parent: 1
-  - uid: 2084
+  - uid: 1570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-12.5
       parent: 1
-  - uid: 2102
+  - uid: 1571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 1
-  - uid: 2103
+  - uid: 1572
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-0.5
       parent: 1
-  - uid: 2162
+  - uid: 1573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 2163
+  - uid: 1574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10611,818 +10775,818 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerStraight
   entities:
-  - uid: 1981
+  - uid: 1575
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 1982
+  - uid: 1576
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 1983
+  - uid: 1577
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 1984
+  - uid: 1578
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 1985
+  - uid: 1579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 1986
+  - uid: 1580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 1987
+  - uid: 1581
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 1988
+  - uid: 1582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 1995
+  - uid: 1583
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 1
-  - uid: 1996
+  - uid: 1584
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-10.5
       parent: 1
-  - uid: 1997
+  - uid: 1585
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 1
-  - uid: 2003
+  - uid: 1586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,10.5
       parent: 1
-  - uid: 2012
+  - uid: 1587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-19.5
       parent: 1
-  - uid: 2013
+  - uid: 1588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-18.5
       parent: 1
-  - uid: 2014
+  - uid: 1589
     components:
     - type: Transform
       pos: 5.5,-18.5
       parent: 1
-  - uid: 2015
+  - uid: 1590
     components:
     - type: Transform
       pos: 7.5,-19.5
       parent: 1
-  - uid: 2028
+  - uid: 1591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,3.5
       parent: 1
-  - uid: 2029
+  - uid: 1592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,7.5
       parent: 1
-  - uid: 2030
+  - uid: 1593
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,11.5
       parent: 1
-  - uid: 2031
+  - uid: 1594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,12.5
       parent: 1
-  - uid: 2032
+  - uid: 1595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,12.5
       parent: 1
-  - uid: 2033
+  - uid: 1596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,8.5
       parent: 1
-  - uid: 2034
+  - uid: 1597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,8.5
       parent: 1
-  - uid: 2035
+  - uid: 1598
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 1
-  - uid: 2036
+  - uid: 1599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 1
-  - uid: 2037
+  - uid: 1600
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 1
-  - uid: 2038
+  - uid: 1601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 2039
+  - uid: 1602
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,6.5
       parent: 1
-  - uid: 2040
+  - uid: 1603
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 1
-  - uid: 2041
+  - uid: 1604
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,10.5
       parent: 1
-  - uid: 2042
+  - uid: 1605
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,10.5
       parent: 1
-  - uid: 2043
+  - uid: 1606
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,10.5
       parent: 1
-  - uid: 2044
+  - uid: 1607
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 1
-  - uid: 2045
+  - uid: 1608
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,6.5
       parent: 1
-  - uid: 2046
+  - uid: 1609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,2.5
       parent: 1
-  - uid: 2047
+  - uid: 1610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,2.5
       parent: 1
-  - uid: 2048
+  - uid: 1611
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,4.5
       parent: 1
-  - uid: 2049
+  - uid: 1612
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,4.5
       parent: 1
-  - uid: 2050
+  - uid: 1613
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,8.5
       parent: 1
-  - uid: 2051
+  - uid: 1614
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,8.5
       parent: 1
-  - uid: 2052
+  - uid: 1615
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,12.5
       parent: 1
-  - uid: 2053
+  - uid: 1616
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,12.5
       parent: 1
-  - uid: 2054
+  - uid: 1617
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 1
-  - uid: 2061
+  - uid: 1618
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 1
-  - uid: 2062
+  - uid: 1619
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 1
-  - uid: 2077
+  - uid: 1620
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-13.5
       parent: 1
-  - uid: 2078
+  - uid: 1621
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-13.5
       parent: 1
-  - uid: 2080
+  - uid: 1622
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-6.5
       parent: 1
-  - uid: 2081
+  - uid: 1623
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-7.5
       parent: 1
-  - uid: 2082
+  - uid: 1624
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-8.5
       parent: 1
-  - uid: 2083
+  - uid: 1625
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-9.5
       parent: 1
-  - uid: 2087
+  - uid: 1626
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 1
-  - uid: 2090
+  - uid: 1627
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 2091
+  - uid: 1628
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 2092
+  - uid: 1629
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 2095
+  - uid: 1630
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-13.5
       parent: 1
-  - uid: 2096
+  - uid: 1631
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-13.5
       parent: 1
-  - uid: 2097
+  - uid: 1632
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-13.5
       parent: 1
-  - uid: 2098
+  - uid: 1633
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-13.5
       parent: 1
-  - uid: 2099
+  - uid: 1634
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-13.5
       parent: 1
-  - uid: 2104
+  - uid: 1635
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 2105
+  - uid: 1636
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 1
-  - uid: 2106
+  - uid: 1637
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
-  - uid: 2107
+  - uid: 1638
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-3.5
       parent: 1
-  - uid: 2108
+  - uid: 1639
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 1
-  - uid: 2109
+  - uid: 1640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-3.5
       parent: 1
-  - uid: 2110
+  - uid: 1641
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-2.5
       parent: 1
-  - uid: 2111
+  - uid: 1642
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-1.5
       parent: 1
-  - uid: 2112
+  - uid: 1643
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 2113
+  - uid: 1644
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,0.5
       parent: 1
-  - uid: 2114
+  - uid: 1645
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,0.5
       parent: 1
-  - uid: 2115
+  - uid: 1646
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 1
-  - uid: 2116
+  - uid: 1647
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 1
-  - uid: 2117
+  - uid: 1648
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 2118
+  - uid: 1649
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
-  - uid: 2119
+  - uid: 1650
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 1
-  - uid: 2120
+  - uid: 1651
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 1
-  - uid: 2121
+  - uid: 1652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-3.5
       parent: 1
-  - uid: 2122
+  - uid: 1653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-3.5
       parent: 1
-  - uid: 2123
+  - uid: 1654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-3.5
       parent: 1
-  - uid: 2124
+  - uid: 1655
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-2.5
       parent: 1
-  - uid: 2125
+  - uid: 1656
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-1.5
       parent: 1
-  - uid: 2127
+  - uid: 1657
     components:
     - type: Transform
       pos: 9.5,-6.5
       parent: 1
-  - uid: 2128
+  - uid: 1658
     components:
     - type: Transform
       pos: 9.5,-7.5
       parent: 1
-  - uid: 2129
+  - uid: 1659
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
-  - uid: 2130
+  - uid: 1660
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 1
-  - uid: 2131
+  - uid: 1661
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-6.5
       parent: 1
-  - uid: 2132
+  - uid: 1662
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-7.5
       parent: 1
-  - uid: 2133
+  - uid: 1663
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-8.5
       parent: 1
-  - uid: 2134
+  - uid: 1664
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-9.5
       parent: 1
-  - uid: 2136
+  - uid: 1665
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-5.5
       parent: 1
-  - uid: 2137
+  - uid: 1666
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-5.5
       parent: 1
-  - uid: 2138
+  - uid: 1667
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 1
-  - uid: 2139
+  - uid: 1668
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 1
-  - uid: 2140
+  - uid: 1669
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 1
-  - uid: 2141
+  - uid: 1670
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 1
-  - uid: 2142
+  - uid: 1671
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 1
-  - uid: 2143
+  - uid: 1672
     components:
     - type: Transform
       pos: -8.5,-10.5
       parent: 1
-  - uid: 2144
+  - uid: 1673
     components:
     - type: Transform
       pos: -8.5,-11.5
       parent: 1
-  - uid: 2145
+  - uid: 1674
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 1
-  - uid: 2146
+  - uid: 1675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 1
-  - uid: 2147
+  - uid: 1676
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-5.5
       parent: 1
-  - uid: 2148
+  - uid: 1677
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-6.5
       parent: 1
-  - uid: 2149
+  - uid: 1678
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-7.5
       parent: 1
-  - uid: 2150
+  - uid: 1679
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-8.5
       parent: 1
-  - uid: 2151
+  - uid: 1680
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-9.5
       parent: 1
-  - uid: 2152
+  - uid: 1681
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-10.5
       parent: 1
-  - uid: 2153
+  - uid: 1682
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-11.5
       parent: 1
-  - uid: 2154
+  - uid: 1683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-11.5
       parent: 1
-  - uid: 2155
+  - uid: 1684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-11.5
       parent: 1
-  - uid: 2164
+  - uid: 1685
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 2165
+  - uid: 1686
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 2166
+  - uid: 1687
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 2167
+  - uid: 1688
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 2168
+  - uid: 1689
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 2169
+  - uid: 1690
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 2170
+  - uid: 1691
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 2171
+  - uid: 1692
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 2172
+  - uid: 1693
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 2173
+  - uid: 1694
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 2174
+  - uid: 1695
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 1
-  - uid: 2175
+  - uid: 1696
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,1.5
       parent: 1
-  - uid: 2176
+  - uid: 1697
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 2177
+  - uid: 1698
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 1
-  - uid: 2178
+  - uid: 1699
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-1.5
       parent: 1
-  - uid: 2179
+  - uid: 1700
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-2.5
       parent: 1
-  - uid: 2180
+  - uid: 1701
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-3.5
       parent: 1
-  - uid: 2181
+  - uid: 1702
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 1
-  - uid: 2182
+  - uid: 1703
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-  - uid: 2183
+  - uid: 1704
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 2184
+  - uid: 1705
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 2185
+  - uid: 1706
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 2186
+  - uid: 1707
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 2187
+  - uid: 1708
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 2188
+  - uid: 1709
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 2189
+  - uid: 1710
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 2190
+  - uid: 1711
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 2191
+  - uid: 1712
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 2192
+  - uid: 1713
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 2193
+  - uid: 1714
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 2194
+  - uid: 1715
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 2195
+  - uid: 1716
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,0.5
       parent: 1
-  - uid: 2196
+  - uid: 1717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-0.5
       parent: 1
-  - uid: 2197
+  - uid: 1718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11430,60 +11594,84 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 1454
+  - uid: 1719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-12.5
       parent: 1
-  - uid: 1455
+  - uid: 1720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-13.5
       parent: 1
-  - uid: 1456
+  - uid: 1721
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-12.5
       parent: 1
-  - uid: 1457
+  - uid: 1722
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-13.5
       parent: 1
+  - uid: 1723
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-13.5
+      parent: 1
+  - uid: 1724
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 1725
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-13.5
+      parent: 1
+  - uid: 1726
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-13.5
+      parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 1458
+  - uid: 1727
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-8.5
       parent: 1
-- proto: ShieldGeneratorSmall
+- proto: ShieldGeneratorMedium
   entities:
-  - uid: 1459
+  - uid: 1728
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 1460
+  - uid: 1729
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-3.5
       parent: 1
-  - uid: 1461
+  - uid: 1730
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-4.5
       parent: 1
-  - uid: 1462
+  - uid: 1731
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11491,78 +11679,68 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 1463
+  - uid: 1732
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 1464
+  - uid: 1733
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 1465
+  - uid: 1734
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 1466
+  - uid: 1735
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 1
-  - uid: 1467
+  - uid: 1736
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 1468
-    components:
-    - type: Transform
-      pos: 5.5,-12.5
-      parent: 1
-  - uid: 1469
-    components:
-    - type: Transform
-      pos: -6.5,-12.5
-      parent: 1
-  - uid: 1470
+  - uid: 1737
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 1471
+  - uid: 1738
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 1
-  - uid: 1472
+  - uid: 1739
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 1
-  - uid: 1473
+  - uid: 1740
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 1
-  - uid: 1474
+  - uid: 1741
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
-  - uid: 1475
+  - uid: 1742
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
 - proto: StairDark
   entities:
-  - uid: 1476
+  - uid: 1743
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11570,23 +11748,23 @@ entities:
       parent: 1
 - proto: Stairs
   entities:
-  - uid: 1477
+  - uid: 1744
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
-  - uid: 1478
+  - uid: 1745
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 1479
+  - uid: 1746
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-9.5
       parent: 1
-  - uid: 1480
+  - uid: 1747
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11594,45 +11772,45 @@ entities:
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 1481
+  - uid: 1748
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 1749
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 1750
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 1482
+  - uid: 1751
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 1483
+  - uid: 1752
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 1484
+  - uid: 1753
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 1485
-    components:
-    - type: Transform
-      pos: 5.5,-9.5
-      parent: 1
-  - uid: 1486
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 1
-  - uid: 1487
+  - uid: 1754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-  - uid: 1488
+  - uid: 1755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11640,103 +11818,107 @@ entities:
       parent: 1
 - proto: SuitStorageM82c
   entities:
-  - uid: 1489
+  - uid: 1756
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 1490
+  - uid: 1757
     components:
     - type: Transform
       pos: -4.5,15.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 1491
+  - uid: 1758
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 1492
+  - uid: 1759
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 1493
+  - uid: 1760
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 1494
+  - uid: 1761
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 1
-  - uid: 1495
+  - uid: 1762
     components:
     - type: Transform
       pos: -11.5,-6.5
       parent: 1
-  - uid: 1496
+  - uid: 1763
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 1
 - proto: ThrusterLargeNfsd
   entities:
-  - uid: 1497
+  - uid: 1764
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 1
-  - uid: 1498
+  - uid: 1765
     components:
     - type: Transform
       pos: -4.5,23.5
       parent: 1
-  - uid: 1499
+  - uid: 1766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,19.5
       parent: 1
-  - uid: 1500
+  - uid: 1767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,18.5
       parent: 1
-  - uid: 1501
+  - uid: 1768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,14.5
       parent: 1
-  - uid: 1502
+  - uid: 1769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,15.5
       parent: 1
-  - uid: 1503
+  - uid: 1770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-17.5
       parent: 1
-  - uid: 1504
+  - uid: 1771
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-18.5
       parent: 1
-  - uid: 1505
+    - type: ApcPowerReceiver
+      powerLoad: 1
+    - type: Thruster
+      enabled: False
+  - uid: 1772
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-17.5
       parent: 1
-  - uid: 1506
+  - uid: 1773
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11744,13 +11926,13 @@ entities:
       parent: 1
 - proto: ThrusterNfsd
   entities:
-  - uid: 828
+  - uid: 1774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-17.5
       parent: 1
-  - uid: 830
+  - uid: 1775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11758,13 +11940,13 @@ entities:
       parent: 1
 - proto: ToiletDirtyWater
   entities:
-  - uid: 1509
+  - uid: 1776
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-4.5
       parent: 1
-  - uid: 1510
+  - uid: 1777
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11772,2059 +11954,2102 @@ entities:
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 1511
+  - uid: 1778
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 1512
+  - uid: 1779
     components:
     - type: Transform
       pos: -4.5,14.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 1513
+  - uid: 1780
     components:
     - type: Transform
-      pos: 7.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-9.5
       parent: 1
-  - uid: 1514
+  - uid: 1781
     components:
     - type: Transform
-      pos: 6.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-9.5
       parent: 1
-  - uid: 1515
+  - uid: 1782
     components:
     - type: Transform
-      pos: 6.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-14.5
       parent: 1
-  - uid: 1516
+  - uid: 1783
     components:
     - type: Transform
-      pos: 5.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-14.5
       parent: 1
-  - uid: 1517
+  - uid: 1784
     components:
     - type: Transform
-      pos: 4.5,-15.5
-      parent: 1
-  - uid: 1518
-    components:
-    - type: Transform
-      pos: 3.5,-15.5
-      parent: 1
-  - uid: 1519
-    components:
-    - type: Transform
-      pos: -4.5,-15.5
-      parent: 1
-  - uid: 1520
-    components:
-    - type: Transform
-      pos: -5.5,-15.5
-      parent: 1
-  - uid: 1521
-    components:
-    - type: Transform
-      pos: -6.5,-15.5
-      parent: 1
-  - uid: 1522
-    components:
-    - type: Transform
-      pos: -7.5,-15.5
-      parent: 1
-  - uid: 1523
-    components:
-    - type: Transform
-      pos: -7.5,-16.5
-      parent: 1
-  - uid: 1524
-    components:
-    - type: Transform
-      pos: -8.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-9.5
       parent: 1
   - uid: 1785
     components:
     - type: Transform
-      pos: -8.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-14.5
       parent: 1
   - uid: 1786
     components:
     - type: Transform
-      pos: 7.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-14.5
       parent: 1
-- proto: WallPlastitaniumCapital
-  entities:
-  - uid: 900
+  - uid: 1787
     components:
     - type: Transform
-      pos: 3.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-14.5
       parent: 1
-  - uid: 1508
+  - uid: 1788
     components:
     - type: Transform
-      pos: -4.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-13.5
       parent: 1
-  - uid: 1525
+  - uid: 1789
     components:
     - type: Transform
-      pos: -3.5,21.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-13.5
       parent: 1
-  - uid: 1526
+  - uid: 1790
     components:
     - type: Transform
-      pos: -2.5,23.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-13.5
       parent: 1
-  - uid: 1527
+  - uid: 1791
     components:
     - type: Transform
-      pos: 1.5,11.5
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-13.5
       parent: 1
-  - uid: 1528
+  - uid: 1792
     components:
     - type: Transform
-      pos: -4.5,21.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-13.5
       parent: 1
-  - uid: 1529
+  - uid: 1793
     components:
     - type: Transform
-      pos: 1.5,13.5
+      pos: 7.5,-16.5
       parent: 1
-  - uid: 1530
+  - uid: 1794
     components:
     - type: Transform
-      pos: -5.5,22.5
+      pos: 6.5,-16.5
       parent: 1
-  - uid: 1531
+  - uid: 1795
     components:
     - type: Transform
-      pos: 1.5,14.5
+      pos: 6.5,-15.5
       parent: 1
-  - uid: 1532
+  - uid: 1796
     components:
     - type: Transform
-      pos: 1.5,23.5
+      pos: 5.5,-15.5
       parent: 1
-  - uid: 1533
+  - uid: 1797
     components:
     - type: Transform
-      pos: 1.5,22.5
+      pos: 4.5,-15.5
       parent: 1
-  - uid: 1534
+  - uid: 1798
     components:
     - type: Transform
-      pos: -2.5,22.5
+      pos: 3.5,-15.5
       parent: 1
-  - uid: 1535
+  - uid: 1799
     components:
     - type: Transform
-      pos: 1.5,20.5
+      pos: -4.5,-15.5
       parent: 1
-  - uid: 1536
+  - uid: 1800
     components:
     - type: Transform
-      pos: 1.5,17.5
+      pos: -5.5,-15.5
       parent: 1
-  - uid: 1537
+  - uid: 1801
     components:
     - type: Transform
-      pos: -2.5,21.5
+      pos: -6.5,-15.5
       parent: 1
-  - uid: 1538
+  - uid: 1802
     components:
     - type: Transform
-      pos: 1.5,19.5
+      pos: -7.5,-15.5
       parent: 1
-  - uid: 1539
+  - uid: 1803
     components:
     - type: Transform
-      pos: 4.5,21.5
+      pos: -7.5,-16.5
       parent: 1
-  - uid: 1540
+  - uid: 1804
     components:
     - type: Transform
-      pos: 3.5,21.5
+      pos: -8.5,-16.5
       parent: 1
-  - uid: 1541
+  - uid: 1805
     components:
     - type: Transform
-      pos: 2.5,21.5
+      pos: -4.5,0.5
       parent: 1
-  - uid: 1542
+  - uid: 1806
     components:
     - type: Transform
-      pos: -5.5,21.5
+      pos: -4.5,-1.5
       parent: 1
-  - uid: 1543
+  - uid: 1807
     components:
     - type: Transform
-      pos: 1.5,12.5
+      pos: -4.5,-2.5
       parent: 1
-  - uid: 1544
+  - uid: 1808
     components:
     - type: Transform
-      pos: 4.5,22.5
+      pos: 3.5,-2.5
       parent: 1
-  - uid: 1545
+  - uid: 1809
     components:
     - type: Transform
-      pos: 4.5,23.5
+      pos: 3.5,-1.5
       parent: 1
-  - uid: 1546
+  - uid: 1810
     components:
     - type: Transform
-      pos: -5.5,23.5
+      pos: 3.5,0.5
       parent: 1
-  - uid: 1547
+  - uid: 1811
     components:
     - type: Transform
-      pos: 1.5,21.5
+      pos: 2.5,0.5
       parent: 1
-  - uid: 1548
+  - uid: 1812
     components:
     - type: Transform
-      pos: 1.5,16.5
+      pos: -3.5,0.5
       parent: 1
-  - uid: 1549
+  - uid: 1813
     components:
     - type: Transform
-      pos: 1.5,18.5
+      pos: -6.5,0.5
       parent: 1
-  - uid: 1550
+  - uid: 1814
     components:
     - type: Transform
-      pos: 1.5,10.5
+      pos: 5.5,0.5
       parent: 1
-  - uid: 1551
+  - uid: 1815
     components:
     - type: Transform
-      pos: 1.5,9.5
+      pos: -6.5,-2.5
       parent: 1
-  - uid: 1552
+  - uid: 1816
     components:
     - type: Transform
-      pos: 1.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-14.5
       parent: 1
-  - uid: 1553
+  - uid: 1817
     components:
     - type: Transform
-      pos: 1.5,7.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-14.5
       parent: 1
-  - uid: 1554
+  - uid: 1818
     components:
     - type: Transform
-      pos: 1.5,6.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-14.5
       parent: 1
-  - uid: 1555
+  - uid: 1819
     components:
     - type: Transform
-      pos: 1.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-13.5
       parent: 1
-  - uid: 1556
+  - uid: 1820
     components:
     - type: Transform
-      pos: -2.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-13.5
       parent: 1
-  - uid: 1557
+  - uid: 1821
     components:
     - type: Transform
-      pos: -2.5,6.5
-      parent: 1
-  - uid: 1558
-    components:
-    - type: Transform
-      pos: -2.5,7.5
-      parent: 1
-  - uid: 1559
-    components:
-    - type: Transform
-      pos: -2.5,8.5
-      parent: 1
-  - uid: 1560
-    components:
-    - type: Transform
-      pos: -2.5,9.5
-      parent: 1
-  - uid: 1561
-    components:
-    - type: Transform
-      pos: -2.5,10.5
-      parent: 1
-  - uid: 1562
-    components:
-    - type: Transform
-      pos: -2.5,11.5
-      parent: 1
-  - uid: 1563
-    components:
-    - type: Transform
-      pos: -2.5,12.5
-      parent: 1
-  - uid: 1564
-    components:
-    - type: Transform
-      pos: -2.5,13.5
-      parent: 1
-  - uid: 1565
-    components:
-    - type: Transform
-      pos: -2.5,14.5
-      parent: 1
-  - uid: 1566
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 1
-  - uid: 1567
-    components:
-    - type: Transform
-      pos: -2.5,17.5
-      parent: 1
-  - uid: 1568
-    components:
-    - type: Transform
-      pos: -2.5,18.5
-      parent: 1
-  - uid: 1569
-    components:
-    - type: Transform
-      pos: -2.5,19.5
-      parent: 1
-  - uid: 1570
-    components:
-    - type: Transform
-      pos: -2.5,20.5
-      parent: 1
-  - uid: 1571
-    components:
-    - type: Transform
-      pos: -6.5,20.5
-      parent: 1
-  - uid: 1572
-    components:
-    - type: Transform
-      pos: -6.5,17.5
-      parent: 1
-  - uid: 1573
-    components:
-    - type: Transform
-      pos: -7.5,16.5
-      parent: 1
-  - uid: 1574
-    components:
-    - type: Transform
-      pos: -7.5,13.5
-      parent: 1
-  - uid: 1575
-    components:
-    - type: Transform
-      pos: 5.5,20.5
-      parent: 1
-  - uid: 1576
-    components:
-    - type: Transform
-      pos: -4.5,19.5
-      parent: 1
-  - uid: 1577
-    components:
-    - type: Transform
-      pos: -4.5,18.5
-      parent: 1
-  - uid: 1578
-    components:
-    - type: Transform
-      pos: 5.5,17.5
-      parent: 1
-  - uid: 1579
-    components:
-    - type: Transform
-      pos: 6.5,16.5
-      parent: 1
-  - uid: 1580
-    components:
-    - type: Transform
-      pos: -4.5,17.5
-      parent: 1
-  - uid: 1581
-    components:
-    - type: Transform
-      pos: -5.5,17.5
-      parent: 1
-  - uid: 1582
-    components:
-    - type: Transform
-      pos: 6.5,13.5
-      parent: 1
-  - uid: 1583
-    components:
-    - type: Transform
-      pos: 6.5,9.5
-      parent: 1
-  - uid: 1584
-    components:
-    - type: Transform
-      pos: -7.5,9.5
-      parent: 1
-  - uid: 1585
-    components:
-    - type: Transform
-      pos: -5.5,6.5
-      parent: 1
-  - uid: 1586
-    components:
-    - type: Transform
-      pos: -5.5,7.5
-      parent: 1
-  - uid: 1587
-    components:
-    - type: Transform
-      pos: -5.5,8.5
-      parent: 1
-  - uid: 1588
-    components:
-    - type: Transform
-      pos: -8.5,5.5
-      parent: 1
-  - uid: 1589
-    components:
-    - type: Transform
-      pos: 7.5,5.5
-      parent: 1
-  - uid: 1590
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 1591
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 1592
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 1593
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-  - uid: 1594
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 1595
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 1596
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 1597
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 1598
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 1
-  - uid: 1599
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 1600
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 1601
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 1602
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 1603
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 1604
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 1
-  - uid: 1605
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 1
-  - uid: 1606
-    components:
-    - type: Transform
-      pos: 5.5,1.5
-      parent: 1
-  - uid: 1607
-    components:
-    - type: Transform
-      pos: 7.5,1.5
-      parent: 1
-  - uid: 1608
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 1
-  - uid: 1609
-    components:
-    - type: Transform
-      pos: 8.5,1.5
-      parent: 1
-  - uid: 1610
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
-  - uid: 1611
-    components:
-    - type: Transform
-      pos: 9.5,-0.5
-      parent: 1
-  - uid: 1612
-    components:
-    - type: Transform
-      pos: 9.5,-1.5
-      parent: 1
-  - uid: 1613
-    components:
-    - type: Transform
-      pos: 9.5,-2.5
-      parent: 1
-  - uid: 1614
-    components:
-    - type: Transform
-      pos: 10.5,-3.5
-      parent: 1
-  - uid: 1615
-    components:
-    - type: Transform
-      pos: 10.5,-4.5
-      parent: 1
-  - uid: 1616
-    components:
-    - type: Transform
-      pos: 11.5,-5.5
-      parent: 1
-  - uid: 1617
-    components:
-    - type: Transform
-      pos: 11.5,-6.5
-      parent: 1
-  - uid: 1618
-    components:
-    - type: Transform
-      pos: 11.5,-8.5
-      parent: 1
-  - uid: 1620
-    components:
-    - type: Transform
-      pos: 11.5,-9.5
-      parent: 1
-  - uid: 1621
-    components:
-    - type: Transform
-      pos: -12.5,-9.5
-      parent: 1
-  - uid: 1623
-    components:
-    - type: Transform
-      pos: -13.5,-8.5
-      parent: 1
-  - uid: 1624
-    components:
-    - type: Transform
-      pos: -12.5,-6.5
-      parent: 1
-  - uid: 1625
-    components:
-    - type: Transform
-      pos: -12.5,-5.5
-      parent: 1
-  - uid: 1626
-    components:
-    - type: Transform
-      pos: -11.5,-4.5
-      parent: 1
-  - uid: 1627
-    components:
-    - type: Transform
-      pos: -11.5,-3.5
-      parent: 1
-  - uid: 1628
-    components:
-    - type: Transform
-      pos: -10.5,-2.5
-      parent: 1
-  - uid: 1629
-    components:
-    - type: Transform
-      pos: -10.5,-1.5
-      parent: 1
-  - uid: 1630
-    components:
-    - type: Transform
-      pos: -10.5,-0.5
-      parent: 1
-  - uid: 1631
-    components:
-    - type: Transform
-      pos: -10.5,0.5
-      parent: 1
-  - uid: 1632
-    components:
-    - type: Transform
-      pos: -9.5,1.5
-      parent: 1
-  - uid: 1633
-    components:
-    - type: Transform
-      pos: 10.5,-10.5
-      parent: 1
-  - uid: 1634
-    components:
-    - type: Transform
-      pos: 10.5,-11.5
-      parent: 1
-  - uid: 1635
-    components:
-    - type: Transform
-      pos: 10.5,-12.5
-      parent: 1
-  - uid: 1636
-    components:
-    - type: Transform
-      pos: 8.5,-16.5
-      parent: 1
-  - uid: 1637
-    components:
-    - type: Transform
-      pos: 9.5,-14.5
-      parent: 1
-  - uid: 1638
-    components:
-    - type: Transform
-      pos: 9.5,-15.5
-      parent: 1
-  - uid: 1639
-    components:
-    - type: Transform
-      pos: 9.5,-13.5
-      parent: 1
-  - uid: 1640
-    components:
-    - type: Transform
-      pos: 8.5,-17.5
-      parent: 1
-  - uid: 1641
-    components:
-    - type: Transform
-      pos: 8.5,-18.5
-      parent: 1
-  - uid: 1642
-    components:
-    - type: Transform
-      pos: -9.5,-18.5
-      parent: 1
-  - uid: 1643
-    components:
-    - type: Transform
-      pos: -9.5,-17.5
-      parent: 1
-  - uid: 1644
-    components:
-    - type: Transform
-      pos: -10.5,-14.5
-      parent: 1
-  - uid: 1645
-    components:
-    - type: Transform
-      pos: -10.5,-15.5
-      parent: 1
-  - uid: 1646
-    components:
-    - type: Transform
-      pos: -11.5,-12.5
-      parent: 1
-  - uid: 1647
-    components:
-    - type: Transform
-      pos: -11.5,-11.5
-      parent: 1
-  - uid: 1648
-    components:
-    - type: Transform
-      pos: -11.5,-10.5
-      parent: 1
-  - uid: 1649
-    components:
-    - type: Transform
-      pos: -9.5,-16.5
-      parent: 1
-  - uid: 1650
-    components:
-    - type: Transform
-      pos: -10.5,-13.5
-      parent: 1
-  - uid: 1651
-    components:
-    - type: Transform
-      pos: -9.5,-15.5
-      parent: 1
-  - uid: 1652
-    components:
-    - type: Transform
-      pos: -10.5,-12.5
-      parent: 1
-  - uid: 1653
-    components:
-    - type: Transform
-      pos: -11.5,-9.5
-      parent: 1
-  - uid: 1654
-    components:
-    - type: Transform
-      pos: -12.5,-8.5
-      parent: 1
-  - uid: 1655
-    components:
-    - type: Transform
-      pos: 8.5,-15.5
-      parent: 1
-  - uid: 1656
-    components:
-    - type: Transform
-      pos: 9.5,-12.5
-      parent: 1
-  - uid: 1657
-    components:
-    - type: Transform
-      pos: 10.5,-9.5
-      parent: 1
-  - uid: 1658
-    components:
-    - type: Transform
-      pos: 11.5,-7.5
-      parent: 1
-  - uid: 1659
-    components:
-    - type: Transform
-      pos: 12.5,-8.5
-      parent: 1
-  - uid: 1660
-    components:
-    - type: Transform
-      pos: -12.5,-7.5
-      parent: 1
-  - uid: 1661
-    components:
-    - type: Transform
-      pos: -11.5,-5.5
-      parent: 1
-  - uid: 1662
-    components:
-    - type: Transform
-      pos: -10.5,-3.5
-      parent: 1
-  - uid: 1663
-    components:
-    - type: Transform
-      pos: 9.5,-3.5
-      parent: 1
-  - uid: 1664
-    components:
-    - type: Transform
-      pos: 10.5,-5.5
-      parent: 1
-  - uid: 1665
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-  - uid: 1666
-    components:
-    - type: Transform
-      pos: 5.5,2.5
-      parent: 1
-  - uid: 1667
-    components:
-    - type: Transform
-      pos: -9.5,0.5
-      parent: 1
-  - uid: 1668
-    components:
-    - type: Transform
-      pos: -5.5,5.5
-      parent: 1
-  - uid: 1669
-    components:
-    - type: Transform
-      pos: 5.5,16.5
-      parent: 1
-  - uid: 1670
-    components:
-    - type: Transform
-      pos: -6.5,16.5
-      parent: 1
-  - uid: 1672
-    components:
-    - type: Transform
-      pos: 4.5,20.5
-      parent: 1
-  - uid: 1673
-    components:
-    - type: Transform
-      pos: 3.5,20.5
-      parent: 1
-  - uid: 1674
-    components:
-    - type: Transform
-      pos: -4.5,20.5
-      parent: 1
-  - uid: 1675
-    components:
-    - type: Transform
-      pos: 2.5,-16.5
-      parent: 1
-  - uid: 1676
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 1
-  - uid: 1677
-    components:
-    - type: Transform
-      pos: 2.5,-17.5
-      parent: 1
-  - uid: 1678
-    components:
-    - type: Transform
-      pos: 2.5,-18.5
-      parent: 1
-  - uid: 1679
-    components:
-    - type: Transform
-      pos: -2.5,-19.5
-      parent: 1
-  - uid: 1680
-    components:
-    - type: Transform
-      pos: 2.5,-15.5
-      parent: 1
-  - uid: 1681
-    components:
-    - type: Transform
-      pos: -3.5,-15.5
-      parent: 1
-  - uid: 1682
-    components:
-    - type: Transform
-      pos: -3.5,-16.5
-      parent: 1
-  - uid: 1683
-    components:
-    - type: Transform
-      pos: -3.5,-17.5
-      parent: 1
-  - uid: 1684
-    components:
-    - type: Transform
-      pos: -3.5,-18.5
-      parent: 1
-  - uid: 1685
-    components:
-    - type: Transform
-      pos: 1.5,-19.5
-      parent: 1
-  - uid: 1686
-    components:
-    - type: Transform
-      pos: -2.5,-21.5
-      parent: 1
-  - uid: 1687
-    components:
-    - type: Transform
-      pos: -2.5,-22.5
-      parent: 1
-  - uid: 1688
-    components:
-    - type: Transform
-      pos: 1.5,-20.5
-      parent: 1
-  - uid: 1689
-    components:
-    - type: Transform
-      pos: 1.5,-21.5
-      parent: 1
-  - uid: 1690
-    components:
-    - type: Transform
-      pos: 1.5,-22.5
-      parent: 1
-  - uid: 1691
-    components:
-    - type: Transform
-      pos: 3.5,19.5
-      parent: 1
-  - uid: 1692
-    components:
-    - type: Transform
-      pos: 3.5,18.5
-      parent: 1
-  - uid: 1693
-    components:
-    - type: Transform
-      pos: 3.5,17.5
-      parent: 1
-  - uid: 1694
-    components:
-    - type: Transform
-      pos: 4.5,17.5
-      parent: 1
-  - uid: 1695
-    components:
-    - type: Transform
-      pos: 4.5,16.5
-      parent: 1
-  - uid: 1696
-    components:
-    - type: Transform
-      pos: 4.5,15.5
-      parent: 1
-  - uid: 1697
-    components:
-    - type: Transform
-      pos: 4.5,14.5
-      parent: 1
-  - uid: 1698
-    components:
-    - type: Transform
-      pos: 4.5,13.5
-      parent: 1
-  - uid: 1699
-    components:
-    - type: Transform
-      pos: 5.5,13.5
-      parent: 1
-  - uid: 1700
-    components:
-    - type: Transform
-      pos: -5.5,16.5
-      parent: 1
-  - uid: 1701
-    components:
-    - type: Transform
-      pos: -5.5,15.5
-      parent: 1
-  - uid: 1702
-    components:
-    - type: Transform
-      pos: -5.5,14.5
-      parent: 1
-  - uid: 1703
-    components:
-    - type: Transform
-      pos: -5.5,13.5
-      parent: 1
-  - uid: 1704
-    components:
-    - type: Transform
-      pos: -6.5,13.5
-      parent: 1
-  - uid: 1705
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 1706
-    components:
-    - type: Transform
-      pos: -2.5,-18.5
-      parent: 1
-  - uid: 1707
-    components:
-    - type: Transform
-      pos: 1.5,-18.5
-      parent: 1
-  - uid: 1708
-    components:
-    - type: Transform
-      pos: 4.5,8.5
-      parent: 1
-  - uid: 1709
-    components:
-    - type: Transform
-      pos: -4.5,13.5
-      parent: 1
-  - uid: 1710
-    components:
-    - type: Transform
-      pos: -4.5,12.5
-      parent: 1
-  - uid: 1711
-    components:
-    - type: Transform
-      pos: -4.5,11.5
-      parent: 1
-  - uid: 1712
-    components:
-    - type: Transform
-      pos: -4.5,10.5
-      parent: 1
-  - uid: 1713
-    components:
-    - type: Transform
-      pos: -4.5,9.5
-      parent: 1
-  - uid: 1714
-    components:
-    - type: Transform
-      pos: -6.5,9.5
-      parent: 1
-  - uid: 1715
-    components:
-    - type: Transform
-      pos: -5.5,9.5
-      parent: 1
-  - uid: 1716
-    components:
-    - type: Transform
-      pos: 3.5,13.5
-      parent: 1
-  - uid: 1717
-    components:
-    - type: Transform
-      pos: 3.5,12.5
-      parent: 1
-  - uid: 1718
-    components:
-    - type: Transform
-      pos: 3.5,11.5
-      parent: 1
-  - uid: 1719
-    components:
-    - type: Transform
-      pos: 3.5,10.5
-      parent: 1
-  - uid: 1720
-    components:
-    - type: Transform
-      pos: 3.5,9.5
-      parent: 1
-  - uid: 1721
-    components:
-    - type: Transform
-      pos: 4.5,9.5
-      parent: 1
-  - uid: 1722
-    components:
-    - type: Transform
-      pos: 5.5,9.5
-      parent: 1
-  - uid: 1723
-    components:
-    - type: Transform
-      pos: -6.5,5.5
-      parent: 1
-  - uid: 1724
-    components:
-    - type: Transform
-      pos: -7.5,5.5
-      parent: 1
-  - uid: 1725
-    components:
-    - type: Transform
-      pos: 4.5,7.5
-      parent: 1
-  - uid: 1726
-    components:
-    - type: Transform
-      pos: 4.5,6.5
-      parent: 1
-  - uid: 1727
-    components:
-    - type: Transform
-      pos: 4.5,5.5
-      parent: 1
-  - uid: 1728
-    components:
-    - type: Transform
-      pos: 5.5,5.5
-      parent: 1
-  - uid: 1729
-    components:
-    - type: Transform
-      pos: 6.5,5.5
-      parent: 1
-  - uid: 1730
-    components:
-    - type: Transform
-      pos: 5.5,3.5
-      parent: 1
-  - uid: 1731
-    components:
-    - type: Transform
-      pos: 5.5,4.5
-      parent: 1
-  - uid: 1732
-    components:
-    - type: Transform
-      pos: -6.5,4.5
-      parent: 1
-  - uid: 1733
-    components:
-    - type: Transform
-      pos: -6.5,3.5
-      parent: 1
-  - uid: 1734
-    components:
-    - type: Transform
-      pos: -6.5,2.5
-      parent: 1
-  - uid: 1735
-    components:
-    - type: Transform
-      pos: -6.5,1.5
-      parent: 1
-  - uid: 1736
-    components:
-    - type: Transform
-      pos: -7.5,1.5
-      parent: 1
-  - uid: 1737
-    components:
-    - type: Transform
-      pos: -8.5,1.5
-      parent: 1
-  - uid: 1759
-    components:
-    - type: Transform
-      pos: 11.5,-10.5
-      parent: 1
-  - uid: 1766
-    components:
-    - type: Transform
-      pos: -12.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-14.5
       parent: 1
   - uid: 1822
     components:
     - type: Transform
-      pos: 1.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-14.5
       parent: 1
   - uid: 1823
     components:
     - type: Transform
-      pos: 0.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-14.5
       parent: 1
   - uid: 1824
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: -6.5,-0.5
       parent: 1
   - uid: 1825
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: -6.5,-3.5
       parent: 1
   - uid: 1826
     components:
     - type: Transform
-      pos: -2.5,-3.5
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 1827
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 1828
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 1829
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 1830
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 1831
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 1832
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 1833
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 1834
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 1835
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
       parent: 1
   - uid: 1836
     components:
     - type: Transform
-      pos: -2.5,-8.5
+      pos: -4.5,-5.5
       parent: 1
   - uid: 1837
     components:
     - type: Transform
-      pos: 1.5,-8.5
+      pos: 3.5,-4.5
       parent: 1
   - uid: 1838
     components:
     - type: Transform
-      pos: -0.5,-8.5
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 1839
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 1840
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
       parent: 1
   - uid: 1841
     components:
     - type: Transform
-      pos: 1.5,-10.5
+      pos: 9.5,-4.5
       parent: 1
   - uid: 1842
     components:
     - type: Transform
-      pos: 1.5,-11.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-11.5
       parent: 1
   - uid: 1843
     components:
     - type: Transform
-      pos: -2.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-11.5
       parent: 1
   - uid: 1844
     components:
     - type: Transform
-      pos: -2.5,-11.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-11.5
       parent: 1
   - uid: 1845
     components:
     - type: Transform
-      pos: -1.5,-11.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-9.5
       parent: 1
   - uid: 1846
     components:
     - type: Transform
-      pos: 0.5,-11.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-9.5
       parent: 1
   - uid: 1847
     components:
     - type: Transform
-      pos: -1.5,-8.5
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-11.5
       parent: 1
   - uid: 1848
     components:
     - type: Transform
-      pos: -2.5,-9.5
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-13.5
       parent: 1
   - uid: 1849
     components:
     - type: Transform
-      pos: 1.5,-9.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 1850
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 1851
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 1852
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 1853
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 1854
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 1855
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 1856
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-10.5
+      parent: 1
+  - uid: 1857
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 1858
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 1859
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 1860
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
       parent: 1
   - uid: 1861
     components:
     - type: Transform
-      pos: 0.5,-8.5
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 1862
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 1
+  - uid: 1863
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 1
+  - uid: 1864
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 1
+  - uid: 1865
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 1
+  - uid: 1866
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 1
+  - uid: 1867
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-6.5
+      parent: 1
+  - uid: 1868
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-9.5
+      parent: 1
+  - uid: 1869
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-9.5
+      parent: 1
+  - uid: 1870
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-9.5
+      parent: 1
+  - uid: 1871
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-9.5
+      parent: 1
+  - uid: 1872
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-9.5
+      parent: 1
+  - uid: 1873
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-10.5
+      parent: 1
+- proto: WallPlastitaniumCapital
+  entities:
+  - uid: 1874
+    components:
+    - type: Transform
+      pos: 3.5,-16.5
+      parent: 1
+  - uid: 1875
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 1
+  - uid: 1876
+    components:
+    - type: Transform
+      pos: -3.5,21.5
+      parent: 1
+  - uid: 1877
+    components:
+    - type: Transform
+      pos: -2.5,23.5
+      parent: 1
+  - uid: 1878
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 1879
+    components:
+    - type: Transform
+      pos: -4.5,21.5
+      parent: 1
+  - uid: 1880
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 1881
+    components:
+    - type: Transform
+      pos: -5.5,22.5
+      parent: 1
+  - uid: 1882
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 1883
+    components:
+    - type: Transform
+      pos: 1.5,23.5
+      parent: 1
+  - uid: 1884
+    components:
+    - type: Transform
+      pos: 1.5,22.5
+      parent: 1
+  - uid: 1885
+    components:
+    - type: Transform
+      pos: -2.5,22.5
+      parent: 1
+  - uid: 1886
+    components:
+    - type: Transform
+      pos: 1.5,20.5
+      parent: 1
+  - uid: 1887
+    components:
+    - type: Transform
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 1888
+    components:
+    - type: Transform
+      pos: -2.5,21.5
+      parent: 1
+  - uid: 1889
+    components:
+    - type: Transform
+      pos: 1.5,19.5
+      parent: 1
+  - uid: 1890
+    components:
+    - type: Transform
+      pos: 4.5,21.5
+      parent: 1
+  - uid: 1891
+    components:
+    - type: Transform
+      pos: 3.5,21.5
+      parent: 1
+  - uid: 1892
+    components:
+    - type: Transform
+      pos: 2.5,21.5
+      parent: 1
+  - uid: 1893
+    components:
+    - type: Transform
+      pos: -5.5,21.5
+      parent: 1
+  - uid: 1894
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 1895
+    components:
+    - type: Transform
+      pos: 4.5,22.5
+      parent: 1
+  - uid: 1896
+    components:
+    - type: Transform
+      pos: 4.5,23.5
+      parent: 1
+  - uid: 1897
+    components:
+    - type: Transform
+      pos: -5.5,23.5
+      parent: 1
+  - uid: 1898
+    components:
+    - type: Transform
+      pos: 1.5,21.5
+      parent: 1
+  - uid: 1899
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 1900
+    components:
+    - type: Transform
+      pos: 1.5,18.5
+      parent: 1
+  - uid: 1901
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 1902
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 1903
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 1904
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 1905
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 1906
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 1907
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 1908
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 1909
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 1910
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 1911
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 1912
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 1913
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 1914
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 1915
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 1916
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 1917
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 1918
+    components:
+    - type: Transform
+      pos: -2.5,17.5
+      parent: 1
+  - uid: 1919
+    components:
+    - type: Transform
+      pos: -2.5,18.5
+      parent: 1
+  - uid: 1920
+    components:
+    - type: Transform
+      pos: -2.5,19.5
+      parent: 1
+  - uid: 1921
+    components:
+    - type: Transform
+      pos: -2.5,20.5
+      parent: 1
+  - uid: 1922
+    components:
+    - type: Transform
+      pos: -6.5,20.5
+      parent: 1
+  - uid: 1923
+    components:
+    - type: Transform
+      pos: -6.5,17.5
+      parent: 1
+  - uid: 1924
+    components:
+    - type: Transform
+      pos: -7.5,16.5
+      parent: 1
+  - uid: 1925
+    components:
+    - type: Transform
+      pos: -7.5,13.5
+      parent: 1
+  - uid: 1926
+    components:
+    - type: Transform
+      pos: 5.5,20.5
+      parent: 1
+  - uid: 1927
+    components:
+    - type: Transform
+      pos: -4.5,19.5
+      parent: 1
+  - uid: 1928
+    components:
+    - type: Transform
+      pos: -4.5,18.5
+      parent: 1
+  - uid: 1929
+    components:
+    - type: Transform
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 1930
+    components:
+    - type: Transform
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 1931
+    components:
+    - type: Transform
+      pos: -4.5,17.5
+      parent: 1
+  - uid: 1932
+    components:
+    - type: Transform
+      pos: -5.5,17.5
+      parent: 1
+  - uid: 1933
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 1934
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 1935
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 1936
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 1937
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 1938
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 1939
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 1
+  - uid: 1940
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 1941
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 1942
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 1943
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 1944
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 1945
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 1946
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 1947
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 1948
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 1949
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 1950
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 1951
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 1952
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 1953
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 1954
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 1955
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 1956
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 1957
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 1958
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 1959
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 1960
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 1961
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 1962
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 1963
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 1964
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 1965
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 1966
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 1
+  - uid: 1967
+    components:
+    - type: Transform
+      pos: 11.5,-5.5
+      parent: 1
+  - uid: 1968
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 1
+  - uid: 1969
+    components:
+    - type: Transform
+      pos: 11.5,-8.5
+      parent: 1
+  - uid: 1970
+    components:
+    - type: Transform
+      pos: 11.5,-9.5
+      parent: 1
+  - uid: 1971
+    components:
+    - type: Transform
+      pos: -12.5,-9.5
+      parent: 1
+  - uid: 1972
+    components:
+    - type: Transform
+      pos: -13.5,-8.5
+      parent: 1
+  - uid: 1973
+    components:
+    - type: Transform
+      pos: -12.5,-6.5
+      parent: 1
+  - uid: 1974
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 1
+  - uid: 1975
+    components:
+    - type: Transform
+      pos: -11.5,-4.5
+      parent: 1
+  - uid: 1976
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 1
+  - uid: 1977
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 1
+  - uid: 1978
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 1
+  - uid: 1979
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 1
+  - uid: 1980
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 1
+  - uid: 1981
+    components:
+    - type: Transform
+      pos: -9.5,1.5
+      parent: 1
+  - uid: 1982
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 1
+  - uid: 1983
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 1
+  - uid: 1984
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 1
+  - uid: 1985
+    components:
+    - type: Transform
+      pos: 8.5,-16.5
+      parent: 1
+  - uid: 1986
+    components:
+    - type: Transform
+      pos: 9.5,-14.5
+      parent: 1
+  - uid: 1987
+    components:
+    - type: Transform
+      pos: 9.5,-15.5
+      parent: 1
+  - uid: 1988
+    components:
+    - type: Transform
+      pos: 9.5,-13.5
+      parent: 1
+  - uid: 1989
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 1
+  - uid: 1990
+    components:
+    - type: Transform
+      pos: 8.5,-18.5
+      parent: 1
+  - uid: 1991
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
+      parent: 1
+  - uid: 1992
+    components:
+    - type: Transform
+      pos: -9.5,-17.5
+      parent: 1
+  - uid: 1993
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 1
+  - uid: 1994
+    components:
+    - type: Transform
+      pos: -10.5,-15.5
+      parent: 1
+  - uid: 1995
+    components:
+    - type: Transform
+      pos: -11.5,-12.5
+      parent: 1
+  - uid: 1996
+    components:
+    - type: Transform
+      pos: -11.5,-11.5
+      parent: 1
+  - uid: 1997
+    components:
+    - type: Transform
+      pos: -11.5,-10.5
+      parent: 1
+  - uid: 1998
+    components:
+    - type: Transform
+      pos: -9.5,-16.5
+      parent: 1
+  - uid: 1999
+    components:
+    - type: Transform
+      pos: -10.5,-13.5
+      parent: 1
+  - uid: 2000
+    components:
+    - type: Transform
+      pos: -10.5,-12.5
+      parent: 1
+  - uid: 2001
+    components:
+    - type: Transform
+      pos: -11.5,-9.5
+      parent: 1
+  - uid: 2002
+    components:
+    - type: Transform
+      pos: -12.5,-8.5
+      parent: 1
+  - uid: 2003
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 1
+  - uid: 2004
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 1
+  - uid: 2005
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 1
+  - uid: 2006
+    components:
+    - type: Transform
+      pos: 12.5,-8.5
+      parent: 1
+  - uid: 2007
+    components:
+    - type: Transform
+      pos: -12.5,-7.5
+      parent: 1
+  - uid: 2008
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 1
+  - uid: 2009
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 1
+  - uid: 2010
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 2011
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 1
+  - uid: 2012
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 2013
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 2014
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 1
+  - uid: 2015
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 2016
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 2017
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 2018
+    components:
+    - type: Transform
+      pos: 4.5,20.5
+      parent: 1
+  - uid: 2019
+    components:
+    - type: Transform
+      pos: 3.5,20.5
+      parent: 1
+  - uid: 2020
+    components:
+    - type: Transform
+      pos: -4.5,20.5
+      parent: 1
+  - uid: 2021
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 1
+  - uid: 2022
+    components:
+    - type: Transform
+      pos: -2.5,-20.5
+      parent: 1
+  - uid: 2023
+    components:
+    - type: Transform
+      pos: 2.5,-17.5
+      parent: 1
+  - uid: 2024
+    components:
+    - type: Transform
+      pos: 2.5,-18.5
+      parent: 1
+  - uid: 2025
+    components:
+    - type: Transform
+      pos: -2.5,-19.5
+      parent: 1
+  - uid: 2026
+    components:
+    - type: Transform
+      pos: 2.5,-15.5
+      parent: 1
+  - uid: 2027
+    components:
+    - type: Transform
+      pos: -3.5,-15.5
+      parent: 1
+  - uid: 2028
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 1
+  - uid: 2029
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 1
+  - uid: 2030
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 1
+  - uid: 2031
+    components:
+    - type: Transform
+      pos: 1.5,-19.5
+      parent: 1
+  - uid: 2032
+    components:
+    - type: Transform
+      pos: -2.5,-21.5
+      parent: 1
+  - uid: 2033
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
+      parent: 1
+  - uid: 2034
+    components:
+    - type: Transform
+      pos: 1.5,-20.5
+      parent: 1
+  - uid: 2035
+    components:
+    - type: Transform
+      pos: 1.5,-21.5
+      parent: 1
+  - uid: 2036
+    components:
+    - type: Transform
+      pos: 1.5,-22.5
+      parent: 1
+  - uid: 2037
+    components:
+    - type: Transform
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 2038
+    components:
+    - type: Transform
+      pos: 3.5,18.5
+      parent: 1
+  - uid: 2039
+    components:
+    - type: Transform
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 2040
+    components:
+    - type: Transform
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 2041
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 2042
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 2043
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 2044
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 2045
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 2046
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 2047
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 2048
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 2049
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 2050
+    components:
+    - type: Transform
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 2051
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 2052
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 1
+  - uid: 2053
+    components:
+    - type: Transform
+      pos: 1.5,-18.5
+      parent: 1
+  - uid: 2054
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 2055
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 2056
+    components:
+    - type: Transform
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 2057
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 2058
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 2059
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 2060
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 2061
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 2062
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 2063
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 2064
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 2065
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 2066
+    components:
+    - type: Transform
+      pos: 3.5,9.5
       parent: 1
   - uid: 2067
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 2068
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 2069
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 2070
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 2071
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 2072
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 2073
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 2074
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 2075
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 2076
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 2077
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 2078
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 2079
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 2080
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 2081
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 2082
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 2083
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 2084
+    components:
+    - type: Transform
+      pos: 11.5,-10.5
+      parent: 1
+  - uid: 2085
+    components:
+    - type: Transform
+      pos: -12.5,-10.5
+      parent: 1
+  - uid: 2086
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 2087
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 2088
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 2089
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 2090
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 2091
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 2092
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 2093
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 2094
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 2095
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 2096
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 2097
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 2098
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 2099
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 2100
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 2101
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 2102
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 2103
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 2104
     components:
     - type: Transform
       pos: -5.5,20.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 1738
+  - uid: 2105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 1739
+  - uid: 2106
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
 - proto: WallPlastitaniumDiagonalCapital
   entities:
-  - uid: 210
+  - uid: 2107
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-11.5
       parent: 1
-  - uid: 211
+  - uid: 2108
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-11.5
       parent: 1
-  - uid: 1619
+  - uid: 2109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-9.5
       parent: 1
-  - uid: 1622
+  - uid: 2110
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-9.5
       parent: 1
-  - uid: 1740
+  - uid: 2111
     components:
     - type: Transform
       pos: -6.5,21.5
       parent: 1
-  - uid: 1741
+  - uid: 2112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,21.5
       parent: 1
-  - uid: 1742
+  - uid: 2113
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 1
-  - uid: 1743
+  - uid: 2114
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,24.5
       parent: 1
-  - uid: 1744
+  - uid: 2115
     components:
     - type: Transform
       pos: -5.5,24.5
       parent: 1
-  - uid: 1745
+  - uid: 2116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,24.5
       parent: 1
-  - uid: 1746
+  - uid: 2117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-7.5
       parent: 1
-  - uid: 1747
+  - uid: 2118
     components:
     - type: Transform
       pos: -7.5,17.5
       parent: 1
-  - uid: 1748
+  - uid: 2119
     components:
     - type: Transform
       pos: -8.5,9.5
       parent: 1
-  - uid: 1749
+  - uid: 2120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,17.5
       parent: 1
-  - uid: 1750
+  - uid: 2121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,9.5
       parent: 1
-  - uid: 1751
+  - uid: 2122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,5.5
       parent: 1
-  - uid: 1752
+  - uid: 2123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,1.5
       parent: 1
-  - uid: 1753
+  - uid: 2124
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 1
-  - uid: 1754
+  - uid: 2125
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 1
-  - uid: 1755
+  - uid: 2126
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 1
-  - uid: 1756
+  - uid: 2127
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 1
-  - uid: 1757
+  - uid: 2128
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 1
-  - uid: 1758
+  - uid: 2129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-4.5
       parent: 1
-  - uid: 1760
+  - uid: 2130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-13.5
       parent: 1
-  - uid: 1761
+  - uid: 2131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-16.5
       parent: 1
-  - uid: 1762
+  - uid: 2132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-19.5
       parent: 1
-  - uid: 1763
+  - uid: 2133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-19.5
       parent: 1
-  - uid: 1764
+  - uid: 2134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-16.5
       parent: 1
-  - uid: 1765
+  - uid: 2135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-13.5
       parent: 1
-  - uid: 1767
+  - uid: 2136
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-2.5
       parent: 1
-  - uid: 1768
+  - uid: 2137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-19.5
       parent: 1
-  - uid: 1769
+  - uid: 2138
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-19.5
       parent: 1
-  - uid: 1770
+  - uid: 2139
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 1
-  - uid: 1771
+  - uid: 2140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 1772
+  - uid: 2141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,8.5
       parent: 1
-  - uid: 1773
+  - uid: 2142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,12.5
       parent: 1
-  - uid: 1774
+  - uid: 2143
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,10.5
       parent: 1
-  - uid: 1775
+  - uid: 2144
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 1
-  - uid: 1776
+  - uid: 2145
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,12.5
       parent: 1
-  - uid: 1777
+  - uid: 2146
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 1
-  - uid: 1778
+  - uid: 2147
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,4.5
       parent: 1
-  - uid: 1779
+  - uid: 2148
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 1
-  - uid: 1780
+  - uid: 2149
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 1
-  - uid: 1781
+  - uid: 2150
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 1782
+  - uid: 2151
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 1783
+  - uid: 2152
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 1
-  - uid: 1784
+  - uid: 2153
     components:
     - type: Transform
       pos: -3.5,20.5
       parent: 1
-  - uid: 1787
+  - uid: 2154
     components:
     - type: Transform
       pos: -3.5,19.5
       parent: 1
-  - uid: 1788
+  - uid: 2155
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 1
-  - uid: 1789
+  - uid: 2156
     components:
     - type: Transform
       pos: -4.5,16.5
       parent: 1
-  - uid: 1790
+  - uid: 2157
     components:
     - type: Transform
       pos: 3.5,16.5
       parent: 1
-  - uid: 1791
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 1
-  - uid: 1792
-    components:
-    - type: Transform
-      pos: -4.5,-1.5
-      parent: 1
-  - uid: 1793
-    components:
-    - type: Transform
-      pos: -4.5,-2.5
-      parent: 1
-  - uid: 1794
+  - uid: 2158
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 1795
+  - uid: 2159
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 1796
-    components:
-    - type: Transform
-      pos: 3.5,-2.5
-      parent: 1
-  - uid: 1797
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 1798
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 1799
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 1800
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 1801
-    components:
-    - type: Transform
-      pos: 5.5,-14.5
-      parent: 1
-  - uid: 1802
-    components:
-    - type: Transform
-      pos: 4.5,-14.5
-      parent: 1
-  - uid: 1803
-    components:
-    - type: Transform
-      pos: 3.5,-14.5
-      parent: 1
-  - uid: 1804
-    components:
-    - type: Transform
-      pos: 3.5,-13.5
-      parent: 1
-  - uid: 1805
-    components:
-    - type: Transform
-      pos: -4.5,-13.5
-      parent: 1
-  - uid: 1806
-    components:
-    - type: Transform
-      pos: -4.5,-14.5
-      parent: 1
-  - uid: 1807
-    components:
-    - type: Transform
-      pos: -5.5,-14.5
-      parent: 1
-  - uid: 1808
-    components:
-    - type: Transform
-      pos: -6.5,-14.5
-      parent: 1
-  - uid: 1809
+  - uid: 2160
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 1810
-    components:
-    - type: Transform
-      pos: -6.5,0.5
-      parent: 1
-  - uid: 1811
-    components:
-    - type: Transform
-      pos: 5.5,0.5
-      parent: 1
-  - uid: 1812
-    components:
-    - type: Transform
-      pos: -6.5,-2.5
-      parent: 1
-  - uid: 1813
-    components:
-    - type: Transform
-      pos: -6.5,-0.5
-      parent: 1
-  - uid: 1814
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 1
-  - uid: 1815
-    components:
-    - type: Transform
-      pos: -4.5,-3.5
-      parent: 1
-  - uid: 1816
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
-  - uid: 1817
-    components:
-    - type: Transform
-      pos: 5.5,-3.5
-      parent: 1
-  - uid: 1818
-    components:
-    - type: Transform
-      pos: 5.5,-2.5
-      parent: 1
-  - uid: 1819
-    components:
-    - type: Transform
-      pos: 5.5,-0.5
-      parent: 1
-  - uid: 1820
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 1821
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
-      parent: 1
-  - uid: 1827
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 1
-  - uid: 1828
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 1
-  - uid: 1829
-    components:
-    - type: Transform
-      pos: -4.5,-4.5
-      parent: 1
-  - uid: 1830
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 1
-  - uid: 1831
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-  - uid: 1832
-    components:
-    - type: Transform
-      pos: 3.5,-5.5
-      parent: 1
-  - uid: 1833
+  - uid: 2161
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 1834
+  - uid: 2162
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 1835
+  - uid: 2163
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 1839
+  - uid: 2164
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 1840
+  - uid: 2165
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 1850
-    components:
-    - type: Transform
-      pos: 3.5,-11.5
-      parent: 1
-  - uid: 1851
+  - uid: 2166
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 1852
-    components:
-    - type: Transform
-      pos: -4.5,-11.5
-      parent: 1
-  - uid: 1853
-    components:
-    - type: Transform
-      pos: 6.5,-11.5
-      parent: 1
-  - uid: 1854
-    components:
-    - type: Transform
-      pos: 7.5,-11.5
-      parent: 1
-  - uid: 1855
-    components:
-    - type: Transform
-      pos: 8.5,-11.5
-      parent: 1
-  - uid: 1856
-    components:
-    - type: Transform
-      pos: 9.5,-11.5
-      parent: 1
-  - uid: 1857
-    components:
-    - type: Transform
-      pos: 6.5,-10.5
-      parent: 1
-  - uid: 1858
-    components:
-    - type: Transform
-      pos: 6.5,-9.5
-      parent: 1
-  - uid: 1859
+  - uid: 2167
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 1
-  - uid: 1860
+  - uid: 2168
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 1862
-    components:
-    - type: Transform
-      pos: -7.5,-9.5
-      parent: 1
-  - uid: 1863
-    components:
-    - type: Transform
-      pos: -7.5,-10.5
-      parent: 1
-  - uid: 1864
-    components:
-    - type: Transform
-      pos: -7.5,-11.5
-      parent: 1
-  - uid: 1865
-    components:
-    - type: Transform
-      pos: -8.5,-11.5
-      parent: 1
-  - uid: 1866
-    components:
-    - type: Transform
-      pos: -9.5,-11.5
-      parent: 1
-  - uid: 1867
-    components:
-    - type: Transform
-      pos: -10.5,-11.5
-      parent: 1
-  - uid: 1868
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 1
-  - uid: 1869
-    components:
-    - type: Transform
-      pos: -5.5,-9.5
-      parent: 1
-  - uid: 1870
-    components:
-    - type: Transform
-      pos: -4.5,-9.5
-      parent: 1
-  - uid: 1871
-    components:
-    - type: Transform
-      pos: -4.5,-10.5
-      parent: 1
-  - uid: 1872
-    components:
-    - type: Transform
-      pos: 3.5,-9.5
-      parent: 1
-  - uid: 1873
-    components:
-    - type: Transform
-      pos: 3.5,-10.5
-      parent: 1
-  - uid: 1874
-    components:
-    - type: Transform
-      pos: 4.5,-9.5
-      parent: 1
-  - uid: 1875
-    components:
-    - type: Transform
-      pos: 5.5,-9.5
-      parent: 1
-  - uid: 1876
-    components:
-    - type: Transform
-      pos: 9.5,-10.5
-      parent: 1
-  - uid: 1877
-    components:
-    - type: Transform
-      pos: 6.5,-2.5
-      parent: 1
-  - uid: 1878
-    components:
-    - type: Transform
-      pos: 8.5,-2.5
-      parent: 1
-  - uid: 1879
-    components:
-    - type: Transform
-      pos: 9.5,-4.5
-      parent: 1
-  - uid: 1880
-    components:
-    - type: Transform
-      pos: 8.5,-4.5
-      parent: 1
-  - uid: 1881
-    components:
-    - type: Transform
-      pos: 7.5,-4.5
-      parent: 1
-  - uid: 1882
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
-      parent: 1
-  - uid: 1883
-    components:
-    - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-  - uid: 1884
-    components:
-    - type: Transform
-      pos: -7.5,-3.5
-      parent: 1
-  - uid: 1885
-    components:
-    - type: Transform
-      pos: -8.5,-3.5
-      parent: 1
-  - uid: 1886
-    components:
-    - type: Transform
-      pos: -8.5,-4.5
-      parent: 1
-  - uid: 1887
-    components:
-    - type: Transform
-      pos: -8.5,-5.5
-      parent: 1
-  - uid: 1888
-    components:
-    - type: Transform
-      pos: -9.5,-5.5
-      parent: 1
-  - uid: 1889
-    components:
-    - type: Transform
-      pos: -10.5,-5.5
-      parent: 1
-  - uid: 1890
+  - uid: 2169
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 1891
+  - uid: 2170
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 1
-  - uid: 1892
+  - uid: 2171
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 1
-  - uid: 1893
+  - uid: 2172
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 1
-  - uid: 1894
+  - uid: 2173
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
-  - uid: 1895
-    components:
-    - type: Transform
-      pos: 8.5,-9.5
-      parent: 1
-  - uid: 1896
-    components:
-    - type: Transform
-      pos: 7.5,-9.5
-      parent: 1
-  - uid: 1897
-    components:
-    - type: Transform
-      pos: 9.5,-9.5
-      parent: 1
-  - uid: 1898
+  - uid: 2174
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 1899
+  - uid: 2175
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 1900
+  - uid: 2176
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 1
-  - uid: 1901
-    components:
-    - type: Transform
-      pos: -9.5,-9.5
-      parent: 1
-  - uid: 1902
-    components:
-    - type: Transform
-      pos: -10.5,-9.5
-      parent: 1
-  - uid: 1903
-    components:
-    - type: Transform
-      pos: -8.5,-6.5
-      parent: 1
-  - uid: 1904
-    components:
-    - type: Transform
-      pos: -8.5,-9.5
-      parent: 1
-  - uid: 1905
-    components:
-    - type: Transform
-      pos: -10.5,-10.5
-      parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 1906
+  - uid: 2177
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
 - proto: WeaponLaserTurretL1Phalanx
   entities:
-  - uid: 1907
+  - uid: 2178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-6.5
       parent: 1
-  - uid: 1908
+  - uid: 2179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13832,37 +14057,37 @@ entities:
       parent: 1
 - proto: WeaponTurretAk820
   entities:
-  - uid: 1912
+  - uid: 2180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 1
-  - uid: 1913
+  - uid: 2181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,11.5
       parent: 1
-  - uid: 1914
+  - uid: 2182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,7.5
       parent: 1
-  - uid: 1915
+  - uid: 2183
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,7.5
       parent: 1
-  - uid: 1916
+  - uid: 2184
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 1917
+  - uid: 2185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13870,7 +14095,7 @@ entities:
       parent: 1
 - proto: WeaponTurretCharonReload
   entities:
-  - uid: 1911
+  - uid: 2186
     components:
     - type: Transform
       rot: 3.141592653589793 rad


### PR DESCRIPTION
## About the PR
Slightly changed the polaris' interior to make it not instantly one shottable by a light breeze to the AME

## Why / Balance
it just felt weird to have 1 wall to AME

## Media
<img width="621" height="1185" alt="Capture d&#39;écran 2026-07-16 132422" src="https://github.com/user-attachments/assets/080b5ce3-2d17-4b6a-bf69-56a877697565" />
<img width="721" height="1183" alt="Capture d&#39;écran 2026-07-16 132407" src="https://github.com/user-attachments/assets/5d288999-bccf-49b5-9740-976574aabd94" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
shipyard, watch

## Breaking changes
fuck no

**Changelog**
:cl:
- tweak: Changed the Polaris's internal layout slightly and made it so it didn't blind everyone with 500 lights