### PR TITLE
Fixed Plates (without Added Stuff)

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Armor/armor_plates.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Armor/armor_plates.yml
@@ -1,4 +1,8 @@
 # Blunt and Slash
+#READ THIS BEFORE EDITING THE ABSORPTION RATIOS
+# The maths for how the damage is calculated is "damage - [Multiplyer*damage]" so if the value is set to over 1, it removes all damage but if its set to a negative it adds damage
+# e.g. heat plate before fix: 24-[24*1.2] = 24-26.4 = -2.4 (which does no damage)
+# after fix it would be: 24-[24*-0.2] = 24+2.4 = 26.4 (which does more damage)
 - type: entity
   parent: BaseItem
   id: ArmorPlateBlunt_Slash
@@ -17,9 +21,9 @@
     sprintSpeedModifier: 0.95
     staminaDamageMultiplier: 1.0
     absorptionRatios:
-      Blunt: 0.7
-      Slash: 0.7
-      Burn: 1.2
+      Blunt: 0.3
+      Slash: 0.3
+      Heat: -0.2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -49,8 +53,8 @@
     sprintSpeedModifier: 0.95
     staminaDamageMultiplier: 1.0
     absorptionRatios:
-      Piercing: 0.7
-      Burn: 1.2
+      Piercing: 0.3
+      Heat: -0.2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -80,8 +84,8 @@
     sprintSpeedModifier: 0.95
     staminaDamageMultiplier: 1.0
     absorptionRatios:
-      Heat: 0.7
-      Piercing: 1.2
+      Heat: 0.3
+      Piercing: -0.2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -111,10 +115,10 @@
     sprintSpeedModifier: 1.1
     staminaDamageMultiplier: 2
     absorptionRatios:
-      Burn: 1.2
-      Piercing: 1.2
-      Blunt: 1.2
-      Slash: 1.2
+      Heat: -0.2
+      Piercing: -0.2
+      Blunt: -0.2
+      Slash: -0.2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible


### PR DESCRIPTION
Changed "burns" to heat
Added 3 new notes (line 3,4 and 5)
Fixed armour values so they actually work

## About the PR
Fixed bugs (plate bugs) and changed the armour values so they work
The maths behind the plates makes it so if the value is over 1 it removes all damage and negative numbers add damage (see edited file for more information)

## Why / Balance
Its a bug fix is why.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Shoot someone with a plate on, it should do more or less damage depending on the plate.

## Breaking changes
I didn't break anything

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: DTDumb
- fix: Fixed plates so they actually deal increased damage depending on the plate and protect from the correct amount of damage
