### PR TITLE
Shiv Tweaks

### DIFF
--- a/Resources/SharedMaps/_Mono/Shuttles/Nfsd/shiv.yml
+++ b/Resources/SharedMaps/_Mono/Shuttles/Nfsd/shiv.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/17/2026 09:49:01
-  entityCount: 538
+  time: 07/18/2026 20:29:29
+  entityCount: 541
 maps: []
 grids:
 - 1
@@ -70,11 +70,11 @@ entities:
           version: 7
         -1,-1:
           ind: -1,-1
-          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAFAAAAAAAABcAAAAAAAARAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABQAAAAAAAAAAAAAAAAACgAAAAAAAAoAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAABoAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAaAAAAAAAAGgAAAAAAAA==
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAFAAAAAAAABcAAAAAAAARAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABQAAAAAAAAAAAAAAAAACgAAAAAAAAoAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGQAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAABoAAAAAAAADAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAaAAAAAAAAAwAAAAAAAA==
           version: 7
         -1,0:
           ind: -1,0
-          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAB0AAAAAAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAdAAAAAAAAHQAAAAAAAAAAAAAAAAAaAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABQAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAAAAAAAAAAACAAAAAAAAADAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAAcAAAAAAAAAwAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA0AAAAAAAAAAAAAAAAAIQAAAAAAABwAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAACEAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAeAAAAAAAAHAAAAAAAAAAAAAAAAAAiAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAGgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAB0AAAAAAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAbAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAdAAAAAAAAHQAAAAAAAAAAAAAAAAAaAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABQAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAAAAAAAAAAACAAAAAAAAADAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAAcAAAAAAAAAwAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA0AAAAAAAAAAAAAAAAAIQAAAAAAABwAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAACEAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAeAAAAAAAAHAAAAAAAAAAAAAAAAAAiAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
           version: 7
     - type: Broadphase
     - type: Physics
@@ -87,10 +87,10 @@ entities:
     - type: ThermalSignature
     - type: SpreaderGrid
       spreadQueues:
+        Smoke: []
         Kudzu: []
         MetalFoam: []
         Puddle: []
-        Smoke: []
     - type: Shuttle
       dampingModifier: 0.25
     - type: ImplicitRoof
@@ -103,10 +103,10 @@ entities:
         version: 2
         nodes:
         - node:
-            color: '#FFFFFFFF'
-            id: BrickTileDarkInnerNe
+            color: '#D58C18FF'
+            id: Bot
           decals:
-            77: -3,8
+            168: -1,0
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkInnerSe
@@ -159,10 +159,10 @@ entities:
             140: 3,0
             141: -2,-1
         - node:
-            color: '#0096FFFF'
+            color: '#209BD8FF'
             id: DeliveryGreyscale
           decals:
-            145: -1,0
+            170: -1,-1
         - node:
             color: '#FFA647FF'
             id: DeliveryGreyscale
@@ -180,10 +180,10 @@ entities:
           decals:
             150: -2,-2
         - node:
-            color: '#D2D2D2FF'
+            color: '#FFFFFFFF'
             id: GrayConcreteTrimLineW
           decals:
-            147: -1,-1
+            166: -1,0
         - node:
             color: '#D2D2D2FF'
             id: Rust
@@ -198,6 +198,7 @@ entities:
             id: TechE
           decals:
             18: 2,-1
+            167: -1,0
         - node:
             color: '#FFFFFFFF'
             id: TechN
@@ -243,8 +244,8 @@ entities:
             id: TechSW
           decals:
             16: 1,-2
-            83: -3,8
             108: 1,3
+            171: -3,8
         - node:
             color: '#FFFFFFFF'
             id: TechW
@@ -253,6 +254,7 @@ entities:
             80: -3,11
             81: -3,10
             82: -3,9
+            157: -3,5
         - node:
             color: '#334E6DFF'
             id: TrimWarnEast
@@ -310,8 +312,12 @@ entities:
             color: '#334E6DFF'
             id: TrimlineNorthEastCorner
           decals:
-            90: -3,8
             135: 1,-2
+        - node:
+            color: '#345973E5'
+            id: TrimlineNorthEastCorner
+          decals:
+            172: -3,8
         - node:
             color: '#334E6DBF'
             id: TrimlineNorthWest
@@ -415,17 +421,17 @@ entities:
           1,0:
             0: 30579
           1,1:
-            1: 26880
-            0: 1632
+            1: 3840
+            0: 96
           1,-1:
             0: 47361
             1: 1226
           0,-2:
-            1: 388
-            0: 13376
+            1: 12676
+            0: 1088
           -1,-2:
-            0: 52224
-            1: 369
+            1: 3441
+            0: 49152
           -1,-1:
             0: 61024
           1,-2:
@@ -468,7 +474,7 @@ entities:
       locked: False
 - proto: AirAlarm
   entities:
-  - uid: 516
+  - uid: 2
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -476,27 +482,26 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 514
-      - 513
-      - 512
-      - 187
-      - 186
-  - uid: 517
+      - 216
+      - 215
+      - 214
+      - 292
+  - uid: 3
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
     - type: DeviceList
       devices:
-      - 511
-      - 238
-      - 237
-      - 513
-      - 236
-      - 235
-      - 244
-      - 243
-  - uid: 518
+      - 213
+      - 294
+      - 288
+      - 215
+      - 287
+      - 293
+      - 291
+      - 297
+  - uid: 4
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -504,77 +509,76 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 241
-      - 242
-      - 515
-      - 514
+      - 296
+      - 290
+      - 217
+      - 216
 - proto: AirlockExternalGlassNfsdLocked
   entities:
-  - uid: 465
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,12.5
-      parent: 1
-  - uid: 466
+  - uid: 6
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,3.5
       parent: 1
-  - uid: 467
+  - uid: 7
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
 - proto: AirlockNfsdLocked
   entities:
-  - uid: 378
+  - uid: 5
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,2.5
-      parent: 1
-  - uid: 379
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,1.5
-      parent: 1
-  - uid: 470
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,5.5
-      parent: 1
-  - uid: 471
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
+      rot: -1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 472
+  - uid: 8
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: -1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 1.5,1.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
       parent: 1
 - proto: AirlockShuttleNfsdLocked
   entities:
-  - uid: 458
+  - uid: 13
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,14.5
       parent: 1
-  - uid: 459
+  - uid: 14
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 460
+  - uid: 15
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -582,19 +586,19 @@ entities:
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 370
+  - uid: 16
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 371
+  - uid: 17
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 372
+  - uid: 18
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -602,64 +606,57 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 477
+  - uid: 19
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 1
-  - uid: 478
+  - uid: 20
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 479
+  - uid: 21
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,2.5
       parent: 1
-  - uid: 480
+  - uid: 22
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 481
+  - uid: 23
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,14.5
       parent: 1
-- proto: Autolathe
-  entities:
-  - uid: 208
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 233
+  - uid: 25
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,6.5
       parent: 1
-  - uid: 234
+  - uid: 26
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 1
-  - uid: 461
+  - uid: 27
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 462
+  - uid: 28
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -667,19 +664,19 @@ entities:
       parent: 1
 - proto: ButtonFrameCaution
   entities:
-  - uid: 474
+  - uid: 29
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,1.5
       parent: 1
-  - uid: 476
+  - uid: 30
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,0.5
       parent: 1
-  - uid: 510
+  - uid: 31
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -687,844 +684,821 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 356
+  - uid: 32
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 401
+  - uid: 33
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 402
+  - uid: 34
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 403
+  - uid: 35
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 404
+  - uid: 36
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 405
+  - uid: 37
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 406
+  - uid: 38
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 407
+  - uid: 39
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 408
+  - uid: 40
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 409
+  - uid: 41
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
-  - uid: 410
+  - uid: 42
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 411
+  - uid: 43
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 412
+  - uid: 44
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 413
+  - uid: 45
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 414
+  - uid: 46
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 415
+  - uid: 47
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 416
+  - uid: 48
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 417
+  - uid: 49
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
-  - uid: 418
+  - uid: 50
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 419
+  - uid: 51
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 420
+  - uid: 52
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 421
+  - uid: 53
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 422
+  - uid: 54
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 423
+  - uid: 55
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 424
+  - uid: 56
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 425
+  - uid: 57
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 426
+  - uid: 58
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 427
+  - uid: 59
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 428
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 1
-  - uid: 429
+  - uid: 61
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 430
+  - uid: 62
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 431
+  - uid: 63
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 432
+  - uid: 64
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 433
+  - uid: 65
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 434
+  - uid: 66
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 435
+  - uid: 67
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 436
+  - uid: 68
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 1
-  - uid: 437
+  - uid: 69
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 438
+  - uid: 70
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 439
+  - uid: 71
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 440
+  - uid: 72
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 441
+  - uid: 73
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 442
+  - uid: 74
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 443
+  - uid: 75
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 444
+  - uid: 76
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 445
+  - uid: 77
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
-  - uid: 446
+  - uid: 78
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 1
-  - uid: 447
+  - uid: 79
     components:
     - type: Transform
       pos: -2.5,14.5
       parent: 1
-  - uid: 448
+  - uid: 80
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 449
+  - uid: 81
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 450
+  - uid: 82
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 451
+  - uid: 83
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 469
+  - uid: 84
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 529
+  - uid: 85
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-- proto: CableHV
-  entities:
-  - uid: 124
-    components:
-    - type: Transform
-      pos: -3.5,10.5
-      parent: 1
-  - uid: 134
-    components:
-    - type: Transform
-      pos: 1.5,12.5
-      parent: 1
-  - uid: 135
-    components:
-    - type: Transform
-      pos: 1.5,11.5
-      parent: 1
-  - uid: 136
-    components:
-    - type: Transform
-      pos: 1.5,10.5
-      parent: 1
-  - uid: 137
-    components:
-    - type: Transform
-      pos: 1.5,9.5
-      parent: 1
-  - uid: 138
-    components:
-    - type: Transform
-      pos: 2.5,11.5
-      parent: 1
-  - uid: 139
-    components:
-    - type: Transform
-      pos: 3.5,11.5
-      parent: 1
-  - uid: 140
-    components:
-    - type: Transform
-      pos: 3.5,10.5
-      parent: 1
-  - uid: 141
-    components:
-    - type: Transform
-      pos: 3.5,8.5
-      parent: 1
-  - uid: 142
-    components:
-    - type: Transform
-      pos: 3.5,9.5
-      parent: 1
-  - uid: 143
-    components:
-    - type: Transform
-      pos: 3.5,13.5
-      parent: 1
-  - uid: 144
-    components:
-    - type: Transform
-      pos: 3.5,12.5
-      parent: 1
-  - uid: 145
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 1
-  - uid: 146
-    components:
-    - type: Transform
-      pos: -0.5,11.5
-      parent: 1
-  - uid: 147
-    components:
-    - type: Transform
-      pos: -1.5,11.5
-      parent: 1
-  - uid: 148
-    components:
-    - type: Transform
-      pos: -1.5,10.5
-      parent: 1
-  - uid: 149
-    components:
-    - type: Transform
-      pos: -4.5,8.5
-      parent: 1
-  - uid: 150
-    components:
-    - type: Transform
-      pos: -4.5,9.5
-      parent: 1
-  - uid: 151
-    components:
-    - type: Transform
-      pos: -4.5,10.5
-      parent: 1
-  - uid: 152
-    components:
-    - type: Transform
-      pos: -2.5,10.5
-      parent: 1
-  - uid: 154
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 1
-  - uid: 158
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 1
-  - uid: 159
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 160
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 161
+  - uid: 226
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 162
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 111
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 163
+  - uid: 112
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 164
+  - uid: 113
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 165
+  - uid: 114
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 167
+  - uid: 115
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 168
+  - uid: 116
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 169
+  - uid: 117
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 170
+  - uid: 118
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 171
+  - uid: 119
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 172
+  - uid: 120
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 173
+  - uid: 121
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 174
+  - uid: 122
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 373
+  - uid: 123
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 374
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 375
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 1
-  - uid: 376
+  - uid: 126
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 377
+  - uid: 127
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 380
+  - uid: 128
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 381
+  - uid: 129
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 382
+  - uid: 130
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 383
+  - uid: 131
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 384
+  - uid: 132
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 385
+  - uid: 133
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 386
+  - uid: 134
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 387
+  - uid: 135
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 388
+  - uid: 136
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 389
+  - uid: 137
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 390
+  - uid: 138
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 391
+  - uid: 139
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 392
+  - uid: 140
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 393
+  - uid: 141
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 394
+  - uid: 142
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 395
+  - uid: 143
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 396
+  - uid: 144
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 397
+  - uid: 145
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 398
+  - uid: 146
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 399
+  - uid: 147
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 400
+  - uid: 148
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 468
+  - uid: 149
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 153
+  - uid: 150
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 175
+  - uid: 151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 1
-- proto: CardBoxBlack
-  entities:
-  - uid: 223
-    components:
-    - type: Transform
-      pos: 1.3604096,-1.4920015
-      parent: 1
 - proto: Catwalk
   entities:
-  - uid: 261
+  - uid: 153
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 295
+  - uid: 154
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 296
+  - uid: 155
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 297
+  - uid: 156
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 298
+  - uid: 157
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 302
+  - uid: 158
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 303
+  - uid: 159
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 305
+  - uid: 160
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 306
+  - uid: 161
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 308
+  - uid: 162
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 310
+  - uid: 163
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 313
+  - uid: 164
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 315
+  - uid: 165
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 316
+  - uid: 166
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 317
+  - uid: 167
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 318
+  - uid: 168
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 319
+  - uid: 169
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 320
+  - uid: 170
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 321
+  - uid: 171
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 322
+  - uid: 172
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 323
+  - uid: 173
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 324
+  - uid: 174
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 325
+  - uid: 175
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 326
+  - uid: 176
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 327
+  - uid: 177
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 328
+  - uid: 178
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 1
-  - uid: 329
+  - uid: 179
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 334
+  - uid: 180
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 335
+  - uid: 181
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 336
+  - uid: 182
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 1
-  - uid: 337
+  - uid: 183
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 338
-    components:
-    - type: Transform
-      pos: 3.5,11.5
-      parent: 1
-  - uid: 339
-    components:
-    - type: Transform
-      pos: 3.5,10.5
-      parent: 1
-  - uid: 340
+  - uid: 185
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 342
+  - uid: 186
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 343
+  - uid: 187
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 1
-  - uid: 344
+  - uid: 188
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 345
+  - uid: 189
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 346
+  - uid: 190
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 348
+  - uid: 191
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 457
+  - uid: 192
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-0.5
+      pos: 3.5,10.5
       parent: 1
 - proto: ChairFolding
   entities:
-  - uid: 219
+  - uid: 193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.3604097,-1.3982515
       parent: 1
-  - uid: 222
+  - uid: 194
     components:
     - type: Transform
       pos: 1.3604096,-0.46075153
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 301
+  - uid: 195
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1532,7 +1506,7 @@ entities:
       parent: 1
 - proto: ComputerGunneryConsole
   entities:
-  - uid: 201
+  - uid: 196
     components:
     - type: Transform
       pos: 1.5,4.5
@@ -1543,7 +1517,7 @@ entities:
       startingCharge: 0
 - proto: ComputerIFF
   entities:
-  - uid: 203
+  - uid: 197
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1555,7 +1529,7 @@ entities:
       startingCharge: 0
 - proto: ComputerShuttleTSFNVWS
   entities:
-  - uid: 202
+  - uid: 198
     components:
     - type: Transform
       pos: 2.5,4.5
@@ -1566,7 +1540,7 @@ entities:
       startingCharge: 0
 - proto: ComputerSolarControl
   entities:
-  - uid: 132
+  - uid: 199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1578,7 +1552,7 @@ entities:
       startingCharge: 0
 - proto: ComputerWallmountStationRecords
   entities:
-  - uid: 483
+  - uid: 200
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1590,47 +1564,52 @@ entities:
       startingCharge: 0
 - proto: DarkCatwalkMono
   entities:
-  - uid: 299
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 201
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 300
+  - uid: 202
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
-  - uid: 304
+  - uid: 203
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 307
+  - uid: 204
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 330
+  - uid: 205
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 331
+  - uid: 206
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 332
+  - uid: 207
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 333
+  - uid: 208
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 455
+  - uid: 209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1638,15 +1617,22 @@ entities:
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 537
+  - uid: 210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
+- proto: DrinkWaterBottleFull
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 1.2384782,-1.352252
+      parent: 1
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 357
+  - uid: 211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1654,14 +1640,14 @@ entities:
       parent: 1
 - proto: FaxMachineShip
   entities:
-  - uid: 217
+  - uid: 212
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: Firelock
   entities:
-  - uid: 511
+  - uid: 213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1669,8 +1655,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 517
-  - uid: 512
+      - 3
+  - uid: 214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1678,8 +1664,8 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 516
-  - uid: 513
+      - 2
+  - uid: 215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1687,9 +1673,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 516
-      - 517
-  - uid: 514
+      - 2
+      - 3
+  - uid: 216
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1697,9 +1683,9 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 516
-      - 518
-  - uid: 515
+      - 2
+      - 4
+  - uid: 217
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1707,51 +1693,65 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 518
+      - 4
+- proto: FoodSnackNutribrickMRE
+  entities:
+  - uid: 539
+    components:
+    - type: Transform
+      pos: 1.7060914,-1.2291355
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 1.5708438,-1.5125713
+      parent: 1
 - proto: FuelPlasma1
   entities:
-  - uid: 179
+  - uid: 218
     components:
     - type: Transform
       pos: -2.628427,-1.4109726
       parent: 1
-  - uid: 180
+  - uid: 219
     components:
     - type: Transform
       pos: -2.550302,-1.5828476
       parent: 1
-  - uid: 181
+  - uid: 220
     components:
     - type: Transform
       pos: -2.456552,-1.4422226
       parent: 1
-  - uid: 182
+  - uid: 221
     components:
     - type: Transform
       pos: -2.347177,-1.6297226
       parent: 1
-  - uid: 183
+  - uid: 222
     components:
     - type: Transform
       pos: -2.519052,-1.495266
       parent: 1
-- proto: GasMixerOn
+- proto: GasMixerOnFlipped
   entities:
-  - uid: 105
+  - uid: 415
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
     - type: GasMixer
-      inletTwoConcentration: 0.20999998
-      inletOneConcentration: 0.79
+      inletTwoConcentration: 0.75
+      inletOneConcentration: 0.25
+      targetPressure: 200
     - type: AtmosPipeLayers
       pipeLayer: Secondary
-    - type: ActiveUserInterface
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPassiveVent
   entities:
-  - uid: 193
+  - uid: 224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1763,19 +1763,23 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBendAlt1
   entities:
-  - uid: 189
+  - uid: 124
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 190
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-0.5
-      parent: 1
-  - uid: 253
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 227
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1783,7 +1787,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 263
+  - uid: 228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1791,14 +1795,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 271
+  - uid: 229
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 273
+  - uid: 230
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1806,7 +1810,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 275
+  - uid: 231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1814,7 +1818,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 277
+  - uid: 232
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1822,7 +1826,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 282
+  - uid: 233
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1830,16 +1834,24 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 290
+  - uid: 234
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeBendAlt2
   entities:
-  - uid: 194
+  - uid: 235
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1847,7 +1859,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 197
+  - uid: 236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1855,7 +1867,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 254
+  - uid: 237
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1863,7 +1875,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 260
+  - uid: 238
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1871,7 +1883,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 270
+  - uid: 239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1879,14 +1891,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 272
+  - uid: 240
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 274
+  - uid: 241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1894,7 +1906,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 284
+  - uid: 242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1902,7 +1914,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 291
+  - uid: 243
     components:
     - type: Transform
       pos: 1.5,4.5
@@ -1911,49 +1923,49 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraightAlt1
   entities:
-  - uid: 247
+  - uid: 244
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 248
+  - uid: 245
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 249
+  - uid: 246
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 250
+  - uid: 247
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 251
+  - uid: 248
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 252
+  - uid: 249
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 266
+  - uid: 250
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1961,7 +1973,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 267
+  - uid: 251
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1969,14 +1981,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 280
+  - uid: 252
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 281
+  - uid: 253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1984,7 +1996,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 285
+  - uid: 254
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1992,21 +2004,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 287
+  - uid: 255
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 288
+  - uid: 256
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 294
+  - uid: 257
     components:
     - type: Transform
       pos: -1.5,1.5
@@ -2015,7 +2027,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeStraightAlt2
   entities:
-  - uid: 195
+  - uid: 258
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2023,7 +2035,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 198
+  - uid: 259
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2031,7 +2043,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 199
+  - uid: 260
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2039,42 +2051,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 255
+  - uid: 261
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 256
+  - uid: 262
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 257
+  - uid: 263
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 258
+  - uid: 264
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 259
+  - uid: 265
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 264
+  - uid: 266
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2082,7 +2094,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 265
+  - uid: 267
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2090,42 +2102,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 276
+  - uid: 268
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 278
+  - uid: 269
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 279
+  - uid: 270
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 289
+  - uid: 271
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 292
+  - uid: 272
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 293
+  - uid: 273
     components:
     - type: Transform
       pos: -1.5,1.5
@@ -2134,22 +2146,22 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunctionAlt1
   entities:
-  - uid: 188
+  - uid: 223
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 245
+  - uid: 275
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 246
+  - uid: 276
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2157,7 +2169,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 268
+  - uid: 277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2165,7 +2177,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 283
+  - uid: 278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2175,7 +2187,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeTJunctionAlt2
   entities:
-  - uid: 196
+  - uid: 279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2183,7 +2195,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 232
+  - uid: 280
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2191,14 +2203,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 262
+  - uid: 281
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 269
+  - uid: 282
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2206,7 +2218,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 286
+  - uid: 283
     components:
     - type: Transform
       pos: 3.5,-0.5
@@ -2215,37 +2227,39 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 191
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-    - type: AtmosPipeLayers
-      pipeLayer: Secondary
-  - uid: 192
+  - uid: 285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
     - type: AtmosPipeLayers
       pipeLayer: Secondary
-- proto: GasVentPump
-  entities:
-  - uid: 186
+  - uid: 329
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
       parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 516
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 236
+- proto: GasVentPump
+  entities:
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2253,12 +2267,12 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 517
+      - 3
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 237
+  - uid: 288
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2266,12 +2280,12 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 517
+      - 3
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 240
+  - uid: 289
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2281,7 +2295,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 242
+  - uid: 290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2289,38 +2303,38 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 518
+      - 4
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 244
+  - uid: 291
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 517
+      - 3
     - type: AtmosPipeLayers
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 187
+  - uid: 292
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 516
+      - 2
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 235
+  - uid: 293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2328,12 +2342,12 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 517
+      - 3
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 238
+  - uid: 294
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2341,12 +2355,12 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 517
+      - 3
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 239
+  - uid: 295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2356,7 +2370,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 241
+  - uid: 296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2364,159 +2378,166 @@ entities:
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 518
+      - 4
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 243
+  - uid: 297
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
-      - 517
+      - 3
     - type: AtmosPipeLayers
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GeneratorCRPinchShuttle
   entities:
-  - uid: 157
+  - uid: 298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
 - proto: Grille
   entities:
-  - uid: 87
+  - uid: 299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,4.5
       parent: 1
-  - uid: 311
+  - uid: 300
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 312
+  - uid: 301
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
-  - uid: 314
+  - uid: 302
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 347
+  - uid: 303
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 349
+  - uid: 304
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 352
+  - uid: 305
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 353
+  - uid: 306
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 358
+  - uid: 307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-4.5
       parent: 1
-  - uid: 359
+  - uid: 308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-3.5
       parent: 1
-  - uid: 360
+  - uid: 309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 361
+  - uid: 310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,11.5
       parent: 1
-  - uid: 363
+  - uid: 311
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,10.5
       parent: 1
-  - uid: 364
+  - uid: 312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 365
+  - uid: 313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,6.5
       parent: 1
-  - uid: 367
+  - uid: 314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 368
+  - uid: 315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-2.5
       parent: 1
-  - uid: 533
+  - uid: 316
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 309
+  - uid: 317
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 354
+  - uid: 318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 355
+  - uid: 319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 1
-  - uid: 535
+  - uid: 320
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 536
+  - uid: 321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2524,7 +2545,7 @@ entities:
       parent: 1
 - proto: GunneryServerMedium
   entities:
-  - uid: 114
+  - uid: 322
     components:
     - type: Transform
       pos: -0.5,7.5
@@ -2535,13 +2556,13 @@ entities:
       powerLoad: 10
 - proto: GyroscopeNfsd
   entities:
-  - uid: 215
+  - uid: 323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 216
+  - uid: 324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2549,63 +2570,63 @@ entities:
       parent: 1
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 207
+  - uid: 325
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
 - proto: LockerSalvageSpecialistFilledHardsuit
   entities:
-  - uid: 221
+  - uid: 326
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 113
+  - uid: 327
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
 - proto: MachineOreMagnet
   entities:
-  - uid: 204
+  - uid: 328
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
 - proto: MachineSalvageRadar
   entities:
-  - uid: 78
+  - uid: 536
     components:
     - type: Transform
-      pos: 7.5,-0.5
+      pos: 7.5,-1.5
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 218
+  - uid: 330
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
 - proto: NFMagnetBoxConstruction
   entities:
-  - uid: 209
+  - uid: 331
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
 - proto: NFMagnetBoxOre
   entities:
-  - uid: 224
+  - uid: 332
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 177
+  - uid: 333
     components:
     - type: Transform
       anchored: True
@@ -2615,80 +2636,87 @@ entities:
       bodyType: Static
 - proto: OreProcessorIndustrial
   entities:
-  - uid: 206
+  - uid: 334
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 176
+  - uid: 125
     components:
     - type: Transform
       anchored: True
-      pos: -0.5,0.5
+      pos: -0.5,-0.5
       parent: 1
     - type: Physics
       bodyType: Static
 - proto: PlastitaniumWindow
   entities:
-  - uid: 24
+  - uid: 336
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-2.5
       parent: 1
-  - uid: 36
+  - uid: 337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 50
+  - uid: 338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 58
+  - uid: 339
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,11.5
       parent: 1
-  - uid: 59
+  - uid: 340
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 70
+  - uid: 341
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,6.5
       parent: 1
-  - uid: 351
+  - uid: 342
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,10.5
       parent: 1
-  - uid: 362
+  - uid: 343
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,4.5
       parent: 1
+- proto: PlushieAtmosian
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 7.541412,-0.58826256
+      parent: 1
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 491
+  - uid: 344
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 1
-  - uid: 525
+  - uid: 345
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2696,13 +2724,13 @@ entities:
       parent: 1
 - proto: PoweredlightBlue
   entities:
-  - uid: 521
+  - uid: 346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 523
+  - uid: 347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2710,13 +2738,13 @@ entities:
       parent: 1
 - proto: PoweredlightExterior
   entities:
-  - uid: 6
+  - uid: 348
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,14.5
       parent: 1
-  - uid: 463
+  - uid: 349
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2724,13 +2752,13 @@ entities:
       parent: 1
 - proto: PoweredlightOrange
   entities:
-  - uid: 520
+  - uid: 350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 522
+  - uid: 351
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2738,111 +2766,111 @@ entities:
       parent: 1
 - proto: PoweredlightRed
   entities:
-  - uid: 519
+  - uid: 352
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 526
+  - uid: 353
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 527
+  - uid: 354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 528
+  - uid: 355
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
 - proto: Rack
   entities:
-  - uid: 178
+  - uid: 356
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
+      rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 1
 - proto: RadarEdgeMarkerDiagonal
   entities:
-  - uid: 464
+  - uid: 357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,13.5
       parent: 1
-  - uid: 485
+  - uid: 358
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 486
+  - uid: 359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 487
+  - uid: 360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,10.5
       parent: 1
-  - uid: 488
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,9.5
       parent: 1
-  - uid: 489
+  - uid: 362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,12.5
       parent: 1
-  - uid: 490
+  - uid: 363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,11.5
       parent: 1
-  - uid: 492
+  - uid: 364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-  - uid: 495
+  - uid: 365
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 505
+  - uid: 366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 1
-  - uid: 506
+  - uid: 367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 507
+  - uid: 368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,2.5
       parent: 1
-  - uid: 508
+  - uid: 369
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2850,54 +2878,54 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerHalftiltLeft
   entities:
-  - uid: 44
+  - uid: 370
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 493
+  - uid: 371
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,8.5
       parent: 1
-  - uid: 494
+  - uid: 372
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
-  - uid: 496
+  - uid: 373
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 497
+  - uid: 374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 1
-  - uid: 500
+  - uid: 375
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 501
+  - uid: 376
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 503
+  - uid: 377
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 504
+  - uid: 378
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2905,25 +2933,25 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerStraight
   entities:
-  - uid: 498
+  - uid: 379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,5.5
       parent: 1
-  - uid: 502
+  - uid: 380
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 530
+  - uid: 381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 531
+  - uid: 382
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2931,75 +2959,75 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 5
+  - uid: 383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-0.5
       parent: 1
-  - uid: 211
+  - uid: 384
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 213
+  - uid: 385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 214
+  - uid: 386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-5.5
       parent: 1
-  - uid: 225
+  - uid: 387
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 226
+  - uid: 388
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 231
+  - uid: 389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,4.5
       parent: 1
-  - uid: 369
+  - uid: 390
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 453
+  - uid: 391
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 62
+  - uid: 392
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 1
-  - uid: 166
+  - uid: 393
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 228
+  - uid: 394
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 229
+  - uid: 395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3007,13 +3035,13 @@ entities:
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 227
+  - uid: 396
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 1
-  - uid: 456
+  - uid: 397
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3021,31 +3049,38 @@ entities:
       parent: 1
 - proto: RailingRound
   entities:
-  - uid: 7
+  - uid: 398
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 8
+  - uid: 399
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 230
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: SalvageTechfabNF
+  entities:
+  - uid: 24
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
 - proto: ScrapProcessor
   entities:
-  - uid: 205
+  - uid: 401
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 473
+  - uid: 402
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3053,19 +3088,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        472:
-        - - Pressed
-          - DoorBolt
-        378:
-        - - Pressed
-          - DoorBolt
-        461:
+        27:
         - - Pressed
           - Close
-        462:
+        28:
         - - Pressed
           - Close
-  - uid: 475
+  - uid: 403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3073,13 +3102,13 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        462:
+        28:
         - - Pressed
           - Toggle
-        461:
+        27:
         - - Pressed
           - Toggle
-  - uid: 509
+  - uid: 404
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3087,90 +3116,84 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        234:
+        26:
         - - Pressed
           - Toggle
-        233:
+        25:
         - - Pressed
           - Toggle
 - proto: SinkWide
   entities:
-  - uid: 538
+  - uid: 405
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 156
+  - uid: 406
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
 - proto: SMESBasic
   entities:
-  - uid: 133
+  - uid: 407
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
 - proto: SolarPanelUranium
   entities:
-  - uid: 106
+  - uid: 408
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,13.5
       parent: 1
-  - uid: 120
+  - uid: 409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 121
+  - uid: 410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,10.5
       parent: 1
-  - uid: 122
+  - uid: 411
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 126
+  - uid: 412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 127
+  - uid: 413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,10.5
       parent: 1
-  - uid: 130
+  - uid: 414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,12.5
       parent: 1
-  - uid: 131
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,11.5
-      parent: 1
-  - uid: 341
+  - uid: 416
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,8.5
       parent: 1
-  - uid: 350
+  - uid: 417
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3178,7 +3201,13 @@ entities:
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 484
+  - uid: 11
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 418
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3186,33 +3215,33 @@ entities:
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 155
+  - uid: 419
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
 - proto: TableFolding
   entities:
-  - uid: 220
+  - uid: 420
     components:
     - type: Transform
       pos: 1.4854096,-1.4920015
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 212
+  - uid: 421
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: ThrusterNfsd
   entities:
-  - uid: 4
+  - uid: 422
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
-  - uid: 10
+  - uid: 423
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3220,72 +3249,72 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 14
+  - uid: 424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 73
+  - uid: 425
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 86
+  - uid: 426
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 88
+  - uid: 427
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
       parent: 1
-  - uid: 89
+  - uid: 428
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 91
+  - uid: 429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 1
-  - uid: 92
+  - uid: 430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-  - uid: 93
+  - uid: 431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 94
+  - uid: 432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 524
+  - uid: 433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 532
+  - uid: 434
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 534
+  - uid: 435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3293,7 +3322,7 @@ entities:
       parent: 1
 - proto: UraniumReinforcedWindowDirectional
   entities:
-  - uid: 184
+  - uid: 436
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3303,455 +3332,455 @@ entities:
       gridUid: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 454
+  - uid: 437
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
 - proto: WallPlastitanium
   entities:
-  - uid: 2
+  - uid: 438
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 3
+  - uid: 439
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 11
+  - uid: 440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 1
-  - uid: 12
+  - uid: 441
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 1
-  - uid: 13
+  - uid: 442
     components:
     - type: Transform
       pos: -3.5,14.5
       parent: 1
-  - uid: 15
+  - uid: 443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-  - uid: 16
+  - uid: 444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 17
+  - uid: 445
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 18
+  - uid: 446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 19
+  - uid: 447
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 20
+  - uid: 448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 21
+  - uid: 449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 22
+  - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 23
+  - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-2.5
       parent: 1
-  - uid: 25
+  - uid: 452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 26
+  - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 27
+  - uid: 454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 1
-  - uid: 29
+  - uid: 455
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 30
+  - uid: 456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 32
+  - uid: 457
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 33
+  - uid: 458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 1
-  - uid: 34
+  - uid: 459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-1.5
       parent: 1
-  - uid: 35
+  - uid: 460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 1
-  - uid: 37
+  - uid: 461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,0.5
       parent: 1
-  - uid: 38
+  - uid: 462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 1
-  - uid: 39
+  - uid: 463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 40
+  - uid: 464
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 1
-  - uid: 42
+  - uid: 465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 43
+  - uid: 466
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 45
+  - uid: 467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-  - uid: 46
+  - uid: 468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
-  - uid: 47
+  - uid: 469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
       parent: 1
-  - uid: 48
+  - uid: 470
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 49
+  - uid: 471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
-  - uid: 51
+  - uid: 472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 52
+  - uid: 473
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 53
+  - uid: 474
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 1
-  - uid: 54
+  - uid: 475
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 56
+  - uid: 476
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 57
+  - uid: 477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,9.5
       parent: 1
-  - uid: 60
+  - uid: 478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 1
-  - uid: 61
+  - uid: 479
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 1
-  - uid: 63
+  - uid: 480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,13.5
       parent: 1
-  - uid: 65
+  - uid: 481
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 66
+  - uid: 482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,10.5
       parent: 1
-  - uid: 67
+  - uid: 483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
-  - uid: 68
+  - uid: 484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
-  - uid: 69
+  - uid: 485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,7.5
       parent: 1
-  - uid: 71
+  - uid: 486
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,5.5
       parent: 1
-  - uid: 72
+  - uid: 487
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 1
-  - uid: 74
+  - uid: 488
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 75
+  - uid: 489
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 76
+  - uid: 490
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 1
-  - uid: 77
+  - uid: 491
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,5.5
       parent: 1
-  - uid: 80
+  - uid: 492
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 85
+  - uid: 493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-  - uid: 90
+  - uid: 494
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 95
+  - uid: 495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,8.5
       parent: 1
-  - uid: 96
+  - uid: 496
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,8.5
       parent: 1
-  - uid: 97
+  - uid: 497
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 98
+  - uid: 498
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 99
+  - uid: 499
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 100
+  - uid: 500
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 101
+  - uid: 501
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 102
+  - uid: 502
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 103
+  - uid: 503
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 104
+  - uid: 504
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 107
+  - uid: 505
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 1
-  - uid: 109
+  - uid: 506
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 110
+  - uid: 507
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 111
+  - uid: 508
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 112
+  - uid: 509
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 115
+  - uid: 510
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 1
-  - uid: 116
+  - uid: 511
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,6.5
       parent: 1
-  - uid: 117
+  - uid: 512
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,5.5
       parent: 1
-  - uid: 200
+  - uid: 513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-0.5
       parent: 1
-  - uid: 366
+  - uid: 514
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 1
-  - uid: 452
+  - uid: 515
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 1
-  - uid: 499
+  - uid: 516
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3759,55 +3788,55 @@ entities:
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 28
+  - uid: 517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-5.5
       parent: 1
-  - uid: 31
+  - uid: 518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 41
+  - uid: 519
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 1
-  - uid: 55
+  - uid: 520
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,9.5
       parent: 1
-  - uid: 79
+  - uid: 521
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-2.5
       parent: 1
-  - uid: 81
+  - uid: 522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 1
-  - uid: 82
+  - uid: 523
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-4.5
       parent: 1
-  - uid: 83
+  - uid: 524
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 84
+  - uid: 525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3815,7 +3844,7 @@ entities:
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 482
+  - uid: 526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3823,23 +3852,23 @@ entities:
       parent: 1
 - proto: WeaponLaserTurretL1Phalanx
   entities:
-  - uid: 118
+  - uid: 527
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 119
+  - uid: 528
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 128
+  - uid: 529
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,7.5
       parent: 1
-  - uid: 129
+  - uid: 530
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3847,19 +3876,19 @@ entities:
       parent: 1
 - proto: WeaponTurretDravon
   entities:
-  - uid: 9
+  - uid: 531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,14.5
       parent: 1
-  - uid: 64
+  - uid: 532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,13.5
       parent: 1
-  - uid: 108
+  - uid: 533
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3867,27 +3896,27 @@ entities:
       parent: 1
 - proto: WeaponTurretM25
   entities:
-  - uid: 123
+  - uid: 534
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,12.5
       parent: 1
-  - uid: 125
+  - uid: 535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,9.5
       parent: 1
-  - uid: 210
+  - uid: 538
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 7.5,-1.5
+      pos: 3.5,11.5
       parent: 1
 - proto: WindoorSecureUranium
   entities:
-  - uid: 185
+  - uid: 537
     components:
     - type: Transform
       rot: 3.141592653589793 rad


### PR DESCRIPTION
## About the PR
- Added a gravity generator
- Some decals
- Added some food and drink
- There was an unpowered external light, turned that on.
- Swapped the autolathe for a Salvage Techfab since it print out any lost mining equipment 
- Coloured some pipes
- Added a late-join spawn point
- Moved the mining pulser in the corner at the bottom left side of the craft to a more sensible location. The mining pulsers still don't have a great firing arc compared to the original incarnation of the craft, but they are perfectly functional. if need be I can rectify that.

Nothing major.
## Why / Balance
The main issue was the lack of a gravity generator, the pulser placement (there was only a very narrow area where they overlapped) and the unpowered light but I though while I'm here I'm going to tweak some stuff that I think are going to be beneficial. 

## Media<br>
<img width="448" height="768" alt="shiv-0" src="https://github.com/user-attachments/assets/12250462-18e2-46bb-a0d3-46def0773e01" /><br>

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Buy a Shiv and feel gravity anchoring you.

## Breaking changes
Nothing, just maps

**Changelog**
:cl:
- tweak: The Shiv should have gravity now and its mining pulsers properly overlap now

