### PR TITLE
Implement the Ability for Admins to Make Jobslots Unlimited via Toolshed

### DIFF
--- a/Content.Server/Station/Commands/JobsCommand.cs
+++ b/Content.Server/Station/Commands/JobsCommand.cs
@@ -86,6 +86,18 @@ public sealed class JobsCommand : ToolshedCommand
     [CommandImplementation("amount")]
     public IEnumerable<int> Amount([PipedArgument] IEnumerable<JobSlotRef> @ref)
         => @ref.Select(Amount);
+
+    [CommandImplementation("unlimited")]
+    public JobSlotRef Unlimited([PipedArgument] JobSlotRef @ref)
+    {
+        _jobs ??= GetSys<StationJobsSystem>();
+        _jobs.MakeJobUnlimited(@ref.Station, @ref.Job);
+        return @ref;
+    }
+
+    [CommandImplementation("unlimited")]
+    public IEnumerable<JobSlotRef> Unlimited([PipedArgument] IEnumerable<JobSlotRef> @ref)
+        => @ref.Select(Unlimited);
 }
 
 // Used for Toolshed queries.

--- a/Resources/Locale/en-US/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/commands/toolshed-commands.ftl
@@ -18,6 +18,8 @@ command-description-jobs-set =
     Sets the number of slots for the given job.
 command-description-jobs-amount =
     Returns the number of slots for the given job.
+command-description-jobs-unlimited =
+    Makes the given job have unlimited slots.
 command-description-laws-list =
     Returns a list of all law bound entities.
 command-description-laws-get =


### PR DESCRIPTION
## About the PR
It adds 1 arg

## Why / Balance
Convenience and i dont want to go to VV hell

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

**Changelog**
No player-facing changes.
