### PR TITLE
Tiny Wheelchair User Fix

### DIFF
--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -29,6 +29,7 @@ using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nyanotrasen.Item.PseudoItem;
 using Content.Shared.Storage;
+using Content.Shared.Traits.Assorted; //Mono: Wheelchair user check
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Server.GameObjects;
@@ -329,6 +330,7 @@ namespace Content.Server.Carrying
             _actionBlockerSystem.UpdateCanMove(carried);
             _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
             _transform.AttachToGridOrMap(carried);
+            if (!HasComp<LegsParalyzedComponent>(carried)) // Mono: Check wheelchair user before standing
             _standingState.Stand(carried);
             _movementSpeed.RefreshMovementSpeedModifiers(carrier);
         }

--- a/Content.Server/_EE/Carrying/CarryingSystem.cs
+++ b/Content.Server/_EE/Carrying/CarryingSystem.cs
@@ -331,7 +331,7 @@ namespace Content.Server.Carrying
             _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
             _transform.AttachToGridOrMap(carried);
             if (!HasComp<LegsParalyzedComponent>(carried)) // Mono: Check wheelchair user before standing
-            _standingState.Stand(carried);
+                _standingState.Stand(carried);
             _movementSpeed.RefreshMovementSpeedModifiers(carrier);
         }
 

--- a/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
@@ -116,7 +116,8 @@ public abstract partial class SharedLayingDownSystem : EntitySystem
         // If the entity is not on a grid, try to make it stand up to avoid issues
         if (!TryComp<StandingStateComponent>(uid, out var standingState)
             || standingState.CurrentState is StandingState.Standing
-            || CanLieDown(uid)) // Mono
+            || CanLieDown(uid) // Mono
+            || HasComp<LegsParalyzedComponent>(uid)) // Mono
         {
             return;
         }

--- a/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
+using Content.Shared.Traits.Assorted; //Mono: Wheelchair user check
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
@@ -57,6 +58,9 @@ public abstract partial class SharedLayingDownSystem : EntitySystem
             return;
 
         var uid = args.SenderSession.AttachedEntity.Value;
+
+        if (HasComp<LegsParalyzedComponent>(uid)) //Mono: Stop wheelchair user trait from standing
+            return;
 
         // TODO: Wizard
         //if (HasComp<FrozenComponent>(uid))


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Attempting to toggle your standing state through SharedLayingDownSystem doesn't check if you are a paraplegic which causes a loophole situation where your standing state can be altered.

This change adds a quick and dirty check to prevent standing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix

Also technically a buff because you have no reason to stand up when taking wheelchair user trait. You might as well be constantly prone for that evasion.

Despite being prone in space I don't really really think their inability to use jetpacks or move at all in space really allows for any advantageous abuse. Maybe you'll survive a few extra gunshots but like what are you going to do without jetpack capabilities?

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

Use wheelchair user trait
Attempt to stand up
Space yourself and also try your best to stand 

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

Fix

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Prevented standing up when using wheelchair user trait
