### PR TITLE
Industry 2.8?

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1468,7 +1468,7 @@
       ComponentBrickEconomy1:
         amount: 1
         defaultPrototype: ComponentBrickEconomy1
-      ElectromagnetEconomy2:
+      ElectromagnetEconomy1:
         amount: 1
         defaultPrototype: ElectromagnetEconomy1
       ArmorPlateEconomy3:

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/scrap_processor.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/scrap_processor.yml
@@ -134,28 +134,17 @@
         - id: CapacitorStockPart
         - id: MicroManipulatorStockPart
         - id: MatterBinStockPart
-        - id: SalvagePartsT2Spawner
       - !type:GroupSelector
         children:
-        - id: AdvancedCapacitorStockPart
-        - id: NanoManipulatorStockPart
-        - id: AdvancedMatterBinStockPart
         - id: SalvagePartsT2Spawner
+      - !type:GroupSelector
+        weight: 0.5
+        children:
         - id: SalvagePartsT3Spawner
       - !type:GroupSelector
         weight: 0.5
         children:
-        - id: SuperCapacitorStockPart
-        - id: PicoManipulatorStockPart
-        - id: SuperMatterBinStockPart
-        - id: SalvagePartsT3Spawner
-      - !type:GroupSelector
-        weight: 0.5
-        children:
-        - id: QuadraticCapacitorStockPart
-        - id: FemtoManipulatorStockPart
-        - id: BluespaceMatterBinStockPart
-        - id: SalvagePartsT3T4Spawner
+        - id: SalvagePartsT4Spawner
    - !type:GroupSelector
      weight: 0.75
      children:

--- a/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/scrap_processor.yml
+++ b/Resources/Prototypes/_Mono/Entities/Markers/Spawners/Random/scrap_processor.yml
@@ -134,23 +134,28 @@
         - id: CapacitorStockPart
         - id: MicroManipulatorStockPart
         - id: MatterBinStockPart
+        - id: SalvagePartsT2Spawner
       - !type:GroupSelector
         children:
         - id: AdvancedCapacitorStockPart
         - id: NanoManipulatorStockPart
         - id: AdvancedMatterBinStockPart
+        - id: SalvagePartsT2Spawner
+        - id: SalvagePartsT3Spawner
       - !type:GroupSelector
         weight: 0.5
         children:
         - id: SuperCapacitorStockPart
         - id: PicoManipulatorStockPart
         - id: SuperMatterBinStockPart
+        - id: SalvagePartsT3Spawner
       - !type:GroupSelector
         weight: 0.5
         children:
         - id: QuadraticCapacitorStockPart
         - id: FemtoManipulatorStockPart
         - id: BluespaceMatterBinStockPart
+        - id: SalvagePartsT3T4Spawner
    - !type:GroupSelector
      weight: 0.75
      children:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Economy/arc_furnace.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Economy/arc_furnace.yml
@@ -200,6 +200,9 @@
         acts: [ "Destruction" ]
   - type: StaticPrice
     price: 3000
+  - type: Construction
+    graph: ArmorPlateEconomy2Finish
+    node: finished
 
 - type: entity
   name: heavy armor plate (unfinished)
@@ -457,7 +460,7 @@
 
 - type: entity
   name: EMAG armor plate (unfinished)
-  description: The ceramic/metallic plate component of an EMAG armor plate, fresh off the forge and awaiting its electronic components. Needs 30 LV cables to begin construction, then significant screwing and cutting.
+  description: The ceramic/metallic plate component of an EMAG armor plate, fresh off the forge and awaiting its electronic components. Needs a compound electromagnet to begin construction, then significant screwing and cutting.
   parent: ArmorPlateEconomy4Broken
   id: ArmorPlateEconomy4Start
   components:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Economy/components.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Economy/components.yml
@@ -432,7 +432,7 @@
 
 - type: entity
   name: superconductive electromagnet (unfinished)
-  description: A work-in-progress superconductive electromagnet. Needs 10 LV cables to begin construction, then significant welding.
+  description: A work-in-progress superconductive electromagnet. Needs further assembling in an precision assembler.
   parent: BaseEconomyGoodTier2
   id: ElectromagnetEconomy3Start
   components:

--- a/Resources/Prototypes/_Mono/Recipes/Cooking/precision_assembler_recipes.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Cooking/precision_assembler_recipes.yml
@@ -49,6 +49,21 @@
     SiliconBouleEconomy: 1
   recipeType: PrecisionAssembler
 
+# Optics
+
+- type: microwaveMealRecipe
+  id: RecipeOpticsEconomy2
+  name: precision optical sensor recipe
+  result: OpticsEconomy2
+  time: 15
+  group: PrecisionAssembler
+  solids:
+    OpticsEconomy1: 1
+    CapacitorEconomy1: 2
+  reagents:
+    Phenol: 20
+  recipeType: PrecisionAssembler
+
 # Capacitors
 
 - type: microwaveMealRecipe

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/components.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/components.yml
@@ -41,3 +41,14 @@
     Copper: 300
     Lithium: 500
 
+- type: latheRecipe
+  id: OpticsEconomy1Recipe
+  result: OpticsEconomy1
+  categories:
+  - Materials
+  completetime: 10
+  materials:
+    Steel: 300
+    Copper: 100
+    Glass: 300
+

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/components.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Economy/components.yml
@@ -48,7 +48,7 @@
   - Materials
   completetime: 10
   materials:
+    Glass: 500
+    Copper: 300
     Steel: 300
-    Copper: 100
-    Glass: 300
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
@@ -1,6 +1,6 @@
 - type: latheRecipePack
   id: IndustrialPressEconomyElectronics
-  recipes:y
+  recipes:
   - MicroprocessorEconomy1Recipe
   - CapacitorEconomy1Recipe
   - OpticsEconomy1Recipe

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
@@ -1,12 +1,13 @@
 - type: latheRecipePack
   id: IndustrialPressEconomyElectronics
-  recipes:
-  - MatterBinEconomy1Recipe
+  recipes:y
   - MicroprocessorEconomy1Recipe
   - CapacitorEconomy1Recipe
+  - OpticsEconomy1Recipe
 
 - type: latheRecipePack
   id: IndustrialPressEconomyPlates
   recipes:
   - ArmorPlateEconomy1Recipe
   - ElectromagnetEconomy1Recipe
+  - MatterBinEconomy1Recipe


### PR DESCRIPTION
## About the PR
fixes heavy armor plate being broken
fixes both optics being unobtainable
moves matter bins to plate press
adds industry comps to refined scrap table

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Scrap processor can now drop some economy components at a rare chance.
- tweak: Moved economy matter bins to the plate press from electronics press.
- fix: Fixed heavy armor plates and optics being unobtainable from Industry.
