### PR TITLE
Convert Remaining Shitshield Suits Into Monoshield

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/phaethon_dynasty.yml
@@ -153,10 +153,10 @@
     - RogueHardsuit
 
 - type: entity
-  parent: [ ClothingOuterHardsuitSyndieElite, EnergyShieldClothing ]
+  parent: [ ClothingOuterHardsuitSyndieElite, MonoEnergyShieldClothing ]
   id: ClothingOuterHardsuitAshenElite
   name: PDV CV-53 combat tacsuit
-  description: Originally based off of the CV-32 hardsuit, the CV-53 tacsuit sacrifices conventional armor plating for environmental protection, and a rechargeable hard-shield.
+  description: Originally based off of the CV-32 hardsuit, the CV-53 tacsuit sacrifices conventional armor plating for environmental protection, and a fast-recharging energy shield.
   components:
   - type: Sprite
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/syndieelite.rsi
@@ -192,42 +192,22 @@
     tags:
     - RogueHardsuit
   # Shielding
-  - type: Blocking
-    passiveBlockModifier:
-      coefficients:
-        Blunt: 0.1
-        Slash: 0.1
-        Piercing: 0.1
-        Heat: 0.1
-    activeBlockModifier:
-      coefficients:
-        Blunt: 0.1
-        Slash: 0.1
-        Piercing: 0.1
-        Heat: 0.1
-      flatReductions:
-        Heat: 5
-    passiveBlockFraction: 1.0
-    activeBlockFraction: 1.0
-    isClothing: true
-  - type: Damageable
-    damageContainer: Shield
+  - type: PersonalShield
+    color: "#FF3300"
+    shatterTime: 0.4
+    scale: 1.6
+    shield:
+      maxCharge: 175
+      regenRate: 20 # Basically a free glancing shot-shield, spools and recharges super fast but cant take much damage.
+      spinupTime: 0.1
+      breakCooldown: 3
+      powerDraw: 0.5
   - type: Battery
-    maxCharge: 10
-    startingCharge: 10
+    maxCharge: 20
+    startingCharge: 20
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 1
-  - type: RechargeableBlocking
-    chargedRechargeRate: 0
-    dischargedRechargeRate: 0.3
-  - type: UseDelay
-    delay: 10
-  - type: PointLight
-    enabled: false
-    radius: 1.4
-    energy: 2
-    color: "#5dd439"
+    autoRechargeRate: 0.6
 
 - type: entity
   parent: ClothingOuterHardsuitAshen

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/tsfmc.yml
@@ -154,10 +154,10 @@
     id: ClothingOuterHardsuitTacsuitHighValue
 
 - type: entity
-  parent: [ClothingOuterHardsuitJuggernaut, EnergyShieldClothing, BaseFactionGearTSFT3 ] # Jugger Suit
+  parent: [ClothingOuterHardsuitJuggernaut, MonoEnergyShieldClothing, BaseFactionGearTSFT3 ] # Jugger Suit
   id: ClothingOuterHardsuitNfsdExperimental
   name: TSFMC M92-X tacsuit
-  description: An experimental modification of the M92 tacsuit for spec-ops units of the TSFMC. Durable, and comes with an integrated soft-shield along with numerous gadgets at the cost of insulation and solid armor.
+  description: An experimental modification of the M92 tacsuit for spec-ops units of the TSFMC. Durable, and comes with an integrated slow-recharging yet sturdy shield along with numerous gadgets at the cost of insulation and solid armor.
   components:
   - type: Sprite
     sprite: _Mono/Clothing/OuterClothing/Hardsuits/tsfmc_experimental.rsi # Mono
@@ -197,42 +197,30 @@
     coefficient: 0.25
   - type: PirateBountyItem # Mono
     id: ClothingOuterHardsuitTacsuitHighValue
-  # Mono - Shielding comps
-  - type: Blocking
-    passiveBlockModifier:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
-    activeBlockModifier:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
-      flatReductions:
-        Heat: 5
-        Piercing: 5
-    passiveBlockFraction: 0.6
-    activeBlockFraction: 0.6
-    isClothing: true
-  - type: Damageable
-    damageContainer: Shield
+  # Shielding
+  - type: PersonalShield
+    color: "#179EFF"
+    shatterTime: 0.2
+    scale: 1.9
+    breathDepth: 0.12
+    rimLevel: 0.9
+    shield:
+      maxCharge: 750
+      regenRate: 5 # Slow recharge. Giant health pool.
+      spinupTime: 2
+      breakCooldown: 30
+      powerDraw: 5
   - type: Battery
-    maxCharge: 150
-    startingCharge: 150
+    maxCharge: 80
+    startingCharge: 80
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 1.5
-  - type: RechargeableBlocking
-  - type: UseDelay
-    delay: 10
+    autoRechargeRate: 6
 
 # MARSOC only
 
 - type: entity
-  parent: [EnergyShieldClothing, ClothingOuterHardsuitM86, BaseFactionGearTSFT3]
+  parent: [MonoEnergyShieldClothing, ClothingOuterHardsuitM86, BaseFactionGearTSFT3]
   id: ClothingOuterHardsuitM86Mk4
   name: M86 Mk.4(B) hardsuit
   description: A limited-production redesign proposal for the M86 Mk.3(R), outfitted with an inbuilt personal shield generator.
@@ -268,3 +256,20 @@
       head: ClothingHeadHelmetHardsuitM86Mk4
       helmetcover: ClothingHeadHelmetCoverBlock
       helmetattachment: ClothingHeadHelmetAttachmentBlock
+  # Shielding - buffed dupe of CV-53 cuz im lazy
+  - type: PersonalShield
+    color: "#FF0059"
+    shatterTime: 0.4
+    scale: 1.6
+    shield:
+      maxCharge: 250
+      regenRate: 35
+      spinupTime: 0.1
+      breakCooldown: 3
+      powerDraw: 0.5
+  - type: Battery
+    maxCharge: 20
+    startingCharge: 20
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 0.6


### PR DESCRIPTION
## About the PR
dnm until eris fixes shield shaders not being separate instances and overriding eachother (❤️❤️❤️❤️)
switches MARSOC & CV-53 to fast recharging small shields and M92-X to slow recharging giant shield instead of softshield/hardshield

## Why / Balance
less buggy and easier to work with

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Updated CV-53, M86 Mk.4 (B), and M92-X to new energy shield system. Rebalanced into fast-recharging small shields for M86/CV-53 and slow-recharging large shield for M92-X.