### PR TITLE
Machine FRIEND PR

### DIFF
--- a/Content.IntegrationTests/Tests/Construction/Interaction/MachineConstruction.cs
+++ b/Content.IntegrationTests/Tests/Construction/Interaction/MachineConstruction.cs
@@ -21,7 +21,7 @@ public sealed class MachineConstruction : InteractionTest
         ClientAssertPrototype(Unfinished, Target);
         await Interact(Wrench, Cable);
         AssertPrototype(MachineFrame);
-        await Interact(ProtolatheBoard, Bin1, Bin1, Manipulator1, Manipulator1, Beaker, Beaker, Processor, Processor, Motor, Screw);
+        await Interact(ProtolatheBoard, Bin1, Bin1, Manipulator1, Manipulator1, Beaker, Beaker, Screw);
         AssertPrototype(Protolathe);
     }
 
@@ -39,8 +39,6 @@ public sealed class MachineConstruction : InteractionTest
             (Steel, 5),
             (Cable, 1),
             (Beaker, 2),
-            (Motor, 1),
-            (Processor, 2),
             (Manipulator1, 2),
             (Bin1, 2),
             (ProtolatheBoard, 1));
@@ -57,7 +55,7 @@ public sealed class MachineConstruction : InteractionTest
         // Change it into an autolathe
         await InteractUsing("AutolatheMachineCircuitboard");
         AssertPrototype(MachineFrame);
-        await Interact(Bin1, Bin1, Bin1, Manipulator1, Glass, Beaker, Beaker, Motor, Screw);
+        await Interact(Bin1, Bin1, Bin1, Manipulator1, Glass, Beaker, Beaker, Screw);
         AssertPrototype("Autolathe");
     }
 
@@ -79,7 +77,7 @@ public sealed class MachineConstruction : InteractionTest
         AssertPrototype(MachineFrame);
 
         // Reconstruct with better parts.
-        await Interact(ProtolatheBoard, Bin4, Bin4, Manipulator4, Manipulator4, Beaker, Beaker, Processor, Processor, Motor);
+        await Interact(ProtolatheBoard, Bin4, Bin4, Manipulator4, Manipulator4, Beaker, Beaker);
         await Interact(Screw);
         AssertPrototype(Protolathe);
 

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -51,12 +51,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-        MicroprocessorEconomy1:
-          amount: 2
-          defaultPrototype: MicroprocessorEconomy1
-        MotorEconomy1:
-          amount: 1
-          defaultPrototype: MotorEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -88,10 +82,6 @@
         MatterBin: 4 # Frontier stackRequirements<requirements
       stackRequirements:
         Glass: 1
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 2
-          defaultPrototype: MicroprocessorEconomy1
 
 - type: entity
   id: SecurityTechFabCircuitboard
@@ -110,12 +100,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-        MicroprocessorEconomy1: # Mono
-          amount: 3
-          defaultPrototype: MicroprocessorEconomy1
-        MotorEconomy1: # Mono
-          amount: 1
-          defaultPrototype: MotorEconomy1
 
 - type: entity
   id: AmmoTechFabCircuitboard
@@ -131,12 +115,9 @@
         MatterBin: 1 # Frontier stackRequirements<requirements
         Manipulator: 1 # Frontier stackRequirements<requirements
       tagRequirements:
-        MicroprocessorEconomy1: # Mono
+        GlassBeaker:
           amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        ComponentBrickEconomy1: # Mono
-          amount: 1
-          defaultPrototype: ComponentBrickEconomy1
+          defaultPrototype: Beaker
 
 - type: entity
   id: MedicalTechFabCircuitboard
@@ -155,12 +136,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-        MicroprocessorEconomy1: # Mono
-          amount: 2
-          defaultPrototype: MicroprocessorEconomy1
-        MotorEconomy1: # Mono
-          amount: 1
-          defaultPrototype: MotorEconomy1
     - type: StealTarget
       stealGroup: MedicalTechFabCircuitboard
     - type: PirateBountyItem # Frontier
@@ -178,16 +153,10 @@
     requirements: # Frontier
       MatterBin: 1 # Frontier stackRequirements<requirements
       Manipulator: 1 # Frontier stackRequirements<requirements
-    tagRequirements: # Mono
+    tagRequirements:
       GlassBeaker:
         amount: 2
         defaultPrototype: Beaker
-      MicroprocessorEconomy1:
-        amount: 2
-        defaultPrototype: MicroprocessorEconomy1
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -224,15 +193,9 @@
     stackRequirements:
       Glass: 5
     tagRequirements: # Mono
-      MicroprocessorEconomy1:
+      GlassBeaker:
         amount: 2
-        defaultPrototype: MicroprocessorEconomy1
-      MotorEconomy1:
-        amount: 4
-        defaultPrototype: MotorEconomy1
-      ComponentBrickEconomy1:
-        amount: 2
-        defaultPrototype: ComponentBrickEconomy1
+        defaultPrototype: Beaker
   - type: GuideHelp
     guides:
     - Robotics
@@ -274,9 +237,6 @@
       GlassBeaker:
         amount: 1
         defaultPrototype: Beaker
-      MicroprocessorEconomy1: # Mono
-        amount: 2
-        defaultPrototype: MicroprocessorEconomy1
 
 - type: entity
   id: UniformPrinterMachineCircuitboard
@@ -288,10 +248,6 @@
     requirements: # Frontier
       MatterBin: 1 # Frontier stackRequirements<requirements
       Manipulator: 2 # Frontier stackRequirements<requirements
-    tagRequirements: # Mono
-      MicroprocessorEconomy1:
-        amount: 1
-        defaultPrototype: MicroprocessorEconomy1
 
 - type: entity
   id: VaccinatorMachineCircuitboard
@@ -347,16 +303,6 @@
         Capacitor: 1 # Frontier stackRequirements<requirements
       stackRequirements:
         Glass: 5
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 3
-          defaultPrototype: MicroprocessorEconomy1
-        RadioEconomy1:
-          amount: 1
-          defaultPrototype: RadioEconomy1
-        ComponentBrickEconomy1:
-          amount: 1
-          defaultPrototype: ComponentBrickEconomy1
     - type: PirateBountyItem # Frontier
       id: ArtifactAnalyzerMachineCircuitboard # Frontier
 
@@ -375,13 +321,6 @@
     stackRequirements:
       Glass: 1
       Steel: 5
-    tagRequirements: # Mono
-      MotorEconomy1:
-        amount: 4
-        defaultPrototype: MotorEconomy1
-      ArmorPlateEconomy1:
-        amount: 1
-        defaultPrototype: ArmorPlateEconomy1
 
 - type: entity
   id: OrganHarvesterMachineCircuitboard
@@ -400,13 +339,6 @@
     stackRequirements:
       Glass: 1
       Steel: 3
-    tagRequirements: # Mono
-      MotorEconomy1:
-        amount: 2
-        defaultPrototype: MotorEconomy1
-      ArmorPlateEconomy1:
-        amount: 1
-        defaultPrototype: ArmorPlateEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -423,13 +355,6 @@
       stackRequirements:
         Cable: 1
         PlasmaGlass: 10
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        RadioEconomy1:
-          amount: 1
-          defaultPrototype: RadioEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -448,15 +373,12 @@
       PlasmaGlass: 15
       MetalRod: 4
     tagRequirements: # Mono
-      MicroprocessorEconomy2:
+      MicroprocessorEconomy3:
         amount: 2
-        defaultPrototype: MicroprocessorEconomy2
+        defaultPrototype: MicroprocessorEconomy3
       RadioEconomy1:
         amount: 1
         defaultPrototype: RadioEconomy1
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -474,13 +396,6 @@
       stackRequirements:
         PlasmaGlass: 5
         Cable: 5
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        RadioEconomy1:
-          amount: 2
-          defaultPrototype: RadioEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -497,13 +412,6 @@
       stackRequirements:
         Cable: 1
         Glass: 1
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        ElectromagnetEconomy1:
-          amount: 2
-          defaultPrototype: ElectromagnetEconomy1
 
 - type: entity
   id: ThermomachineFreezerMachineCircuitBoard
@@ -520,10 +428,6 @@
       Capacitor: 2 # Frontier stackRequirements<requirements
     stackRequirements:
       Cable: 5
-    tagRequirements: # Mono
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
   - type: Construction
     deconstructionTarget: null
     graph: ThermomachineBoard
@@ -544,10 +448,6 @@
       Capacitor: 2 # Frontier stackRequirements<requirements
     stackRequirements:
       Cable: 5
-    tagRequirements: # Mono
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
   - type: Construction
     graph: ThermomachineBoard
     deconstructionTarget: null
@@ -621,10 +521,6 @@
       MatterBin: 1 # Frontier stackRequirements<requirements
     stackRequirements:
       Glass: 1
-    tagRequirements: # Mono
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
 
 - type: entity
   id: PortableScrubberMachineCircuitBoard
@@ -642,10 +538,6 @@
     stackRequirements:
       Cable: 5
       Glass: 2
-    tagRequirements: # Mono
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
 
 - type: entity
   id: SpaceHeaterMachineCircuitBoard
@@ -769,12 +661,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-        MicroprocessorEconomy1: # Mono
-          amount: 4
-          defaultPrototype: MicroprocessorEconomy1
-        OpticsEconomy1: # Mono
-          amount: 1
-          defaultPrototype: OpticsEconomy1
 
 - type: entity
   id: ChemDispenserMachineCircuitboard
@@ -796,12 +682,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-        MicroprocessorEconomy1: # Mono
-          amount: 4
-          defaultPrototype: MicroprocessorEconomy1
-        OpticsEconomy1: # Mono
-          amount: 1
-          defaultPrototype: OpticsEconomy1
 
 - type: entity
   id: BiomassReclaimerMachineCircuitboard
@@ -821,9 +701,6 @@
           amount: 2
           defaultPrototype: KitchenKnife
           examineName: construction-insert-info-examine-name-knife
-        MotorEconomy1: # Mono
-          amount: 4
-          defaultPrototype: MotorEconomy1
 
 - type: entity
   id: HydroponicsTrayMachineCircuitboard
@@ -874,17 +751,10 @@
     - type: MachineBoard
       prototype: SMESBasicEmpty
       requirements: # Frontier
-        Capacitor: 1 # Frontier stackRequirements<requirements
+        Capacitor: 4 # Frontier stackRequirements<requirements
         PowerCell: 4 # Frontier componentRequirements<requirements
       stackRequirements:
         CableHV: 10
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        ElectromagnetEconomy1:
-          amount: 2
-          defaultPrototype: ElectromagnetEconomy1
 
 - type: entity
   id: SMESAdvancedMachineCircuitboard
@@ -898,17 +768,10 @@
   - type: MachineBoard
     prototype: SMESAdvancedEmpty
     requirements: # Frontier
-        Capacitor: 2 # Frontier stackRequirements<requirements
+        Capacitor: 8 # Frontier stackRequirements<requirements
         PowerCell: 8 # Frontier componentRequirements<requirements, 4<8
     stackRequirements:
       CableHV: 20
-    tagRequirements: # Mono
-      MicroprocessorEconomy1:
-        amount: 1
-        defaultPrototype: MicroprocessorEconomy1
-      ElectromagnetEconomy2:
-        amount: 2
-        defaultPrototype: ElectromagnetEconomy2
 
 - type: entity
   id: CellRechargerCircuitboard
@@ -948,13 +811,6 @@
       stackRequirements:
         Steel: 5
         Cable: 10
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        ElectromagnetEconomy1:
-          amount: 1
-          defaultPrototype: ElectromagnetEconomy1
     - type: PhysicalComposition
       materialComposition:
         Steel: 30
@@ -977,13 +833,6 @@
         Capacitor: 2 # Frontier stackRequirements<requirements
       stackRequirements:
         Cable: 5
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        ElectromagnetEconomy1:
-          amount: 1
-          defaultPrototype: ElectromagnetEconomy1
     - type: PhysicalComposition
       materialComposition:
         Steel: 30
@@ -1054,13 +903,6 @@
       stackRequirements:
         CableMV: 5
         CableHV: 5
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        ComponentBrickEconomy1:
-          amount: 1
-          defaultPrototype: ComponentBrickEconomy1
     - type: PhysicalComposition
       materialComposition:
         Glass: 200
@@ -1116,15 +958,9 @@
       stackRequirements:
         CableHV: 5
       tagRequirements: # Mono
-        ComponentBrickEconomy1:
-          amount: 1
-          defaultPrototype: ComponentBrickEconomy1
         MotorEconomy1: # Stator!
           amount: 1
           defaultPrototype: MotorEconomy1
-        MicroprocessorEconomy1:
-          amount: 2
-          defaultPrototype: MicroprocessorEconomy1
     - type: PhysicalComposition
       materialComposition:
         Glass: 200
@@ -1189,15 +1025,9 @@
       stackRequirements:
         CableHV: 10
       tagRequirements: # Mono
-        ComponentBrickEconomy1:
-          amount: 2
-          defaultPrototype: ComponentBrickEconomy1
         MotorEconomy1: # Stator!
           amount: 1
           defaultPrototype: MotorEconomy1
-        MicroprocessorEconomy1:
-          amount: 3
-          defaultPrototype: MicroprocessorEconomy1
     - type: PhysicalComposition
       materialComposition:
         Glass: 200
@@ -1219,10 +1049,6 @@
         Capacitor: 1 # Frontier stackRequirements<requirements
       stackRequirements:
         Cable: 10
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
     - type: PhysicalComposition
       materialComposition:
         Glass: 200
@@ -1246,9 +1072,6 @@
         GlassBeaker:
           amount: 1
           defaultPrototype: Beaker
-        MotorEconomy1: # Mono
-          amount: 1
-          defaultPrototype: MotorEconomy1
 
 - type: entity
   id: HotplateMachineCircuitboard
@@ -1292,13 +1115,6 @@
       stackRequirements:
         Cable: 3
         Steel: 2
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 2
-          defaultPrototype: MicroprocessorEconomy1
-        ComponentBrickEconomy1:
-          amount: 1
-          defaultPrototype: ComponentBrickEconomy1
 
 - type: entity
   id: ElectrolysisUnitMachineCircuitboard
@@ -1365,19 +1181,6 @@
         Manipulator: 3 # Frontier stackRequirements<requirements
       stackRequirements:
         Glass: 1
-      tagRequirements: # Mono
-        MicroprocessorEconomy1:
-          amount: 2
-          defaultPrototype: MicroprocessorEconomy1
-        ComponentBrickEconomy1:
-          amount: 1
-          defaultPrototype: ComponentBrickEconomy1
-        ElectromagnetEconomy1:
-          amount: 2
-          defaultPrototype: ElectromagnetEconomy1
-        ArmorPlateEconomy2:
-          amount: 1
-          defaultPrototype: ArmorPlateEconomy2
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -1478,19 +1281,6 @@
     requirements: # Frontier
       Manipulator: 2 # Frontier stackRequirements<requirements
       MatterBin: 1 # Frontier stackRequirements<requirements
-    tagRequirements: # Mono
-      MicroprocessorEconomy1:
-        amount: 2
-        defaultPrototype: MicroprocessorEconomy1
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
-      ElectromagnetEconomy1:
-        amount: 1
-        defaultPrototype: ElectromagnetEconomy1
-      OpticsEconomy1:
-        amount: 2
-        defaultPrototype: OpticsEconomy1
 
 - type: entity
   id: EmitterCircuitboard
@@ -1581,13 +1371,6 @@
       stackRequirements:
         Cable: 2
         Glass: 1
-      tagRequirements: # Mono
-        RadioEconomy1:
-          amount: 1
-          defaultPrototype: RadioEconomy1
-        CameraEconomy1:
-          amount: 1
-          defaultPrototype: CameraEconomy1
 
 - type: entity
   id: GasRecyclerMachineCircuitboard
@@ -1603,13 +1386,6 @@
     stackRequirements:
       Steel: 10
       Plasma: 5
-    tagRequirements: # Mono
-      MotorEconomy1:
-        amount: 2
-        defaultPrototype: RadioEconomy1
-      ComponentBrickEconomy1:
-        amount: 2
-        defaultPrototype: CameraEconomy1
 
 - type: entity
   id: BoozeDispenserMachineCircuitboard
@@ -1699,13 +1475,6 @@
       Steel: 5
       CableHV: 5
       Cable: 2
-    tagRequirements: # Mono
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
-      ElectromagnetEconomy1:
-        amount: 2
-        defaultPrototype: ElectromagnetEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -1760,9 +1529,6 @@
     stackRequirements:
       Glass: 1
     tagRequirements: # Mono
-      ComponentBrickEconomy1:
-        amount: 2
-        defaultPrototype: ComponentBrickEconomy1
       MotorEconomy1:
         amount: 4
         defaultPrototype: MotorEconomy1
@@ -1794,13 +1560,6 @@
     stackRequirements:
       Steel: 2
       Cable: 1
-    tagRequirements: # Mono
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
-      MotorEconomy1:
-        amount: 2
-        defaultPrototype: MotorEconomy1
 
 # Shitmed Change Start
 - type: entity
@@ -1816,13 +1575,6 @@
       requirements:
         MatterBin: 2
         Manipulator: 2
-      tagRequirements: # Mono
-        ComponentBrickEconomy1:
-          amount: 2
-          defaultPrototype: ComponentBrickEconomy1
-        MotorEconomy1:
-          amount: 1
-          defaultPrototype: MotorEconomy1
 # Shitmed Change End
 
 # Assmos - /tg/ gases

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -15,9 +15,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-        MotorEconomy1:
-          amount: 1
-          defaultPrototype: MotorEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -977,16 +977,6 @@
       Capacitor: 1 # Frontier stackRequirements<requirements. Mono 4<1
     stackRequirements:
       Steel: 5
-    tagRequirements: # Mono
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
-      ElectromagnetEconomy1:
-        amount: 2
-        defaultPrototype: ElectromagnetEconomy1
-      ArmorPlateEconomy1:
-        amount: 2
-        defaultPrototype: ArmorPlateEconomy1
 
 - type: entity
   id: GyroscopeMachineCircuitboard
@@ -1000,13 +990,6 @@
       Capacitor: 1 # Frontier stackRequirements<requirements
     stackRequirements:
       Glass: 2
-    tagRequirements: # Mono
-      ComponentBrickEconomy1:
-        amount: 2
-        defaultPrototype: ComponentBrickEconomy1
-      ArmorPlateEconomy1:
-        amount: 2
-        defaultPrototype: ArmorPlateEconomy1
 
 - type: entity
   id: PortableGeneratorSuperPacmanMachineCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -37,13 +37,11 @@
       Gold: 500
       Lithium: 500 # Mono
       Copper: 500 # Mono
-      Bluespace: 100
     baseComputerCost:
       Steel: 500
       Glass: 250
       Silver: 100
       Gold: 50
-      Bluespace: 50
   - type: Machine
     board: FlatpackerMachineCircuitboard
   - type: MaterialStorage

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/machine.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/machine.yml
@@ -12,11 +12,9 @@
       Manipulator: 4
     stackRequirements:
       Steel: 6
+      Copper: 2
+      Lithium: 2
       Cable: 5
-    tagRequirements:
-      MotorEconomy1: # Mono
-        amount: 1
-        defaultPrototype: MotorEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -34,10 +32,6 @@
     stackRequirements:
       Steel: 10
       Cable: 5
-    tagRequirements:
-      MotorEconomy1: # Mono
-        amount: 2
-        defaultPrototype: MotorEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -67,8 +61,6 @@
       Manipulator: 4
     stackRequirements:
       Plastic: 4
+      Copper: 2
+      Lithium: 2
       Cable: 5
-    tagRequirements:
-      MotorEconomy1: # Mono
-        amount: 1
-        defaultPrototype: MotorEconomy1

--- a/Resources/Prototypes/_Mono/Catalogs/Cargo/cargo_economy.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Cargo/cargo_economy.yml
@@ -18,7 +18,7 @@
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: armor1
   product: ArmorPlateEconomy1
-  cost: 2000
+  cost: 2500
   category: cargoproduct-category-name-economy
   group: market
 
@@ -38,7 +38,7 @@
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: capacitor1
   product: CapacitorEconomy1
-  cost: 400
+  cost: 1200
   category: cargoproduct-category-name-economy
   group: market
 
@@ -48,7 +48,7 @@
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: optics1
   product: OpticsEconomy1
-  cost: 400
+  cost: 1200
   category: cargoproduct-category-name-economy
   group: market
 
@@ -58,7 +58,7 @@
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: canister
   product: MatterBinEconomy1
-  cost: 600
+  cost: 1400
   category: cargoproduct-category-name-economy
   group: market
 
@@ -68,7 +68,7 @@
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: microprocessor1
   product: MicroprocessorEconomy1
-  cost: 600
+  cost: 1600
   category: cargoproduct-category-name-economy
   group: market
 
@@ -80,7 +80,7 @@
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: componentbrick1
   product: ComponentBrickEconomy1
-  cost: 1000
+  cost: 2000
   category: cargoproduct-category-name-economy
   group: market
 
@@ -90,6 +90,6 @@
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: motor
   product: MotorEconomy1
-  cost: 1200
+  cost: 2400
   category: cargoproduct-category-name-economy
   group: market

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/economy.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/economy.yml
@@ -7,6 +7,7 @@
   - type: Sprite
     state: engineering
   - type: MachineBoard
+    flatpackable: false
     prototype: CentrifugeLatheMini
     requirements:
       MatterBin: 2
@@ -78,6 +79,7 @@
   - type: Sprite
     state: engineering
   - type: MachineBoard
+    flatpackable: false
     prototype: IndustrialPressEconomyPlates
     requirements:
       MatterBin: 2
@@ -100,6 +102,7 @@
   - type: Sprite
     state: engineering
   - type: MachineBoard
+    flatpackable: false
     prototype: IndustrialPressEconomyPlatesMMC
     requirements:
       MatterBin: 2
@@ -125,6 +128,7 @@
   - type: Sprite
     state: engineering
   - type: MachineBoard
+    flatpackable: false
     prototype: IndustrialPressEconomyElectronics
     requirements:
       MatterBin: 2
@@ -147,6 +151,7 @@
   - type: Sprite
     state: engineering
   - type: MachineBoard
+    flatpackable: false
     prototype: IndustrialPressEconomyElectronicsMMC
     requirements:
       MatterBin: 2

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/economy.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/economy.yml
@@ -85,13 +85,7 @@
     stackRequirements:
       Lithium: 5
       CableHV: 10
-    tagRequirements: # todo: make it take a press plate component
-      ArmorPlateEconomy1: # Stand in for the base of the press or something
-        amount: 1
-        defaultPrototype: ArmorPlateEconomy1
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
+    # Doesnt require industry comps because it's entry-level. Let's you get to the other ones. It's called progression sir.
   - type: Construction
     deconstructionTarget: null
     graph: IndustrialPress
@@ -113,13 +107,10 @@
     stackRequirements: # faster mmc variant
       Lithium: 10
       CableHV: 20
-    tagRequirements: # todo: make it take a press plate component
-      ArmorPlateEconomy2: # Stand in for the base of the press or something
+    tagRequirements:
+      ArmorPlateEconomy1:
         amount: 1
-        defaultPrototype: ArmorPlateEconomy2
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
+        defaultPrototype: ArmorPlateEconomy1
   - type: Construction
     deconstructionTarget: null
     graph: IndustrialPressMMC
@@ -141,13 +132,7 @@
     stackRequirements:
       Lithium: 5
       CableHV: 10
-    tagRequirements: # todo: make it take a press plate component
-      ArmorPlateEconomy1: # Stand in for the base of the press or something
-        amount: 1
-        defaultPrototype: ArmorPlateEconomy1
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
+    # Doesnt require industry comps because it's entry-level. Let's you get to the other ones. It's called progression sir.
   - type: Construction
     deconstructionTarget: null
     graph: IndustrialPress
@@ -169,13 +154,10 @@
     stackRequirements: # faster mmc variant
       Lithium: 10
       CableHV: 20
-    tagRequirements: # todo: make it take a press plate component
-      ArmorPlateEconomy2: # Stand in for the base of the press or something
+    tagRequirements:
+      ArmorPlateEconomy1:
         amount: 1
-        defaultPrototype: ArmorPlateEconomy2
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
+        defaultPrototype: ArmorPlateEconomy1
   - type: Construction
     deconstructionTarget: null
     graph: IndustrialPressMMC

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/misc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/misc.yml
@@ -11,7 +11,7 @@
       Capacitor: 2
       Manipulator: 2
     tagRequirements:
-      RadioEconomy1:
+      RadioEconomy1: # Lag prevention, I guess?
         amount: 1
         defaultPrototype: RadioEconomy1
 
@@ -29,9 +29,9 @@
     stackRequirements:
       Plasteel: 4
     tagRequirements:
-      ElectromagnetEconomy2:
+      ElectromagnetEconomy1:
         amount: 1
-        defaultPrototype: ElectromagnetEconomy2
+        defaultPrototype: ElectromagnetEconomy1
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -70,7 +70,5 @@
     prototype: MachineShipDrill
     stackRequirements:
       Steel: 7
-    tagRequirements:
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
+    requirements:
+      Capacitor: 2

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/salvage.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/salvage.yml
@@ -13,7 +13,3 @@
     stackRequirements:
       Steel: 5
       CableHV: 5
-    tagRequirements:
-      ElectromagnetEconomy1:
-        amount: 2
-        defaultPrototype: ElectromagnetEconomy1

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/shields.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/shields.yml
@@ -8,6 +8,7 @@
       state: security
     - type: MachineBoard
       prototype: ShieldGeneratorSmall
+      flatpackable: false
       stackRequirements:
         Glass: 10
         Steel: 10
@@ -37,6 +38,7 @@
     state: security
   - type: MachineBoard
     prototype: ShieldGeneratorMedium
+    flatpackable: false
     stackRequirements:
       Glass: 10
       Steel: 10
@@ -69,6 +71,7 @@
     state: security
   - type: MachineBoard
     prototype: ShieldGenerator
+    flatpackable: false
     stackRequirements:
       Glass: 30
       Steel: 30

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/ship_components.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/ship_components.yml
@@ -48,6 +48,7 @@
     state: security
   - type: MachineBoard
     prototype: MachineFTLDrive
+    flatpackable: false
     requirements:
       Capacitor: 4
       Manipulator: 2
@@ -196,6 +197,7 @@
     state: security
   - type: MachineBoard
     prototype: MachineFTLDrive25S
+    flatpackable: false
     requirements:
       Capacitor: 8
       Manipulator: 4
@@ -227,6 +229,7 @@
     state: security
   - type: MachineBoard
     prototype: MachineFTLDrive50
+    flatpackable: false
     requirements:
       Capacitor: 8
       Manipulator: 4

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/techfab.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/techfab.yml
@@ -15,12 +15,6 @@
       GlassBeaker:
         amount: 2
         defaultPrototype: Beaker
-      MicroprocessorEconomy1:
-        amount: 3
-        defaultPrototype: MicroprocessorEconomy1
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
 
 - type: entity
   id: USSPTechfabMachineCircuitboard
@@ -39,12 +33,6 @@
       GlassBeaker:
         amount: 2
         defaultPrototype: Beaker
-      MicroprocessorEconomy1:
-        amount: 3
-        defaultPrototype: MicroprocessorEconomy1
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
 
 - type: entity
   id: VGTechfabMachineCircuitboard
@@ -63,12 +51,6 @@
       GlassBeaker:
         amount: 2
         defaultPrototype: Beaker
-      MicroprocessorEconomy1:
-        amount: 3
-        defaultPrototype: MicroprocessorEconomy1
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1
 
 - type: entity
   id: MMCTechfabMachineCircuitboard
@@ -87,9 +69,3 @@
       GlassBeaker:
         amount: 2
         defaultPrototype: Beaker
-      MicroprocessorEconomy1:
-        amount: 3
-        defaultPrototype: MicroprocessorEconomy1
-      MotorEconomy1:
-        amount: 1
-        defaultPrototype: MotorEconomy1

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/turrets.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Circuitboards/Machine/turrets.yml
@@ -17,11 +17,8 @@
       Plasma: 3
       CableHV: 2
     tagRequirements:
-      ElectromagnetEconomy1:
-        amount: 1
-        defaultPrototype: ElectromagnetEconomy1
       MicroprocessorEconomy1:
-        amount: 3
+        amount: 2
         defaultPrototype: MicroprocessorEconomy1
       MotorEconomy1:
         amount: 1

--- a/Resources/Prototypes/_Mono/Entities/Objects/Economy/arc_furnace.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Economy/arc_furnace.yml
@@ -94,6 +94,8 @@
   - type: Sprite
     sprite: _Mono/Objects/Materials/silicon.rsi
     state: "wafer"
+  - type: StaticPrice
+    price: 500
   - type: Destructible
     thresholds:
     - trigger:
@@ -338,6 +340,8 @@
   - type: PhysicalComposition
     chemicalComposition:
       Silicon: 100
+  - type: StaticPrice
+    price: 500
 
 - type: entity
   name: silicon boule scrap

--- a/Resources/Prototypes/_Mono/Entities/Objects/Economy/arc_furnace.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Economy/arc_furnace.yml
@@ -296,6 +296,8 @@
     chemicalComposition:
       Carbon: 15
       Silicon: 15
+  - type: StaticPrice
+    price: 1500
 
 # silicon
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Economy/base.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Economy/base.yml
@@ -58,6 +58,8 @@
   - type: GuideHelp
     guides:
     - EconomyRecipes
+  - type: StaticPrice
+    price: 300
 
 - type: entity
   name: base economy item

--- a/Resources/Prototypes/_Mono/Entities/Objects/Economy/components.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Economy/components.yml
@@ -559,8 +559,8 @@
       !type:PhysShapeCircle
       radius: 2
     repeating: true
-    - type: StaticPrice
-      price: 1200
+  - type: StaticPrice
+    price: 1200
 
 # end camera
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Economy/components.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Economy/components.yml
@@ -66,6 +66,8 @@
     solution: capsule
   - type: Spillable
     solution: capsule
+  - type: StaticPrice
+    price: 200
 
 - type: entity
   id: MatterBinEconomy2
@@ -101,6 +103,8 @@
       Steel: 1000
       Plastic: 1000
       Glass: 500
+  - type: StaticPrice
+    price: 600
 
 - type: entity
   name: basic components
@@ -152,6 +156,8 @@
       Steel: 1000
       Plastic: 1000
       Glass: 500
+  - type: StaticPrice
+    price: 2000
 
 # end matter bins
 
@@ -183,6 +189,8 @@
           collection: MetalBreak
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: StaticPrice
+    price: 300
 
 - type: entity
   name: nanoprocessor
@@ -210,6 +218,8 @@
           collection: MetalBreak
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: StaticPrice
+    price: 600
 
 - type: entity
   name: quantum processor
@@ -237,6 +247,8 @@
           collection: MetalBreak
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: StaticPrice
+    price: 2500
 
 # end microprocessors
 
@@ -259,6 +271,8 @@
     - type: MachinePart
       part: Capacitor
       rating: 1
+    - type: StaticPrice
+      price: 200
 
 - type: entity
   name: industrial advanced capacitor
@@ -276,6 +290,8 @@
     - type: MachinePart
       part: Capacitor
       rating: 3
+    - type: StaticPrice
+      price: 600
 
 - type: entity
   name: industrial supercapacitor
@@ -292,6 +308,8 @@
     - type: MachinePart
       part: Capacitor
       rating: 4
+    - type: StaticPrice
+      price: 1400
 
 # end capacitors
 
@@ -310,6 +328,8 @@
   - type: Sprite
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: "componentbrick1"
+  - type: StaticPrice
+    price: 800
 
 - type: entity
   name: basic components
@@ -340,6 +360,8 @@
   - type: Sprite
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: "componentbrick2"
+  - type: StaticPrice
+    price: 3000
 
 - type: entity
   name: super components
@@ -354,6 +376,8 @@
   - type: Sprite
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: "componentbrick3"
+  - type: StaticPrice
+    price: 5000
 
 # end component bricks
 
@@ -372,6 +396,8 @@
   - type: Sprite
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: "electromagnet1"
+  - type: StaticPrice
+    price: 800
 
 - type: entity
   name: compound electromagnet (unfinished)
@@ -399,6 +425,8 @@
   - type: Sprite
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: "electromagnet2"
+  - type: StaticPrice
+    price: 1600
 
 - type: entity
   name: superconductive electromagnet (unfinished)
@@ -426,6 +454,8 @@
   - type: Sprite
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: "electromagnet3"
+  - type: StaticPrice
+    price: 3000
 
 # end magnets
 
@@ -444,6 +474,8 @@
     - type: Sprite
       sprite: _Mono/Objects/Materials/bayponents.rsi
       state: "radio1"
+    - type: StaticPrice
+      price: 800
 
 - type: entity
   name: HF signal tranciever component
@@ -458,6 +490,8 @@
     - type: Sprite
       sprite: _Mono/Objects/Materials/bayponents.rsi
       state: "radio2"
+    - type: StaticPrice
+      price: 1200
 
 # end radios
 
@@ -476,6 +510,8 @@
     - type: Sprite
       sprite: _Mono/Objects/Materials/bayponents.rsi
       state: "optics1"
+    - type: StaticPrice
+      price: 800
 
 - type: entity
   name: precision optical sensor
@@ -490,6 +526,8 @@
     - type: Sprite
       sprite: _Mono/Objects/Materials/bayponents.rsi
       state: "optics2"
+    - type: StaticPrice
+      price: 1200
 
 # end optics
 
@@ -521,6 +559,8 @@
       !type:PhysShapeCircle
       radius: 2
     repeating: true
+    - type: StaticPrice
+      price: 1200
 
 # end camera
 
@@ -539,3 +579,5 @@
   - type: Sprite
     sprite: _Mono/Objects/Materials/bayponents.rsi
     state: "motor"
+  - type: StaticPrice
+    price: 800

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/carrion.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/carrion.yml
@@ -5,7 +5,7 @@
   parent: BaseVesselAntag
   name: ELH Carrion
   description: A fighter armed with 4x 90mm DRAVON autocannons and a GPOB-L bomb bay, built for reconnaissance and extreme-speed skirmishing.
-  price: 46962 #Appraised at 44962
+  price: 48962 #Appraised at 44962
   category: Small
   group: BlackMarket
   access: Pirate

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/fenrir.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/fenrir.yml
@@ -5,7 +5,7 @@
   parent: BaseVesselAntag
   name: BT-Y Fenrir
   description: A versalite support destroyer armed with an M381 Mass Driver, 2 Dravons, 2 Scattercannons, 4 20mm autocannons and outfitted with 2 Medium Size Mechbays capable of deploying S-2 and S-1 Mechs but does not come with Mechs. Well armored but slow.
-  price: 173385
+  price: 199385
   purchasable: false # voucher only
   category: Medium
   group: BlackMarket

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/layak.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/layak.yml
@@ -5,7 +5,7 @@
   parent: BaseVesselAntag
   name: PD-VI Layak
   description: A light escort corvette for combating light ships and incoming missiles. Outfitted with 4 DRAVONs for flak, 4 AK-570s, 2 CYREXAs, and 2 flare pods.
-  price: 164803 #162803 appraisal
+  price: 169803 #167803 appraisal
   purchasable: false # voucher only
   category: Medium
   group: BlackMarket

--- a/Resources/Prototypes/_Mono/Shipyard/BlackMarket/saintie.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/BlackMarket/saintie.yml
@@ -8,7 +8,7 @@
   limit: 2
   hyperwarLimit: 4
   hyperwarTimelock: 3600
-  price: 349358
+  price: 379358
   purchasable: false # Voucher only
   category: Large
   group: BlackMarket

--- a/Resources/Prototypes/_Mono/Shipyard/Mieyo/autumn_mieyo.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Mieyo/autumn_mieyo.yml
@@ -3,7 +3,7 @@
   parent: BaseVessel
   name: MMC-SKR Mieyo-Autumn
   description: A licensed production variant of the Autumn. All we did for this one was swap out the floor tiles and the suits.
-  price: 189831
+  price: 224831
   category: Large
   group: Mieyo
   access: Mieyo

--- a/Resources/Prototypes/_Mono/Shipyard/Nfsd/andromeda.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Nfsd/andromeda.yml
@@ -8,7 +8,7 @@
   limit: 3
   hyperwarLimit: 5
   hyperwarTimelock: 1800
-  price: 358869
+  price: 388869
   purchasable: false # voucher only
   category: Large
   group: Security

--- a/Resources/Prototypes/_Mono/Shipyard/Nfsd/fujian.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Nfsd/fujian.yml
@@ -7,7 +7,7 @@
   description: A decently-sized escort carrier, capable of holding 4 Zephyrs or Zephyr-ECs. Carries quite a bit of armor to defend itself and its fighters.
   limit: 2
   hyperwarLimit: 3
-  price: 341601
+  price: 425601
   category: Large
   purchasable: false # voucher only
   group: Security

--- a/Resources/Prototypes/_Mono/Shipyard/Nfsd/polaris.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Nfsd/polaris.yml
@@ -8,7 +8,7 @@
   limit: 2
   hyperwarLimit: 3
   hyperwarTimelock: 3600
-  price: 341987
+  price: 386987
   purchasable: false # voucher only
   category: Large
   group: Security

--- a/Resources/Prototypes/_Mono/Shipyard/Nfsd/spekter.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Nfsd/spekter.yml
@@ -7,7 +7,7 @@
   parent: BaseVesselAntag
   name: TSF-SKR Spekter # I would've liked to make this weakly armored & stealthy to fit the name, but there isn't really anything for that.
   description: An averagely armored corvette with an armament focused on it's 3 torpedo mounts on both sides.
-  price: 236118 # appraises at 233118
+  price: 255118 # appraises at 252551
   hyperwarTimelock: 1800
   purchasable: false # voucher only
   category: Medium

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/skelraak.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/skelraak.yml
@@ -9,7 +9,7 @@
   parent: BaseVessel
   name: VOX-Skelraak
   description: An imposing near-capital warship of Vox design - Featuring a nitrogen atmosphere. It comes equipped with a dizzying array of weaponry, centered around a spinally mounted Leviathan Siege Cannon. It struggles when used outside of fleet engagements, as Vox raiding fleets typically include countless escorts - A ship of this class is reserved for experienced Vox captains.
-  price: 376500 # felt right idk
+  price: 396500 # felt right idk
   category: large
   group: Scrap
   access: Mercenary

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/thorax.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/thorax.yml
@@ -7,7 +7,7 @@
   parent: BaseVessel
   name: Thorax
   description: A light mech carrier and factory, including 4 different docks for assistance.
-  price: 72070
+  price: 101070
   category: Medium
   group: Sr
   access: Brig

--- a/Resources/Prototypes/_Mono/Shipyard/autumn.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/autumn.yml
@@ -9,7 +9,7 @@
   parent: BaseVessel
   name: TSF-SKR Autumn
   description: A long-range cargo freighter. The cargo bay is (relatively) heavily armored with a plastitanium inner layer, and the ship is equipped with a heavy FTL drive. Armed with 4x 57mms.
-  price: 187811
+  price: 217811
   category: Large
   group: Shipyard
   shuttlePath: /SharedMaps/_Mono/Shuttles/autumn.yml

--- a/Resources/Prototypes/_Mono/Shipyard/hammerhead.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/hammerhead.yml
@@ -9,7 +9,7 @@
   parent: BaseVessel
   name: UI-SKR Hammerhead
   description: A multipurpose mercenary ship with an armament of 4 225mm cannons, 4 20mm PD guns, and 6 57mm autocannons. Lacks a bit in protection compared to proper military ships of this size.
-  price: 264616 # Its a ~10k markup, it really is that expensive.
+  price: 324616 # Its a ~10k markup, it really is that expensive.
   category: Large
   group: Shipyard
   access: Mercenary

--- a/Resources/Prototypes/_Mono/Shipyard/olympus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/olympus.yml
@@ -8,7 +8,7 @@
   parent: BaseVessel
   name: DIS Olympus
   description: A massive cargo freighter, the pride and joy of DIS. Furnished with an 185 tile dedicated cargo space, a 50 type drive and dedicated shield & point defense system. In sum all you need to run smooth, large scale transport operations.
-  price: 279891
+  price: 299891
   category: Large
   group: Shipyard
   shuttlePath: /SharedMaps/_Mono/Shuttles/olympus.yml

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
@@ -137,16 +137,6 @@
       Capacitor: 1 # Mono 1<4
     stackRequirements:
       Steel: 5
-    tagRequirements:
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
-      ElectromagnetEconomy1:
-        amount: 1
-        defaultPrototype: ElectromagnetEconomy1
-      ArmorPlateEconomy1:
-        amount: 1
-        defaultPrototype: ArmorPlateEconomy1
   - type: StaticPrice
     price: 18 # 12.5<18
   - type: Tag # Frontier
@@ -198,13 +188,6 @@
       Capacitor: 1
     stackRequirements:
       Glass: 2
-    tagRequirements:
-      ComponentBrickEconomy1:
-        amount: 1
-        defaultPrototype: ComponentBrickEconomy1
-      ArmorPlateEconomy1:
-        amount: 1
-        defaultPrototype: ArmorPlateEconomy1
   - type: StaticPrice
     price: 17.5
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Devices/production.yml
@@ -26,13 +26,6 @@
       requirements:
         MatterBin: 2
         Manipulator: 2
-      tagRequirements:
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        MotorEconomy1:
-          amount: 1
-          defaultPrototype: MotorEconomy1
 
 - type: entity
   id: MercenaryTechFabCircuitboardNF
@@ -46,12 +39,9 @@
         MatterBin: 2
         Manipulator: 2
       tagRequirements:
-        MicroprocessorEconomy1:
+        GlassBeaker:
           amount: 2
-          defaultPrototype: MicroprocessorEconomy1
-        MotorEconomy1:
-          amount: 1
-          defaultPrototype: MotorEconomy1
+          defaultPrototype: Beaker
 
 - type: entity
   id: MercenaryTechFabCircuitboardHackedNF
@@ -68,12 +58,9 @@
         MatterBin: 2
         Manipulator: 2
       tagRequirements:
-        MicroprocessorEconomy1:
+        GlassBeaker:
           amount: 2
-          defaultPrototype: MicroprocessorEconomy1
-        MotorEconomy1:
-          amount: 1
-          defaultPrototype: MotorEconomy1
+          defaultPrototype: Beaker
 
 - type: entity
   id: NFScrapProcessorCircuitboard
@@ -92,12 +79,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-        MicroprocessorEconomy1:
-          amount: 1
-          defaultPrototype: MicroprocessorEconomy1
-        MotorEconomy1:
-          amount: 4
-          defaultPrototype: MotorEconomy1
 
 # TechFab
 - type: entity
@@ -242,15 +223,12 @@
       stackRequirements:
         CableHV: 10
       tagRequirements:
-        ComponentBrickEconomy2:
-          amount: 2
-          defaultPrototype: ComponentBrickEconomy2
         MotorEconomy1: # Stator!
-          amount: 2
-          defaultPrototype: MotorEconomy1
-        MicroprocessorEconomy2:
           amount: 1
-          defaultPrototype: MicroprocessorEconomy2
+          defaultPrototype: MotorEconomy1
+        MicroprocessorEconomy1:
+          amount: 1
+          defaultPrototype: MicroprocessorEconomy1
     - type: PhysicalComposition
       materialComposition:
         Glass: 200
@@ -274,15 +252,12 @@
       stackRequirements:
         CableHV: 10
       tagRequirements:
-        ComponentBrickEconomy2:
-          amount: 4
-          defaultPrototype: ComponentBrickEconomy2
         MotorEconomy1: # Stator!
-          amount: 4
+          amount: 1
           defaultPrototype: MotorEconomy1
-        MicroprocessorEconomy2:
-          amount: 2
-          defaultPrototype: MicroprocessorEconomy2
+        MicroprocessorEconomy1:
+          amount: 1
+          defaultPrototype: MicroprocessorEconomy1
     - type: PhysicalComposition
       materialComposition:
         Glass: 200


### PR DESCRIPTION
## About the PR
Removes economy comps from a lot of basic stuff / stuff that you build in-mass or stuff thats pretty simple (such as drills, autolathes, chemmasters, etc). Removes comp costs from basic economy presses (not MMC) so you can make the parts yourself without needing an economy machine to start with.
Not everything is removed of course, comps are still kept for:
- Ship flight-control components like thrusters & gyros, since we don't really want a million thrusters being built anyways and building more thrusters isn't essential for anything.
- High tier machines that either Do Cool Stuff (cloning equipment, crystalizer), or are upgrades (hellfire heaters/freezers, industrial ore processor, industrial reagent grinder, experimental anomaly vessel, etc), or other economy machines (centrifuge, arc furnace, precision assembler).
- Stuff that you don't build often that mostly come with ships and stations like R&D servers or silos, to serve as a way to add a flat cost to ships that have these capabilities (silos, R&D servers, camera routers, GCS servers, shields, FTL drives). Nobody is going to care about the R&D server costing a few processors still.

## Why / Balance
Most of the machines that have had it removed in this PR weren't too OP and didn't need the blocking, since if you were building them it was probably for a gimmick. Stuff that we still don't want built in stupid amounts for cheesing like 30 million silos or 20 thrusters or a room full of datafarms keep their cost. If you want those, then you do the economy chain (and it'll be easier now that you don't need a POI to get started)

Also, upgraded machines keep the cost because what's the point of the normal ore processor or the normal freezer when you can get the 10x better ones for an extra minute of work?

<img width="453" height="303" alt="image" src="https://github.com/user-attachments/assets/b2e7ce82-126b-4165-a57a-b318fb37f905" />


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Nuked economy components from a lot of basic machines like autolathes, interactors, ship drills, etc. Don't get your expectations too high, the powerful stuff like crystallizer and industrial processors still need it.
- tweak: Industrial presses don't need any economy components to be made, so you don't need a POI to get started with any of it now if you have an autolathe & circuit imprinter.
- tweak: Economy components have actual monetary value now.