### PR TITLE
Make Portstrikes Sane

### DIFF
--- a/Resources/Prototypes/_Mono/GameRules/timings.yml
+++ b/Resources/Prototypes/_Mono/GameRules/timings.yml
@@ -17,13 +17,13 @@
     warLevel: true
 
 - type: entity
-  id: PortstrikeAnnounceRuleRandom1To3
+  id: PortstrikeAnnounceRuleRandom35To45
   parent: PortstrikeAnnounceRuleHour4
   components:
   - type: GameRule
     delay:
-      min: 3600 # 1 hr
-      max: 10800 # 3 hr
+      min: 12600 # 3.5hr
+      max: 16200 # 4.5hr
 
 - type: entity
   id: PortstrikeAnnounceRuleHour2

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -17,7 +17,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom1To3
+  - PortstrikeAnnounceRuleRandom35To45
 
 - type: gamePreset
   id: MonoRogueTSF
@@ -33,7 +33,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom1To3
+  - PortstrikeAnnounceRuleRandom35To45
 
 - type: gamePreset
   id: MonoRogueUSSP
@@ -49,7 +49,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom1To3
+  - PortstrikeAnnounceRuleRandom35To45
 
 - type: gamePreset
   id: MonoTSFUSSP
@@ -65,7 +65,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom1To3
+  - PortstrikeAnnounceRuleRandom35To45
 
 - type: gamePreset
   id: MonoADS
@@ -84,7 +84,7 @@
   - MonoAISTCShuttleSpawnerSchedulerTier2
   #- MonoAsakimSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom1To3
+  - PortstrikeAnnounceRuleRandom35To45
 
 - type: gamePreset
   id: MonoChimera
@@ -101,7 +101,7 @@
   - FrontierRoundstartVariation
   - MonoChimeraSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom1To3
+  - PortstrikeAnnounceRuleRandom35To45
 
 - type: gamePreset
   id: MonoMixed
@@ -121,7 +121,7 @@
   - MonoAISTCShuttleSpawnerSchedulerTier2Slow
   #- MonoAsakimSTCShuttleSpawnerSchedulerSlow
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom1To3
+  - PortstrikeAnnounceRuleRandom35To45
 
 - type: gamePreset
   id: MonoAllAtOnce


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
portstrike now starts randomly from 3.5h to 4.5h instead of 1h and 3h
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
no one likes defending base from reactor explosion for 5 hours
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Portstrike timing has been changed - Now its random from 3.5h to 4.5h
