### PR TITLE
Armor Plate Fix

### DIFF
--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
@@ -51,7 +51,9 @@
   id: ArcFurnaceStatic
   recipes:
   - ArmorPlate2
+  - ArmorPlate2Alt
   - ArmorPlate3
+  - ArmorPlate3Alt
   - ArmorPlate4Start
   - SiliconBoule
   - IriditePowderIntoCrystal

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/Packs/Economy/economy.yml
@@ -55,6 +55,7 @@
   - ArmorPlate3
   - ArmorPlate3Alt
   - ArmorPlate4Start
+  - ArmorPlate4StartAlt
   - SiliconBoule
   - IriditePowderIntoCrystal
   - IriditeCrystalIntoPlate

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/arc_furnace.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/arc_furnace.yml
@@ -3,9 +3,16 @@
   result: ArmorPlateEconomy2
   completetime: 15
   entities:
-    ArmorPlateEconomy3Fragment: 2
+    ArmorPlateEconomy1: 2
+
+- type: latheRecipe
+  id: ArmorPlate2Alt
+  result: ArmorPlateEconomy2
+  completetime: 10
+  entities:
+    ArmorPlateEconomy3Fragment: 1
   reagents:
-    Silver: 100
+    Silver: 50
 
 - type: latheRecipe
   id: ArmorPlate3
@@ -13,6 +20,13 @@
   completetime: 15
   entities:
     ArmorPlateEconomy2: 2
+
+- type: latheRecipe
+  id: ArmorPlate3Alt
+  result: ArmorPlateEconomy3
+  completetime: 10
+  entities:
+    ArmorPlateEconomy2: 1
   reagents:
     LithiumHydroxide: 30
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/arc_furnace.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/arc_furnace.yml
@@ -1,6 +1,8 @@
 - type: latheRecipe
   id: ArmorPlate2
   result: ArmorPlateEconomy2
+  categories:
+  - Components
   completetime: 15
   entities:
     ArmorPlateEconomy1: 2
@@ -8,6 +10,9 @@
 - type: latheRecipe
   id: ArmorPlate2Alt
   result: ArmorPlateEconomy2
+  categories:
+  - Components
+  - AltRecipes
   completetime: 10
   entities:
     ArmorPlateEconomy3Fragment: 1
@@ -17,6 +22,8 @@
 - type: latheRecipe
   id: ArmorPlate3
   result: ArmorPlateEconomy3
+  categories:
+  - Components
   completetime: 15
   entities:
     ArmorPlateEconomy2: 2
@@ -24,6 +31,9 @@
 - type: latheRecipe
   id: ArmorPlate3Alt
   result: ArmorPlateEconomy3
+  categories:
+  - Components
+  - AltRecipes
   completetime: 10
   entities:
     ArmorPlateEconomy2: 1
@@ -33,9 +43,21 @@
 - type: latheRecipe
   id: ArmorPlate4Start
   result: ArmorPlateEconomy4Start
+  categories:
+  - Components
   completetime: 20
   entities:
     ArmorPlateEconomy3: 1
+
+- type: latheRecipe
+  id: ArmorPlate4StartAlt
+  result: ArmorPlateEconomy4Start
+  categories:
+  - Components
+  - AltRecipes
+  completetime: 15
+  entities:
+    ArmorPlateEconomy3Fragment: 2
   reagents:
     Superconductant: 60
 
@@ -44,7 +66,9 @@
 - type: latheRecipe
   id: SiliconBoule
   result: SiliconBouleEconomy
-  completetime: 30
+  categories:
+  - Components
+  completetime: 20
   entities:
     MaterialDiamond1: 1 # seed crystal
   reagents:
@@ -77,14 +101,4 @@
     FluorosulfuricAcid: 40
 
 # end iridite
-
-- type: latheRecipe
-  id: MaterialIndustrySterile
-  result: MaterialIndustrySterile
-  categories:
-  - ComponentMaterials
-  completetime: 5
-  resultCount: 2
-  entities:
-    ComponentBrickEconomy1: 1 # replace this with something fitting one day
 

--- a/Resources/Prototypes/_Mono/Recipes/Lathes/precision_assembler.yml
+++ b/Resources/Prototypes/_Mono/Recipes/Lathes/precision_assembler.yml
@@ -354,3 +354,15 @@
     MaterialIndustryPlates: 1
     MaterialIndustryElectronics: 1
     MaterialIndustryFCS: 1
+
+- type: latheRecipe
+  id: MaterialIndustrySterile
+  result: MaterialIndustrySterile
+  categories:
+  - ComponentMaterials
+  completetime: 10
+  resultCount: 2
+  entities:
+    ComponentBrickEconomy1: 1 # replace this with something fitting one day
+  reagents:
+    Bleach: 20


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes heavy armor plates being broken and not being craftable
Also adds alt/normal recipes to level 2 , 3 and 4 armor plates w/ chemicals and without, making them with chemicals is more efficient but not necessary.
Sterile comps cost bleach now
Marked armor plates with categories
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
broken
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- add: Heavy/ceramic armor plates now have non-chemical requiring recipes.
- fix: Fixed not being able to craft heavy armor plates.
