### PR TITLE
Personal Shields (Suit Shield Rework)

### DIFF
--- a/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
+++ b/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
@@ -1,0 +1,131 @@
+using System.Numerics;
+using Content.Shared._Mono.PersonalShield;
+using Content.Shared.Inventory;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._Mono.PersonalShield;
+
+public sealed partial class PersonalShieldOverlay : Overlay
+{
+    [Dependency] private IEntityManager _entManager = null!;
+
+    private static readonly ProtoId<ShaderPrototype> ShaderId = "PersonalShieldSkin";
+
+    private readonly SharedTransformSystem _transform;
+    private readonly SpriteSystem _sprite;
+    private readonly InventorySystem _inventory;
+    private readonly ShaderInstance _shader;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public PersonalShieldOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _transform = _entManager.System<SharedTransformSystem>();
+        _sprite = _entManager.System<SpriteSystem>();
+        _inventory = _entManager.System<InventorySystem>();
+        var protoMan = IoCManager.Resolve<IPrototypeManager>();
+        _shader = protoMan.Index(ShaderId).InstanceUnique();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (args.MapId == MapId.Nullspace)
+            return;
+
+        var handle = args.WorldHandle;
+
+        // Cancel the eye rotation so the shield is always "upright".
+        var eyeRot = args.Viewport.Eye?.Rotation ?? Angle.Zero;
+        var counterRot = Matrix3Helpers.CreateRotation(-eyeRot);
+
+        var query = _entManager.EntityQueryEnumerator<PersonalShieldComponent>();
+        while (query.MoveNext(out var uid, out var shield))
+        {
+            if (shield.Runtime.Form <= 0f && shield.Runtime.Shatter <= 0f)
+                continue;
+
+            if (!_inventory.TryGetContainingEntity(uid, out var wearer))
+                continue;
+
+            if (!_entManager.TryGetComponent(wearer, out SpriteComponent? sprite) || !sprite.Visible)
+                continue;
+
+            if (!_entManager.TryGetComponent(wearer, out TransformComponent? xform) || xform.MapID != args.MapId)
+                continue;
+
+            if (!TryGetHitboxSize(wearer.Value, sprite, out var extents))
+                continue;
+
+            var size = extents * shield.Scale;
+
+            _shader.SetParameter("progress", GetProgress(shield));
+            _shader.SetParameter("skin_color", shield.Color);
+            _shader.SetParameter("brightness", shield.Brightness);
+            _shader.SetParameter("pixel_grid", shield.PixelGrid);
+            _shader.SetParameter("hex_density", shield.HexDensity);
+            _shader.SetParameter("form_origin", shield.FormOrigin);
+            _shader.SetParameter("fill_level", shield.FillLevel);
+            _shader.SetParameter("line_level", shield.LineLevel);
+            _shader.SetParameter("rim_level", shield.RimLevel);
+            _shader.SetParameter("core_fade", shield.CoreFade);
+            _shader.SetParameter("shard_scale", shield.ShardScale);
+            _shader.SetParameter("alpha_bands", shield.AlphaBands);
+            _shader.SetParameter("breath_depth", shield.BreathDepth);
+
+            handle.UseShader(_shader);
+
+            var worldPos = _transform.GetWorldPosition(xform);
+            handle.SetTransform(Matrix3x2.Multiply(counterRot, Matrix3Helpers.CreateTranslation(worldPos)));
+            handle.DrawTextureRect(Texture.White, Box2.CenteredAround(Vector2.Zero, size));
+        }
+
+        handle.SetTransform(Matrix3x2.Identity);
+        handle.UseShader(null);
+    }
+
+    private bool TryGetHitboxSize(EntityUid uid, SpriteComponent sprite, out Vector2 extents)
+    {
+        extents = Vector2.Zero;
+
+        if (_entManager.TryGetComponent(uid, out FixturesComponent? fixtures) && fixtures.FixtureCount > 0)
+        {
+            var identity = new Transform(Vector2.Zero, 0f);
+            Box2? union = null;
+
+            foreach (var fixture in fixtures.Fixtures.Values)
+            {
+                if (!fixture.Hard)
+                    continue;
+
+                var aabb = fixture.Shape.ComputeAABB(identity, 0);
+                union = union?.Union(aabb) ?? aabb;
+            }
+
+            if (union is { } box && box.Width > 0f && box.Height > 0f)
+            {
+                extents = box.Size;
+                return true;
+            }
+        }
+
+        var bounds = _sprite.GetLocalBounds((uid, sprite));
+        extents = bounds.Size;
+        return extents is { X: > 0f, Y: > 0f };
+    }
+
+    private static float GetProgress(PersonalShieldComponent shield)
+    {
+        return shield.Runtime.Shatter > 0f
+            ? 1f + MathF.Min(shield.Runtime.Shatter, 1f)
+            : shield.Runtime.Form;
+    }
+}

--- a/Content.Client/_Mono/PersonalShield/PersonalShieldSystem.cs
+++ b/Content.Client/_Mono/PersonalShield/PersonalShieldSystem.cs
@@ -1,0 +1,20 @@
+using Robust.Client.Graphics;
+
+namespace Content.Client._Mono.PersonalShield;
+
+public sealed partial class PersonalShieldSystem : EntitySystem
+{
+    [Dependency] private IOverlayManager _overlayMan = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _overlayMan.AddOverlay(new PersonalShieldOverlay());
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _overlayMan.RemoveOverlay<PersonalShieldOverlay>();
+    }
+}

--- a/Content.Shared/_Mono/PersonalShield/PersonalShieldComponent.cs
+++ b/Content.Shared/_Mono/PersonalShield/PersonalShieldComponent.cs
@@ -1,0 +1,164 @@
+using System.Numerics;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Mono.PersonalShield;
+
+/// <summary>
+/// Mono: New energy shields. Act as a wall until they break.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PersonalShieldComponent : Component
+{
+    /// <summary>
+    /// Settings of the shield itself; stuff like how much damage it takes.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public PersonalShieldSettings Shield = new();
+
+    /// <summary>
+    /// Current state of the shield. We put it here so the component is """clean"""
+    /// </summary>
+    [ViewVariables, AutoNetworkedField]
+    public PersonalShieldRuntime Runtime;
+
+    /// <summary>Is the shield actually on?</summary>
+    public bool IsUp => Runtime.Form >= 1f && Runtime.Shatter <= 0f;
+
+    #region Appearance
+
+    /// <summary>Field tint. The alpha scales the strength of the whole effect.</summary>
+    [DataField, AutoNetworkedField]
+    public Color Color = Color.FromHex("#00AAFF").WithAlpha(0.95f);
+
+    /// <summary>
+    /// Multiplies the field's RGB brightness.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Brightness = 1.0f;
+
+    /// <summary>
+    /// How pixellated the shield itself is.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float PixelGrid = 96f;
+
+    /// <summary>
+    /// How many hex cells span the sprite.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float HexDensity = 4.0f;
+
+    /// <summary>
+    /// How much bigger than the wearer's hitbox the bubble is drawn.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Scale = 2.2f;
+
+    /// <summary>
+    /// How much the field hollows out toward the middle of the dome. Starch wanted this.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float CoreFade = 0.85f;
+
+    /// <summary>Strength of the wash inside the shell.</summary>
+    [DataField, AutoNetworkedField]
+    public float FillLevel = 0.08f;
+
+    /// <summary>Strength of the hex cell borders.</summary>
+    [DataField, AutoNetworkedField]
+    public float LineLevel = 0.50f;
+
+    /// <summary>Strength of the glow along the dome's limb.</summary>
+    [DataField, AutoNetworkedField]
+    public float RimLevel = 0.75f;
+
+    /// <summary>
+    /// How many alpha bands the field is posterised into.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float AlphaBands = 6f;
+
+    /// <summary>
+    /// Depth of the slow pulse over the field.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BreathDepth = 0.08f;
+
+    /// <summary>
+    /// Where the spin-up crawl sweeps out from.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Vector2 FormOrigin = new(0f, 0f); // The Center
+
+    /// <summary>
+    /// Scale of the noise when the shield shuts off.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float ShardScale = 5f;
+
+    /// <summary>
+    /// How long the shatter animation plays for when the shield breaks.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float ShatterTime = 1.0f;
+
+    #endregion
+}
+
+/// <summary>
+/// Tuning for how a <see cref="PersonalShieldComponent"/> behaves, kept together so the
+/// shield's numbers sit under one YAML node rather than mixed in with its appearance.
+/// </summary>
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class PersonalShieldSettings
+{
+    /// <summary>How much damage the shield can take before it blows up.</summary>
+    [DataField]
+    public float MaxCharge = 60f;
+
+    /// <summary>Charge regained per second while the shield is on.</summary>
+    [DataField]
+    public float RegenRate = 2f;
+
+    /// <summary>
+    /// How long the shield takes to spin up.
+    /// </summary>
+    [DataField]
+    public float SpinupTime = 4f;
+
+    /// <summary>
+    /// How long the shield stays dead after fracturing.
+    /// </summary>
+    [DataField]
+    public float BreakCooldown = 10f;
+
+    /// <summary>
+    /// Battery charge drawn per second while the shield is running. If it runs out, no more shield.
+    /// </summary>
+    [DataField]
+    public float PowerDraw = 1.5f;
+}
+
+
+[Serializable, NetSerializable]
+public struct PersonalShieldRuntime
+{
+    /// <summary>Damage capacity remaining.</summary>
+    public float Charge;
+
+    /// <summary>
+    /// How far the field has crawled in.
+    /// </summary>
+    public float Form;
+
+    /// <summary>
+    /// Progress of the destruction fadeout.
+    /// </summary>
+    public float Shatter;
+
+    /// <summary>
+    /// Seconds left before a fractured shield may start spinning up again.
+    /// </summary>
+    public float Offline;
+}

--- a/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
+++ b/Content.Shared/_Mono/PersonalShield/SharedPersonalShieldSystem.cs
@@ -1,0 +1,174 @@
+using Content.Shared.Damage;
+using Content.Shared.Examine;
+using Content.Shared.Inventory;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Power.Components;
+using Content.Shared.Power.EntitySystems;
+using Robust.Shared.Network;
+
+namespace Content.Shared._Mono.PersonalShield;
+
+public sealed partial class SharedPersonalShieldSystem : EntitySystem
+{
+    [Dependency] private SharedBatterySystem _battery = default!;
+    [Dependency] private INetManager _net = default!;
+    [Dependency] private ItemToggleSystem _toggle = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PersonalShieldComponent, InventoryRelayedEvent<DamageModifyEvent>>(OnDamageModify);
+        SubscribeLocalEvent<PersonalShieldComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
+        SubscribeLocalEvent<PersonalShieldComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnDamageModify(Entity<PersonalShieldComponent> ent, ref InventoryRelayedEvent<DamageModifyEvent> args)
+    {
+        var shield = ent.Comp;
+        if (!shield.IsUp || shield.Runtime.Charge <= 0f)
+            return;
+
+        var incoming = args.Args.Damage.GetTotal().Float();
+        if (incoming <= 0f)
+            return;
+
+        var soaked = MathF.Min(incoming, shield.Runtime.Charge);
+        shield.Runtime.Charge -= soaked;
+
+        args.Args.Damage *= (incoming - soaked) / incoming;
+
+        if (shield.Runtime.Charge <= 0f)
+            Fracture(ent); // Uh oh.
+        else
+            Dirty(ent, shield);
+    }
+
+    private void OnActivateAttempt(Entity<PersonalShieldComponent> ent, ref ItemToggleActivateAttemptEvent args)
+    {
+        var runtime = ent.Comp.Runtime;
+        if (runtime.Offline <= 0f && runtime.Shatter <= 0f)
+            return;
+
+        args.Cancelled = true;
+        args.Popup = Loc.GetString("personal-shield-toggle-fractured",
+            ("seconds", (int) MathF.Ceiling(runtime.Offline)));
+    }
+
+    private void OnExamined(Entity<PersonalShieldComponent> ent, ref ExaminedEvent args)
+    {
+        var shield = ent.Comp;
+        string msg;
+
+        if (shield.Runtime.Shatter > 0f)
+            msg = Loc.GetString("personal-shield-examine-broken");
+        else if (shield.Runtime.Offline > 0f)
+            msg = Loc.GetString("personal-shield-examine-offline",
+                ("seconds", (int)MathF.Ceiling(shield.Runtime.Offline)));
+        else if (shield.IsUp)
+            msg = Loc.GetString("personal-shield-examine-up",
+                ("percent", (int)MathF.Round(shield.Runtime.Charge / MathF.Max(shield.Shield.MaxCharge, 1f) * 100f)));
+        else if (shield.Runtime.Form > 0f)
+            msg = Loc.GetString("personal-shield-examine-spinup",
+                ("percent", (int)MathF.Round(shield.Runtime.Form * 100f)));
+        else
+            msg = Loc.GetString("personal-shield-examine-down");
+
+        args.PushMarkup(msg);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_net.IsClient)
+            return;
+
+        var query = EntityQueryEnumerator<PersonalShieldComponent>();
+        while (query.MoveNext(out var uid, out var shield))
+        {
+            var ent = (uid, shield);
+            var before = shield.Runtime;
+            var cfg = shield.Shield;
+
+            if (shield.Runtime.Shatter > 0f)
+            {
+                shield.Runtime.Shatter += frameTime / MathF.Max(shield.ShatterTime, 0.01f);
+                if (shield.Runtime.Shatter >= 1f)
+                {
+                    shield.Runtime.Shatter = 0f;
+                    shield.Runtime.Form = 0f;
+                }
+
+                DirtyIfChanged(ent, before);
+                continue;
+            }
+
+            if (shield.Runtime.Offline > 0f)
+            {
+                shield.Runtime.Offline = MathF.Max(shield.Runtime.Offline - frameTime, 0f);
+                DirtyIfChanged(ent, before);
+                continue;
+            }
+
+            var running = (!TryComp<ItemToggleComponent>(uid, out var toggle) || toggle.Activated)
+                          && TryDrawPower(ent, frameTime);
+
+            var step = frameTime / MathF.Max(cfg.SpinupTime, 0.01f);
+
+            if (running)
+            {
+                shield.Runtime.Form = MathF.Min(shield.Runtime.Form + step, 1f);
+
+                shield.Runtime.Charge = shield.Runtime.Form < 1f
+                    ? cfg.MaxCharge * shield.Runtime.Form
+                    : MathF.Min(shield.Runtime.Charge + cfg.RegenRate * frameTime, cfg.MaxCharge);
+            }
+            else if (shield.Runtime.Form >= 1f)
+            {
+                shield.Runtime.Shatter = float.Epsilon;
+                shield.Runtime.Charge = 0f;
+            }
+            else if (shield.Runtime.Form > 0f)
+            {
+                shield.Runtime.Form = MathF.Max(shield.Runtime.Form - step, 0f);
+                shield.Runtime.Charge = cfg.MaxCharge * shield.Runtime.Form;
+            }
+
+            DirtyIfChanged(ent, before);
+        }
+    }
+
+    private bool TryDrawPower(Entity<PersonalShieldComponent> ent, float frameTime)
+    {
+        if (ent.Comp.Shield.PowerDraw <= 0f || !HasComp<BatteryComponent>(ent))
+            return true;
+
+        return _battery.TryUseCharge(ent, ent.Comp.Shield.PowerDraw * frameTime);
+    }
+
+    // Oops!
+    public void Fracture(Entity<PersonalShieldComponent> ent)
+    {
+        ent.Comp.Runtime.Shatter = float.Epsilon;
+        ent.Comp.Runtime.Charge = 0f;
+        ent.Comp.Runtime.Offline = ent.Comp.Shield.BreakCooldown;
+        Dirty(ent, ent.Comp);
+        _toggle.TryDeactivate(ent.Owner);
+    }
+
+    private void DirtyIfChanged(Entity<PersonalShieldComponent> ent, PersonalShieldRuntime before)
+    {
+        var now = ent.Comp.Runtime;
+        if (MathHelper.CloseTo(before.Form, now.Form)
+            && MathHelper.CloseTo(before.Shatter, now.Shatter)
+            && MathHelper.CloseTo(before.Charge, now.Charge)
+            && MathHelper.CloseTo(before.Offline, now.Offline))
+        {
+            return;
+        }
+
+        Dirty(ent, ent.Comp);
+    }
+}

--- a/Resources/Locale/en-US/_Mono/personal-shield.ftl
+++ b/Resources/Locale/en-US/_Mono/personal-shield.ftl
@@ -1,0 +1,6 @@
+personal-shield-examine-up = The shield is [color=#00AAFF]up[/color], at [color=#00AAFF]{ $percent }%[/color] capacity.
+personal-shield-examine-spinup = The shield is [color=orange]spinning up[/color].
+personal-shield-examine-broken = The shield is [color=red]shutting down[/color].
+personal-shield-examine-offline = The shield is [color=red]respooling[/color]. { $seconds } seconds until it restarts.
+personal-shield-examine-down = The shield is [color=darkgray]down[/color].
+personal-shield-toggle-fractured = Shield respooling. { $seconds } seconds remaining.

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ui.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/ui.yml
@@ -38,7 +38,7 @@
     coefficient: 0.55
 
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, EnergyShieldClothing, BaseFactionGearOtherFactionT2 ]
+  parent: [ ClothingOuterHardsuitBase, MonoEnergyShieldClothing, BaseFactionGearOtherFactionT2 ]
   id: ClothingOuterHardsuitUIEnforcerMKII
   name: U.I. ENFORCER MKII combat tacsuit
   description: Based off of the infamous MKI design with versatility in mind. This is Ullman Industries' top of the line combat suit. Whether it be slipping away from the feds, taking out the competition, or serving your corporate overlords, this marvel of engineering will make sure that you get it done.
@@ -61,22 +61,16 @@
         Heat: 0.5
         Radiation: 0.6
         Caustic: 0.7
-  - type: Blocking
-    passiveBlockModifier:
-      coefficients:
-        Blunt: 0.4
-        Slash: 0.25
-        Piercing: 0.5
-        Heat: 0.3
-      flatReductions:
-        Heat: 15
-        Piercing: 5
-    passiveBlockFraction: 0.5
-    activeBlockFraction: 1.0
-    isClothing: true
+  - type: PersonalShield
+    shield:
+      maxCharge: 600
+      regenRate: 6
+      spinupTime: 1
+      breakCooldown: 30
+      powerDraw: 0.5
   - type: Battery
-    maxCharge: 15
-    startingCharge: 15
+    maxCharge: 60
+    startingCharge: 60
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 0.1

--- a/Resources/Prototypes/_Mono/Entities/Clothing/base_shielding.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/base_shielding.yml
@@ -70,3 +70,33 @@
     autoRecharge: true
     autoRechargeRate: 5
   - type: RechargeableBlocking
+
+- type: entity
+  abstract: true
+  id: MonoEnergyShieldClothing
+  components:
+  - type: PersonalShield
+    shield:
+      maxCharge: 300
+      regenRate: 3
+      spinupTime: 1
+      breakCooldown: 15
+      powerDraw: 0.5
+  - type: ItemToggle
+    onUse: false
+    onAltUse: true
+    onActivate: false
+    soundActivate:
+      path: /Audio/Weapons/ebladeon.ogg
+    soundDeactivate:
+      path: /Audio/Weapons/ebladeoff.ogg
+    soundFailToActivate:
+      path: /Audio/Machines/button.ogg
+      params:
+        variation: 0.250
+  - type: Battery
+    maxCharge: 40
+    startingCharge: 40
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 4

--- a/Resources/Prototypes/_Mono/Shaders/personal_shields.yml
+++ b/Resources/Prototypes/_Mono/Shaders/personal_shields.yml
@@ -1,0 +1,7 @@
+# WARNING: Vibecoded. This shader is entirely vibecoded. Here be dragons.
+# While the shader has been tested extensively and I can somewhat comprehend it,
+# I have no way of confirming it will be stable outside of intended use.
+- type: shader
+  id: PersonalShieldSkin
+  kind: source
+  path: "/Textures/_Mono/Shaders/shield_skin.swsl"

--- a/Resources/Textures/_Mono/Shaders/shield_skin.swsl
+++ b/Resources/Textures/_Mono/Shaders/shield_skin.swsl
@@ -1,0 +1,175 @@
+light_mode unshaded;
+
+// Monolith: energy shield skin — a procedural hexfield dome, entirely
+// textureless (the whole pattern is shader math). Reused for both the planetary
+// shield (drawn over a planet disc) and the personal shield (drawn as a bubble
+// over a mob by PersonalShieldOverlay). The quad's UV is treated as a unit disc
+// (r = 1 at the quad edge), bulged into fake sphere coordinates so the hex cells
+// foreshorten toward the limb, then composed from a per-cell shimmering fill,
+// bright hex border lines, and a limb rim glow.
+//
+// `progress` runs 0 -> 2 in three phases:
+//   0.0 -> 1.0  the field crawls in across the dome from the top (activation).
+//   1.0 -> 1.8  the field shatters: a perlin dissolve eats it away in ragged
+//               noisy shards, each flashing hot right as it breaks off.
+//   1.8 -> 2.0  fully gone (invisible tail, so the clock can reset seamlessly).
+
+uniform highp float progress;
+uniform highp vec4 skin_color;
+
+// Multiplies the field's RGB — >1 pushes the colours hot/bloomy, <1 dims them.
+// Alpha (overall opacity) still comes from skin_color.a.
+uniform highp float brightness;
+
+// Pixellation: number of quantisation cells across the quad. Higher = finer (less
+// chunky); at/below 1 the spatial snap is skipped entirely and the field renders
+// smooth. Set by the overlay from the shield's PixelGrid field.
+uniform highp float pixel_grid;
+
+// Hex density: how many hex cells span the dome. Lower = fewer, larger cells. Set
+// by the overlay from the shield's HexDensity field.
+uniform highp float hex_density;
+
+// Formation origin, in disc space (-1..1, r = 1 at the dome edge): the point the
+// activation crawl sweeps out from. (0, -0.85) is the top of the dome. Set by the
+// overlay from the shield's FormOrigin field.
+uniform highp vec2 form_origin;
+
+// Strengths of the three layers: the wash inside the shell, the hex cell borders, and
+// the glow along the limb.
+uniform highp float fill_level;
+uniform highp float line_level;
+uniform highp float rim_level;
+
+// How much the field hollows out toward the middle. 0 fills the whole dome evenly; 1
+// leaves the centre almost clear and concentrates everything near the rim, so the
+// wearer stays visible through it the way a sci-fi bubble should.
+uniform highp float core_fade;
+
+// Frequency of the shatter noise. Higher = smaller, finer shards.
+uniform highp float shard_scale;
+
+// Posterise bands (lower = chunkier stepping) and depth of the slow pulse.
+uniform highp float alpha_bands;
+uniform highp float breath_depth;
+
+highp float hash21(highp vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// Value noise: smooth interpolated hash lattice. Used for the shatter dissolve so
+// the break front is organic and ragged rather than a clean sweep.
+highp float vnoise(highp vec2 p) {
+    highp vec2 i = floor(p);
+    highp vec2 f = fract(p);
+    highp float a = hash21(i);
+    highp float b = hash21(i + vec2(1.0, 0.0));
+    highp float c = hash21(i + vec2(0.0, 1.0));
+    highp float d = hash21(i + vec2(1.0, 1.0));
+    highp vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+// Signed-ish distance to the hex cell border: 0 at the centre, 0.5 at an edge.
+highp float hexDist(highp vec2 p) {
+    p = abs(p);
+    return max(dot(p, vec2(0.5, 0.866025)), p.x);
+}
+
+// Hex tiling: returns (edge distance, cell id hash) for the cell containing uv.
+highp vec2 hexCell(highp vec2 uv) {
+    highp vec2 r = vec2(1.0, 1.732051);
+    highp vec2 h = r * 0.5;
+    highp vec2 a = mod(uv, r) - h;
+    highp vec2 b = mod(uv - h, r) - h;
+    highp float useB = step(dot(b, b), dot(a, a));
+    highp vec2 gv = mix(a, b, useB);
+    highp vec2 id = uv - gv;
+    return vec2(hexDist(gv), hash21(id));
+}
+
+void fragment() {
+    // Pixel-art quantisation: snap the sample point to a coarse grid and step the
+    // clock at ~8 fps, so the field is chunky in space AND time — smooth per-frame
+    // motion on a pixel grid reads as cheap; steppy motion reads as sprite animation.
+    // pixel_grid <= 1 disables the spatial snap (smooth field) for small bubbles
+    // where a coarse grid looks too blocky.
+    highp vec2 uvq = UV;
+    if (pixel_grid > 1.0)
+        uvq = (floor(UV * pixel_grid) + vec2(0.5)) / pixel_grid;
+    highp float t = floor(TIME * 8.0) / 8.0;
+
+    // Disc space: r = 1 at the quad's inscribed circle (the overlay sizes the quad
+    // to the sprite, so the field hugs the disc).
+    highp vec2 p = (uvq - vec2(0.5)) * 2.0;
+    highp float r = length(p);
+
+    // Hard disc mask with a little AA; everything below multiplies into this.
+    highp float mask = 1.0 - smoothstep(0.97, 1.0, r);
+
+    // Fake dome: z is the shell height (1 centre → 0 limb). The equal-angle bulge
+    // asin(r)/r runs the hex grid faster toward the limb, so cells visibly
+    // foreshorten there — reads as a curved shell, not wallpaper.
+    highp float rc = min(r, 1.0);
+    highp float z = sqrt(max(1.0 - rc * rc, 0.0));
+    highp float warp = asin(rc) / max(rc, 0.0001);
+    highp vec2 q = p * warp;
+
+    highp vec2 cell = hexCell(q * hex_density);
+    highp float edge = cell.x;
+    highp float id = cell.y;
+
+    // Phase split: form is the 0 → 1 crawl parameter; shatter is the 0 → 1 dissolve
+    // parameter mapped from progress 1.0 → 1.8 (progress ≥ 1.8 leaves it clamped at
+    // 1, i.e. fully broken → invisible, for the 1.8 → 2.0 reset tail).
+    highp float form = clamp(progress, 0.0, 1.0);
+    highp float shatter = clamp((progress - 1.0) / 0.8, 0.0, 1.0);
+
+    // Formation crawl outward from the configurable origin.
+    highp float front = distance(p, form_origin) * 0.5;
+    highp float jitter = (id - 0.5) * 0.12;
+    highp float appear = step(front + jitter, form);
+    highp float fresh = smoothstep(0.25, 0.0, form - (front + jitter));
+
+    // Per-cell shimmer so the field feels energised without strobing.
+    highp float shimmer = 0.75 + 0.25 * sin(t * 1.7 + id * 6.2832);
+
+    // Edge weighting: (1 - z) is 0 dead centre and 1 out at the limb. Fading the wash and
+    // the hex lines by it hollows the dome out, so you look THROUGH the middle and the
+    // structure only reads near the edges — the usual sci-fi bubble. core_fade = 0 restores
+    // the old evenly-filled shell.
+    highp float limb = 1.0 - z;
+    highp float edgeWeight = mix(1.0, limb * limb, clamp(core_fade, 0.0, 1.0));
+
+    // Faint cell fill, brighter borders, hot pop-in, and the limb glow. The pop-in flash is
+    // NOT edge-weighted: it should read across the whole dome as the field sweeps in.
+    highp float border = smoothstep(0.42, 0.5, edge);
+    highp float fill = fill_level * shimmer * edgeWeight;
+    highp float lines = line_level * border * edgeWeight;
+    highp float rim = pow(limb, 3.0) * rim_level;
+
+    highp float a = (fill + lines + fresh * 0.6 + rim) * appear * mask;
+
+    // Shatter dissolve: every bit of the dome gets a break threshold from a noisy
+    // field (spatial perlin blended with per-cell jitter) so it comes apart in
+    // ragged clumps, not a ruler line. As `shatter` climbs past a fragment's
+    // threshold it winks out; fragments right at the front flash hot for the beat
+    // they break off, selling the shatter.
+    // Break threshold, scaled into [0, 0.85] so even the last-to-go fragment (plus
+    // its dissolve window and glow band) fully clears before `shatter` reaches 1 —
+    // otherwise the highest-threshold cells freeze mid-fade and never disappear.
+    highp float thr = clamp(vnoise(q * shard_scale) * 0.7 + id * 0.3, 0.0, 1.0) * 0.85;
+    highp float shard = 1.0 - smoothstep(thr, thr + 0.1, shatter);
+    highp float breakGlow = smoothstep(0.12, 0.0, abs(shatter - thr)) * step(0.001, shatter);
+    a = a * shard + breakGlow * 0.7 * mask;
+
+    // Slow breath over the whole shell — alive, never flickering off.
+    a *= (1.0 - breath_depth) + breath_depth * sin(t * 0.9);
+
+    // Posterise into a handful of alpha bands: no smooth gradients, just the
+    // stepped shading pixel art actually has.
+    highp float bands = max(alpha_bands, 1.0);
+    a = floor(clamp(a, 0.0, 1.0) * bands + 0.5) / bands;
+
+    COLOR = vec4(skin_color.rgb * brightness, skin_color.a * a);
+}


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Adds a new component for a full-body shield that tanks damage as a replacement for the existing suit shields. This only applies to one suit for now; migration can be done if no major bugs crop up.

## Why / Balance
I dislike the current shields.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
The shield shader is entirely vibecoded, I'm going to be honest. 

## How to test
Put on the Enforcer hardsuit that was changed and alt-click the equipped armor, then try taking some direct damage.

## Breaking changes
:P

**Changelog**
:cl:
- add: Ullman has released a new model of their ENFORCER MKII combat tacsuit with an upgraded shield generator.
