### PR TITLE
Shenzhen/Neptune Nerfs and Plates Fix

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Armor/armor_plates.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Armor/armor_plates.yml
@@ -19,7 +19,7 @@
     absorptionRatios:
       Blunt: 0.7
       Slash: 0.7
-      Burn: 1.2
+      Heat: -0.2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -50,7 +50,7 @@
     staminaDamageMultiplier: 1.0
     absorptionRatios:
       Piercing: 0.7
-      Burn: 1.2
+      Heat: -0.2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -81,7 +81,7 @@
     staminaDamageMultiplier: 1.0
     absorptionRatios:
       Heat: 0.7
-      Piercing: 1.2
+      Piercing: -0.2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -111,10 +111,10 @@
     sprintSpeedModifier: 1.1
     staminaDamageMultiplier: 2
     absorptionRatios:
-      Burn: 1.2
-      Piercing: 1.2
-      Blunt: 1.2
-      Slash: 1.2
+      Heat: -0.2
+      Piercing: -0.2
+      Blunt: -0.2
+      Slash: -0.2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
@@ -614,7 +614,7 @@
 - type: entity
   parent: BaseShipLPCRenewable
   id: ShipVoucherNeptune
-  name: PDV Neptune LPC [T1]
+  name: PDV Neptune LPC [T2]
   description: A small card that contains the data for the procurement of a Neptune-class frigate from the flagship's reserves.
   components:
   - type: Sprite
@@ -683,7 +683,6 @@
     vessels:
     - Scorpion
     - Bastion
-    - Neptune
     - Fenrir
     - Garm
     - Kalisto
@@ -844,6 +843,7 @@
     - Vulture
     - Ganymede
     - KortikR
+    - Neptune
 # end T2
 
 # start T3

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -80,9 +80,12 @@
   - type: HitscanBasicDamage
     damage:
       types:
-        Piercing: 120
+        Piercing: 20
+        Heat: 55
+        Shock: 5
         Structural: 500
-    armorPenetration: 0.8
+    ignoreResistances: true
+    #armorPenetration: 0.8
   - type: HitscanBasicRaycast
     maxDistance: 200
     collisionMask:

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/neptune.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/neptune.yml
@@ -3,8 +3,11 @@
 - type: vessel
   id: Neptune
   parent: BaseVesselAntag
-  name: PDW Neptune
+  name: PDV Neptune
   description: Equipped with heavy frontal armor, 6 Fang heavy 90mms, and 2 Trident torpedoes. Good for dealing with heavier targets in head on brawls, but it lacks capabilities to fight nimble and small targets.
+  limit: 3
+  hyperwarLimit: 5
+  hyperwarTimelock: 1800
   price: 153555 #126k appraisal
   purchasable: false # voucher only
   category: Medium


### PR DESCRIPTION
## About the PR
I'm going to ENJOY the public discourse on this one.

Neptune: I know that this thing has been rampantly deployed ever since T1 vouchers stopped being gatcha and the PDV uses it because it's cheap and it's the best lower tier ship they got. Why use their other even higher tier ships if they can spam Neptune and throw ms-250 shield on it to win? Bonus if you use it to ram. I know there are plans to shield shunt it, but right now, that is a while off, the Neptune map still has a shield on it...and right now in my opinion it functions much like the former Andromeda which was ALSO spammed heavily. It's a sub-tier 2 ship masquerading as a tier 1 ship, and this will force the PDV to choose what kind of T2 ships they want instead of going 'Neptune, duh'. Once the other changes the maints want to do to PDV tech in general come through, it can be re-evaluated where it belongs in the Tier list.

The SHENZHEN: Such a hot topic of debate for the PDV, this thing feels like it was made to counter the juggsuit. It used to do 120 damage with AP modification and it would guarantee a 1 hit, 1 shot critical, or stamcrit if a plate blocked it. It always felt weird to me that a laser coilgun that goes through glass doors shoots a pierce projectile anyway. I have modified the stats to do TRUE damage of 55 heat/5 shock/20 pierce. That way it doesn't have to overcompensate for a high AP juggsuit and overdamages everything in its path. It also allows the PDV to use either a heat or pierce plate to try to negate some of the damage. The planned PDV suit modifications to heat resistance is going to have no bearing on this since it's doing true damage.

Now for the PLATES: DTDumb and I were going over the code and we discovered that the 1.2 pierce resistance didn't add extra pierce damage as intended, it actually negated it. Same went for heat: if people had been running heat plates, they would've been resistant to both heat AND pierce, just nobody was using it since lasers weren't exactly super common. And likewise, SPEED plates pretty much negated everything. It's been modified to do -0.2 damage, which math wise..applies the 20% extra damage properly now. (Also in some places heat was incorrectly labeled as burn.)


<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="577" height="575" alt="Screenshot 2170" src="https://github.com/user-attachments/assets/8adf0897-1a6c-4b7f-bf91-3d8338f639c9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Moved Neptune to T2
- tweak: Modified Shenzhen to not be a 1 shot gun
- fix: Fixed plates to properly add damage it's weak to
