### PR TITLE
Shuttle Console IFF Labels Change

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -69,7 +69,6 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
     public bool ShowDocks { get; set; } = true;
 
     public float MaximumIFFDistance { get; set; } = 3000f; // Frontier // Mono - 3000 by default to not gigaclutter
-    public bool HideCoords { get; set; } = false; // Frontier
 
     private static Color _dockLabelColor = Color.White; // Frontier
 
@@ -546,7 +545,6 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
         // Frontier
         if (state.MaxIffRange != null)
             MaximumIFFDistance = state.MaxIffRange.Value;
-        HideCoords = state.HideCoords;
         // End Frontier
 
         _docks = state.Docks;
@@ -763,6 +761,7 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
                     var labelText = Loc.GetString("shuttle-console-iff-label", ("name", labelName)!, ("distance", displayedDistance));
 
                     var coordsText = $"({gridMapPos.X:0.0}, {gridMapPos.Y:0.0})";
+                    var trackIdText = iff != null ? Loc.GetString("shuttle-console-track-label") + $"{iff.Address}" : Loc.GetString("shuttle-console-track-unknown-label");
 
                     #region Mono
 
@@ -791,9 +790,10 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
                     var radius = Width * 0.5f;
                     var squaredRadius = radius * radius;
 
+
                     // If true, flip the entire label to the right side of the blip and left-align it.
                     // We default to the label being on the left side of the blip because it looked better to me in testing. (arbitrary)
-                    var flipLabel = isOnLeftSide && labelCorners.Any(corner => corner.LengthSquared() > squaredRadius);
+                    var flipLabel = true; // isOnLeftSide && labelCorners.Any(corner => corner.LengthSquared() > squaredRadius); // Mono - comment out, we dont want this teehee
 
                     // Calculate unscaled offsets.
                     var labelOffset = new Vector2()
@@ -826,30 +826,30 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
                     // Draw main ship label with company color if available
                     handle.DrawString(Font, (uiPosition + labelOffset) * UIScale, mainLabel, UIScale * 0.9f, displayColor);
 
-                    // Draw company label if present
-                    if (!hideLabel && lines.Length > 1)
-                    {
-                        var companyLabel = lines[1];
-                        var companyLabelOffset = new Vector2(
-                            labelOffset.X,
-                            labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y
-                        );
+                    // Mono start - draw main stack of info
+                            // Get company label & draw
+                            var companyLabel =  !hideLabel ? lines[1] : Loc.GetString("shuttle-console-company-unknown");
+                            var companyLabelOffset = new Vector2(
+                                labelOffset.X,
+                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y
+                            );
+                            handle.DrawString(Font, (uiPosition + companyLabelOffset) * UIScale, companyLabel, UIScale * 0.7f, displayColor);
 
-                        handle.DrawString(Font, (uiPosition + companyLabelOffset) * UIScale, companyLabel, UIScale * 0.9f, displayColor);
-                    }
+                            // Draw coordinates
+                            var coordDimensions = handle.GetDimensions(Font, coordsText, 0.7f);
+                            var coordOffset = new Vector2(
+                                labelOffset.X,
+                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y + handle.GetDimensions(Font, companyLabel, 0.7f).Y);
+                            handle.DrawString(Font, (uiPosition + coordOffset) * UIScale, coordsText, 0.7f * UIScale, displayColor);
 
-                    if (isMouseOver && !HideCoords)
-                    {
-                        var coordDimensions = handle.GetDimensions(Font, coordsText, 0.7f);
-                        var coordOffset = new Vector2()
-                        {
-                            X = uiPosition.X > Width / 2f
-                                ? -coordDimensions.X - blipSize / 0.7f // right align the text to left of the blip (0.7 needed for scale)
-                                : blipSize, // left align the text to the right of the blip
-                            Y = labelOffset.Y + handle.GetDimensions(Font, mainLabel, 1f).Y + (lines.Length > 1 ? handle.GetDimensions(Font, lines[1], 1f).Y : 0) + 5
-                        };
-                        handle.DrawString(Font, (uiPosition + coordOffset) * UIScale, coordsText, 0.7f * UIScale, displayColor);
-                    }
+                            // Draw track ID (if it has one)
+                            var trackIdDimensions = handle.GetDimensions(Font, trackIdText, 0.7f);
+                            var trackIdOffset = new Vector2(
+                                labelOffset.X,
+                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y + handle.GetDimensions(Font, companyLabel, 0.7f).Y + handle.GetDimensions(Font, coordsText, 0.7f).Y);
+                            if (iff != null)
+                                handle.DrawString(Font, (uiPosition + trackIdOffset) * UIScale, trackIdText, 0.7f * UIScale, displayColor);
+                    // Mono end
                 }
 
                 NfAddBlipToList(_tempBlipDataList, isOutsideRadarCircle, uiPosition, uiXCentre, uiYCentre, labelColor, hideLabel ? default : gUid); // Frontier code

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -27,7 +27,7 @@ public sealed partial class ShuttleSystem
     private void OnIFFStartup(EntityUid uid, IFFComponent component, ComponentStartup args)
     {
         var num = _random.Next();
-        var address = $"{num >> 16:X4}-{num & 0xFFFF:X4}";
+        var address = $" {num >> 16:X4}-{num & 0xFFFF:X4}";
         component.Address = address;
     }
     // Mono end

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -9,8 +9,6 @@ namespace Content.Server.Shuttles.Systems;
 
 public sealed partial class ShuttleSystem
 {
-    private EntityQuery<IFFComponent> _iffQuery; // Mono
-
     private void InitializeIFF()
     {
         SubscribeLocalEvent<IFFConsoleComponent, AnchorStateChangedEvent>(OnIFFConsoleAnchor);
@@ -18,19 +16,7 @@ public sealed partial class ShuttleSystem
         SubscribeLocalEvent<IFFConsoleComponent, IFFShowVesselMessage>(OnIFFShowVessel);
         SubscribeLocalEvent<IFFConsoleComponent, BoundUIOpenedEvent>(OnIFFConsoleOpen);
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
-
-        _iffQuery = GetEntityQuery<IFFComponent>(); // Mono
-        SubscribeLocalEvent<IFFComponent, ComponentStartup>(OnIFFStartup); // Mono
     }
-
-    // Mono start
-    private void OnIFFStartup(EntityUid uid, IFFComponent component, ComponentStartup args)
-    {
-        var num = _random.Next();
-        var address = $" {num >> 16:X4}-{num & 0xFFFF:X4}";
-        component.Address = address;
-    }
-    // Mono end
 
     private void OnGridSplit(ref GridSplitEvent ev)
     {

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -9,6 +9,8 @@ namespace Content.Server.Shuttles.Systems;
 
 public sealed partial class ShuttleSystem
 {
+    private EntityQuery<IFFComponent> _iffQuery; // Mono
+
     private void InitializeIFF()
     {
         SubscribeLocalEvent<IFFConsoleComponent, AnchorStateChangedEvent>(OnIFFConsoleAnchor);
@@ -16,7 +18,19 @@ public sealed partial class ShuttleSystem
         SubscribeLocalEvent<IFFConsoleComponent, IFFShowVesselMessage>(OnIFFShowVessel);
         SubscribeLocalEvent<IFFConsoleComponent, BoundUIOpenedEvent>(OnIFFConsoleOpen);
         SubscribeLocalEvent<GridSplitEvent>(OnGridSplit);
+
+        _iffQuery = GetEntityQuery<IFFComponent>(); // Mono
+        SubscribeLocalEvent<IFFComponent, ComponentStartup>(OnIFFStartup); // Mono
     }
+
+    // Mono start
+    private void OnIFFStartup(EntityUid uid, IFFComponent component, ComponentStartup args)
+    {
+        var num = _random.Next();
+        var address = $"{num >> 16:X4}-{num & 0xFFFF:X4}";
+        component.Address = address;
+    }
+    // Mono end
 
     private void OnGridSplit(ref GridSplitEvent ev)
     {

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -36,6 +36,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Content.Shared.Maps;
+using Content.Shared.Shuttles.Components;
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -99,6 +100,7 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
 
         SubscribeLocalEvent<ShuttleComponent, ComponentStartup>(OnShuttleStartup);
         SubscribeLocalEvent<ShuttleComponent, ComponentShutdown>(OnShuttleShutdown);
+        SubscribeLocalEvent<IFFComponent, ComponentStartup>(OnShuttleIFFStartup); // Mono
         SubscribeLocalEvent<ShuttleComponent, TileFrictionEvent>(OnTileFriction);
         SubscribeLocalEvent<ShuttleComponent, FTLStartedEvent>(OnFTLStarted);
         SubscribeLocalEvent<ShuttleComponent, FTLCompletedEvent>(OnFTLCompleted);
@@ -157,6 +159,22 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
         }
 
         component.DampingModifier = component.BodyModifier;
+    }
+
+    // Mono - track ID
+    private void OnShuttleIFFStartup(EntityUid uid, IFFComponent component, ComponentStartup args)
+    {
+        if (!EntityManager.HasComponent<MapGridComponent>(uid))
+        {
+            return;
+        }
+
+        if (!EntityManager.TryGetComponent(uid, out PhysicsComponent? physicsComponent))
+        {
+            return;
+        }
+        var num = _random.Next();
+        component.Address = $" {num >> 16:X4}-{num & 0xFFFF:X4}";
     }
 
     public void Toggle(EntityUid uid, ShuttleComponent component,

--- a/Content.Shared/Shuttles/Components/IFFComponent.cs
+++ b/Content.Shared/Shuttles/Components/IFFComponent.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using Content.Shared.Shuttles.Systems;
 using Robust.Shared.GameStates;
 

--- a/Content.Shared/Shuttles/Components/IFFComponent.cs
+++ b/Content.Shared/Shuttles/Components/IFFComponent.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Content.Shared.Shuttles.Systems;
 using Robust.Shared.GameStates;
 
@@ -25,6 +26,12 @@ public sealed partial class IFFComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public Color Color = IFFColor;
+
+    /// <summary>
+    ///     Mono - ID to use for track
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    public string? Address = string.Empty;
 
     // Frontier: POI IFF protection
     /// <summary>

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
@@ -43,8 +43,8 @@ public abstract partial class SharedShuttleSystem
         }
 
         // Get the company information if available
-        Color? companyColor = null;
-        string? companyName = null;
+        Color? companyColor = Color.White;
+        string? companyName = Loc.GetString("shuttle-console-company-unknown");
 
         if (TryComp<_Mono.Company.CompanyComponent>(gridUid, out var companyComp) && !string.IsNullOrEmpty(companyComp.CompanyName))
         {

--- a/Resources/Locale/en-US/_NF/shuttles/console.ftl
+++ b/Resources/Locale/en-US/_NF/shuttles/console.ftl
@@ -23,6 +23,8 @@ shuttle-console-signature-unknown =
        *[other] Unknown
     }
 
+shuttle-console-company-unknown = UNAFFILIATED
+
 # Network Port Buttons
 shuttle-console-network-ports = Network Ports
 shuttle-console-network-connect-tooltip = The buttons on the shuttle console send a signal when pressed, use a multitool on the console and connect it up to a device!

--- a/Resources/Locale/en-US/shuttles/console.ftl
+++ b/Resources/Locale/en-US/shuttles/console.ftl
@@ -32,6 +32,8 @@ shuttle-console-travel-state-launching = Launching ({$countdown})
 
 shuttle-console-unknown = Unknown
 shuttle-console-iff-label = {$name} ({$distance}m)
+shuttle-console-track-unknown-label = TRACK.ID UNKNOWN
+shuttle-console-track-label = TRACK.ID
 shuttle-console-exclusion = Exclusion Area
 
 # Buttons

--- a/Resources/Maps/_Mono/Outpost/caelestinus_central.yml
+++ b/Resources/Maps/_Mono/Outpost/caelestinus_central.yml
@@ -129,8 +129,6 @@ entities:
       parent: 1
     - type: ForceAnchor
     - type: StationTransit
-    - type: IFF
-      readOnly: True
     - type: ProtectedGrid
       hostileMobKillSound: !type:SoundPathSpecifier
         path: /Audio/Effects/holy.ogg
@@ -42720,7 +42718,7 @@ entities:
 
 
 
-                      Sincerely, 
+                      Sincerely,
                            Engineering Unanimously
     - type: Physics
       canCollide: False
@@ -42834,7 +42832,7 @@ entities:
 
                                     [head=2]Shooting range is OPEN[/head]
 
-                                  [bold] PLEASE ANNOUNCE OVER PUBLIC 
+                                  [bold] PLEASE ANNOUNCE OVER PUBLIC
                                     CHANNELS BEFORE BEGINNING
                                                     LIVE FIRE TESTS
     - type: Tag

--- a/Resources/Maps/_Mono/Outpost/colonial.yml
+++ b/Resources/Maps/_Mono/Outpost/colonial.yml
@@ -4470,8 +4470,6 @@ entities:
       id: Frontier
     - type: ForceAnchor
     - type: StationTransit
-    - type: IFF
-      readOnly: True
     - type: ProtectedGrid
       preventArtifactTriggers: True
       preventEmpEvents: True

--- a/Resources/Maps/_Mono/Outpost/colossus_central.yml
+++ b/Resources/Maps/_Mono/Outpost/colossus_central.yml
@@ -93,8 +93,6 @@ entities:
       parent: 1
     - type: ForceAnchor
     - type: StationTransit
-    - type: IFF
-      readOnly: True
     - type: ProtectedGrid
       hostileMobKillSound: !type:SoundPathSpecifier
         path: /Audio/Effects/holy.ogg


### PR DESCRIPTION
## About the PR
IFF labels now always show coordinates and now show a unique track ID (allows for communicating info about X track w/o needing to describe it via relative position to a POI or whatever, also easier for communicating while IFF is off i suppose)

## Why / Balance
Larpy

## Media
<img width="213" height="128" alt="image" src="https://github.com/user-attachments/assets/e9ea6baa-e8f6-42f2-bf17-714bd7d3735c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Improved shuttle console IFF labels a bit.