### PR TITLE
Adds SRD Comp to More Things

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
@@ -91,6 +91,9 @@
   - type: FootstepModifier # mono
     footstepSoundCollection:
       collection: FootstepHull
+  - type: ShipRepairable # Mono
+    repairTime: 15
+    repairCost: 100
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/switch.yml
@@ -40,6 +40,9 @@
   - type: Tag
     tags:
     - Structure
+  - type: ShipRepairable # Mono
+    repairTime: 1
+    repairCost: 5
 
 - type: entity
   id: SignalButton
@@ -104,6 +107,9 @@
   - type: Tag
     tags:
     - Structure
+  - type: ShipRepairable # Mono
+    repairTime: 1
+    repairCost: 5
 
 - type: entity
   id: ApcNetSwitch
@@ -194,6 +200,9 @@
     - type: Tag
       tags:
       - Structure
+    - type: ShipRepairable # Mono
+      repairTime: 1
+      repairCost: 5
 
 #directional
 

--- a/Resources/Prototypes/Entities/Structures/catwalk.yml
+++ b/Resources/Prototypes/Entities/Structures/catwalk.yml
@@ -61,3 +61,6 @@
     delay: 2
     fx: EffectRCDDeconstruct2
   - type: RequiresGrid # Mono
+  - type: ShipRepairable # Mono
+    repairTime: 1
+    repairCost: 5

--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -69,6 +69,9 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: SyncSprite # Frontier
+  - type: ShipRepairable # Mono
+    repairTime: 1
+    repairCost: 10
 
 - type: entity
   id: ConveyorBeltAssembly

--- a/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
+++ b/Resources/Prototypes/Entities/Structures/plastic_flaps.yml
@@ -44,6 +44,9 @@
     mode: NoSprite
   - type: StaticPrice
     price: 100
+  - type: ShipRepairable # Mono
+    repairTime: 15
+    repairCost: 50
 
 - type: entity
   id: PlasticFlapsClear

--- a/Resources/Prototypes/_Mono/Entities/Structures/catwalk.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/catwalk.yml
@@ -54,6 +54,9 @@
     delay: 2
     fx: EffectRCDDeconstruct2
   - type: RequiresGrid
+  - type: ShipRepairable # Mono
+    repairTime: 1
+    repairCost: 5
 
 - type: entity
   id: DarkCatwalkMono


### PR DESCRIPTION
## About the PR
adds shiprepairable to like 10 things that didnt have them

## Why / Balance
real QOL

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Added more things to the list of ship-repairable items. Just minor stuff like conveyors, catwalks, plastic flaps, and all constructible machines.
