### PR TITLE
Buff the Dragonfang so It's More on Par with the M90

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/tsfmc.yml
@@ -571,14 +571,15 @@
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: GunWieldBonus
-    minAngle: -8
-    maxAngle: -30
+    minAngle: -6
+    maxAngle: -18
   - type: Gun
-    minAngle: 12
-    maxAngle: 33
+    minAngle: 9
+    maxAngle: 20
     angleIncrease: 4
-    angleDecay: 40
-    fireRate: 4
+    angleDecay: 55
+    fireRate: 4.2
+    damageModifier: 1.2
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
   - type: ItemSlots


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Decrease maximum spread from 33 to 20. Increase recoil recovery from 40 to 55
increases the fireate from 4 to 4.2 and add a damage modifier of 1.2 (42 damage instead of 35 with starting ammo)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Currently the M90 absolutely kills you due to sheer firerat, while the dragonfang can be one handed and used with shield or sword for reflect, it obviously means you're investing way more to make it good. The recent PR made by fluff and starch indicate that the current direction of the server is the round-start combat, not midround to portstrike. balance must reflect this.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

Gun is available as loadout to FTL/Captain, spawn in and test it out

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: IronmoonHeathen
- tweak: Halthe has returned from winter solstice with the improved QBZ Dragonfang design,  the gas operated mechanism was now replaced with a better heavy reciprocating bolt or something like that, all parts are now upgraded. it fires slightly faster. hits harder and is more accurate.


