### PR TITLE
Industry Optics Fix Lol

### DIFF
--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/components.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/components.yml
@@ -41,3 +41,14 @@
     Copper: 300
     Lithium: 500
 
+- type: latheRecipe
+  id: OpticsEconomy1Recipe
+  result: OpticsEconomy1
+  categories:
+  - Materials
+  completetime: 15
+  materials:
+    Glass: 500
+    Copper: 300
+    Steel: 300
+

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
@@ -1,12 +1,13 @@
 - type: latheRecipePack
   id: IndustrialPressEconomyElectronics
   recipes:
-  - MatterBinEconomy1Recipe
   - MicroprocessorEconomy1Recipe
   - CapacitorEconomy1Recipe
+  - OpticsEconomy1Recipe
 
 - type: latheRecipePack
   id: IndustrialPressEconomyPlates
   recipes:
   - ArmorPlateEconomy1Recipe
   - ElectromagnetEconomy1Recipe
+  - MatterBinEconomy1Recipe


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
makes optics craftable now
also moves matter bin to the plates press
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
turns out they're really important + I forgot woops
matter bins are more metal than electronic imo
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
no
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- tweak: Economy matter bins are now made in the plates industrial press.
- fix: Fixed being unable to craft basic optics. Get them at your local electronics press.

