### PR TITLE
Flatpacker Slop

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1546,18 +1546,16 @@
     requirements: # Frontier
       Manipulator: 2 # Frontier stackRequirements<requirements
       MatterBin: 1 # Frontier stackRequirements<requirements
-    stackRequirements:
-      Steel: 1
     tagRequirements: # Mono
       MicroprocessorEconomy1:
         amount: 2
         defaultPrototype: MicroprocessorEconomy1
-      ComponentBrickEconomy1:
+      ComponentBrickEconomy3:
         amount: 1
-        defaultPrototype: ComponentBrickEconomy1
-      MotorEconomy1:
+        defaultPrototype: ComponentBrickEconomy3
+      MotorEconomy2:
         amount: 2
-        defaultPrototype: ElectromagnetEconomy1
+        defaultPrototype: ElectromagnetEconomy2
       OpticsEconomy1:
         amount: 2
         defaultPrototype: OpticsEconomy1

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1553,8 +1553,8 @@
       ComponentBrickEconomy3:
         amount: 1
         defaultPrototype: ComponentBrickEconomy3
-      MotorEconomy2:
-        amount: 2
+      ElectromagnetEconomy2:
+        amount: 1
         defaultPrototype: ElectromagnetEconomy2
       OpticsEconomy1:
         amount: 2

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1550,12 +1550,12 @@
       MicroprocessorEconomy1:
         amount: 2
         defaultPrototype: MicroprocessorEconomy1
-      ComponentBrickEconomy3:
+      ComponentBrickEconomy1:
         amount: 1
-        defaultPrototype: ComponentBrickEconomy3
-      ElectromagnetEconomy2:
+        defaultPrototype: ComponentBrickEconomy1
+      ElectromagnetEconomy1:
         amount: 1
-        defaultPrototype: ElectromagnetEconomy2
+        defaultPrototype: ElectromagnetEconomy1
       OpticsEconomy1:
         amount: 2
         defaultPrototype: OpticsEconomy1

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -32,18 +32,17 @@
           False: { visible: false }
   - type: FlatpackCreator
     baseMachineCost:
-      Steel: 750
+      Steel: 1000
       Silver: 100
-      Gold: 50
-      Lithium: 50 # Mono
-      Copper: 50 # Mono
-      Iridite: 20 # Mono
+      Gold: 500
+      Lithium: 500 # Mono
+      Copper: 500 # Mono
+      Plastitanium: 10
     baseComputerCost:
       Steel: 500
       Glass: 250
       Silver: 100
       Gold: 50
-      Iridite: 20 # Mono
   - type: Machine
     board: FlatpackerMachineCircuitboard
   - type: MaterialStorage

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -37,12 +37,13 @@
       Gold: 500
       Lithium: 500 # Mono
       Copper: 500 # Mono
-      Plastitanium: 10
+      Bluespace: 100
     baseComputerCost:
       Steel: 500
       Glass: 250
       Silver: 100
       Gold: 50
+      Bluespace: 50
   - type: Machine
     board: FlatpackerMachineCircuitboard
   - type: MaterialStorage

--- a/Resources/Prototypes/_Mono/Entities/Objects/Economy/arc_furnace.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Economy/arc_furnace.yml
@@ -81,7 +81,6 @@
     materialComposition:
       Steel: 1000
       Plasteel: 500
-  - type: MultiHandedItem
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.8
@@ -260,7 +259,6 @@
         acts: [ "Destruction" ]
   - type: Item
     size: Huge
-  - type: MultiHandedItem
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.6
@@ -442,7 +440,6 @@
         acts: [ "Destruction" ]
   - type: Item
     size: Huge
-  - type: MultiHandedItem
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.6
@@ -558,7 +555,6 @@
         acts: [ "Destruction" ]
   - type: Item
     size: Huge
-  - type: MultiHandedItem
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.5


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Replaces the iridite cost for flatpacking with plastitanium, and increased the base cost slightly.
Flatpackers themselves also cost more expensive components.
Also removes two handed requirement for armor plates since it blocked automation.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
people didn't like iridite, so now plastitanium is used instead since its more well known.
armor plate bug
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
nah
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- tweak: Flatpackers cost bluespace for tax instead of iridite.
- fix: Armor plates should now fit in interactors.