### PR TITLE
Half Reverts Reverting Secret

### DIFF
--- a/Content.Server/_Mono/AlertLevel/Commands/SetWarLevelCommand.cs
+++ b/Content.Server/_Mono/AlertLevel/Commands/SetWarLevelCommand.cs
@@ -1,0 +1,51 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using JetBrains.Annotations;
+using Robust.Shared.Console;
+
+namespace Content.Server._Mono.AlertLevel.Commands
+{
+    [UsedImplicitly]
+    [AdminCommand(AdminFlags.Fun)]
+    public sealed partial class SetWarLevelCommand : LocalizedCommands
+    {
+        [Dependency] private IEntitySystemManager _entitySystems = default!;
+
+        public override string Command => "setwarlevel";
+
+        public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            return args.Length switch
+            {
+                1 => CompletionResult.FromHintOptions(CompletionHelper.Booleans,
+                    LocalizationManager.GetString("cmd-setwarlevel-hint-1")),
+                _ => CompletionResult.Empty,
+            };
+        }
+
+        public override void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length < 1)
+            {
+                shell.WriteError(LocalizationManager.GetString("shell-wrong-arguments-number"));
+                return;
+            }
+
+            var postwar = false;
+            if (args.Length > 0 && !bool.TryParse(args[0], out postwar))
+            {
+                shell.WriteLine(LocalizationManager.GetString("shell-argument-must-be-boolean"));
+                return;
+            }
+
+            var player = shell.Player;
+            if (player?.AttachedEntity == null)
+            {
+                shell.WriteLine(LocalizationManager.GetString("shell-only-players-can-run-this-command"));
+                return;
+            }
+
+            _entitySystems.GetEntitySystem<WarLevelSystem>().SetLevel(postwar);
+        }
+    }
+}

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -61,7 +61,7 @@ public sealed partial class CCVars
     ///     The preset for the game to fall back to if the selected preset could not be used, and fallback is enabled.
     /// </summary>
     public static readonly CVarDef<string>
-        GameLobbyFallbackPreset = CVarDef.Create("game.fallbackpreset", "Traitor,Extended", CVar.ARCHIVE);
+        GameLobbyFallbackPreset = CVarDef.Create("game.fallbackpreset", "Deathmatch", CVar.ARCHIVE); // mono - trol
 
     /// <summary>
     ///     Controls if people can win the game in Suspicion or Deathmatch.
@@ -364,7 +364,7 @@ public sealed partial class CCVars
     ///     The prototype to use for secret weights.
     /// </summary>
     public static readonly CVarDef<string> SecretWeightPrototype =
-        CVarDef.Create("game.secret_weight_prototype", "Secret", CVar.SERVERONLY);
+        CVarDef.Create("game.secret_weight_prototype", "MonoSecret", CVar.SERVERONLY); // Mono
 
     /// <summary>
     ///     The id of the sound collection to randomly choose a sound from and play when the round ends.
@@ -421,5 +421,5 @@ public sealed partial class CCVars
     ///     Set to 0 to always disable timers and whitelists when dynamic roles are enabled.
     /// </summary>
     public static readonly CVarDef<int> DynamicRolesPlayerThreshold =
-         CVarDef.Create("game.dynamic_roles.player_threshold", 5, CVar.SERVERONLY | CVar.ARCHIVE);
+         CVarDef.Create("game.dynamic_roles.player_threshold", 20, CVar.SERVERONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -364,7 +364,7 @@ public sealed partial class CCVars
     ///     The prototype to use for secret weights.
     /// </summary>
     public static readonly CVarDef<string> SecretWeightPrototype =
-        CVarDef.Create("game.secret_weight_prototype", "MonoSecret", CVar.SERVERONLY); // Mono
+        CVarDef.Create("game.secret_weight_prototype", "Secret", CVar.SERVERONLY);
 
     /// <summary>
     ///     The id of the sound collection to randomly choose a sound from and play when the round ends.

--- a/Resources/Locale/en-US/_Mono/events/shuttles.ftl
+++ b/Resources/Locale/en-US/_Mono/events/shuttles.ftl
@@ -9,6 +9,9 @@ station-event-chimera-shuttle-detected = Unidentified vessel detected near local
 # asakim ship spawns
 station-event-asakim-shuttle-detected = Unidentified Pre-Fracture vessel detected near local space. Caution is advised.
 
+# general ship spawns - prevent metagaming
+station-event-unknown-shuttle-detected = Unidentified vessel detected near local space. Caution is advised.
+
 # redacted AI ship borg stuff
 
 ghost-role-information-redacted-borg = Automated Defense Manipulator

--- a/Resources/Locale/en-US/_Mono/gamerules/gamemodes.ftl
+++ b/Resources/Locale/en-US/_Mono/gamerules/gamemodes.ftl
@@ -24,3 +24,6 @@ mono-chimera-description = Native PDV imperials threaten TSF colonial expansion 
 
 mono-allatonce-title = Apocalypse (ALL, 3hr)
 mono-allatonce-description = A battleground between PDV, and TSF forces alike, with ancient ADS systems and Chimera bioweapons seeping in.
+
+mono-secret-title = Secret (?)
+mono-secret-description = The main threat of the round is unknown. You'll have to figure that out later.

--- a/Resources/Locale/en-US/alert-levels/alert-level-command.ftl
+++ b/Resources/Locale/en-US/alert-levels/alert-level-command.ftl
@@ -9,6 +9,5 @@ cmd-setalertlevel-hint-2 = [locked]
 
 # Mono
 cmd-setwarlevel-desc = Set the war level to HOT (true) or COLD (false).
-cmd-setwarlevel-help = Usage: setwarlevel <postwar>
-cmd-setwarlevel-invalid-grid = You must be on grid of station code that you are going to change.
-cmd-setwarlevel-hint = <postwar>
+cmd-setwarlevel-help = Usage: setwarlevel [postwar]
+cmd-setwarlevel-hint-1 = [postwar]

--- a/Resources/Prototypes/_Mono/GameRules/asakim.yml
+++ b/Resources/Prototypes/_Mono/GameRules/asakim.yml
@@ -10,7 +10,7 @@
   id: UnknownShuttleAsakimSmall
   components:
   - type: StationEvent
-    startAnnouncement: station-event-asakim-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-asakim-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
@@ -25,7 +25,7 @@
   id: UnknownShuttleAsakimMedium
   components:
   - type: StationEvent
-    startAnnouncement: station-event-asakim-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-asakim-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2

--- a/Resources/Prototypes/_Mono/GameRules/chimera.yml
+++ b/Resources/Prototypes/_Mono/GameRules/chimera.yml
@@ -12,7 +12,7 @@
   id: UnknownShuttleChimeraSakuratsu
   components:
   - type: StationEvent
-    startAnnouncement: station-event-chimera-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-chimera-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
@@ -27,7 +27,7 @@
   id: UnknownShuttleChimeraOlympus
   components:
   - type: StationEvent
-    startAnnouncement: station-event-chimera-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-chimera-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
@@ -42,7 +42,7 @@
   id: UnknownShuttleChimeraTethys
   components:
   - type: StationEvent
-    startAnnouncement: station-event-chimera-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-chimera-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
@@ -57,7 +57,7 @@
   id: UnknownShuttleChimeraLegionnaire
   components:
   - type: StationEvent
-    startAnnouncement: station-event-chimera-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-chimera-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2

--- a/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
+++ b/Resources/Prototypes/_Mono/GameRules/damaged_ai.yml
@@ -22,7 +22,7 @@
   id: UnknownShuttleZenith
   components:
   - type: StationEvent
-    startAnnouncement: station-event-ai-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-ai-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
@@ -37,7 +37,7 @@
   id: UnknownShuttleZenithE
   components:
   - type: StationEvent
-    startAnnouncement: station-event-ai-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-ai-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 3
@@ -52,7 +52,7 @@
   id: UnknownShuttleNebula
   components:
   - type: StationEvent
-    startAnnouncement: station-event-ai-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-ai-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2
@@ -67,7 +67,7 @@
   id: UnknownShuttleWyrm
   components:
   - type: StationEvent
-    startAnnouncement: station-event-ai-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-ai-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 3
@@ -82,7 +82,7 @@
   id: UnknownShuttleRazorN
   components:
   - type: StationEvent
-    startAnnouncement: station-event-ai-shuttle-detected
+    startAnnouncement: station-event-unknown-shuttle-detected #station-event-ai-shuttle-detected
     startAudio:
       path: /Audio/Misc/notice1.ogg
     weight: 2 # rare but not too rare since it's in the T2 spawner

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -7,7 +7,7 @@
     - MonoGreenshift
   name: mono-standard-title
   description: mono-standard-description
-  showInVote: false # For admin usage really. Not that boring, but I'd rather just let players choose their main threat instead of choosing no threat.
+  showInVote: true
   rules:
   - NFAdventure
   - BasicStationEventScheduler
@@ -148,7 +148,8 @@
   id: MonoRogueTSFHyperwar
   name: mono-roguetsf-hyperwar-title
   description: mono-roguetsf-hyperwar-description
-  showInVote: false # AO
+  showInVote: true # we ball
+  weight: 0.15 # Giant majority needed
   rules:
   - NFAdventure
   - Hyperwar


### PR DESCRIPTION
## About the PR
basically just makes hyperwar votable (with giant fucking majority required, probably wont happen for a while) & monostandard
also setwarlevel command

## Why / Balance
funny and good for admins

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added standard and hyperwar to gamemode vote. You need a giant majority though.
