### PR TITLE
Radiation Slopping

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -470,7 +470,7 @@
         Slash: 0.8
         Piercing: 0.85
         Heat: 0.35
-        Radiation: 0.01 # Mono 0.0 -> 0.01
+        Radiation: 0.1 # Mono 0.0 -> 0.1
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.8
@@ -545,7 +545,7 @@
         Slash: 0.65 # Mono 0.65 < 0.8
         Piercing: 0.65 # Mono 0.65 < 0.9
         Heat: 0.3
-        Radiation: 0.01 # Mono 0.1 -> 0.0 -> 0.01
+        Radiation: 0.1
         Caustic: 0.2
   - type: ExplosionResistance
     damageCoefficient: 0.1
@@ -769,7 +769,7 @@
         Slash: 0.6
         Piercing: 0.6
         Heat: 0.35
-        Radiation: 0.01
+        Radiation: 0.1 # Mono: 0.01 -> 0.1
         Caustic: 0.5
   - type: Item
     size: Huge

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -117,7 +117,7 @@
     modifiers:
       coefficients:
         Heat: 0.90
-        Radiation: 0.01
+        Radiation: 0.1
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/rad.rsi
   - type: GroupExamine

--- a/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
@@ -5,4 +5,4 @@
     Cold: 0.2
     Heat: 1.5
     Shock: 2.5
-    Radiation: 0.3 # RIP
+    Radiation: 0.5 # RIP

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
@@ -243,7 +243,7 @@
         Heat: 0.7
         Shock: 0.4 # Mono
         Caustic: 0.4 # Mono
-        Radiation: 0.01 # Mono
+        Radiation: 0.1 # Mono
   - type: StaminaDamageResistance
     coefficient: 0.7 # Mono
 

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
@@ -181,7 +181,7 @@
         Slash: 0.75
         Piercing: 0.7
         Heat: 0.2
-        Radiation: 0.01
+        Radiation: 0.1
         Caustic: 0.5
   - type: Item
     size: Huge

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/modsuit.yml
@@ -116,7 +116,7 @@
         Piercing: 0.65
         Heat: 0.5
         Shock: 0.9
-        Radiation: 0.01
+        Radiation: 0.1
   - type: StaminaDamageResistance
     coefficient: 0.9
   - type: FireProtection

--- a/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
+++ b/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
@@ -254,7 +254,7 @@
   - type: RadiationReceiver
   - type: RadiationSource
     intensity: 1.2
-    slope: 1.3
+    slope: 10
   - type: ChainRadiation
     baseIntensity: 1.2
     coefficient: 0.15 # critical mass at 6


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes fissile uranium irradiate a smaller area. Also reduces radiation resistance from a lot of the "99% resistance" armors down to 90% so that you can't just Walk Around With Chernobyl. Also reduces silicon innate rad protection from 70% to 50%.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
people abuse it with IPC + 99% resistance apparently, so this should give IPCs a bit more to sweat about when doing it
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
n/a but three walls mitigates its effects now
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- tweak: 99% rad resist suits have gone down to 90% protection.
- tweak: Fissile uranium should irradiate a smaller area.
- tweak: Silicons are a bit more vulnerable to radiation now.
