### PR TITLE
Fix Wielding + Attachments Making Gun Spread Go Negative

### DIFF
--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -134,10 +134,19 @@ public abstract partial class SharedWieldableSystem : EntitySystem
              noWieldNeeded.GetBonus)
            )
         {
-            args.MinAngle += bonus.Comp.MinAngle;
-            args.MaxAngle += bonus.Comp.MaxAngle;
-            args.AngleDecay += bonus.Comp.AngleDecay;
-            args.AngleIncrease += bonus.Comp.AngleIncrease;
+            // Mono start - do all this stupid bullshit because i'm too lazy to make attachments modify the wieldcomp
+            if (TryComp<GunComponent>(args.Gun, out var gunComp))
+            {
+                var minAngleAdd = bonus.Comp.MinAngle * (gunComp.MinAngleModified / gunComp.MinAngle);
+                var maxAngleAdd = bonus.Comp.MaxAngle * (gunComp.MaxAngleModified / gunComp.MaxAngle);
+                var angleDecayAdd = bonus.Comp.AngleDecay * (gunComp.AngleDecayModified / gunComp.AngleDecay);
+                var angleIncreaseAdd = bonus.Comp.AngleIncrease * (gunComp.AngleIncreaseModified / gunComp.AngleIncrease);
+                args.MinAngle += minAngleAdd;
+                args.MaxAngle += maxAngleAdd;
+                args.AngleDecay += angleDecayAdd;
+                args.AngleIncrease += angleIncreaseAdd;
+            }
+            // Mono end
         }
     }
 


### PR DESCRIPTION
## About the PR
Super ultra jank way to make attachment spread/recoil modifiers apply to the wield bonuses too.

## Why / Balance
Fixes DMRs being useless (scope would make them go into negative spread and thus be shitty accuracy)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed cases where guns could get negative spread from attachments.