### PR TITLE
Space Dragon Lungs

### DIFF
--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
@@ -35,6 +35,7 @@
   components:
   - type: Organ
     onAdd:
+    - type: BreathingImmunity
     - type: ActionGun
       action: ActionDragonsBreath
       gunProto: DragonsBreathGun


### PR DESCRIPTION



## About the PR
I changed the organ itself to act like its fellow carp allowing for no air requirements like its suppost to.

## Why / Balance
Space dragon exists in space with its lungs, had to fix the issue of the lungs it had to meet this bizaar issue of them not working like they are suppost to

## Requirements
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.



**Changelog**

:cl:
- tweak: Dragon lungs now work in space!
