### PR TITLE
Nobody Used that Button Anyways

### DIFF
--- a/Content.Client/Shuttles/UI/NavScreen.xaml
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml
@@ -130,8 +130,8 @@
                             TextAlign="Center"
                             StyleClasses="ButtonSquare"
                             ToggleMode="True"/>
-                    <controls:Button Name="IFFShuttleToggle"
-                             Text="{controls:Loc 'shuttle-console-iffshuttles-toggle'}"
+                    <controls:Button Name="IFFDetailedToggle"
+                             Text="{controls:Loc 'shuttle-console-iff-detailed'}"
                              TextAlign="Center"
                              StyleClasses="ButtonSquare"
                              ToggleMode="True"/>

--- a/Content.Client/Shuttles/UI/NavScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/NavScreen.xaml.cs
@@ -32,8 +32,8 @@ public sealed partial class NavScreen : BoxContainer
         IFFToggle.OnToggled += OnIFFTogglePressed;
         IFFToggle.Pressed = NavRadar.ShowIFF;
 
-        IFFShuttleToggle.OnToggled += OnIFFShuttleTogglePressed;
-        IFFShuttleToggle.Pressed = NavRadar.ShowIFFShuttles;
+        IFFDetailedToggle.OnToggled += OnIFFDetailedTogglePressed; // Mono
+        IFFDetailedToggle.Pressed = NavRadar.ShowIFFDetailed; // Mono
 
         DockToggle.OnToggled += OnDockTogglePressed;
         DockToggle.Pressed = NavRadar.ShowDocks;
@@ -100,10 +100,11 @@ public sealed partial class NavScreen : BoxContainer
         args.Button.Pressed = NavRadar.ShowIFF;
     }
 
-    private void OnIFFShuttleTogglePressed(BaseButton.ButtonEventArgs args)
+    // Mono
+    private void OnIFFDetailedTogglePressed(BaseButton.ButtonEventArgs args)
     {
-        NavRadar.ShowIFFShuttles ^= true;
-        args.Button.Pressed = NavRadar.ShowIFFShuttles;
+        NavRadar.ShowIFFDetailed ^= true;
+        args.Button.Pressed = NavRadar.ShowIFFDetailed;
     }
 
     private void OnDockTogglePressed(BaseButton.ButtonEventArgs args)

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -65,7 +65,7 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
     ];
 
     public bool ShowIFF { get; set; } = true;
-    public bool ShowIFFShuttles { get; set; } = true;
+    public bool ShowIFFDetailed { get; set; } = true;
     public bool ShowDocks { get; set; } = true;
 
     public float MaximumIFFDistance { get; set; } = 3000f; // Frontier // Mono - 3000 by default to not gigaclutter
@@ -695,12 +695,13 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
                 : _shuttles.GetIFFLabel(grid, self: false, component: iff);
 
             var shouldDrawIFF = ShowIFF && labelName != null;
+            var shouldDrawDetailedIFF = ShowIFFDetailed && shouldDrawIFF; // Mono
             if (shouldDrawIFF)
             {
                 if (IFFFilter != null)
                     shouldDrawIFF &= IFFFilter(gUid, grid.Comp, iff, hideLabel, labelName!);
-                if (isPlayerShuttle)
-                    shouldDrawIFF &= ShowIFFShuttles;
+                //if (isPlayerShuttle) // Mono - comments this out, replaced elsewere
+                //    shouldDrawIFF &= ShowIFFShuttles;
             }
 
             //var mapCenter = curGridToWorld. * gridBody.LocalCenter;
@@ -827,6 +828,8 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
                     handle.DrawString(Font, (uiPosition + labelOffset) * UIScale, mainLabel, UIScale * 0.9f, displayColor);
 
                     // Mono start - draw main stack of info
+                    if (shouldDrawDetailedIFF)
+                    {
                             // Get company label & draw
                             var companyLabel =  !hideLabel ? lines[1] : Loc.GetString("shuttle-console-company-unknown");
                             var companyLabelOffset = new Vector2(
@@ -849,6 +852,7 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
                                 labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y + handle.GetDimensions(Font, companyLabel, 0.7f).Y + handle.GetDimensions(Font, coordsText, 0.7f).Y);
                             if (iff != null)
                                 handle.DrawString(Font, (uiPosition + trackIdOffset) * UIScale, trackIdText, 0.7f * UIScale, displayColor);
+                    }
                     // Mono end
                 }
 

--- a/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml
+++ b/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml
@@ -87,6 +87,13 @@
                         <PanelContainer.PanelOverride>
                             <gfx:StyleBoxFlat BorderThickness="4" BorderColor="#2e2e2e" BackgroundColor="#1c1c1c" />
                         </PanelContainer.PanelOverride>
+                        <Button Name="IFFDetailedToggle" Access="Public" Text="{Loc 'shuttle-console-iff-detail'}"
+                                StyleClasses="ButtonSquare" HorizontalExpand="True" Margin="4 4" ToggleMode="True"/>
+                    </PanelContainer>
+                    <PanelContainer VerticalExpand="False" HorizontalExpand="True">
+                        <PanelContainer.PanelOverride>
+                            <gfx:StyleBoxFlat BorderThickness="4" BorderColor="#2e2e2e" BackgroundColor="#1c1c1c" />
+                        </PanelContainer.PanelOverride>
                         <Button Name="DockToggle" Access="Public" Text="{Loc 'shuttle-console-dock-toggle'}"
                                 StyleClasses="ButtonSquare" HorizontalExpand="True" Margin="4 4" ToggleMode="True"/>
                     </PanelContainer>

--- a/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlWindow.xaml.cs
@@ -44,6 +44,9 @@ public sealed partial class FireControlWindow : FancyWindow
         IFFToggle.OnToggled += OnIFFTogglePressed;
         IFFToggle.Pressed = NavRadar.ShowIFF;
 
+        IFFDetailedToggle.OnToggled += OnIFFDetailedTogglePressed; // Mono
+        IFFDetailedToggle.Pressed = NavRadar.ShowIFFDetailed; // Mono
+
         DockToggle.OnToggled += OnDockTogglePressed;
         DockToggle.Pressed = NavRadar.ShowDocks;
     }
@@ -148,6 +151,12 @@ public sealed partial class FireControlWindow : FancyWindow
     {
         NavRadar.ShowIFF ^= true;
         args.Button.Pressed = NavRadar.ShowIFF;
+    }
+
+    private void OnIFFDetailedTogglePressed(BaseButton.ButtonEventArgs args)
+    {
+        NavRadar.ShowIFFDetailed ^= true;
+        args.Button.Pressed = NavRadar.ShowIFFDetailed;
     }
 
     private void OnDockTogglePressed(BaseButton.ButtonEventArgs args)

--- a/Resources/Locale/en-US/shuttles/console.ftl
+++ b/Resources/Locale/en-US/shuttles/console.ftl
@@ -40,6 +40,7 @@ shuttle-console-exclusion = Exclusion Area
 shuttle-console-strafing = Strafing Mode
 shuttle-console-nav-settings = Settings
 shuttle-console-iff-toggle = Show IFF
+shuttle-console-iff-detailed = Detailed IFF
 shuttle-console-dock-toggle = Show Docks
 shuttle-console-iffshuttles-toggle = Show Shuttles
 


### PR DESCRIPTION
## About the PR
Replaces the show shuttles button that did nothing at all with a toggle for show detailed IFF (company/coords/track ID)

## Why / Balance
Readability

## Media
<img width="525" height="217" alt="image" src="https://github.com/user-attachments/assets/f5ca194e-f76f-4d09-ba68-902d461fed7d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a button to GCS and shuttle console to toggle showing detailed IFF.