### PR TITLE
Biggest Shitpost PR Ever

### DIFF
--- a/.github/mapchecker/whitelist.yml
+++ b/.github/mapchecker/whitelist.yml
@@ -1,5 +1,6 @@
 # POI's
 Frontier: true
+BeaconStandard: true
 Nfsd: true
 LPBravo: true
 Cove: true

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -79,7 +79,7 @@ public sealed partial class CCVars
     ///     Controls the game map prototype to load. SS14 stores these prototypes in Prototypes/Maps.
     /// </summary>
     public static readonly CVarDef<string>
-        GameMap = CVarDef.Create("game.map", "Frontier", CVar.SERVERONLY); // Frontier: string.Empty<Frontier
+        GameMap = CVarDef.Create("game.map", string.Empty, CVar.SERVERONLY); // Mono - deforce this from Frontier, so modes like Hyperwar can take back control in their evil ways for their evil maps..
 
     /// <summary>
     ///     Controls whether to use world persistence or not.

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -79,7 +79,7 @@ public sealed partial class CCVars
     ///     Controls the game map prototype to load. SS14 stores these prototypes in Prototypes/Maps.
     /// </summary>
     public static readonly CVarDef<string>
-        GameMap = CVarDef.Create("game.map", string.Empty, CVar.SERVERONLY); // Mono - deforce this from Frontier, so modes like Hyperwar can take back control in their evil ways for their evil maps..
+        GameMap = CVarDef.Create("game.map", string.Empty, CVar.SERVERONLY); // Mono - deforce this from Frontier, so modes like Hyperwar can take back control in their evil ways for their evil maps.
 
     /// <summary>
     ///     Controls whether to use world persistence or not.

--- a/Resources/Maps/_Mono/POI/beaconstation_standard.yml
+++ b/Resources/Maps/_Mono/POI/beaconstation_standard.yml
@@ -97,6 +97,13 @@ entities:
     - type: ImplicitRoof
     - type: RadiationGridResistance
     - type: ExplosionAirtightGrid
+- proto: SpawnPointObserver
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 0.5071793,-0.62499994
+      parent: 1
 - proto: CableApcExtension
   entities:
   - uid: 218

--- a/Resources/Maps/_Mono/POI/beaconstation_standard.yml
+++ b/Resources/Maps/_Mono/POI/beaconstation_standard.yml
@@ -1,0 +1,1347 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 277.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 07/19/2026 23:12:15
+  entityCount: 239
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  6: FloorHullReinforced
+  89: FloorSteel
+  5: LatticeHalfH
+  8: LatticeHalfTiltNESLower
+  2: LatticeHalfTiltNEWUpper
+  9: LatticeHalfTiltNWEUpper
+  12: LatticeHalfTiltNWSLower
+  7: LatticeHalfTiltSENLower
+  17: LatticeHalfTiltSENUpper
+  11: LatticeHalfTiltSWNLower
+  14: LatticeHalfTiltSWNUpper
+  3: LatticeHalfV
+  1: Plating
+  4: PlatingHalfTiltNESLower
+  10: PlatingHalfTiltNWSLower
+  18: PlatingHalfTiltSENLower
+  16: PlatingHalfTiltSEWLower
+  13: PlatingHalfTiltSWELower
+  15: PlatingHalfTiltSWNLower
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Beacon
+    - type: Transform
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAQAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAYAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAEAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAABAAAAAAAABgAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAoAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAABgAAAAAAAAEAAAAAAAALAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAYAAAAAAAABAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,0:
+          ind: 0,0
+          tiles: BgAAAAAAAAYAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAOAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAFAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAFAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAFAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAABgAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: BecomesStation
+      id: BeaconStandard
+    - type: OccluderTree
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes: []
+    - type: SpreaderGrid
+      spreadQueues:
+        Kudzu: []
+        Puddle: []
+        Smoke: []
+        MetalFoam: []
+    - type: GridAtmosphere
+      version: 2
+      data:
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: ThermalSignature
+    - type: ImplicitRoof
+    - type: RadiationGridResistance
+    - type: ExplosionAirtightGrid
+- proto: CableApcExtension
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+- proto: CableApcExtensionUncuttable
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+- proto: GeneratorRTG
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+- proto: LargeAPC
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: PoweredStrobeRedEnabled
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 1
+- proto: RailingCorner
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+- proto: RailingRound
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+- proto: SolarPanel
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+- proto: SolarTracker
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+- proto: StationAnchorIndestructible
+  entities:
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+- proto: WallPlastitaniumIndestructible
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+...

--- a/Resources/Maps/_Mono/POI/beaconstation_standard.yml
+++ b/Resources/Maps/_Mono/POI/beaconstation_standard.yml
@@ -1,16 +1,16 @@
 meta:
   format: 7
-  category: Grid
+  category: Map
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/19/2026 23:12:15
-  entityCount: 239
-maps: []
+  time: 08/05/2026 05:57:06
+  entityCount: 240
+maps:
+- 1
 grids:
-- 1
-orphans:
-- 1
+- 2
+orphans: []
 nullspace: []
 tilemap:
   0: Space
@@ -39,9 +39,21 @@ entities:
   - uid: 1
     components:
     - type: MetaData
+      name: Colossus Sector
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: GridTree
+    - type: Broadphase
+    - type: OccluderTree
+    - type: Parallax
+      parallax: FrontierStation
+  - uid: 2
+    components:
+    - type: MetaData
       name: Beacon
     - type: Transform
-      parent: invalid
+      parent: 1
     - type: MapGrid
       chunks:
         -1,-1:
@@ -84,10 +96,10 @@ entities:
         nodes: []
     - type: SpreaderGrid
       spreadQueues:
-        Kudzu: []
-        Puddle: []
         Smoke: []
         MetalFoam: []
+        Puddle: []
+        Kudzu: []
     - type: GridAtmosphere
       version: 2
       data:
@@ -97,1258 +109,1258 @@ entities:
     - type: ImplicitRoof
     - type: RadiationGridResistance
     - type: ExplosionAirtightGrid
-- proto: SpawnPointObserver
-  entities:
-  - uid: 217
-    components:
-    - type: Transform
-      pos: 0.5071793,-0.62499994
-      parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 218
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 219
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
-      parent: 1
-  - uid: 220
-    components:
-    - type: Transform
-      pos: 2.5,-2.5
-      parent: 1
-  - uid: 221
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 222
-    components:
-    - type: Transform
-      pos: 2.5,-0.5
-      parent: 1
-  - uid: 223
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 224
-    components:
-    - type: Transform
-      pos: 2.5,1.5
-      parent: 1
-  - uid: 225
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
-  - uid: 226
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 1
-  - uid: 227
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 1
-  - uid: 228
-    components:
-    - type: Transform
-      pos: -1.5,2.5
-      parent: 1
-  - uid: 229
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 1
-  - uid: 230
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 231
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 1
-  - uid: 232
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 1
-  - uid: 233
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 1
-  - uid: 234
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 1
-  - uid: 235
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-  - uid: 236
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 237
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 238
-    components:
-    - type: Transform
-      pos: 3.5,-2.5
-      parent: 1
-  - uid: 239
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-- proto: CableApcExtensionUncuttable
-  entities:
-  - uid: 2
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
-  - uid: 3
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
   - uid: 4
     components:
     - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
+      pos: 2.5,-4.5
+      parent: 2
   - uid: 5
     components:
     - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
+      pos: 2.5,-3.5
+      parent: 2
   - uid: 6
     components:
     - type: Transform
-      pos: 0.5,1.5
-      parent: 1
+      pos: 2.5,-2.5
+      parent: 2
   - uid: 7
     components:
     - type: Transform
-      pos: 0.5,2.5
-      parent: 1
+      pos: 2.5,-1.5
+      parent: 2
   - uid: 8
     components:
     - type: Transform
-      pos: 0.5,3.5
-      parent: 1
+      pos: 2.5,-0.5
+      parent: 2
   - uid: 9
     components:
     - type: Transform
-      pos: 0.5,4.5
-      parent: 1
+      pos: 2.5,0.5
+      parent: 2
   - uid: 10
     components:
     - type: Transform
-      pos: 0.5,5.5
-      parent: 1
+      pos: 2.5,1.5
+      parent: 2
   - uid: 11
     components:
     - type: Transform
-      pos: 0.5,6.5
-      parent: 1
+      pos: 2.5,2.5
+      parent: 2
   - uid: 12
     components:
     - type: Transform
-      pos: 0.5,7.5
-      parent: 1
+      pos: 2.5,3.5
+      parent: 2
   - uid: 13
     components:
     - type: Transform
-      pos: 0.5,8.5
-      parent: 1
+      pos: -1.5,3.5
+      parent: 2
   - uid: 14
     components:
     - type: Transform
-      pos: 0.5,9.5
-      parent: 1
+      pos: -1.5,2.5
+      parent: 2
   - uid: 15
     components:
     - type: Transform
-      pos: 0.5,10.5
-      parent: 1
+      pos: -1.5,1.5
+      parent: 2
   - uid: 16
     components:
     - type: Transform
-      pos: 0.5,11.5
-      parent: 1
+      pos: -1.5,0.5
+      parent: 2
   - uid: 17
     components:
     - type: Transform
-      pos: 0.5,12.5
-      parent: 1
+      pos: -1.5,-0.5
+      parent: 2
   - uid: 18
     components:
     - type: Transform
-      pos: 0.5,13.5
-      parent: 1
+      pos: -1.5,-1.5
+      parent: 2
   - uid: 19
     components:
     - type: Transform
-      pos: 0.5,14.5
-      parent: 1
-- proto: CableHV
-  entities:
+      pos: -1.5,-2.5
+      parent: 2
   - uid: 20
     components:
     - type: Transform
-      pos: 0.5,0.5
-      parent: 1
+      pos: -1.5,-3.5
+      parent: 2
   - uid: 21
     components:
     - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
+      pos: -1.5,-4.5
+      parent: 2
   - uid: 22
     components:
     - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
+      pos: -2.5,0.5
+      parent: 2
   - uid: 23
     components:
     - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
+      pos: 3.5,0.5
+      parent: 2
   - uid: 24
     components:
     - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
+      pos: 3.5,-2.5
+      parent: 2
   - uid: 25
     components:
     - type: Transform
-      pos: 0.5,1.5
-      parent: 1
+      pos: -2.5,-2.5
+      parent: 2
+- proto: CableApcExtensionUncuttable
+  entities:
   - uid: 26
     components:
     - type: Transform
-      pos: 5.5,0.5
-      parent: 1
+      pos: 0.5,0.5
+      parent: 2
   - uid: 27
     components:
     - type: Transform
-      pos: 4.5,0.5
-      parent: 1
+      pos: 1.5,-0.5
+      parent: 2
   - uid: 28
     components:
     - type: Transform
-      pos: 3.5,0.5
-      parent: 1
+      pos: 0.5,-0.5
+      parent: 2
   - uid: 29
     components:
     - type: Transform
-      pos: 2.5,0.5
-      parent: 1
+      pos: -0.5,-0.5
+      parent: 2
   - uid: 30
     components:
     - type: Transform
-      pos: 1.5,0.5
-      parent: 1
+      pos: 0.5,1.5
+      parent: 2
   - uid: 31
     components:
     - type: Transform
-      pos: -0.5,0.5
-      parent: 1
+      pos: 0.5,2.5
+      parent: 2
   - uid: 32
     components:
     - type: Transform
-      pos: -1.5,0.5
-      parent: 1
+      pos: 0.5,3.5
+      parent: 2
   - uid: 33
     components:
     - type: Transform
-      pos: -2.5,0.5
-      parent: 1
+      pos: 0.5,4.5
+      parent: 2
   - uid: 34
     components:
     - type: Transform
-      pos: -3.5,0.5
-      parent: 1
+      pos: 0.5,5.5
+      parent: 2
   - uid: 35
     components:
     - type: Transform
-      pos: -4.5,0.5
-      parent: 1
+      pos: 0.5,6.5
+      parent: 2
   - uid: 36
     components:
     - type: Transform
-      pos: -4.5,-2.5
-      parent: 1
+      pos: 0.5,7.5
+      parent: 2
   - uid: 37
     components:
     - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
+      pos: 0.5,8.5
+      parent: 2
   - uid: 38
     components:
     - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
+      pos: 0.5,9.5
+      parent: 2
   - uid: 39
     components:
     - type: Transform
-      pos: -1.5,-2.5
-      parent: 1
+      pos: 0.5,10.5
+      parent: 2
   - uid: 40
     components:
     - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
+      pos: 0.5,11.5
+      parent: 2
   - uid: 41
     components:
     - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
+      pos: 0.5,12.5
+      parent: 2
   - uid: 42
     components:
     - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
+      pos: 0.5,13.5
+      parent: 2
   - uid: 43
     components:
     - type: Transform
-      pos: 2.5,-2.5
-      parent: 1
+      pos: 0.5,14.5
+      parent: 2
+- proto: CableHV
+  entities:
   - uid: 44
     components:
     - type: Transform
-      pos: 3.5,-2.5
-      parent: 1
+      pos: 0.5,0.5
+      parent: 2
   - uid: 45
     components:
     - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
+      pos: 0.5,-0.5
+      parent: 2
   - uid: 46
     components:
     - type: Transform
-      pos: 5.5,-2.5
-      parent: 1
+      pos: 0.5,-1.5
+      parent: 2
   - uid: 47
     components:
     - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
+      pos: -0.5,-0.5
+      parent: 2
   - uid: 48
     components:
     - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
+      pos: 1.5,-0.5
+      parent: 2
   - uid: 49
     components:
     - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
+      pos: 0.5,1.5
+      parent: 2
   - uid: 50
     components:
     - type: Transform
-      pos: -2.5,-3.5
-      parent: 1
+      pos: 5.5,0.5
+      parent: 2
   - uid: 51
     components:
     - type: Transform
-      pos: 0.5,2.5
-      parent: 1
+      pos: 4.5,0.5
+      parent: 2
   - uid: 52
     components:
     - type: Transform
-      pos: 0.5,3.5
-      parent: 1
+      pos: 3.5,0.5
+      parent: 2
   - uid: 53
     components:
     - type: Transform
-      pos: 0.5,4.5
-      parent: 1
+      pos: 2.5,0.5
+      parent: 2
   - uid: 54
     components:
     - type: Transform
-      pos: 0.5,5.5
-      parent: 1
+      pos: 1.5,0.5
+      parent: 2
   - uid: 55
     components:
     - type: Transform
-      pos: 0.5,6.5
-      parent: 1
+      pos: -0.5,0.5
+      parent: 2
   - uid: 56
     components:
     - type: Transform
-      pos: 0.5,7.5
-      parent: 1
+      pos: -1.5,0.5
+      parent: 2
   - uid: 57
     components:
     - type: Transform
-      pos: 0.5,8.5
-      parent: 1
+      pos: -2.5,0.5
+      parent: 2
   - uid: 58
     components:
     - type: Transform
-      pos: 0.5,9.5
-      parent: 1
+      pos: -3.5,0.5
+      parent: 2
   - uid: 59
     components:
     - type: Transform
-      pos: 0.5,10.5
-      parent: 1
+      pos: -4.5,0.5
+      parent: 2
   - uid: 60
     components:
     - type: Transform
-      pos: 0.5,11.5
-      parent: 1
+      pos: -4.5,-2.5
+      parent: 2
   - uid: 61
     components:
     - type: Transform
-      pos: 0.5,12.5
-      parent: 1
+      pos: -3.5,-2.5
+      parent: 2
   - uid: 62
     components:
     - type: Transform
-      pos: 0.5,13.5
-      parent: 1
+      pos: -2.5,-2.5
+      parent: 2
   - uid: 63
     components:
     - type: Transform
-      pos: 1.5,13.5
-      parent: 1
+      pos: -1.5,-2.5
+      parent: 2
   - uid: 64
     components:
     - type: Transform
-      pos: 2.5,13.5
-      parent: 1
+      pos: -0.5,-2.5
+      parent: 2
   - uid: 65
     components:
     - type: Transform
-      pos: 2.5,10.5
-      parent: 1
+      pos: 0.5,-2.5
+      parent: 2
   - uid: 66
     components:
     - type: Transform
-      pos: 1.5,10.5
-      parent: 1
+      pos: 1.5,-2.5
+      parent: 2
   - uid: 67
     components:
     - type: Transform
-      pos: 1.5,7.5
-      parent: 1
+      pos: 2.5,-2.5
+      parent: 2
   - uid: 68
     components:
     - type: Transform
-      pos: 2.5,7.5
-      parent: 1
-- proto: Catwalk
-  entities:
+      pos: 3.5,-2.5
+      parent: 2
   - uid: 69
     components:
     - type: Transform
-      pos: 1.5,7.5
-      parent: 1
+      pos: 4.5,-2.5
+      parent: 2
   - uid: 70
     components:
     - type: Transform
-      pos: 4.5,0.5
-      parent: 1
+      pos: 5.5,-2.5
+      parent: 2
   - uid: 71
     components:
     - type: Transform
-      pos: 5.5,0.5
-      parent: 1
+      pos: 3.5,-3.5
+      parent: 2
   - uid: 72
     components:
     - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
+      pos: 3.5,-4.5
+      parent: 2
   - uid: 73
     components:
     - type: Transform
-      pos: 5.5,-2.5
-      parent: 1
+      pos: -2.5,-4.5
+      parent: 2
   - uid: 74
     components:
     - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
+      pos: -2.5,-3.5
+      parent: 2
   - uid: 75
     components:
     - type: Transform
-      pos: -4.5,-2.5
-      parent: 1
+      pos: 0.5,2.5
+      parent: 2
   - uid: 76
     components:
     - type: Transform
-      pos: -3.5,0.5
-      parent: 1
+      pos: 0.5,3.5
+      parent: 2
   - uid: 77
     components:
     - type: Transform
-      pos: -4.5,0.5
-      parent: 1
+      pos: 0.5,4.5
+      parent: 2
   - uid: 78
     components:
     - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
+      pos: 0.5,5.5
+      parent: 2
   - uid: 79
     components:
     - type: Transform
-      pos: -2.5,-3.5
-      parent: 1
+      pos: 0.5,6.5
+      parent: 2
   - uid: 80
     components:
     - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
+      pos: 0.5,7.5
+      parent: 2
   - uid: 81
     components:
     - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
+      pos: 0.5,8.5
+      parent: 2
   - uid: 82
     components:
     - type: Transform
-      pos: 2.5,7.5
-      parent: 1
+      pos: 0.5,9.5
+      parent: 2
   - uid: 83
     components:
     - type: Transform
-      pos: 2.5,10.5
-      parent: 1
+      pos: 0.5,10.5
+      parent: 2
   - uid: 84
     components:
     - type: Transform
-      pos: 1.5,10.5
-      parent: 1
+      pos: 0.5,11.5
+      parent: 2
   - uid: 85
     components:
     - type: Transform
-      pos: 1.5,13.5
-      parent: 1
+      pos: 0.5,12.5
+      parent: 2
   - uid: 86
     components:
     - type: Transform
-      pos: 2.5,13.5
-      parent: 1
-- proto: GeneratorRTG
-  entities:
+      pos: 0.5,13.5
+      parent: 2
   - uid: 87
     components:
     - type: Transform
-      pos: 0.5,0.5
-      parent: 1
+      pos: 1.5,13.5
+      parent: 2
   - uid: 88
     components:
     - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-- proto: Grille
-  entities:
+      pos: 2.5,13.5
+      parent: 2
   - uid: 89
     components:
     - type: Transform
-      pos: 3.5,-1.5
-      parent: 1
+      pos: 2.5,10.5
+      parent: 2
   - uid: 90
     components:
     - type: Transform
-      pos: 3.5,-0.5
-      parent: 1
+      pos: 1.5,10.5
+      parent: 2
   - uid: 91
     components:
     - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
+      pos: 1.5,7.5
+      parent: 2
   - uid: 92
     components:
     - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
+      pos: 2.5,7.5
+      parent: 2
+- proto: Catwalk
+  entities:
   - uid: 93
     components:
     - type: Transform
-      pos: -0.5,6.5
-      parent: 1
+      pos: 1.5,7.5
+      parent: 2
   - uid: 94
     components:
     - type: Transform
-      pos: -0.5,7.5
-      parent: 1
+      pos: 4.5,0.5
+      parent: 2
   - uid: 95
     components:
     - type: Transform
-      pos: -0.5,4.5
-      parent: 1
+      pos: 5.5,0.5
+      parent: 2
   - uid: 96
     components:
     - type: Transform
-      pos: -0.5,9.5
-      parent: 1
+      pos: 4.5,-2.5
+      parent: 2
   - uid: 97
     components:
     - type: Transform
-      pos: -0.5,10.5
-      parent: 1
+      pos: 5.5,-2.5
+      parent: 2
   - uid: 98
     components:
     - type: Transform
-      pos: -0.5,12.5
-      parent: 1
+      pos: -3.5,-2.5
+      parent: 2
   - uid: 99
     components:
     - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 2
+- proto: GeneratorRTG
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 2
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 2
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 2
+  - uid: 123
+    components:
+    - type: Transform
       pos: -0.5,13.5
-      parent: 1
+      parent: 2
 - proto: GrilleDiagonal
   entities:
-  - uid: 100
+  - uid: 124
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
-      parent: 1
-  - uid: 101
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 102
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 1
-  - uid: 103
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-5.5
-      parent: 1
-  - uid: 104
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-3.5
-      parent: 1
-  - uid: 105
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-3.5
-      parent: 1
-- proto: Gyroscope
-  entities:
-  - uid: 106
-    components:
-    - type: Transform
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 107
-    components:
-    - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
-  - uid: 108
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
-  - uid: 109
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
-- proto: LargeAPC
-  entities:
-  - uid: 110
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 111
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
-- proto: PoweredStrobeRedEnabled
-  entities:
-  - uid: 112
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,13.5
-      parent: 1
-  - uid: 113
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 114
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 115
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,7.5
-      parent: 1
-- proto: Railing
-  entities:
-  - uid: 116
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 117
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 118
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-2.5
-      parent: 1
-  - uid: 119
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-2.5
-      parent: 1
-  - uid: 120
-    components:
-    - type: Transform
-      pos: 4.5,0.5
-      parent: 1
-  - uid: 121
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 122
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
-  - uid: 123
-    components:
-    - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
-  - uid: 124
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-3.5
-      parent: 1
+      parent: 2
   - uid: 125
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,-3.5
-      parent: 1
+      pos: 3.5,2.5
+      parent: 2
   - uid: 126
     components:
     - type: Transform
-      pos: 1.5,7.5
-      parent: 1
+      pos: -2.5,2.5
+      parent: 2
   - uid: 127
     components:
     - type: Transform
-      pos: 1.5,10.5
-      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 2
   - uid: 128
     components:
     - type: Transform
-      pos: 1.5,13.5
-      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 2
   - uid: 129
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 1.5,13.5
-      parent: 1
+      pos: 3.5,-3.5
+      parent: 2
+- proto: Gyroscope
+  entities:
   - uid: 130
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,10.5
-      parent: 1
+      pos: 4.5,0.5
+      parent: 2
   - uid: 131
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,7.5
-      parent: 1
-- proto: RailingCorner
-  entities:
+      pos: 4.5,-2.5
+      parent: 2
   - uid: 132
     components:
     - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
+      pos: -3.5,-2.5
+      parent: 2
   - uid: 133
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-4.5
-      parent: 1
-- proto: RailingRound
+      pos: -3.5,0.5
+      parent: 2
+- proto: LargeAPC
   entities:
   - uid: 134
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,13.5
-      parent: 1
+      pos: 1.5,-0.5
+      parent: 2
   - uid: 135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,0.5
-      parent: 1
+      pos: -0.5,-0.5
+      parent: 2
+- proto: PoweredStrobeRedEnabled
+  entities:
   - uid: 136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,-2.5
-      parent: 1
+      pos: 1.5,13.5
+      parent: 2
   - uid: 137
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-2.5
-      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 2
   - uid: 138
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,0.5
-      parent: 1
+      pos: -3.5,0.5
+      parent: 2
   - uid: 139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,10.5
-      parent: 1
+      pos: 1.5,7.5
+      parent: 2
+- proto: Railing
+  entities:
   - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,10.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,7.5
+      parent: 2
+- proto: RailingCorner
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 2
+- proto: RailingRound
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,13.5
+      parent: 2
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 2
+  - uid: 164
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,7.5
-      parent: 1
+      parent: 2
 - proto: SolarPanel
   entities:
-  - uid: 141
-    components:
-    - type: Transform
-      pos: 1.5,13.5
-      parent: 1
-  - uid: 142
-    components:
-    - type: Transform
-      pos: 2.5,13.5
-      parent: 1
-  - uid: 143
-    components:
-    - type: Transform
-      pos: 1.5,10.5
-      parent: 1
-  - uid: 144
-    components:
-    - type: Transform
-      pos: 2.5,10.5
-      parent: 1
-  - uid: 145
-    components:
-    - type: Transform
-      pos: 2.5,7.5
-      parent: 1
-  - uid: 146
-    components:
-    - type: Transform
-      pos: 1.5,7.5
-      parent: 1
-  - uid: 147
-    components:
-    - type: Transform
-      pos: 5.5,-2.5
-      parent: 1
-  - uid: 148
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-  - uid: 149
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
-  - uid: 150
-    components:
-    - type: Transform
-      pos: -4.5,-2.5
-      parent: 1
-- proto: SolarTracker
-  entities:
-  - uid: 151
-    components:
-    - type: Transform
-      pos: 5.5,0.5
-      parent: 1
-  - uid: 152
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 1
-- proto: StationAnchorIndestructible
-  entities:
-  - uid: 153
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-- proto: WallPlastitaniumIndestructible
-  entities:
-  - uid: 154
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 1
-  - uid: 155
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 156
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 157
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 1
-  - uid: 158
-    components:
-    - type: Transform
-      pos: 2.5,1.5
-      parent: 1
-  - uid: 159
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
-  - uid: 160
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 1
-  - uid: 161
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 162
-    components:
-    - type: Transform
-      pos: -0.5,3.5
-      parent: 1
-  - uid: 163
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 1
-  - uid: 164
-    components:
-    - type: Transform
-      pos: 0.5,3.5
-      parent: 1
   - uid: 165
     components:
     - type: Transform
-      pos: -1.5,2.5
-      parent: 1
+      pos: 1.5,13.5
+      parent: 2
   - uid: 166
     components:
     - type: Transform
-      pos: -1.5,1.5
-      parent: 1
+      pos: 2.5,13.5
+      parent: 2
   - uid: 167
     components:
     - type: Transform
-      pos: -1.5,-0.5
-      parent: 1
+      pos: 1.5,10.5
+      parent: 2
   - uid: 168
     components:
     - type: Transform
-      pos: -1.5,0.5
-      parent: 1
+      pos: 2.5,10.5
+      parent: 2
   - uid: 169
     components:
     - type: Transform
-      pos: -1.5,-3.5
-      parent: 1
+      pos: 2.5,7.5
+      parent: 2
   - uid: 170
     components:
     - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
+      pos: 1.5,7.5
+      parent: 2
   - uid: 171
     components:
     - type: Transform
-      pos: -1.5,-2.5
-      parent: 1
+      pos: 5.5,-2.5
+      parent: 2
   - uid: 172
     components:
     - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
+      pos: 3.5,-4.5
+      parent: 2
   - uid: 173
     components:
     - type: Transform
-      pos: 0.5,-4.5
-      parent: 1
+      pos: -2.5,-4.5
+      parent: 2
   - uid: 174
     components:
     - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
+      pos: -4.5,-2.5
+      parent: 2
+- proto: SolarTracker
+  entities:
   - uid: 175
     components:
     - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
+      pos: 5.5,0.5
+      parent: 2
   - uid: 176
     components:
     - type: Transform
-      pos: 2.5,-3.5
-      parent: 1
-  - uid: 177
-    components:
-    - type: Transform
-      pos: 2.5,-2.5
-      parent: 1
-  - uid: 178
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 1
-  - uid: 179
-    components:
-    - type: Transform
-      pos: 2.5,-0.5
-      parent: 1
-  - uid: 180
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 181
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 1
-  - uid: 182
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 1
-  - uid: 183
-    components:
-    - type: Transform
-      pos: -0.5,2.5
-      parent: 1
-  - uid: 184
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 185
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-  - uid: 186
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
-  - uid: 187
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 188
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 189
-    components:
-    - type: Transform
-      pos: 3.5,-2.5
-      parent: 1
-  - uid: 190
-    components:
-    - type: Transform
-      pos: 3.5,1.5
-      parent: 1
-  - uid: 191
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 192
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 193
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-  - uid: 194
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 195
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 1
-  - uid: 196
-    components:
-    - type: Transform
-      pos: 0.5,6.5
-      parent: 1
-  - uid: 197
-    components:
-    - type: Transform
-      pos: 0.5,7.5
-      parent: 1
-  - uid: 198
-    components:
-    - type: Transform
-      pos: 0.5,8.5
-      parent: 1
-  - uid: 199
-    components:
-    - type: Transform
-      pos: 0.5,9.5
-      parent: 1
-  - uid: 200
-    components:
-    - type: Transform
-      pos: 0.5,10.5
-      parent: 1
-  - uid: 201
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 1
-  - uid: 202
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 1
-  - uid: 203
-    components:
-    - type: Transform
-      pos: 0.5,13.5
-      parent: 1
-  - uid: 204
-    components:
-    - type: Transform
-      pos: 0.5,14.5
-      parent: 1
-  - uid: 205
-    components:
-    - type: Transform
-      pos: -0.5,14.5
-      parent: 1
-  - uid: 206
-    components:
-    - type: Transform
-      pos: -0.5,11.5
-      parent: 1
-  - uid: 207
-    components:
-    - type: Transform
-      pos: -0.5,8.5
-      parent: 1
-  - uid: 208
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 1
-  - uid: 209
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 210
-    components:
-    - type: Transform
-      pos: 0.5,1.5
-      parent: 1
-  - uid: 211
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 212
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 1
-  - uid: 213
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 214
-    components:
-    - type: Transform
-      pos: 1.5,0.5
-      parent: 1
-  - uid: 215
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-- proto: WarpPoint
+      pos: -4.5,0.5
+      parent: 2
+- proto: SpawnPointObserver
   entities:
-  - uid: 216
+  - uid: 3
     components:
     - type: Transform
       pos: 0.5,-0.5
-      parent: 1
+      parent: 2
+- proto: StationAnchorIndestructible
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+- proto: WallPlastitaniumIndestructible
+  entities:
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 2
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 2
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 2
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 2
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 2
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 2
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 2
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 2
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 2
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 2
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 2
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+- proto: WarpPoint
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
 ...

--- a/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
+++ b/Resources/Prototypes/_Mono/Entities/World/Biome/basic.yml
@@ -413,6 +413,12 @@
   distanceRange: 0, 18000
   noiseRanges: {}
 
+- type: spaceBiome
+  id: MonoEmptyFallbackHyperwar # No concern for far reaches here.
+  priority: -4
+  distanceRange: null
+  noiseRanges: {}
+
 # 9km Ring
 - type: spaceBiome
   id: MonoWorldgenAsteroidRing9km

--- a/Resources/Prototypes/_Mono/Maps/pools.yml
+++ b/Resources/Prototypes/_Mono/Maps/pools.yml
@@ -1,0 +1,4 @@
+- type: gameMapPool
+  id: EmptyMapPool # Used for hyperwar for now.
+  maps:
+  - BeaconStandard

--- a/Resources/Prototypes/_Mono/Outpost/caelestinus.yml
+++ b/Resources/Prototypes/_Mono/Outpost/caelestinus.yml
@@ -69,3 +69,22 @@
         # - type: StationJobs # mono edit
         #   availableJobs:
         #     Passenger: [ -1, -1 ]
+
+- type: gameMap
+  id: BeaconStandard
+  mapName: Empty (Beacon)
+  mapPath: /Maps/Test/beaconstation_standard.yml
+  minPlayers: 0
+  stations:
+    BeaconStandard:
+      gridComponents:
+      - type: IFF
+        flags: [HideLabel]
+        readOnly: true
+      - type: SolarPoweredGrid
+        trackOnInit: true
+        doNotCull: true
+      stationProto: StandardFrontierStation
+      components:
+      - type: StationNameSetup
+        mapNameTemplate: "Beacon"

--- a/Resources/Prototypes/_Mono/Outpost/caelestinus.yml
+++ b/Resources/Prototypes/_Mono/Outpost/caelestinus.yml
@@ -72,9 +72,12 @@
 
 - type: gameMap
   id: BeaconStandard
-  mapName: Empty (Beacon)
-  mapPath: /Maps/Test/beaconstation_standard.yml
+  mapName: 'Empty (Beacon)'
+  mapPath: /Maps/_Mono/POI/beaconstation_standard.yml
   minPlayers: 0
+  maxPlayers: 100
+  randomRotation: true
+  maxRandomOffset: 0
   stations:
     BeaconStandard:
       gridComponents:

--- a/Resources/Prototypes/_Mono/World/worldgen.yml
+++ b/Resources/Prototypes/_Mono/World/worldgen.yml
@@ -4,6 +4,7 @@
     - type: WorldController
     - type: BiomeSelection
       biomes:
+        - MonoEmptyFallbackHyperwar # Stupid but needed to prevent console error spam
         - MonoWorldgenHyperwarAsteroidRing
 
 - type: worldgenConfig

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -16,7 +16,7 @@
     MonoMixed: 0.1
     MonoChimera: 0.1
     MonoAllAtOnce: 0.1
-    #MonoRogueTSFHyperwar: 0.05
+    MonoRogueTSFHyperwar: 0.02 # Close enough to 1 in 50.
 
 - type: gamePreset
   id: MonoStandard
@@ -111,6 +111,7 @@
   name: mono-chimera-title
   description: mono-chimera-description
   showInVote: true
+  minPlayers: 30
   rules:
   - NFAdventure
   - BasicStationEventScheduler
@@ -128,6 +129,7 @@
   name: mono-mixed-title
   description: mono-mixed-description
   showInVote: true
+  minPlayers: 30
   rules:
   - NFAdventure
   - BasicStationEventScheduler
@@ -149,6 +151,7 @@
   description: mono-allatonce-description
   showInVote: true # we ball
   weight: 0.25 # requires 80% votes
+  minPlayers: 40
   rules:
   - NFAdventure
   - BasicStationEventScheduler
@@ -169,6 +172,8 @@
   name: mono-roguetsf-hyperwar-title
   description: mono-roguetsf-hyperwar-description
   showInVote: false # AO
+  supportedMaps: EmptyMapPool
+  minPlayers: 40
   rules:
   - NFAdventure
   - Hyperwar


### PR DESCRIPTION
## About the PR
adds hyperwar to secret w/ like a 1 in 50 chance (not exactly but close enough so i dont care) (uses a reskinned cluster beacon instead of the debug empty map)
adds minpops to some modes because i forgot
hyperwar is minpop of 40, apoc now has 40 minpop, biothreat now has 30, mixed now has 30
also fixes hyperwar spamming console w/ errors because no biome to fill in chunks with

## Why / Balance
funny

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Hyperwar can now roll as a gamemode with a really rare chance. Like over 1 in 50 chance. Minpop of 40 required.
- tweak: Biothreat, mixed, and apocalypse gamemodes now have minpops required to roll (30-40)