### PR TITLE
[DNM] Shield Blocking Arc

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -4,6 +4,8 @@ using Content.Shared.Item.ItemToggle.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Content.Shared.Blocking.Components;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Blocking;
 
@@ -11,6 +13,8 @@ public sealed partial class BlockingSystem : SharedBlockingSystem // Mono
 {
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
+
+    [Dependency] private EntityQuery<PhysicsComponent> _physQuery = default!;
 
     private void InitializeUser()
     {
@@ -43,38 +47,43 @@ public sealed partial class BlockingSystem : SharedBlockingSystem // Mono
 
     private void OnUserDamageModified(EntityUid uid, BlockingUserComponent component, DamageModifyEvent args)
     {
-        if (TryComp<BlockingComponent>(component.BlockingItem, out var blocking)) // Mono
+        if (!TryComp<BlockingComponent>(component.BlockingItem, out var blocking)) // Mono
+            return;
+
+        if (args.Origin is { } origin // mono
+            && Math.Abs(Angle.ShortestDistance(_transformSystem.GetWorldRotation(uid), _transformSystem.GetWorldRotation(origin).Opposite()).Degrees) >= blocking.BlockingArc/2)
+            return;
+
+        if (args.Damage.GetTotal() <= 0)
+            return;
+
+        // A shield should only block damage it can itself absorb. To determine that we need the Damageable component on it.
+        if (!TryComp<DamageableComponent>(component.BlockingItem, out var dmgComp))
+            return;
+
+        if (TryComp<ItemToggleComponent>(component.BlockingItem, out var toggleComponent) && !toggleComponent.Activated) // Mono
+            return;
+
+        var blockFraction = blocking.IsBlocking ? blocking.ActiveBlockFraction : blocking.PassiveBlockFraction;
+        blockFraction = Math.Clamp(blockFraction, 0, 1);
+        _damageable.TryChangeDamage(component.BlockingItem,
+            blockFraction * args.OriginalDamage,
+            armorPenetration: args.ArmorPenetration); // Goob edit
+
+        var modify = new DamageModifierSet();
+        foreach (var key in dmgComp.Damage.DamageDict.Keys)
         {
-            if (args.Damage.GetTotal() <= 0)
-                return;
-
-            // A shield should only block damage it can itself absorb. To determine that we need the Damageable component on it.
-            if (!TryComp<DamageableComponent>(component.BlockingItem, out var dmgComp))
-                return;
-
-            if (TryComp<ItemToggleComponent>(component.BlockingItem, out var toggleComponent) && !toggleComponent.Activated) // Mono
-                return;
-
-            var blockFraction = blocking.IsBlocking ? blocking.ActiveBlockFraction : blocking.PassiveBlockFraction;
-            blockFraction = Math.Clamp(blockFraction, 0, 1);
-            _damageable.TryChangeDamage(component.BlockingItem,
-                blockFraction * args.OriginalDamage,
-                armorPenetration: args.ArmorPenetration); // Goob edit
-
-            var modify = new DamageModifierSet();
-            foreach (var key in dmgComp.Damage.DamageDict.Keys)
-            {
-                modify.Coefficients.TryAdd(key, 1 - blockFraction);
-            }
-
-            args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage,
-                DamageSpecifier.PenetrateArmor(modify ,args.ArmorPenetration)); // Goob edit
-
-            if (blocking.IsBlocking && !args.Damage.Equals(args.OriginalDamage))
-            {
-                _audio.PlayPvs(blocking.BlockSound, uid);
-            }
+            modify.Coefficients.TryAdd(key, 1 - blockFraction);
         }
+
+        args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage,
+            DamageSpecifier.PenetrateArmor(modify ,args.ArmorPenetration)); // Goob edit
+
+        if (blocking.IsBlocking && !args.Damage.Equals(args.OriginalDamage))
+        {
+            _audio.PlayPvs(blocking.BlockSound, uid);
+        }
+
     }
 
     private void OnDamageModified(EntityUid uid, BlockingComponent component, DamageModifyEvent args)

--- a/Content.Shared/Blocking/Components/BlockingComponent.cs
+++ b/Content.Shared/Blocking/Components/BlockingComponent.cs
@@ -90,4 +90,11 @@ public sealed partial class BlockingComponent : Component
     /// </summary>
     [DataField]
     public bool IsClothing = false;
+
+    /// <summary>
+    /// Mono - Projectiles will be blocked only
+    /// if it's in the arc of blocking user.
+    /// </summary>
+    [DataField]
+    public float BlockingArc = 105f;
 }

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -430,6 +430,7 @@
       reflects:
         - Energy
     - type: Blocking
+      blockingArc: 75 # Smaller than other shields. Mono edit.
       passiveBlockModifier:
         coefficients:
           Blunt: 1.0
@@ -459,9 +460,6 @@
       autoRechargeRate: 5
     - type: RechargeableBlocking
       # WD EDIT END
-    - type: ClothingSpeedModifier # Mono
-      sprintModifier: 0.9
-    - type: HeldSpeedModifier
 
 - type: entity
   name: broken energy shield

--- a/Resources/Prototypes/_Mono/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Shields/shields.yml
@@ -95,7 +95,7 @@
       sprite: _Mono/Objects/Weapons/Melee/shields.rsi
       state: heavy-icon
     - type: Item
-      size: Ginormous
+      size: Huge
       sprite: _Mono/Objects/Weapons/Melee/shields.rsi
       heldPrefix: heavy
     - type: Damageable
@@ -106,18 +106,19 @@
           Blunt: 0.35
           Slash: 0.35
           Piercing: 0.20
-          Heat: 0.35
+          Heat: 0.45
           Shock: 0.35
       passiveBlockFraction: 1
+      blockingArc: 135
     - type: ClothingSpeedModifier
-      sprintModifier: 0.3
-      walkModifier: 0.5
+      sprintModifier: 0.55
+      walkModifier: 0.8
     - type: HeldSpeedModifier
     - type: Destructible
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 200
+            damage: 180
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
awaiting for making clothing blocking system redundant

Shields now only block the arc they are currently facing. 
Removed slowdown from eshield
Heavy shield slowdown is now 45%. Health nerfed from 200 to 180. It receives more damage from the lasers.

Current arc values:
eshield - 75
default - 105
heavy - 135
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I do not like shields just giving you extra 50% on everything
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Heavy ballistic shield is much faster and less resistant now. Heavy ballistic shield blocking arc is now 135
- tweak: All shields now only block the arc they are currently facing. Default is 105
- tweak: Energy shield slowdown has been removed. Energy shield blocking arc is now 75
