### PR TITLE
W Balance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -41,7 +41,7 @@
   name: minigun
   id: WeaponMinigun
   parent: BaseWeaponHeavyMachineGun
-  description: Vzzzzzt! Rahrahrahrah! Vrrrrr! Uses .10 rifle ammo. Illegal for use in the Frontier sector. # Frontier: edit description
+  description: Vzzzzzt! Rahrahrahrah! Vrrrrr! Uses .10 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/HMGs/minigun.rsi
@@ -50,7 +50,7 @@
   - type: Item
     sprite: Objects/Weapons/Guns/HMGs/minigun.rsi
   - type: Gun
-    fireRate: 15
+    fireRate: 50 # Mono
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/minigun.ogg
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -26,7 +26,7 @@
     maxAngle: 45
     angleIncrease: 3
     angleDecay: 20
-    fireRate: 8
+    fireRate: 11 # Mono
     projectileSpeed: 55 # Mono
     selectedMode: FullAuto
     availableModes:
@@ -125,7 +125,7 @@
       maxAngle: 20
       angleIncrease: 3
       angleDecay: 20
-      fireRate: 8
+      fireRate: 12 # Mono
       projectileSpeed: 55 # Mono
       selectedMode: FullAuto
       availableModes:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -26,6 +26,7 @@
     - suitStorage
     - Belt
   - type: Gun
+    damageModifier: 2 # Mono
     fireRate: 6
     selectedMode: SemiAuto
     availableModes:
@@ -275,6 +276,7 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
+    damageModifier: 3 # Mono
     fireRate: 4
     projectileSpeed: 30 # Mono
     soundGunshot:
@@ -326,6 +328,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
   - type: Gun
+    damageModifier: 2 # Mono
     fireRate: 5
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -30,6 +30,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/revolver.ogg
     projectileSpeed: 45 # Mono
+    damageModifier: 3 # Mono
   - type: UseDelay
     delay: 0.66
   - type: ContainerContainer
@@ -132,7 +133,7 @@
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/python_fire.ogg
       params:
         volume: 2.25
-    damageModifier: 0.8
+    damageModifier: 1.8
   - type: StaticPrice
     price: 1
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -16,7 +16,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    fireRate: 5
+    fireRate: 10 # Mono
     projectileSpeed: 55 # Mono
     selectedMode: FullAuto
     availableModes:
@@ -88,7 +88,7 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/Rifles/akm_inhands_32x.rsi # Mono
   - type: Gun
-    fireRate: 5
+    fireRate: 10 # Mono
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -18,8 +18,8 @@
   - type: Gun
     minAngle: 2
     maxAngle: 16
-    fireRate: 8
-    burstFireRate: 8
+    fireRate: 12 # Mono
+    burstFireRate: 14 # Mono
     angleIncrease: 3
     angleDecay: 16
     selectedMode: FullAuto
@@ -103,7 +103,7 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
-    fireRate: 5.5
+    fireRate: 15.67 # Mono
     minAngle: 1
     maxAngle: 6
     angleIncrease: 1.5
@@ -111,7 +111,7 @@
     selectedMode: FullAuto
     shotsPerBurst: 5
     burstCooldown: 0.2
-    burstFireRate: 7
+    burstFireRate: 15.67 # Mono
     availableModes:
     - Burst
     - FullAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -102,6 +102,7 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 3 # Goobstation
+    damageModifier: 1.2 # Mono
     selectedMode: FullAuto
     availableModes:
     - FullAuto
@@ -150,6 +151,7 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 3.5 #3->3.5 Mono
+    damageModifier: 3 # Mono
   - type: GunSpreadModifier #Mono
     spread: 0.4
   - type: BallisticAmmoProvider
@@ -191,7 +193,7 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 2.2 # Mono
-    damageModifier: 1.3
+    damageModifier: 1.5 # Mono
 #  - type: PirateBountyItem # Frontier - Mono
 #    id: Enforcer # Frontier - Mono
   - type: PirateBountyItem # Mono
@@ -223,6 +225,7 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 1.4
+    damageModifier: 2 # Mono
   - type: GunSpreadModifier
     spread: 0.7 #Mono: 0.6 >> 0.7
   - type: Tag
@@ -248,6 +251,7 @@
     sprite: _DV/Objects/Weapons/Guns/Shotguns/sawn.rsi # Delta-V: add _DV prefix, sawn_inhands_64x<sawn
   - type: Gun
     fireRate: 3.5
+    damageModifier: 3 # Mono
   - type: BallisticAmmoProvider
     soundRack: /Audio/Weapons/Guns/Cock/smg_cock.ogg #Mono
     capacity: 2
@@ -287,6 +291,7 @@
     sprite: Objects/Weapons/Guns/Shotguns/hm_pistol.rsi
   - type: Gun
     fireRate: 4
+    damageModifier: 1.2 # Mono
   - type: BallisticAmmoProvider
     soundRack: /Audio/Weapons/Guns/Cock/smg_cock.ogg #Mono
     capacity: 1
@@ -313,6 +318,7 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 2
+    damageModifier: 3 # Mono
   - type: BallisticAmmoProvider
     soundRack: /Audio/Weapons/Guns/Cock/smg_cock.ogg #Mono
     capacity: 1
@@ -337,6 +343,7 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 4 #No reason to stifle the firerate since you have to manually reload every time anyways.
+    damageModifier: 1.5 # Mono
   - type: BallisticAmmoProvider
     soundRack: /Audio/Weapons/Guns/Cock/smg_cock.ogg #Mono
     capacity: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -26,6 +26,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
     projectileSpeed: 65 # Mono
+    damageModifier: 2 # Mono
   - type: BallisticAmmoProvider
     capacity: 10
     proto: Cartridge762x39mmFMJ
@@ -78,6 +79,7 @@
     availableModes:
     - SemiAuto
     projectileSpeed: 25 # Mono
+    damageModifier: 3 # Mono
   - type: UseDelayOnShoot
   - type: UseDelay
     delay: 8 #it's a musket
@@ -110,6 +112,7 @@
     minAngle: 0
     maxAngle: 30 #miss him entirely because the barrel is smoothbore
     projectileSpeed: 25 # Mono
+    damageModifier: 1.2 # Mono
   - type: Item
     size: Small
     storedRotation: 90

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -14,6 +14,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Pistols/mk32.rsi
   - type: Gun
+    damageModifier: 2
     fireRate: 4 # Frontier: 3<4
     availableModes:
     - SemiAuto
@@ -57,6 +58,7 @@
   - type: Clothing
     sprite: _DV/Objects/Weapons/Guns/Pistols/pollock.rsi
   - type: Gun
+    damageModifier: 2
     fireRate: 5
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -19,7 +19,7 @@
     maxAngle: 20
     angleIncrease: 5
     angleDecay: 25
-    fireRate: 3.5 # Mono - 3.5
+    fireRate: 11.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -122,7 +122,7 @@
     maxAngle: 36
     angleIncrease: 2
     angleDecay: 8
-    fireRate: 8
+    fireRate: 12
     projectileSpeed: 35 # Mono
     selectedMode: FullAuto
     availableModes:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -21,7 +21,7 @@
     maxAngle: 45
     angleIncrease: 5
     angleDecay: 20
-    fireRate: 8
+    fireRate: 10
     soundGunshot:
       path: /Audio/_DV/Weapons/Guns/Gunshots/typewriter.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
@@ -24,6 +24,7 @@
     - suitStorage
     - Belt
   - type: Gun
+    damageModifier: 2
     fireRate: 3
     projectileSpeed: 40 # Mono
     availableModes:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
@@ -33,7 +33,7 @@
     projectileSpeed: 15
     minAngle: 42
     maxAngle: 64
-    fireRate: 10
+    fireRate: 12
     burstFireRate: 40
     shotsPerBurst: 5
     burstCooldown: 0.5

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/asakim.yml
@@ -23,7 +23,7 @@
   - type: Gun
     minAngle: 18
     maxAngle: 26
-    fireRate: 6
+    fireRate: 8
     burstFireRate: 15
     shotsPerBurst: 5
     burstCooldown: 1

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/frost.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/frost.yml
@@ -26,7 +26,7 @@
   - type: Gun
     minAngle: 21
     maxAngle: 34
-    fireRate: 5
+    fireRate: 10
     selectedMode: FullAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/magfed_lasers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/magfed_lasers.yml
@@ -15,7 +15,7 @@
   - type: Gun
     minAngle: 23
     maxAngle: 20
-    fireRate: 10
+    fireRate: 15
     selectedMode: FullAuto
     availableModes:
     - FullAuto
@@ -78,7 +78,7 @@
   - type: Gun
     minAngle: 23
     maxAngle: 64
-    fireRate: 0.7
+    fireRate: 1.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/pdv.yml
@@ -18,7 +18,7 @@
   - type: Gun
     minAngle: 35
     maxAngle: 53
-    fireRate: 1
+    fireRate: 3
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/tsf.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/tsf.yml
@@ -20,7 +20,7 @@
     maxAngle: 54
     angleIncrease: 27
     angleDecay: 2
-    fireRate: 3.5
+    fireRate: 6
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -94,7 +94,7 @@
     maxAngle: 22
     angleIncrease: -0.5
     angleDecay: -3
-    fireRate: 5
+    fireRate: 10
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -26,7 +26,7 @@
     maxAngle: 40
     angleIncrease: 7
     angleDecay: 28
-    fireRate: 6 # 360 rpm
+    fireRate: 11.5 # 690 rpm - Based off HK21 series, lowered by 110 because it would be fucking absurd to have it be 800.
     selectedMode: FullAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/pdv.yml
@@ -15,7 +15,7 @@
     maxAngle: 25
     angleIncrease: 3
     angleDecay: 20
-    fireRate: 16
+    fireRate: 50
     projectileSpeed: 45
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/minigun.ogg
@@ -64,7 +64,7 @@
     burstFireRate: 20
     burstCooldown: 0.6
     projectileSpeed: 45
-    fireRate: 7
+    fireRate: 10
     damageModifier: 0.9
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/wspr_fire.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/smartgun.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/smartgun.yml
@@ -19,7 +19,7 @@
     maxAngle: 73
     angleIncrease: 2
     angleDecay: 22
-    fireRate: 9.5
+    fireRate: 14
     cameraRecoilScalar: 0
     selectedMode: FullAuto
     availableModes:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/tsfmc.yml
@@ -20,7 +20,7 @@
     maxAngle: 46
     angleIncrease: 5
     angleDecay: 34
-    fireRate: 6 # 360 rpm
+    fireRate: 11.2
     selectedMode: FullAuto
     availableModes:
     - SemiAuto
@@ -170,7 +170,7 @@
     maxAngle: 12
     angleIncrease: 1
     angleDecay: 12
-    fireRate: 8 # same as L6, but more accurate and heavier
+    fireRate: 11.67
     selectedMode: FullAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/ussp.yml
@@ -19,7 +19,7 @@
     maxAngle: 40
     angleIncrease: 2
     angleDecay: 22
-    fireRate: 8
+    fireRate: 9.16
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/CCTC.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/CCTC.yml
@@ -16,6 +16,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Pistols/mk32.rsi
   - type: Gun
+    damageModifier: 2
     fireRate: 4
     burstFireRate: 18
     shotsPerBurst: 2

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/pistol.yml
@@ -16,6 +16,7 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/Pistols/UllmanSmartMagnumMK5_inhands_32x.rsi
   - type: Gun
+    damageModifier: 1.5
     fireRate: 3.5
     selectedMode: SemiAuto
     availableModes:
@@ -80,6 +81,7 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/Pistols/kuosame.rsi
   - type: Gun
+    damageModifier: 2
     fireRate: 6
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/recharging.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Pistols/recharging.yml
@@ -16,6 +16,7 @@
     - suitStorage
     - Belt
   - type: Gun
+    damageModifier: 1.5
     fireRate: 2
     projectileSpeed: 65
     availableModes:
@@ -69,6 +70,7 @@
     - suitStorage
     - Belt
   - type: Gun
+    damageModifier: 1.5
     fireRate: 1.5
     projectileSpeed: 75
     burstCooldown: 0.75

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/mmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/mmc.yml
@@ -19,9 +19,9 @@
     maxAngle: 62
     angleIncrease: 0.2
     angleDecay: 17
-    fireRate: 5.4
+    fireRate: 12.5
     selectedMode: FullAuto
-    damageModifier: 1.2
+    damageModifier: 1
     availableModes:
     - SemiAuto
     - FullAuto
@@ -87,7 +87,7 @@
     maxAngle: 62
     angleIncrease: 1
     angleDecay: 17
-    fireRate: 3
+    fireRate: 5
     selectedMode: SemiAuto
     damageModifier: 2
     availableModes:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/nt.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/nt.yml
@@ -27,7 +27,7 @@
     angleIncrease: 6
     angleDecay: 40
     cameraRecoilScalar: 0
-    fireRate: 9
+    fireRate: 12.5
     availableModes:
     - FullAuto
     soundGunshot:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/pdv.yml
@@ -19,7 +19,7 @@
     minAngle: -31
     maxAngle: -46
   - type: Gun
-    fireRate: 7
+    fireRate: 11.67
     projectileSpeed: 120
     angleDecay: 6
     angleIncrease: 3
@@ -83,11 +83,12 @@
   - type: Gun
     availableModes:
     - Burst
-    selectedMode: Burst
+    - FullAuto
+    selectedMode: FullAuto
     burstFireRate: 20 # Mono
     burstCooldown: 0.6 # Mono
     projectileSpeed: 45 # Mono
-    fireRate: 7.5 # Mono, does nothing because its burst only but it makes it clear it can fire at this rate.
+    fireRate: 15
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/wspr_fire.ogg # Mono change - Changed audio path
   - type: ItemSlots
@@ -195,7 +196,7 @@
     maxAngle: 64
     angleIncrease: 2
     angleDecay: 25
-    fireRate: 7
+    fireRate: 11.25
     selectedMode: FullAuto
     damageModifier: 0.95
     availableModes:
@@ -325,7 +326,7 @@
     maxAngle: 64
     angleIncrease: 5
     angleDecay: 25
-    fireRate: 6
+    fireRate: 12
     burstFireRate: 12
     burstCooldown: 0.5
     shotsPerBurst: 2

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -78,7 +78,7 @@
     angleIncrease: 76
     angleDecay: 7
     cameraRecoilScalar: 0
-    fireRate: 3
+    fireRate: 10
     selectedMode: Burst
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/light_rifle_1.ogg # Mono
@@ -142,7 +142,7 @@
     angleIncrease: 12
     angleDecay: 20
     cameraRecoilScalar: 0
-    fireRate: 8
+    fireRate: 12
     availableModes:
     - FullAuto
     soundGunshot:
@@ -227,7 +227,7 @@
     maxAngle: 58
     angleIncrease: 1.5
     angleDecay: 20
-    fireRate: 8.4
+    fireRate: 12.5
     selectedMode: FullAuto
     damageModifier: 0.95 # Brings it down to 152.95 DPS from 161 DPS (assuming perfect accuracy with FMJ on an unarmored target); Lecter has less DPS, but Lecter also has really fucking good accuracy and is free roundstart.
     availableModes:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/tsfmc.yml
@@ -19,7 +19,7 @@
     maxAngle: 35
     angleIncrease: 4
     angleDecay: 40
-    fireRate: 11 # 660 rpm
+    fireRate: 16
     shotsPerBurst: 3
     availableModes:
     - Burst
@@ -93,7 +93,7 @@
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: Gun
-    fireRate: 6 # Mono
+    fireRate: 13
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/light_rifle_1.ogg # Mono
   - type: ItemSlots
@@ -252,7 +252,7 @@
     burstFireRate: 12
     burstCooldown: 0.8
     shotsPerBurst: 4
-    fireRate: 7
+    fireRate: 12.5
     projectileSpeed: 42.5 # Mono
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/thock.ogg
@@ -412,7 +412,7 @@
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: Gun
-    fireRate: 6
+    fireRate: 12 # 1 lower than normal lecter, bag tax.
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/light_rifle_1.ogg # Mono
   - type: ItemSlots
@@ -578,7 +578,7 @@
     maxAngle: 33
     angleIncrease: 4
     angleDecay: 40
-    fireRate: 4
+    fireRate: 11.67
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
   - type: ItemSlots

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/ussp.yml
@@ -20,7 +20,7 @@
     maxAngle: 52
     angleIncrease: 6
     angleDecay: 24
-    fireRate: 5 # 300 rpm
+    fireRate: 11
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/ak_fire.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/nt.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/nt.yml
@@ -21,7 +21,7 @@
     sprite: _Mono/Objects/Weapons/Guns/SMGs/ntsf_hclm_45.rsi
   - type: Gun
     damageModifier: 0.8
-    fireRate: 6
+    fireRate: 8
     selectedMode: FullAuto
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/dmr.ogg

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/pdv.yml
@@ -23,7 +23,7 @@
     maxAngle: 40
     angleIncrease: 5
     angleDecay: 20
-    fireRate: 8
+    fireRate: 12
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/mla_fire.ogg
   - type: ChamberMagazineAmmoProvider
@@ -136,7 +136,7 @@
     - state: mag-0
       map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
-    fireRate: 8.5
+    fireRate: 15
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/atreides_fire.ogg
   - type: MagazineVisuals
@@ -191,6 +191,7 @@
     maxAngle: 32
     shotsPerBurst: 5
     damageModifier: 0.85
+    fireRate: 12
     availableModes:
     - Burst
     - FullAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -19,8 +19,8 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/SMGs/vector.rsi
   - type: Gun
-    fireRate: 7.5
-    damageModifier: 0.8
+    fireRate: 20 # jfc
+    damageModifier: 0.7
     selectedMode: Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -29,7 +29,7 @@
     - SemiAuto
     - FullAuto
     burstCooldown: 0.5
-    burstFireRate: 14
+    burstFireRate: 25
     shotsPerBurst: 3
   - type: ItemSlots
     slots:
@@ -145,7 +145,8 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/SMGs/vector.rsi
   - type: Gun
-    fireRate: 6
+    fireRate: 20 # jfc
+    damageModifier: 0.7
     selectedMode: Burst
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
@@ -154,7 +155,7 @@
     - SemiAuto
     - FullAuto
     burstCooldown: 0.5
-    burstFireRate: 14
+    burstFireRate: 25
     shotsPerBurst: 3
   - type: ItemSlots
     slots:
@@ -270,7 +271,8 @@
   - type: Clothing
     sprite: _Mono/Objects/Weapons/Guns/SMGs/knallstock.rsi
   - type: Gun
-    fireRate: 6
+    fireRate: 7.5
+    damageModifier: 1.4
     minAngle: 19
     maxAngle: 21
     angleIncrease: 16
@@ -330,7 +332,7 @@
     maxAngle: 55
     angleIncrease: 18
     angleDecay: 4
-    fireRate: 7
+    fireRate: 10
   - type: StaticPrice
     price: 500
 
@@ -354,7 +356,7 @@
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/SMGs/drozd.rsi
   - type: Gun
-    fireRate: 6
+    fireRate: 11.3
     selectedMode: FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
@@ -403,7 +405,7 @@
     maxAngle: 15
     angleIncrease: 2
     angleDecay: 2
-    fireRate: 7.5
+    fireRate: 15.8
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/atreides_fire.ogg
     availableModes:
@@ -463,7 +465,7 @@
     maxAngle: 32
     angleIncrease: 2
     angleDecay: 2
-    fireRate: 6.5
+    fireRate: 10
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/atreides_fire.ogg
     availableModes:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/tsfmc.yml
@@ -29,7 +29,7 @@
   - type: Gun
     minAngle: 21
     maxAngle: 32
-    fireRate: 7 # Mono
+    fireRate: 15 # Mono
     burstFireRate: 12
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/smg.ogg # Mono

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/SMGs/ussp.yml
@@ -22,7 +22,7 @@
   - type: Gun
     minAngle: 22
     maxAngle: 40
-    fireRate: 6
+    fireRate: 12
     angleIncrease: 21
     angleDecay: 14
     selectedMode: FullAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Shotguns/pdv.yml
@@ -18,6 +18,7 @@
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/bigshotgun_fire.ogg
     fireRate: 0.7
+    damageModifier: 2 # Mono
     selectedMode: Semiauto
     availableModes:
     - SemiAuto
@@ -59,6 +60,7 @@
     soundGunshot:
       path: /Audio/_Mono/Weapons/Guns/SmallArms/Gunshots/bigshotgun_fire.ogg
     fireRate: 4
+    damageModifier: 1.2 # Mono
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/pdv.yml
@@ -11,6 +11,7 @@
   - type: GunRequiresWield
   - type: Gun
     fireRate: 0.75
+    damageModifier: 1.2
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -27,6 +27,7 @@
     minAngle: 27
     maxAngle: 39
     fireRate: 2
+    damageModifier: 3
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/tsfmc.yml
@@ -97,8 +97,8 @@
     maxAngle: 48
     angleIncrease: 27
     angleDecay: 2
-    fireRate: 3 # 180 rpm
-    damageModifier: 1.5
+    fireRate: 4
+    damageModifier: 2
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -237,6 +237,7 @@
   - type: Gun
     minAngle: 32 # Mono
     maxAngle: 54 # Mono
+    damageModifier: 2
     angleIncrease: 14
     angleDecay: 5
     selectedMode: SemiAuto

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/ussp.yml
@@ -25,10 +25,10 @@
     minAngle: -27
     maxAngle: -36
   - type: Gun
+    damageModifier: 2.5
     minAngle: 27
     maxAngle: 39
     fireRate: 2.25
-    damageModifier: 1.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -124,6 +124,8 @@
   - type: EyeCursorOffset
     maxOffset: 1.5
     pvsIncrease: 0.15
+  - type: Gun
+    damageModifier: 2.5
   - type: AltFireMelee
     attackType: Light
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -92,8 +92,8 @@
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/Rifles/gestio.rsi
   - type: Gun
-    fireRate: 4
-    burstFireRate: 8
+    fireRate: 10
+    burstFireRate: 14
     shotsPerBurst: 3
     burstCooldown: 0.4
     selectedMode: Burst
@@ -175,7 +175,7 @@
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/Rifles/novalitec1.rsi
   - type: Gun
-    fireRate: 5
+    fireRate: 12
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto
@@ -257,7 +257,7 @@
     - Back
     - suitStorage
   - type: Gun
-    fireRate: 1.9
+    fireRate: 3
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto
@@ -323,8 +323,8 @@
   - type: Clothing
     sprite: _NF/Objects/Weapons/Guns/Rifles/gestio.rsi
   - type: Gun
-    fireRate: 4
-    burstFireRate: 8
+    fireRate: 10
+    burstFireRate: 14
     shotsPerBurst: 3
     burstCooldown: 0.4
     selectedMode: Burst

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -26,3 +26,5 @@
       - Cartridge357_magnumFMJ
     capacity: 7
     proto: Cartridge357_magnumFMJ
+  - type: Gun
+    damageModifier: 2


### PR DESCRIPTION
## About the PR
Makes every gun too OP for me to care about balance anymore.
Pistols, DMRs/snipers, and revolvers get giant damage buffs.
Rifles, LMGs, and SMGs get Realistic Firerates (so imagine like double the firerate for everything).
Shotguns get damage modifiers too (not 4ga though, and 12ga still doesnt beat it)
also gives fullauto back to wspr for w as val larps

Audio is a little bit fucky with this but you can just `cvar audio.default_concurrent 32` (or more) in console

## Why / Balance
True balance through making every weapon kill in less than a second. No more whining about 1 RPS difference.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Every weapon is like really powerful now. If you're having audio problems with the firerate, do "cvar audio.default_concurrent 32" in console.
- tweak: WSPR has full auto again.
