### PR TITLE
Fix Shields Rendering Behind Walls

### DIFF
--- a/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
+++ b/Content.Client/_Mono/PersonalShield/PersonalShieldOverlay.cs
@@ -24,7 +24,7 @@ public sealed partial class PersonalShieldOverlay : Overlay
     private readonly InventorySystem _inventory;
     private readonly ShaderInstance _shader;
 
-    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
 
     public PersonalShieldOverlay()
     {


### PR DESCRIPTION
I am not even going to bother with a proper description for this one. You can't see people's shields behind walls anymore. That's the fix.