### PR TITLE
Adds an Overlay for Damaged Entities when Using a Nanite Applicator

### DIFF
--- a/Content.Client/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
+++ b/Content.Client/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
@@ -27,11 +27,13 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
     [Dependency] private SharedMapSystem _map = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SpriteSystem _sprite = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
 
     private float _updateTimer = 0.0f;
     private bool _active = false;
 
     private Dictionary<EntityUid, Color> _modifiedEntities = new();
+    private List<NetEntity> _entities = new();
 
     public override void Initialize()
     {
@@ -48,7 +50,7 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
             return;
 
         var player = _player.LocalEntity;
-        if (player == null || !HasComp<NaniteOverlayEyeComponent>(player))
+        if (player == null || !TryComp<NaniteOverlayEyeComponent>(player, out var eye))
         {
             ClearOverlays();
             _active = false;
@@ -66,20 +68,34 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
 
         _updateTimer = 1.0f;
 
-        // 1. Find entities that have Repairable, Damageable & SpriteComponent
-        var query = EntityQueryEnumerator<RepairableComponent, DamageableComponent, SpriteComponent>();
-        List<NetEntity> entities = new();
-
-        while (query.MoveNext(out EntityUid uid, out var repairable, out var damageable, out var sprite))
+        // 0. Remove entities that went out of range
+        List<EntityUid> toRemove = new();
+        foreach (var entity in _modifiedEntities)
         {
-            if (!TerminatingOrDeleted(uid) && damageable.TotalDamage > 0)
+            if ((_transform.GetWorldPosition(Transform(entity.Key)) - _transform.GetWorldPosition(Transform(player.Value))).LengthSquared() > (eye.Range * eye.Range + 1))
+                toRemove.Add(entity.Key);
+        }
+
+        foreach (var entry in toRemove)
+        {
+            _sprite.SetColor(entry, _modifiedEntities[entry]);
+            _modifiedEntities.Remove(entry);
+        }
+
+        // 1. Find entities that have Repairable, Damageable (SpriteComponent too but everything has that)
+        var candidates = _lookup.GetEntitiesInRange<RepairableComponent>(Transform(player.Value).Coordinates, eye.Range, LookupFlags.Uncontained);
+        _entities.Clear();
+
+        foreach (var entity in candidates)
+        {
+            if (!TerminatingOrDeleted(entity) && TryComp<DamageableComponent>(entity, out var damageable) && damageable.TotalDamage > 0)
             {
-                entities.Add(GetNetEntity(uid));
+                _entities.Add(GetNetEntity(entity));
             }
         }
 
         // 2. Ask the server for their damage threshold
-        RaiseNetworkEvent(new NaniteOverlayMessage(entities.ToArray()));
+        RaiseNetworkEvent(new NaniteOverlayMessage(_entities.ToArray()));
 
         // 3. Once server replies, draw them by changing the color of the entity based on the threshold
         // 4. If we lose the overlay eye (tool put away, etc.) change the color of the entities back to what it was previously
@@ -90,14 +106,21 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
         if (message.Responses == null || !_active)
             return;
 
-        int i = -1;
-        foreach (var response in message.Responses)
+        for (int i = 0; i < message.Responses.Length; i++)
         {
-            i++;
-            if (response == 0)
-                continue;
+            var response = message.Responses[i];
 
-            ShowOverlay(GetEntity(message.Targets[i]), response);
+            if (response > 0) // if entity is damaged
+                ShowOverlay(GetEntity(message.Targets[i]), response);
+            else if (response == 0) // entity was repaired and is at full health
+            {
+                var uid = GetEntity(message.Targets[i]);
+                if (!uid.Valid || TerminatingOrDeleted(uid) && _modifiedEntities.ContainsKey(uid))
+                {
+                    _sprite.SetColor(uid, _modifiedEntities[uid]);
+                    _modifiedEntities.Remove(uid);
+                }
+            }
         }
     }
 

--- a/Content.Client/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
+++ b/Content.Client/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
@@ -1,0 +1,173 @@
+
+
+using Content.Client.Hands;
+using Content.Client.NetworkConfigurator.Systems;
+using Content.Shared._Mono.NaniteOverlay;
+using Content.Shared._Mono.ShipRepair.Components;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Content.Shared.Popups;
+using Content.Shared.Repairable;
+using Robust.Client.GameObjects;
+using Robust.Client.Player;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Timing;
+using System.Linq;
+using System.Numerics;
+using static Robust.Client.GameObjects.SpriteComponent;
+
+namespace Content.Client._Mono.NaniteOverlay;
+
+public sealed partial class NaniteOverlaySystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IPlayerManager _player = default!;
+    [Dependency] private IMapManager _mapMan = default!;
+    [Dependency] private SharedMapSystem _map = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SpriteSystem _sprite = default!;
+
+    private float _updateTimer = 0.0f;
+    private bool _active = false;
+
+    private Dictionary<EntityUid, Color> _modifiedEntities = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<NaniteOverlayMessage>(OnNaniteOverlayMessage);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        var player = _player.LocalEntity;
+        if (player == null || !HasComp<NaniteOverlayEyeComponent>(player))
+        {
+            ClearOverlays();
+            _active = false;
+            _updateTimer = 0.0f;
+            return;
+        }
+
+        _active = true;
+
+        if (_updateTimer > 0.0f)
+        {
+            _updateTimer -= frameTime;
+            return;
+        }
+
+        _updateTimer = 1.0f;
+
+        // 1. Find entities that have Repairable, Damageable & SpriteComponent
+        var query = EntityQueryEnumerator<RepairableComponent, DamageableComponent, SpriteComponent>();
+        List<NetEntity> entities = new();
+
+        while (query.MoveNext(out EntityUid uid, out var repairable, out var damageable, out var sprite))
+        {
+            if (!TerminatingOrDeleted(uid) && damageable.TotalDamage > 0)
+            {
+                entities.Add(GetNetEntity(uid));
+            }
+        }
+
+        // 2. Ask the server for their damage threshold
+        RaiseNetworkEvent(new NaniteOverlayMessage(entities.ToArray()));
+
+        // 3. Once server replies, draw them by changing the color of the entity based on the threshold
+        // 4. If we lose the overlay eye (tool put away, etc.) change the color of the entities back to what it was previously
+    }
+
+    public void OnNaniteOverlayMessage(NaniteOverlayMessage message, EntitySessionEventArgs eventArgs)
+    {
+        Logger.GetSawmill("overlay").Warning($"Client received message from server with {message.Responses?.Length} responses!");
+
+        if (message.Responses == null || !_active)
+            return;
+
+        int i = -1;
+        foreach (var response in message.Responses)
+        {
+            i++;
+            if (response == 0)
+                continue;
+
+            ShowOverlay(GetEntity(message.Targets[i]), response);
+        }
+    }
+
+    private void ShowOverlay(EntityUid uid, FixedPoint2 threshold)
+    {
+        if (!uid.Valid || TerminatingOrDeleted(uid))
+            return;
+
+        if(!_modifiedEntities.ContainsKey(uid))
+        {
+            SpriteComponent sc = Comp<SpriteComponent>(uid);
+            _modifiedEntities.Add(uid, sc.Color);
+        }
+
+        DamageableComponent dc = Comp<DamageableComponent>(uid);
+        float health = 1.0f - (dc.TotalDamage / threshold).Float();
+        _sprite.SetColor(uid, GetColor(health));
+    }
+
+    private Color GetColor(float health)
+    {
+        health = Math.Clamp(health, 0.0f, 1.0f);
+
+        float hue = 0.0f;
+        float sat = 1.0f;
+        float val = 1.0f;
+
+        if (health >= 0.85f) // Green to Yellow (Fast 15% window)
+        {
+            float t = (health - 0.85f) / 0.15f;
+            hue = 0.1666f + (t * (0.2200f - 0.1666f));
+            sat = 0.8000f + (t * (0.9000f - 0.8000f));
+            val = 1.0000f - (t * (1.0000f - 0.9500f));
+        }
+        else if (health >= 0.50f) // Yellow to Gold-Orange (35% window)
+        {
+            float t = (health - 0.50f) / 0.35f;
+            hue = 0.1000f + (t * (0.1666f - 0.1000f)); // Ends at 0.1000 hue (a rich neon gold-orange)
+            sat = 1.0000f - (t * (1.0000f - 0.8000f));
+            val = 1.0f;
+        }
+        else if (health >= 0.25f) // Gold-Orange to Red (25% window)
+        {
+            float t = (health - 0.25f) / 0.25f;
+            hue = 0.0000f + (t * 0.1000f);
+            sat = 1.0f;
+            val = 1.0f;
+        }
+        else // Red to Near Black-Red (Only the final 25%)
+        {
+            float t = health / 0.25f;
+            hue = 0.0f;
+            sat = 1.0f;
+            val = 0.08f + (t * 0.92f); // Floor dropped to 0.08f so your final square looks nearly dead
+        }
+
+        return Color.FromHsv(new Vector4(hue, sat, val, 1.0f));
+    }
+
+    private void ClearOverlays()
+    {
+        foreach (var ent in _modifiedEntities)
+        {
+            _sprite.SetColor(ent.Key, ent.Value);
+        }
+
+        _modifiedEntities.Clear();
+    }
+
+    private record struct OverlayData();
+}

--- a/Content.Client/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
+++ b/Content.Client/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
@@ -87,8 +87,6 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
 
     public void OnNaniteOverlayMessage(NaniteOverlayMessage message, EntitySessionEventArgs eventArgs)
     {
-        Logger.GetSawmill("overlay").Warning($"Client received message from server with {message.Responses?.Length} responses!");
-
         if (message.Responses == null || !_active)
             return;
 
@@ -168,6 +166,4 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
 
         _modifiedEntities.Clear();
     }
-
-    private record struct OverlayData();
 }

--- a/Content.Server/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
+++ b/Content.Server/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
@@ -1,0 +1,120 @@
+using Content.Server.Destructible;
+using Content.Server.Destructible.Thresholds.Triggers;
+using Content.Shared._Mono.NaniteOverlay;
+using Content.Shared._Mono.ShipRepair.Components;
+using Content.Shared.Eye;
+using Content.Shared.FixedPoint;
+using Content.Shared.Hands;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Tools.Components;
+using Content.Shared.Tools.Systems;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Content.Server._Mono.NaniteOverlay;
+
+public sealed partial class NaniteOverlaySystem : EntitySystem
+{
+    [Dependency] private SharedEyeSystem _eye = default!;
+    [Dependency] private SharedToolSystem _tool = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ToolComponent, GotEquippedHandEvent>(OnToolHandEquipped);
+        SubscribeLocalEvent<ToolComponent, GotEquippedEvent>(OnToolEquipped);
+        SubscribeLocalEvent<ToolComponent, GotUnequippedHandEvent>(OnToolHandUnequipped);
+        SubscribeLocalEvent<ToolComponent, GotUnequippedEvent>(OnToolUnequipped);
+        SubscribeLocalEvent<NaniteOverlayEyeComponent, GetVisMaskEvent>(OnGetVis);
+
+        SubscribeNetworkEvent<NaniteOverlayMessage>(OnNaniteOverlayMessage);
+    }
+
+    private void OnNaniteOverlayMessage(NaniteOverlayMessage message, EntitySessionEventArgs eventArgs)
+    {
+        //TODO: security?
+
+        var ents = GetEntityArray(message.Targets);
+        var response = new FixedPoint2[ents.Length];
+
+        int i = -1;
+        foreach (var ent in ents)
+        {
+            i++;
+            if (!ent.Valid || !TryComp<DestructibleComponent>(ent, out var destructible))
+            {
+                response[i] = 0;
+                continue;
+            }
+
+            var trigger = (DamageTrigger?)destructible.Thresholds.LastOrDefault(threshold => threshold.Trigger is DamageTrigger)?.Trigger;
+            if (trigger == null)
+            {
+                response[i] = 0;
+                continue;
+            }
+
+            response[i] = trigger.Damage;
+        }
+
+        RaiseNetworkEvent(new NaniteOverlayMessage(message.Targets, response), eventArgs.SenderSession);
+    }
+
+    private void OnEquip(EntityUid user)
+    {
+        var comp = EnsureComp<NaniteOverlayEyeComponent>(user);
+        comp.Count++;
+
+        if (comp.Count > 1)
+            return;
+
+        _eye.RefreshVisibilityMask(user);
+    }
+
+    private void OnUnequip(EntityUid user)
+    {
+        if (!TryComp(user, out NaniteOverlayEyeComponent? comp))
+            return;
+
+        comp.Count--;
+
+        if (comp.Count > 0)
+            return;
+
+        RemComp<NaniteOverlayEyeComponent>(user);
+        _eye.RefreshVisibilityMask(user);
+    }
+
+    private void OnToolHandEquipped(Entity<ToolComponent> ent, ref GotEquippedHandEvent args)
+    {
+        if(_tool.HasQuality(ent, "Applicating"))
+            OnEquip(args.User);
+    }
+
+    private void OnToolEquipped(Entity<ToolComponent> ent, ref GotEquippedEvent args)
+    {
+        if (_tool.HasQuality(ent, "Applicating"))
+            OnEquip(args.Equipee);
+    }
+
+    private void OnToolHandUnequipped(Entity<ToolComponent> ent, ref GotUnequippedHandEvent args)
+    {
+        if (_tool.HasQuality(ent, "Applicating"))
+            OnUnequip(args.User);
+    }
+
+    private void OnToolUnequipped(Entity<ToolComponent> ent, ref GotUnequippedEvent args)
+    {
+        if (_tool.HasQuality(ent, "Applicating"))
+            OnUnequip(args.Equipee);
+    }
+
+    private void OnGetVis(Entity<NaniteOverlayEyeComponent> ent, ref GetVisMaskEvent args)
+    {
+        args.VisibilityMask |= (int)VisibilityFlags.Subfloor;
+    }
+}

--- a/Content.Server/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
+++ b/Content.Server/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
@@ -41,30 +41,27 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
         var ents = GetEntityArray(message.Targets);
         var response = new FixedPoint2[ents.Length];
 
-        int i = -1;
-        foreach (var ent in ents)
+        for (int i = 0; i < ents.Length; i++)
         {
-            i++;
+            var ent = ents[i];
+
             if (!ent.Valid || !TryComp<DestructibleComponent>(ent, out var destructible))
             {
-                response[i] = 0;
+                response[i] = -1;
                 continue;
             }
 
             var trigger = (DamageTrigger?)destructible.Thresholds.LastOrDefault(threshold => threshold.Trigger is DamageTrigger)?.Trigger;
             if (trigger == null)
-            {
-                response[i] = 0;
-                continue;
-            }
-
-            response[i] = trigger.Damage;
+                response[i] = -1;
+            else
+                response[i] = trigger.Damage;
         }
 
         RaiseNetworkEvent(new NaniteOverlayMessage(message.Targets, response), eventArgs.SenderSession);
     }
 
-    private void OnEquip(EntityUid user)
+    private void OnEquip(EntityUid user, Entity<ToolComponent> tool)
     {
         var comp = EnsureComp<NaniteOverlayEyeComponent>(user);
         comp.Count++;
@@ -92,13 +89,13 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
     private void OnToolHandEquipped(Entity<ToolComponent> ent, ref GotEquippedHandEvent args)
     {
         if(_tool.HasQuality(ent, "Applicating"))
-            OnEquip(args.User);
+            OnEquip(args.User, ent);
     }
 
     private void OnToolEquipped(Entity<ToolComponent> ent, ref GotEquippedEvent args)
     {
         if (_tool.HasQuality(ent, "Applicating"))
-            OnEquip(args.Equipee);
+            OnEquip(args.Equipee, ent);
     }
 
     private void OnToolHandUnequipped(Entity<ToolComponent> ent, ref GotUnequippedHandEvent args)

--- a/Content.Server/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
+++ b/Content.Server/_Mono/NaniteOverlay/NaniteOverlaySystem.cs
@@ -36,7 +36,7 @@ public sealed partial class NaniteOverlaySystem : EntitySystem
 
     private void OnNaniteOverlayMessage(NaniteOverlayMessage message, EntitySessionEventArgs eventArgs)
     {
-        //TODO: security?
+        //TODO: security? idk if this could be an issue if someone spams it to lag or dos the server
 
         var ents = GetEntityArray(message.Targets);
         var response = new FixedPoint2[ents.Length];

--- a/Content.Shared/_Mono/NaniteOverlay/NaniteOverlayEyeComponent.cs
+++ b/Content.Shared/_Mono/NaniteOverlay/NaniteOverlayEyeComponent.cs
@@ -11,4 +11,10 @@ public sealed partial class NaniteOverlayEyeComponent : Component
 {
     [DataField]
     public int Count = 0;
+
+    /// <summary>
+    /// How far away should the repairable entities be colored?
+    /// </summary>
+    [DataField]
+    public int Range = 5;
 }

--- a/Content.Shared/_Mono/NaniteOverlay/NaniteOverlayEyeComponent.cs
+++ b/Content.Shared/_Mono/NaniteOverlay/NaniteOverlayEyeComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Mono.NaniteOverlay;
+
+/// <summary>
+/// Added by server to client to tell it that it can now start showing repair ghosts.
+/// Needed because without this client will start showing missing entities immediately but that will also show underfloor entities.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NaniteOverlayEyeComponent : Component
+{
+    [DataField]
+    public int Count = 0;
+}

--- a/Content.Shared/_Mono/NaniteOverlay/NaniteOverlayMessage.cs
+++ b/Content.Shared/_Mono/NaniteOverlay/NaniteOverlayMessage.cs
@@ -1,0 +1,27 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.Network;
+using Robust.Shared.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Content.Shared._Mono.NaniteOverlay;
+
+[Serializable, NetSerializable]
+public sealed class NaniteOverlayMessage : EntityEventArgs
+{
+    public NetEntity[] Targets;
+    public FixedPoint2[]? Responses;
+
+    public NaniteOverlayMessage(NetEntity[] targets)
+    {
+        Targets = targets;
+        Responses = null;
+    }
+
+    public NaniteOverlayMessage(NetEntity[] targets, FixedPoint2[] responses)
+    {
+        Targets = targets;
+        Responses = responses;
+    }
+}


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
you get an overlay which shows you damaged entities when holding a nanite applicator

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
srd has an overlay and shift clicking every wall sucks to find out which one is damaged (or just clicking everything)

idk if security checks are needed on the server handler, or if the way I did it is even good but here you have it

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="294" height="293" alt="image" src="https://github.com/user-attachments/assets/02160c61-7656-470e-be4f-e60e9ad4d77b" />
variously damaged walls, undamaged (that is, 0 damage) entities have no overlay

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->
I used ai for the color code

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Holding a nanite applicator now shows you an overlay of damaged things!

