### PR TITLE
Nuke Overall Onehand Capability for Full-Power Cartridge Rifles

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -12,11 +12,11 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
-    minAngle: -12
-    maxAngle: -18
+    minAngle: -24
+    maxAngle: -44
   - type: Gun
-    minAngle: 13
-    maxAngle: 20
+    minAngle: 24
+    maxAngle: 59
     angleIncrease: 5
     angleDecay: 25
     fireRate: 3.5 # Mono - 3.5

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -20,10 +20,10 @@
     sprite: _Mono/Objects/Weapons/Guns/LMGs/ratel/Ratel-inhands.rsi
   - type: GunWieldBonus
     minAngle: -25
-    maxAngle: -35
+    maxAngle: -45
   - type: Gun
     minAngle: 25
-    maxAngle: 40
+    maxAngle: 60
     angleIncrease: 7
     angleDecay: 28
     fireRate: 6 # 360 rpm

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/LMGs/tsfmc.yml
@@ -13,11 +13,11 @@
     - map: ["gripAttachment"]
     - map: ["opticAttachment"]
   - type: GunWieldBonus
-    minAngle: -24
-    maxAngle: -20
+    minAngle: -54
+    maxAngle: -72
   - type: Gun
-    minAngle: 24
-    maxAngle: 46
+    minAngle: 54
+    maxAngle: 85
     angleIncrease: 5
     angleDecay: 34
     fireRate: 7

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/pdv.yml
@@ -319,10 +319,10 @@
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: GunWieldBonus
-    minAngle: -3
+    minAngle: -30
     maxAngle: -54
   - type: Gun
-    minAngle: 3
+    minAngle: 30
     maxAngle: 64
     angleIncrease: 5
     angleDecay: 25

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -13,11 +13,11 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: GunWieldBonus
-    minAngle: -20
+    minAngle: -21
     maxAngle: -50
   - type: Gun
     minAngle: 21
-    maxAngle: 52
+    maxAngle: 65
     angleIncrease: 1.4
     angleDecay: 24
     fireRate: 4 #240 RPM, its semi-auto anyway

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Rifles/tsfmc.yml
@@ -578,15 +578,15 @@
     soundRack:
       path: /Audio/Weapons/Guns/Cock/sf_rifle_cock.ogg
   - type: GunWieldBonus
-    minAngle: -4
-    maxAngle: -30
+    minAngle: -32
+    maxAngle: -65 # 65 65 65
   - type: Gun
-    minAngle: 4
-    maxAngle: 33
+    minAngle: 32
+    maxAngle: 75
     angleIncrease: 4
     angleDecay: 10
     fireRate: 4.5
-    damageModifier: 1.3
+    damageModifier: 1.3 # very slightly out DPS'd by M-90 still
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
   - type: ItemSlots

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/tsfmc.yml
@@ -90,10 +90,10 @@
     - map: ["gripAttachment"]
     - map: ["opticAttachment"]
   - type: GunWieldBonus
-    minAngle: -21
+    minAngle: -41
     maxAngle: -47
   - type: Gun
-    minAngle: 21
+    minAngle: 41
     maxAngle: 48
     angleIncrease: 27
     angleDecay: 2

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/ussp.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/ussp.yml
@@ -23,10 +23,10 @@
     - suitStorage
   - type: GunWieldBonus
     minAngle: -27
-    maxAngle: -36
+    maxAngle: -47
   - type: Gun
     minAngle: 27
-    maxAngle: 39
+    maxAngle: 54
     fireRate: 2.25
     damageModifier: 2
     selectedMode: SemiAuto


### PR DESCRIPTION
## About the PR
Severely reduces the overall one-handed capability for all full-power cartridge firing rifles (8x65mm, 7.62x54mmR, 7.62x51mm)

## Why / Balance
It seems theres been a misunderstanding here; these are harder-hitting rounds supposed to be used for "heavier" rifles lol, one-handed 7.62x51mm is very contrary to the idea of it being used for said "heavier" rifles (and you are not fucking controlling that shit with one hand)

this is just aids to have kitted-out M-90/dragonfang w/ eshield meta - if you want a onehanded rifle niche, go use an intermediate round

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Nuked one-handed capability for full-power cartridge firing rifles (7.62x51mm, 7.62x54mmR, 8x65mm)