### PR TITLE
Add Planets to Gamemodes (and Also Star Lighting)

### DIFF
--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
@@ -672,12 +672,14 @@ public partial class BaseShuttleControl : MapGridControl
 
         const float BatchSize = 3f * 4096;
 
+        var fillColor = Color.ToSrgb(Color.InterpolateBetween(BackingColor, color, alpha)).WithAlpha(1f);
+
         for (var i = 0; i < Math.Ceiling(triCount / BatchSize); i++)
         {
             var start = (int) (i * BatchSize);
             var end = (int) Math.Min(triCount, start + BatchSize);
             var count = end - start;
-            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, new Span<Vector2>(_allVertices, start, count), color.WithAlpha(alpha));
+            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, new Span<Vector2>(_allVertices, start, count), fillColor);
         }
 
         handle.DrawPrimitives(DrawPrimitiveTopology.LineList, new Span<Vector2>(_allVertices, gridData.EdgeIndex, edgeCount), color);

--- a/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/BaseShuttleControl.xaml.cs
@@ -71,7 +71,7 @@ public partial class BaseShuttleControl : MapGridControl
 
         for (var i = 0; i < 4; i++)
         {
-            var dir = (DirectionFlag) Math.Pow(2, i);
+            var dir = (DirectionFlag)Math.Pow(2, i);
             var dirVec = dir.AsDir().ToIntVec();
             _neighborDirections[i] = (dir, dirVec);
         }
@@ -420,12 +420,12 @@ public partial class BaseShuttleControl : MapGridControl
     private static Vector2 GetAzimuthDirection(Angle baseAngle, float azimuthDegrees)
     {
         var angle = baseAngle + Angle.FromDegrees(azimuthDegrees);
-        var radians = (float) angle.Theta - MathF.PI / 2f;
+        var radians = (float)angle.Theta - MathF.PI / 2f;
         return new Vector2(MathF.Cos(radians), MathF.Sin(radians));
     }
     // End Mono
 
-    protected void DrawGrid(DrawingHandleScreen handle, Matrix3x2 gridToView, Entity<MapGridComponent> grid, Color color, float alpha = 0.01f)
+    protected void DrawGrid(DrawingHandleScreen handle, Matrix3x2 gridToView, Entity<MapGridComponent> grid, Color color, float alpha = 0.01f, bool drawFill = false)
     {
         var rator = Maps.GetAllTilesEnumerator(grid.Owner, grid.Comp);
         var minimapScale = MinimapScale;
@@ -670,19 +670,23 @@ public partial class BaseShuttleControl : MapGridControl
 
         _parallel.ProcessNow(_drawJob, totalData);
 
-        const float BatchSize = 3f * 4096;
-
-        var fillColor = Color.ToSrgb(Color.InterpolateBetween(BackingColor, color, alpha)).WithAlpha(1f);
-
-        for (var i = 0; i < Math.Ceiling(triCount / BatchSize); i++)
+        if (drawFill)
         {
-            var start = (int) (i * BatchSize);
-            var end = (int) Math.Min(triCount, start + BatchSize);
-            var count = end - start;
-            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, new Span<Vector2>(_allVertices, start, count), fillColor);
-        }
+            const float BatchSize = 3f * 4096;
+            var fillColor = Color.ToSrgb(Color.InterpolateBetween(BackingColor, color, alpha)).WithAlpha(1f);
 
-        handle.DrawPrimitives(DrawPrimitiveTopology.LineList, new Span<Vector2>(_allVertices, gridData.EdgeIndex, edgeCount), color);
+            for (var i = 0; i < Math.Ceiling(triCount / BatchSize); i++)
+            {
+                var start = (int)(i * BatchSize);
+                var end = (int)Math.Min(triCount, start + BatchSize);
+                var count = end - start;
+                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, new Span<Vector2>(_allVertices, start, count), fillColor);
+            }
+        }
+        else
+        {
+            handle.DrawPrimitives(DrawPrimitiveTopology.LineList, new Span<Vector2>(_allVertices, gridData.EdgeIndex, edgeCount), color);
+        }
     }
 
     private static int GetDirIndex(Vector2i dir)

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -361,65 +361,66 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
             var left = center + leftOffs;
             var right = center + rightOffs;
 
-            switch (_icon) {
+            switch (_icon)
+            {
                 case RadarModeButtonIcon.Azimuth:
-                {
-                    var iconColor = Color.Black.WithAlpha(0.95f);
-                    var topLeft = center + (up + leftOffs) / MathF.Sqrt(2f);
-                    var topRight = center + (up + rightOffs) / MathF.Sqrt(2f);
-                    var bottomLeft = center + (down + leftOffs) / MathF.Sqrt(2f);
-                    var bottomRight = center + (down + rightOffs) / MathF.Sqrt(2f);
-
-                    handle.DrawLine(topLeft, bottomRight, iconColor);
-                    handle.DrawLine(bottomLeft, topRight, iconColor);
-                    handle.DrawLine(left, right, iconColor);
-                    handle.DrawLine(bottom, top, iconColor);
-                    break;
-                }
-                case RadarModeButtonIcon.Rotation:
-                {
-                    var iconColor = Color.Yellow.WithAlpha(0.95f);
-                    var innerRatio = 0.8f;
-                    var segCount = 3;
-                    var prevOffs = up * innerRatio;
-                    for (var i = 0; i < segCount; i++)
                     {
-                        var angle = Angle.FromDegrees(120f * i / (float)segCount - 15f);
-                        var thisOffs = angle.RotateVec(up * innerRatio);
-                        var thisPointUp = center + thisOffs;
-                        var thisPointDown = center - thisOffs;
-                        var oldPointUp = center + prevOffs;
-                        var oldPointDown = center - prevOffs;
-                        handle.DrawLine(oldPointUp, thisPointUp, iconColor);
-                        handle.DrawLine(oldPointDown, thisPointDown, iconColor);
-                        prevOffs = thisOffs;
-                    }
-                    break;
-                }
-                case RadarModeButtonIcon.Anchor:
-                {
-                    var iconColor = Color.Blue.WithAlpha(0.95f);
-                    var stemTop = center + up * 0.5f;
-                    var crossLeft = center + leftOffs * 0.3f + up * 0.7f;
-                    var crossRight = center + rightOffs * 0.3f + up * 0.7f;;
-                    var leftFluke = center + leftOffs * 0.6f + down * 0.6f;
-                    var rightFluke = center + rightOffs * 0.6f + down * 0.6f;
-                    var innerRadius = radius * 0.4f;
-                    var innerTop = center + up * 0.6f;
+                        var iconColor = Color.Black.WithAlpha(0.95f);
+                        var topLeft = center + (up + leftOffs) / MathF.Sqrt(2f);
+                        var topRight = center + (up + rightOffs) / MathF.Sqrt(2f);
+                        var bottomLeft = center + (down + leftOffs) / MathF.Sqrt(2f);
+                        var bottomRight = center + (down + rightOffs) / MathF.Sqrt(2f);
 
-                    handle.DrawCircle(innerTop, innerRadius, iconColor, false);
-                    handle.DrawLine(stemTop, bottom, iconColor);
-                    handle.DrawLine(crossLeft, crossRight, iconColor);
-                    handle.DrawLine(bottom, leftFluke, iconColor);
-                    handle.DrawLine(bottom, rightFluke, iconColor);
-                    break;
-                }
+                        handle.DrawLine(topLeft, bottomRight, iconColor);
+                        handle.DrawLine(bottomLeft, topRight, iconColor);
+                        handle.DrawLine(left, right, iconColor);
+                        handle.DrawLine(bottom, top, iconColor);
+                        break;
+                    }
+                case RadarModeButtonIcon.Rotation:
+                    {
+                        var iconColor = Color.Yellow.WithAlpha(0.95f);
+                        var innerRatio = 0.8f;
+                        var segCount = 3;
+                        var prevOffs = up * innerRatio;
+                        for (var i = 0; i < segCount; i++)
+                        {
+                            var angle = Angle.FromDegrees(120f * i / (float)segCount - 15f);
+                            var thisOffs = angle.RotateVec(up * innerRatio);
+                            var thisPointUp = center + thisOffs;
+                            var thisPointDown = center - thisOffs;
+                            var oldPointUp = center + prevOffs;
+                            var oldPointDown = center - prevOffs;
+                            handle.DrawLine(oldPointUp, thisPointUp, iconColor);
+                            handle.DrawLine(oldPointDown, thisPointDown, iconColor);
+                            prevOffs = thisOffs;
+                        }
+                        break;
+                    }
+                case RadarModeButtonIcon.Anchor:
+                    {
+                        var iconColor = Color.Blue.WithAlpha(0.95f);
+                        var stemTop = center + up * 0.5f;
+                        var crossLeft = center + leftOffs * 0.3f + up * 0.7f;
+                        var crossRight = center + rightOffs * 0.3f + up * 0.7f; ;
+                        var leftFluke = center + leftOffs * 0.6f + down * 0.6f;
+                        var rightFluke = center + rightOffs * 0.6f + down * 0.6f;
+                        var innerRadius = radius * 0.4f;
+                        var innerTop = center + up * 0.6f;
+
+                        handle.DrawCircle(innerTop, innerRadius, iconColor, false);
+                        handle.DrawLine(stemTop, bottom, iconColor);
+                        handle.DrawLine(crossLeft, crossRight, iconColor);
+                        handle.DrawLine(bottom, leftFluke, iconColor);
+                        handle.DrawLine(bottom, rightFluke, iconColor);
+                        break;
+                    }
                 case RadarModeButtonIcon.Reset:
-                {
-                    var iconColor = Color.Red.WithAlpha(0.95f);
-                    handle.DrawLine(left, right, iconColor);
-                    break;
-                }
+                    {
+                        var iconColor = Color.Red.WithAlpha(0.95f);
+                        handle.DrawLine(left, right, iconColor);
+                        break;
+                    }
                 default:
                     break;
             }
@@ -557,7 +558,6 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
         base.Draw(handle);
 
         DrawBacking(handle);
-        DrawCircles(handle);
 
         // No data
         if (_coordinates == null || _rotation == null)
@@ -567,7 +567,6 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
 
         var xformQuery = EntManager.GetEntityQuery<TransformComponent>();
         var fixturesQuery = EntManager.GetEntityQuery<FixturesComponent>();
-        var bodyQuery = EntManager.GetEntityQuery<PhysicsComponent>();
 
         if (!xformQuery.TryGetComponent(_coordinates.Value.EntityId, out var xform)
             || xform.MapID == MapId.Nullspace)
@@ -597,6 +596,27 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
         var worldToView = worldToShuttle * shuttleToView;
 
         DrawStarSystem(handle, worldToShuttle, shuttleToView, xform.MapUid); // Far Horizons
+
+        _grids.Clear();
+        _mapManager.FindGridsIntersecting(xform.MapID, new Box2(mapPos.Position - MaxRadarRangeVector, mapPos.Position + MaxRadarRangeVector), ref _grids, approx: true, includeMap: false);
+
+        // Draw our grid's fill.
+        var ourGridId = xform.GridUid;
+        if (EntManager.TryGetComponent<MapGridComponent>(ourGridId, out var ourGrid) &&
+            fixturesQuery.HasComponent(ourGridId.Value))
+        {
+            var ourGridToWorld = _transform.GetWorldMatrix(ourGridId.Value);
+            var ourGridToShuttle = Matrix3x2.Multiply(ourGridToWorld, worldToShuttle);
+            var ourGridToView = ourGridToShuttle * shuttleToView;
+            var color = _shuttles.GetIFFColor(ourGridId.Value, self: true);
+
+            DrawGrid(handle, ourGridToView, (ourGridId.Value, ourGrid), color, 0.01f, true);
+        }
+
+        DrawGrids(_grids, handle, (ourGrid != null && ourGridId.HasValue) ? (ourGridId.Value, ourGrid) : null, true);
+
+        DrawCircles(handle);
+
         DrawIFFBeacons(handle, worldToView, mapPos, xform.MapUid); // Far Horizons
 
         // Draw shields
@@ -622,14 +642,12 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
         }
 
         // Draw our grid in detail
-        var ourGridId = xform.GridUid;
-        if (EntManager.TryGetComponent<MapGridComponent>(ourGridId, out var ourGrid) &&
-            fixturesQuery.HasComponent(ourGridId.Value))
+        if (ourGridId.HasValue && ourGrid != null && fixturesQuery.HasComponent(ourGridId.Value))
         {
             var ourGridToWorld = _transform.GetWorldMatrix(ourGridId.Value);
             var ourGridToShuttle = Matrix3x2.Multiply(ourGridToWorld, worldToShuttle);
             var ourGridToView = ourGridToShuttle * shuttleToView;
-            var color = _shuttles.GetIFFColor(ourGridId.Value, self: true);
+            var color = _shuttles.GetIFFColor(ourGridId.Value, self: true); // This is such a waste running all of these again...
 
             DrawGrid(handle, ourGridToView, (ourGridId.Value, ourGrid), color);
             DrawDocks(handle, ourGridId.Value, ourGridToView);
@@ -645,254 +663,12 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
 
         handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, radarPosVerts, Color.Lime);
 
-        var viewBounds = new Box2Rotated(new Box2(-WorldRange, -WorldRange, WorldRange, WorldRange).Translated(mapPos.Position), worldRot, mapPos.Position);
-        var viewAABB = viewBounds.CalcBoundingBox();
-
-        _grids.Clear();
-        _mapManager.FindGridsIntersecting(xform.MapID, new Box2(mapPos.Position - MaxRadarRangeVector, mapPos.Position + MaxRadarRangeVector), ref _grids, approx: true, includeMap: false);
-
         // Mono edited: Frontier - collect blip location data outside foreach - more changes ahead
         _tempBlipDataList.Clear();
 
         _visibleGridsSet.Clear();
 
-        // Draw other grids... differently
-        foreach (var grid in _grids)
-        {
-            var gUid = grid.Owner;
-            if (gUid == ourGridId || !fixturesQuery.HasComponent(gUid))
-                continue;
-
-            var gridBody = bodyQuery.GetComponent(gUid);
-            EntManager.TryGetComponent<IFFComponent>(gUid, out var iff);
-
-            if (!_shuttles.CanDraw(gUid, gridBody, iff))
-                continue;
-
-            var hideLabel = iff != null && (iff.Flags & IFFFlags.HideLabel) != 0x0;
-            var noLabel = iff != null && (iff.Flags & IFFFlags.HideLabelAlways) != 0x0;
-            var detectionLevel = _consoleEntity == null ? DetectionLevel.Detected : GetGridDetected(grid.Owner);
-            var detected = detectionLevel != DetectionLevel.Undetected || !hideLabel;
-            var blipOnly = detectionLevel != DetectionLevel.Detected; // don't show outline outside of detection radius even if IFF on
-            if (!detected)
-                continue;
-
-            if (!blipOnly)
-                _visibleGridsSet.Add(grid);
-            var curGridToWorld = _transform.GetWorldMatrix(gUid);
-            var curGridToView = curGridToWorld * worldToView;
-
-            var hideColor = hideLabel && iff != null && (iff.Flags & IFFFlags.AlwaysShowColor) == 0x0;
-            var labelColor = hideColor ? blipOnly ? Color.Orange : Color.White : _shuttles.GetIFFColor(grid, self: false, iff);
-            var coordColor = new Color(labelColor.R * 0.8f, labelColor.G * 0.8f, labelColor.B * 0.8f, 0.5f);
-
-            var isPlayerShuttle = iff != null && (iff.Flags & IFFFlags.IsPlayerShuttle) != 0x0;
-            // Others default:
-            // Color.FromHex("#FFC000FF")
-            // Hostile default: Color.Firebrick
-            // Mono
-            var labelName = noLabel ? null : hideLabel ?
-                detectionLevel == DetectionLevel.PartialDetected ?
-                    Loc.GetString($"shuttle-console-signature-infrared")
-                    : _detection.HandleUnknownMassLabel(grid.Owner)
-                : _shuttles.GetIFFLabel(grid, self: false, component: iff);
-
-            var shouldDrawIFF = ShowIFF && labelName != null;
-            var shouldDrawDetailedIFF = ShowIFFDetailed && shouldDrawIFF; // Mono
-            if (shouldDrawIFF)
-            {
-                if (IFFFilter != null)
-                    shouldDrawIFF &= IFFFilter(gUid, grid.Comp, iff, hideLabel, labelName!);
-                //if (isPlayerShuttle) // Mono - comments this out, replaced elsewere
-                //    shouldDrawIFF &= ShowIFFShuttles;
-            }
-
-            //var mapCenter = curGridToWorld. * gridBody.LocalCenter;
-            //shouldDrawIFF = NfCheckShouldDrawIffRangeCondition(shouldDrawIFF, mapCenter, curGridToWorld); // Frontier code
-            // Frontier: range checks // Mono
-            var gridMapPos = _transform.ToMapCoordinates(new EntityCoordinates(gUid, gridBody.LocalCenter)).Position;
-            if (!hideLabel) // Mono - show thermal signatures even at long range
-                shouldDrawIFF = NfCheckShouldDrawIffRangeCondition(shouldDrawIFF, mapPos.Position - gridMapPos);
-            // End Frontier
-
-            // Mono
-            var gridUiPosition = Vector2.Transform(gridBody.LocalCenter, curGridToView) / UIScale;
-
-            if (shouldDrawIFF)
-            {
-                //var gridCentre = Vector2.Transform(gridBody.LocalCenter, curGridToView);
-                //gridCentre.Y = -gridCentre.Y;
-
-                // Frontier: IFF drawing functions
-                // The actual position in the UI. We offset the matrix position to render it off by half its width
-                // plus by the offset.
-                //var uiPosition = ScalePosition(gridCentre) / UIScale;
-                var uiPosition = gridUiPosition; // Mono
-
-                // Confines the UI position within the viewport.
-                var uiXCentre = (int)Width / 2;
-                var uiYCentre = (int)Height / 2;
-                var uiXOffset = uiPosition.X - uiXCentre;
-                var uiYOffset = uiPosition.Y - uiYCentre;
-                var uiDistance = (int)Math.Sqrt(Math.Pow(uiXOffset, 2) + Math.Pow(uiYOffset, 2));
-                var uiX = uiXCentre * uiXOffset / uiDistance;
-                var uiY = uiYCentre * uiYOffset / uiDistance;
-
-                var isOutsideRadarCircle = uiDistance > Math.Abs(uiX) && uiDistance > Math.Abs(uiY);
-                if (isOutsideRadarCircle)
-                {
-                    // 0.95f for offsetting the icons slightly away from edge of radar so it doesnt clip.
-                    uiX = uiXCentre * uiXOffset / uiDistance * 0.95f;
-                    uiY = uiYCentre * uiYOffset / uiDistance * 0.95f;
-                    uiPosition = new Vector2(
-                        x: uiX + uiXCentre,
-                        y: uiY + uiYCentre
-                    );
-                }
-
-                var scaledMousePosition = GetMouseCoordinatesFromCenter().Position * UIScale;
-                var isMouseOver = Vector2.Distance(scaledMousePosition, uiPosition * UIScale) < 30f;
-
-                // Distant stations that are not player controlled ships
-                var isDistantPOI = iff != null || (iff == null || (iff.Flags & IFFFlags.IsPlayerShuttle) == 0x0);
-
-                var distance = Vector2.Distance(gridMapPos, mapPos.Position);
-
-                if (!isOutsideRadarCircle || isDistantPOI || isMouseOver)
-                {
-                    // Shows decimal when distance is < 50m, otherwise pointless to show it.
-                    var displayedDistance = distance < 50f ? $"{distance:0.0}" : distance < 1000 ? $"{distance:0}" : $"{distance / 1000:0.0}k";
-                    var labelText = Loc.GetString("shuttle-console-iff-label", ("name", labelName)!, ("distance", displayedDistance));
-
-                    var coordsText = $"({gridMapPos.X:0.0}, {gridMapPos.Y:0.0})";
-                    var trackIdText = iff != null ? Loc.GetString("shuttle-console-track-label") + $"{iff.Address}" : Loc.GetString("shuttle-console-track-unknown-label");
-
-                    #region Mono
-
-                    // Why are the magic numbers 0.9 and 0.7 used? I have no fucking clue.
-                    var labelDimensions = handle.GetDimensions(Font, labelText, 0.9f);
-                    var blipSize = RadarBlipSize * 0.7f;
-
-                    // The center of the radar in UI space.
-                    var uiCenter = new Vector2(Width * 0.5f, Height * 0.5f);
-
-                    // Whether the blip is on the left side of the center of the radar.
-                    var isOnLeftSide = (uiPosition - uiCenter).X < 0;
-
-                    // The UI position of the bottom-left corner of the label, relative to the UI center of the radar, when the label is right-aligned.
-                    var labelPosition = uiPosition + new Vector2(-labelDimensions.X - blipSize, -labelDimensions.Y * 0.5f) - uiCenter;
-
-                    // The bounds corners of the label, relative to labelPosition.
-                    var labelCorners = new Vector2[] {
-                        labelPosition,
-                        labelPosition + new Vector2(labelDimensions.X, 0),
-                        labelPosition + new Vector2(0, labelDimensions.Y),
-                        labelPosition + labelDimensions
-                    };
-
-                    // The radius and squared radius of the radar, in virtual pixels.
-                    var radius = Width * 0.5f;
-                    var squaredRadius = radius * radius;
-
-
-                    // If true, flip the entire label to the right side of the blip and left-align it.
-                    // We default to the label being on the left side of the blip because it looked better to me in testing. (arbitrary)
-                    var flipLabel = true; // isOnLeftSide && labelCorners.Any(corner => corner.LengthSquared() > squaredRadius); // Mono - comment out, we dont want this teehee
-
-                    // Calculate unscaled offsets.
-                    var labelOffset = new Vector2()
-                    {
-                        X = flipLabel
-                            ? blipSize // Label on the right side of the blip, left-aligned text.
-                            : -labelDimensions.X - blipSize, // Label on the left side of the blip, right-aligned text.
-                        Y = -labelDimensions.Y * 0.5f
-                    };
-
-                    #endregion Mono
-
-                    // Get company color if entity has CompanyComponent
-                    var displayColor = labelColor;
-                    if (!hideLabel && EntManager.TryGetComponent(gUid, out Shared._Mono.Company.CompanyComponent? companyComp) &&
-                        !string.IsNullOrEmpty(companyComp.CompanyName))
-                    {
-                        var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
-                        CompanyPrototype? prototype = null;
-                        if (prototypeManager.TryIndex(companyComp.CompanyName, out prototype) && prototype != null)
-                        {
-                            displayColor = prototype.Color;
-                        }
-                    }
-
-                    // Split label text into lines
-                    var lines = labelText.Split('\n');
-                    var mainLabel = lines[0];
-
-                    // Draw main ship label with company color if available
-                    handle.DrawString(Font, (uiPosition + labelOffset) * UIScale, mainLabel, UIScale * 0.9f, displayColor);
-
-                    // Mono start - draw main stack of info
-                    if (shouldDrawDetailedIFF)
-                    {
-                            // Get company label & draw
-                            var companyLabel =  !hideLabel ? lines[1] : Loc.GetString("shuttle-console-company-unknown");
-                            var companyLabelOffset = new Vector2(
-                                labelOffset.X,
-                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y
-                            );
-                            handle.DrawString(Font, (uiPosition + companyLabelOffset) * UIScale, companyLabel, UIScale * 0.7f, displayColor);
-
-                            // Draw coordinates
-                            var coordDimensions = handle.GetDimensions(Font, coordsText, 0.7f);
-                            var coordOffset = new Vector2(
-                                labelOffset.X,
-                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y + handle.GetDimensions(Font, companyLabel, 0.7f).Y);
-                            handle.DrawString(Font, (uiPosition + coordOffset) * UIScale, coordsText, 0.7f * UIScale, displayColor);
-
-                            // Draw track ID (if it has one)
-                            var trackIdDimensions = handle.GetDimensions(Font, trackIdText, 0.7f);
-                            var trackIdOffset = new Vector2(
-                                labelOffset.X,
-                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y + handle.GetDimensions(Font, companyLabel, 0.7f).Y + handle.GetDimensions(Font, coordsText, 0.7f).Y);
-                            if (iff != null)
-                                handle.DrawString(Font, (uiPosition + trackIdOffset) * UIScale, trackIdText, 0.7f * UIScale, displayColor);
-                    }
-                    // Mono end
-                }
-
-                NfAddBlipToList(_tempBlipDataList, isOutsideRadarCircle, uiPosition, uiXCentre, uiYCentre, labelColor, hideLabel ? default : gUid); // Frontier code
-                // End Frontier: IFF drawing functions
-            }
-
-            // Frontier Don't skip drawing blips if they're out of range.
-            NfDrawBlips(handle, _tempBlipDataList);
-
-            // Detailed view
-            var gridAABB = curGridToWorld.TransformBox(grid.Comp.LocalAABB);
-
-            // Skip drawing if it's out of range.
-            if (!gridAABB.Intersects(viewAABB))
-                continue;
-
-            // Mono
-            if (!blipOnly)
-            {
-                DrawGrid(handle, curGridToView, grid, labelColor);
-                DrawDocks(handle, gUid, curGridToView);
-            }
-        }
-
-        // If we've set the controlling console, and it's on a different grid
-        // to the shuttle itself, then draw an additional marker to help the
-        // player determine where they are relative to the shuttle.
-        if (_consoleEntity != null && xformQuery.TryGetComponent(_consoleEntity, out var consoleXform))
-        {
-            if (consoleXform.ParentUid != _coordinates.Value.EntityId)
-            {
-                var consolePositionWorld = _transform.GetWorldPosition((EntityUid)_consoleEntity);
-                var p = Vector2.Transform(consolePositionWorld, worldToView);
-                handle.DrawCircle(p, 5, Color.ToSrgb(Color.Cyan), true);
-            }
-        }
+        DrawGrids(_grids, handle, (ourGrid != null && ourGridId.HasValue) ? (ourGridId.Value, ourGrid) : null, false);
 
         #region Mono
         // Draw radar line
@@ -982,6 +758,286 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
             }
         }
         #endregion
+    }
+
+    private void DrawGrids(List<Entity<MapGridComponent>> _grids, DrawingHandleScreen handle, Entity<MapGridComponent>? ourGrid, bool renderFill)
+    {
+        var xformQuery = EntManager.GetEntityQuery<TransformComponent>();
+        var fixturesQuery = EntManager.GetEntityQuery<FixturesComponent>();
+        var bodyQuery = EntManager.GetEntityQuery<PhysicsComponent>();
+
+        var worldRot = _rotation!.Value;
+        var mapPos = _transform.ToMapCoordinates(_coordinates!.Value).Offset(_rotation.Value.RotateVec(Offset));
+        var mapCoord = _transform.ToCoordinates(mapPos);
+        var worldToShuttle = Matrix3Helpers.CreateTranslation(-mapCoord.Position) * Matrix3Helpers.CreateRotation(-worldRot);
+        Matrix3x2.Invert(worldToShuttle, out var shuttleToWorld);
+        var shuttleToView = Matrix3x2.CreateScale(new Vector2(MinimapScale, -MinimapScale)) * Matrix3x2.CreateTranslation(MidPointVector);
+        var worldToView = worldToShuttle * shuttleToView;
+
+        var viewBounds = new Box2Rotated(new Box2(-WorldRange, -WorldRange, WorldRange, WorldRange).Translated(mapPos.Position), worldRot, mapPos.Position);
+        var viewAABB = viewBounds.CalcBoundingBox();
+
+        foreach (var grid in _grids)
+        {
+            if (renderFill)
+            {
+                var detectionLevel = _consoleEntity == null ? DetectionLevel.Detected : GetGridDetected(grid.Owner);
+                var blipOnly = detectionLevel != DetectionLevel.Detected; // don't show outline outside of detection radius even if IFF on
+
+                var curGridToWorld = _transform.GetWorldMatrix(grid.Owner);
+                var curGridToView = curGridToWorld * worldToView;
+
+                var gridBody = bodyQuery.GetComponent(grid.Owner);
+                EntManager.TryGetComponent<IFFComponent>(grid.Owner, out var iff);
+
+                if (!_shuttles.CanDraw(grid.Owner, gridBody, iff))
+                    continue;
+                var hideLabel = iff != null && (iff.Flags & IFFFlags.HideLabel) != 0x0;
+                var hideColor = hideLabel && iff != null && (iff.Flags & IFFFlags.AlwaysShowColor) == 0x0;
+                var labelColor = hideColor ? blipOnly ? Color.Orange : Color.White : _shuttles.GetIFFColor(grid, self: false, iff);
+
+                if (!blipOnly)
+                {
+                    DrawGrid(handle, curGridToView, grid, labelColor, 0.01f, true);
+                }
+            }
+            else
+            {
+                var gUid = grid.Owner;
+                if (ourGrid != null && gUid == ourGrid.Value.Owner || !fixturesQuery.HasComponent(gUid))
+                    continue;
+
+                var gridBody = bodyQuery.GetComponent(gUid);
+                EntManager.TryGetComponent<IFFComponent>(gUid, out var iff);
+
+                if (!_shuttles.CanDraw(gUid, gridBody, iff))
+                    continue;
+
+                var hideLabel = iff != null && (iff.Flags & IFFFlags.HideLabel) != 0x0;
+                var noLabel = iff != null && (iff.Flags & IFFFlags.HideLabelAlways) != 0x0;
+                var detectionLevel = _consoleEntity == null ? DetectionLevel.Detected : GetGridDetected(grid.Owner);
+                var detected = detectionLevel != DetectionLevel.Undetected || !hideLabel;
+                var blipOnly = detectionLevel != DetectionLevel.Detected; // don't show outline outside of detection radius even if IFF on
+                if (!detected)
+                    continue;
+
+                if (!blipOnly)
+                    _visibleGridsSet.Add(grid);
+                var curGridToWorld = _transform.GetWorldMatrix(gUid);
+                var curGridToView = curGridToWorld * worldToView;
+
+                var hideColor = hideLabel && iff != null && (iff.Flags & IFFFlags.AlwaysShowColor) == 0x0;
+                var labelColor = hideColor ? blipOnly ? Color.Orange : Color.White : _shuttles.GetIFFColor(grid, self: false, iff);
+                var coordColor = new Color(labelColor.R * 0.8f, labelColor.G * 0.8f, labelColor.B * 0.8f, 0.5f);
+
+                var isPlayerShuttle = iff != null && (iff.Flags & IFFFlags.IsPlayerShuttle) != 0x0;
+                // Others default:
+                // Color.FromHex("#FFC000FF")
+                // Hostile default: Color.Firebrick
+                // Mono
+                var labelName = noLabel ? null : hideLabel ?
+                    detectionLevel == DetectionLevel.PartialDetected ?
+                        Loc.GetString($"shuttle-console-signature-infrared")
+                        : _detection.HandleUnknownMassLabel(grid.Owner)
+                    : _shuttles.GetIFFLabel(grid, self: false, component: iff);
+
+                var shouldDrawIFF = ShowIFF && labelName != null;
+                var shouldDrawDetailedIFF = ShowIFFDetailed && shouldDrawIFF; // Mono
+                if (shouldDrawIFF)
+                {
+                    if (IFFFilter != null)
+                        shouldDrawIFF &= IFFFilter(gUid, grid.Comp, iff, hideLabel, labelName!);
+                    //if (isPlayerShuttle) // Mono - comments this out, replaced elsewere
+                    //    shouldDrawIFF &= ShowIFFShuttles;
+                }
+
+                //var mapCenter = curGridToWorld. * gridBody.LocalCenter;
+                //shouldDrawIFF = NfCheckShouldDrawIffRangeCondition(shouldDrawIFF, mapCenter, curGridToWorld); // Frontier code
+                // Frontier: range checks // Mono
+                var gridMapPos = _transform.ToMapCoordinates(new EntityCoordinates(gUid, gridBody.LocalCenter)).Position;
+                if (!hideLabel) // Mono - show thermal signatures even at long range
+                    shouldDrawIFF = NfCheckShouldDrawIffRangeCondition(shouldDrawIFF, mapPos.Position - gridMapPos);
+                // End Frontier
+
+                // Mono
+                var gridUiPosition = Vector2.Transform(gridBody.LocalCenter, curGridToView) / UIScale;
+
+                if (shouldDrawIFF)
+                {
+                    //var gridCentre = Vector2.Transform(gridBody.LocalCenter, curGridToView);
+                    //gridCentre.Y = -gridCentre.Y;
+
+                    // Frontier: IFF drawing functions
+                    // The actual position in the UI. We offset the matrix position to render it off by half its width
+                    // plus by the offset.
+                    //var uiPosition = ScalePosition(gridCentre) / UIScale;
+                    var uiPosition = gridUiPosition; // Mono
+
+                    // Confines the UI position within the viewport.
+                    var uiXCentre = (int)Width / 2;
+                    var uiYCentre = (int)Height / 2;
+                    var uiXOffset = uiPosition.X - uiXCentre;
+                    var uiYOffset = uiPosition.Y - uiYCentre;
+                    var uiDistance = (int)Math.Sqrt(Math.Pow(uiXOffset, 2) + Math.Pow(uiYOffset, 2));
+                    var uiX = uiXCentre * uiXOffset / uiDistance;
+                    var uiY = uiYCentre * uiYOffset / uiDistance;
+
+                    var isOutsideRadarCircle = uiDistance > Math.Abs(uiX) && uiDistance > Math.Abs(uiY);
+                    if (isOutsideRadarCircle)
+                    {
+                        // 0.95f for offsetting the icons slightly away from edge of radar so it doesnt clip.
+                        uiX = uiXCentre * uiXOffset / uiDistance * 0.95f;
+                        uiY = uiYCentre * uiYOffset / uiDistance * 0.95f;
+                        uiPosition = new Vector2(
+                            x: uiX + uiXCentre,
+                            y: uiY + uiYCentre
+                        );
+                    }
+
+                    var scaledMousePosition = GetMouseCoordinatesFromCenter().Position * UIScale;
+                    var isMouseOver = Vector2.Distance(scaledMousePosition, uiPosition * UIScale) < 30f;
+
+                    // Distant stations that are not player controlled ships
+                    var isDistantPOI = iff != null || (iff == null || (iff.Flags & IFFFlags.IsPlayerShuttle) == 0x0);
+
+                    var distance = Vector2.Distance(gridMapPos, mapPos.Position);
+
+                    if (!isOutsideRadarCircle || isDistantPOI || isMouseOver)
+                    {
+                        // Shows decimal when distance is < 50m, otherwise pointless to show it.
+                        var displayedDistance = distance < 50f ? $"{distance:0.0}" : distance < 1000 ? $"{distance:0}" : $"{distance / 1000:0.0}k";
+                        var labelText = Loc.GetString("shuttle-console-iff-label", ("name", labelName)!, ("distance", displayedDistance));
+
+                        var coordsText = $"({gridMapPos.X:0.0}, {gridMapPos.Y:0.0})";
+                        var trackIdText = iff != null ? Loc.GetString("shuttle-console-track-label") + $"{iff.Address}" : Loc.GetString("shuttle-console-track-unknown-label");
+
+                        #region Mono
+
+                        // Why are the magic numbers 0.9 and 0.7 used? I have no fucking clue.
+                        var labelDimensions = handle.GetDimensions(Font, labelText, 0.9f);
+                        var blipSize = RadarBlipSize * 0.7f;
+
+                        // The center of the radar in UI space.
+                        var uiCenter = new Vector2(Width * 0.5f, Height * 0.5f);
+
+                        // Whether the blip is on the left side of the center of the radar.
+                        var isOnLeftSide = (uiPosition - uiCenter).X < 0;
+
+                        // The UI position of the bottom-left corner of the label, relative to the UI center of the radar, when the label is right-aligned.
+                        var labelPosition = uiPosition + new Vector2(-labelDimensions.X - blipSize, -labelDimensions.Y * 0.5f) - uiCenter;
+
+                        // The bounds corners of the label, relative to labelPosition.
+                        var labelCorners = new Vector2[] {
+                        labelPosition,
+                        labelPosition + new Vector2(labelDimensions.X, 0),
+                        labelPosition + new Vector2(0, labelDimensions.Y),
+                        labelPosition + labelDimensions
+                    };
+
+                        // The radius and squared radius of the radar, in virtual pixels.
+                        var radius = Width * 0.5f;
+                        var squaredRadius = radius * radius;
+
+
+                        // If true, flip the entire label to the right side of the blip and left-align it.
+                        // We default to the label being on the left side of the blip because it looked better to me in testing. (arbitrary)
+                        var flipLabel = true; // isOnLeftSide && labelCorners.Any(corner => corner.LengthSquared() > squaredRadius); // Mono - comment out, we dont want this teehee
+
+                        // Calculate unscaled offsets.
+                        var labelOffset = new Vector2()
+                        {
+                            X = flipLabel
+                                ? blipSize // Label on the right side of the blip, left-aligned text.
+                                : -labelDimensions.X - blipSize, // Label on the left side of the blip, right-aligned text.
+                            Y = -labelDimensions.Y * 0.5f
+                        };
+
+                        #endregion Mono
+
+                        // Get company color if entity has CompanyComponent
+                        var displayColor = labelColor;
+                        if (!hideLabel && EntManager.TryGetComponent(gUid, out Shared._Mono.Company.CompanyComponent? companyComp) &&
+                            !string.IsNullOrEmpty(companyComp.CompanyName))
+                        {
+                            var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+                            CompanyPrototype? prototype = null;
+                            if (prototypeManager.TryIndex(companyComp.CompanyName, out prototype) && prototype != null)
+                            {
+                                displayColor = prototype.Color;
+                            }
+                        }
+
+                        // Split label text into lines
+                        var lines = labelText.Split('\n');
+                        var mainLabel = lines[0];
+
+                        // Draw main ship label with company color if available
+                        handle.DrawString(Font, (uiPosition + labelOffset) * UIScale, mainLabel, UIScale * 0.9f, displayColor);
+
+                        // Mono start - draw main stack of info
+                        if (shouldDrawDetailedIFF)
+                        {
+                            // Get company label & draw
+                            var companyLabel = !hideLabel ? lines[1] : Loc.GetString("shuttle-console-company-unknown");
+                            var companyLabelOffset = new Vector2(
+                                labelOffset.X,
+                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y
+                            );
+                            handle.DrawString(Font, (uiPosition + companyLabelOffset) * UIScale, companyLabel, UIScale * 0.7f, displayColor);
+
+                            // Draw coordinates
+                            var coordDimensions = handle.GetDimensions(Font, coordsText, 0.7f);
+                            var coordOffset = new Vector2(
+                                labelOffset.X,
+                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y + handle.GetDimensions(Font, companyLabel, 0.7f).Y);
+                            handle.DrawString(Font, (uiPosition + coordOffset) * UIScale, coordsText, 0.7f * UIScale, displayColor);
+
+                            // Draw track ID (if it has one)
+                            var trackIdDimensions = handle.GetDimensions(Font, trackIdText, 0.7f);
+                            var trackIdOffset = new Vector2(
+                                labelOffset.X,
+                                labelOffset.Y + handle.GetDimensions(Font, mainLabel, 0.9f).Y + handle.GetDimensions(Font, companyLabel, 0.7f).Y + handle.GetDimensions(Font, coordsText, 0.7f).Y);
+                            if (iff != null)
+                                handle.DrawString(Font, (uiPosition + trackIdOffset) * UIScale, trackIdText, 0.7f * UIScale, displayColor);
+                        }
+                        // Mono end
+                    }
+
+                    NfAddBlipToList(_tempBlipDataList, isOutsideRadarCircle, uiPosition, uiXCentre, uiYCentre, labelColor, hideLabel ? default : gUid); // Frontier code
+                                                                                                                                                        // End Frontier: IFF drawing functions
+                }
+
+                // Frontier Don't skip drawing blips if they're out of range.
+                NfDrawBlips(handle, _tempBlipDataList);
+
+                // Detailed view
+                var gridAABB = curGridToWorld.TransformBox(grid.Comp.LocalAABB);
+
+                // Skip drawing if it's out of range.
+                if (!gridAABB.Intersects(viewAABB))
+                    continue;
+
+                // Mono
+                if (!blipOnly)
+                {
+                    DrawGrid(handle, curGridToView, grid, labelColor);
+                    DrawDocks(handle, gUid, curGridToView);
+                }
+            }
+
+            // If we've set the controlling console, and it's on a different grid
+            // to the shuttle itself, then draw an additional marker to help the
+            // player determine where they are relative to the shuttle.
+            if (_consoleEntity != null && xformQuery.TryGetComponent(_consoleEntity, out var consoleXform))
+            {
+                if (consoleXform.ParentUid != _coordinates!.Value.EntityId)
+                {
+                    var consolePositionWorld = _transform.GetWorldPosition((EntityUid)_consoleEntity);
+                    var p = Vector2.Transform(consolePositionWorld, worldToView);
+                    handle.DrawCircle(p, 5, Color.ToSrgb(Color.Cyan), true);
+                }
+            }
+        }
     }
 
     protected DetectionLevel GetGridDetected(EntityUid grid)
@@ -1232,7 +1288,7 @@ public partial class ShuttleNavControl : BaseShuttleControl // Mono
             if (shieldFixture == null || shieldFixture.Shape is not ChainShape)
                 continue;
 
-            ChainShape chain = (ChainShape) shieldFixture.Shape;
+            ChainShape chain = (ChainShape)shieldFixture.Shape;
 
             var count = chain.Count;
             var verticies = chain.Vertices;

--- a/Content.Client/_FarHorizons/StarSystem/StarLightOverlay.cs
+++ b/Content.Client/_FarHorizons/StarSystem/StarLightOverlay.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Client._FarHorizons.StarSystem;
 
@@ -35,18 +36,19 @@ public sealed class StarLightOverlay : Overlay
 
     private readonly SharedMapSystem _mapSystem;
     private readonly SharedTransformSystem _xformSystem;
-    private readonly EntityLookupSystem _lookup;
 
-    private readonly EntityQuery<OccluderComponent> _occluderQuery;
+    private readonly OccluderSystem _occluders;
+    private readonly EntityQuery<MapGridComponent> _gridQuery;
+    private readonly List<Entity<OccluderComponent, TransformComponent>> _occluderResults = new();
 
     /// <summary>
     /// Walls we've seen before. This is so once the walls get unloaded by PVS, they still occlude so light doesnt bleed through.
     /// It would likely be better to just inform the client of the occluding area somehow, but this is simpler for the time being.
     /// </summary>
     private readonly Dictionary<NetEntity, HashSet<Vector2i>> _remembered = new();
+    private readonly Dictionary<NetEntity, (GameTick Tick, List<Vector2i> Tiles)> _transparent = new();
 
     private HashSet<Vector2i> _known = new();
-    private Vector2 _eyeLocal;
     private float _trustRange;
     private List<Entity<MapGridComponent>> _grids = new();
     private readonly Vector2[] _extruded = new Vector2[6];
@@ -78,8 +80,8 @@ public sealed class StarLightOverlay : Overlay
 
         _mapSystem = entMan.System<SharedMapSystem>();
         _xformSystem = entMan.System<SharedTransformSystem>();
-        _lookup = entMan.System<EntityLookupSystem>();
-        _occluderQuery = entMan.GetEntityQuery<OccluderComponent>();
+        _occluders = entMan.System<OccluderSystem>();
+        _gridQuery = entMan.GetEntityQuery<MapGridComponent>();
 
         ZIndex = ContentZIndex;
     }
@@ -197,10 +199,11 @@ public sealed class StarLightOverlay : Overlay
             handle.SetTransform(Matrix3x2.Identity);
             _shadowVerts.Clear();
 
+            RefreshOccluders(mapId, casterBounds);
+
             foreach (var pass in _passes)
             {
                 _known = GetRemembered(_entMan.GetNetEntity(pass.Grid.Owner));
-                _eyeLocal = pass.EyeLocal;
                 DrawShadows(handle, pass.Grid, casterBounds, pass.StarLocal, shadowLength, pass.Matrix, shadowColor);
             }
 
@@ -226,20 +229,21 @@ public sealed class StarLightOverlay : Overlay
         Matrix3x2 matrix,
         Color shadowColor)
     {
-        var tiles = _mapSystem.GetTilesEnumerator(grid.Owner, grid, bounds);
+        var tileSize = grid.Comp.TileSize;
+        var localBounds = _xformSystem.GetInvWorldMatrix(grid.Owner).TransformBox(bounds);
 
-        while (tiles.MoveNext(out var tileRef))
+        foreach (var idx in _known)
         {
-            if (!IsOccluding(grid, tileRef.GridIndices))
-                continue;
+            var local = Box2.FromDimensions(idx * tileSize, new Vector2(tileSize, tileSize));
 
-            var local = _lookup.GetLocalBounds(tileRef, grid.Comp.TileSize);
+            if (!localBounds.Intersects(local))
+                continue;
 
             var toStar = starLocal - local.Center;
             var dist = toStar.Length();
             var dir = dist < 0.001f ? Vector2.UnitX : toStar / dist;
 
-            if (IsHidden(grid, tileRef.GridIndices, -Math.Sign(dir.X), -Math.Sign(dir.Y)))
+            if (IsHidden(idx, -Math.Sign(dir.X), -Math.Sign(dir.Y)))
                 continue;
 
             var castOffset = -dir * shadowLength;
@@ -285,14 +289,15 @@ public sealed class StarLightOverlay : Overlay
         float starRadius,
         Color glowColor)
     {
-        var openings = _mapSystem.GetTilesEnumerator(grid.Owner, grid, bounds);
+        var tileSize = grid.Comp.TileSize;
+        var localBounds = _xformSystem.GetInvWorldMatrix(grid.Owner).TransformBox(bounds);
 
-        while (openings.MoveNext(out var tileRef))
+        foreach (var idx in GetTransparent(grid))
         {
-            if (!IsTransparent(tileRef.Tile))
-                continue;
+            var local = Box2.FromDimensions(idx * tileSize, new Vector2(tileSize, tileSize));
 
-            var local = _lookup.GetLocalBounds(tileRef, grid.Comp.TileSize);
+            if (!localBounds.Intersects(local))
+                continue;
 
             var over = DiscCoverage(local, starLocal, starRadius);
 
@@ -322,6 +327,28 @@ public sealed class StarLightOverlay : Overlay
             return 1f;
 
         return (radius - min) / MathF.Max(max - min, 0.0001f);
+    }
+
+    private List<Vector2i> GetTransparent(Entity<MapGridComponent> grid)
+    {
+        var net = _entMan.GetNetEntity(grid.Owner);
+
+        if (_transparent.TryGetValue(net, out var cached) && cached.Tick == grid.Comp.LastTileModifiedTick)
+            return cached.Tiles;
+
+        var tiles = cached.Tiles ?? new List<Vector2i>();
+        tiles.Clear();
+
+        var rator = _mapSystem.GetAllTilesEnumerator(grid.Owner, grid.Comp);
+
+        while (rator.MoveNext(out var tileRef))
+        {
+            if (IsTransparent(tileRef.Value.Tile))
+                tiles.Add(tileRef.Value.GridIndices);
+        }
+
+        _transparent[net] = (grid.Comp.LastTileModifiedTick, tiles);
+        return tiles;
     }
 
     private bool IsTransparent(Tile tile)
@@ -369,49 +396,56 @@ public sealed class StarLightOverlay : Overlay
         };
     }
 
-    private bool IsHidden(Entity<MapGridComponent> grid, Vector2i idx, int sx, int sy)
+    private bool IsHidden(Vector2i idx, int sx, int sy)
     {
-        if (sx != 0 && !IsOccluding(grid, idx + new Vector2i(sx, 0)))
+        if (sx != 0 && !_known.Contains(idx + new Vector2i(sx, 0)))
             return false;
 
-        if (sy != 0 && !IsOccluding(grid, idx + new Vector2i(0, sy)))
+        if (sy != 0 && !_known.Contains(idx + new Vector2i(0, sy)))
             return false;
 
-        if (sx != 0 && sy != 0 && !IsOccluding(grid, idx + new Vector2i(sx, sy)))
+        if (sx != 0 && sy != 0 && !_known.Contains(idx + new Vector2i(sx, sy)))
             return false;
 
         return true;
     }
 
     /// <summary>
-    /// Stolen from lighting code.
+    /// Borrow the engine's perfectly good occluders cache.
     /// </summary>
-    private bool IsOccluding(Entity<MapGridComponent> grid, Vector2i idx)
+    private void RefreshOccluders(MapId mapId, Box2Rotated bounds)
     {
-        var centre = (idx + new Vector2(0.5f, 0.5f)) * grid.Comp.TileSize;
+        _occluderResults.Clear();
+        _occluders.QueryAabb(_occluderResults, mapId, bounds);
 
-        // Outside of PVS? Trust the cache and pray that the wall didn't get eaten recently.
-        if ((centre - _eyeLocal).LengthSquared() > _trustRange * _trustRange)
-            return _known.Contains(idx);
-
-        var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(grid.Owner, grid.Comp, idx);
-
-        while (anchored.MoveNext(out var ent))
+        foreach (var pass in _passes)
         {
-            if (_occluderQuery.TryGetComponent(ent, out var occluder) && occluder.Enabled)
-            {
-                _known.Add(idx);
-                return true;
-            }
+            var known = GetRemembered(_entMan.GetNetEntity(pass.Grid.Owner));
+            var trustSqr = _trustRange * _trustRange;
+            var tileSize = pass.Grid.Comp.TileSize;
+            var eye = pass.EyeLocal;
+
+            known.RemoveWhere(idx =>
+                (((idx + new Vector2(0.5f, 0.5f)) * tileSize) - eye).LengthSquared() <= trustSqr);
         }
 
-        _known.Remove(idx);
-        return false;
+        foreach (var occluder in _occluderResults)
+        {
+            if (!occluder.Comp1.Enabled || occluder.Comp2.GridUid is not { } gridUid)
+                continue;
+
+            if (!_gridQuery.TryGetComponent(gridUid, out var gridComp))
+                continue;
+
+            var known = GetRemembered(_entMan.GetNetEntity(gridUid));
+            known.Add(_mapSystem.TileIndicesFor(gridUid, gridComp, occluder.Comp2.Coordinates));
+        }
     }
 
     public void ResetMemory()
     {
         _remembered.Clear();
+        _transparent.Clear();
     }
 
     private HashSet<Vector2i> GetRemembered(NetEntity grid)

--- a/Content.Client/_FarHorizons/StarSystem/StarLightOverlay.cs
+++ b/Content.Client/_FarHorizons/StarSystem/StarLightOverlay.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Runtime.InteropServices;
 using Content.Client.Light;
 using Content.Shared._FarHorizons.StarSystem;
 using Content.Shared._FarHorizons.StarSystem.Helpers;
@@ -49,7 +50,12 @@ public sealed class StarLightOverlay : Overlay
     private float _trustRange;
     private List<Entity<MapGridComponent>> _grids = new();
     private readonly Vector2[] _extruded = new Vector2[6];
-    private readonly List<(Entity<MapGridComponent> Grid, Matrix3x2 Matrix, Vector2 StarLocal, Vector2 EyeLocal, Color Shadow, Color Glow)> _passes = new();
+
+    private readonly List<Vector2> _shadowVerts = new();
+
+    private const int MaxShadowVerts = 12 * 4096;
+
+    private readonly List<(Entity<MapGridComponent> Grid, Matrix3x2 Matrix, Vector2 StarLocal, Vector2 EyeLocal, Color Glow)> _passes = new();
     private ShaderInstance? _shader;
 
     public override OverlaySpace Space => OverlaySpace.BeforeLighting;
@@ -171,10 +177,7 @@ public sealed class StarLightOverlay : Overlay
 
             var starLocal = (-gridRot).RotateVec(toStar);
 
-            var shadowAlpha = Math.Clamp(comp.ShadowStrength, 0f, 1f);
             var lit = Attenuate(dist, range, comp.Falloff, comp.CurveFactor) * power;
-
-            var shadowColor = comp.AmbientFloor.WithAlpha(shadowAlpha);
 
             var overStar = dist <= starRadius + grid.Comp.LocalAABB.Size.Length();
 
@@ -183,18 +186,25 @@ public sealed class StarLightOverlay : Overlay
                 : Color.Transparent;
 
             var eyeLocal = (-gridRot).RotateVec(eyeWorld - gridPos);
-            _passes.Add((grid, matrix, starLocal, eyeLocal, shadowColor, glowColor));
+            _passes.Add((grid, matrix, starLocal, eyeLocal, glowColor));
         }
 
-        foreach (var pass in _passes)
-        {
-            if (pass.Shadow.A <= 0f)
-                continue;
+        var shadowColor = comp.AmbientFloor.WithAlpha(Math.Clamp(comp.ShadowStrength, 0f, 1f));
 
-            handle.SetTransform(pass.Matrix);
-            _known = GetRemembered(_entMan.GetNetEntity(pass.Grid.Owner));
-            _eyeLocal = pass.EyeLocal;
-            DrawShadows(handle, pass.Grid, casterBounds, pass.StarLocal, shadowLength, pass.Shadow);
+        if (shadowColor.A > 0f)
+        {
+            // vertices are already in target space, so nothing further to transform
+            handle.SetTransform(Matrix3x2.Identity);
+            _shadowVerts.Clear();
+
+            foreach (var pass in _passes)
+            {
+                _known = GetRemembered(_entMan.GetNetEntity(pass.Grid.Owner));
+                _eyeLocal = pass.EyeLocal;
+                DrawShadows(handle, pass.Grid, casterBounds, pass.StarLocal, shadowLength, pass.Matrix, shadowColor);
+            }
+
+            FlushShadows(handle, shadowColor);
         }
 
         foreach (var pass in _passes)
@@ -213,6 +223,7 @@ public sealed class StarLightOverlay : Overlay
         Box2Rotated bounds,
         Vector2 starLocal,
         float shadowLength,
+        Matrix3x2 matrix,
         Color shadowColor)
     {
         var tiles = _mapSystem.GetTilesEnumerator(grid.Owner, grid, bounds);
@@ -233,8 +244,37 @@ public sealed class StarLightOverlay : Overlay
 
             var castOffset = -dir * shadowLength;
             Sweep(local.Enlarged(ShadowBleed), castOffset, _extruded);
-            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, _extruded.AsSpan(0, 6), shadowColor);
+            AppendFan(matrix);
+
+            if (_shadowVerts.Count >= MaxShadowVerts)
+                FlushShadows(handle, shadowColor);
         }
+    }
+
+    private void AppendFan(Matrix3x2 matrix)
+    {
+        var origin = Vector2.Transform(_extruded[0], matrix);
+        var prev = Vector2.Transform(_extruded[1], matrix);
+
+        for (var i = 2; i < 6; i++)
+        {
+            var current = Vector2.Transform(_extruded[i], matrix);
+
+            _shadowVerts.Add(origin);
+            _shadowVerts.Add(prev);
+            _shadowVerts.Add(current);
+
+            prev = current;
+        }
+    }
+
+    private void FlushShadows(DrawingHandleWorld handle, Color shadowColor)
+    {
+        if (_shadowVerts.Count == 0)
+            return;
+
+        handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, CollectionsMarshal.AsSpan(_shadowVerts), shadowColor);
+        _shadowVerts.Clear();
     }
 
     private void DrawGlow(

--- a/Content.Client/_FarHorizons/StarSystem/StarLightOverlay.cs
+++ b/Content.Client/_FarHorizons/StarSystem/StarLightOverlay.cs
@@ -329,11 +329,6 @@ public sealed class StarLightOverlay : Overlay
         };
     }
 
-    /// <summary>
-    /// A tile stops casting only once every neighbour the shadow could have come from is
-    /// solid. Testing all of them keeps this continuous as the grid rotates, which picking a
-    /// single rounded neighbour did not.
-    /// </summary>
     private bool IsHidden(Entity<MapGridComponent> grid, Vector2i idx, int sx, int sy)
     {
         if (sx != 0 && !IsOccluding(grid, idx + new Vector2i(sx, 0)))
@@ -349,16 +344,13 @@ public sealed class StarLightOverlay : Overlay
     }
 
     /// <summary>
-    /// Same test the engine's own lighting uses. Walls and tinted windows carry an enabled
-    /// occluder; plain windows carry none at all, so starlight passes straight through them.
+    /// Stolen from lighting code.
     /// </summary>
     private bool IsOccluding(Entity<MapGridComponent> grid, Vector2i idx)
     {
         var centre = (idx + new Vector2(0.5f, 0.5f)) * grid.Comp.TileSize;
 
-        // Outside PVS the absence of a wall entity means nothing: the chunk is still
-        // replicated, so an unsent wall looks exactly like an empty room. Only believe what
-        // we see close in, and fall back on what we saw last time further out.
+        // Outside of PVS? Trust the cache and pray that the wall didn't get eaten recently.
         if ((centre - _eyeLocal).LengthSquared() > _trustRange * _trustRange)
             return _known.Contains(idx);
 
@@ -377,9 +369,6 @@ public sealed class StarLightOverlay : Overlay
         return false;
     }
 
-    /// <summary>
-    /// Forgets every remembered occluder, for when the map itself changes underneath us.
-    /// </summary>
     public void ResetMemory()
     {
         _remembered.Clear();

--- a/Content.Client/_FarHorizons/StarSystem/StarLightOverlay.cs
+++ b/Content.Client/_FarHorizons/StarSystem/StarLightOverlay.cs
@@ -1,0 +1,397 @@
+using System.Numerics;
+using Content.Client.Light;
+using Content.Shared._FarHorizons.StarSystem;
+using Content.Shared._FarHorizons.StarSystem.Helpers;
+using Content.Shared.Maps;
+using Robust.Client.Graphics;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._FarHorizons.StarSystem;
+
+/// <summary>
+/// I was tempted to paste in a few verses from that one song "Fireflies", but I have restraint.
+/// </summary>
+public sealed class StarLightOverlay : Overlay
+{
+    private static readonly ProtoId<ShaderPrototype> StarLightShader = "StarLight";
+
+    /// <summary>
+    /// No, diagonal wall corners don't bleed light
+    /// </summary>
+    private const float ShadowBleed = 0.05f;
+
+    private readonly IEntityManager _entMan;
+    private readonly IMapManager _mapMan;
+    private readonly IPrototypeManager _protoMan;
+    private readonly IOverlayManager _overlayMan;
+    private readonly ITileDefinitionManager _tileDefMan;
+    private readonly IConfigurationManager _cfg;
+
+    private readonly SharedMapSystem _mapSystem;
+    private readonly SharedTransformSystem _xformSystem;
+    private readonly EntityLookupSystem _lookup;
+
+    private readonly EntityQuery<OccluderComponent> _occluderQuery;
+
+    /// <summary>
+    /// Walls we've seen before. This is so once the walls get unloaded by PVS, they still occlude so light doesnt bleed through.
+    /// It would likely be better to just inform the client of the occluding area somehow, but this is simpler for the time being.
+    /// </summary>
+    private readonly Dictionary<NetEntity, HashSet<Vector2i>> _remembered = new();
+
+    private HashSet<Vector2i> _known = new();
+    private Vector2 _eyeLocal;
+    private float _trustRange;
+    private List<Entity<MapGridComponent>> _grids = new();
+    private readonly Vector2[] _extruded = new Vector2[6];
+    private readonly List<(Entity<MapGridComponent> Grid, Matrix3x2 Matrix, Vector2 StarLocal, Vector2 EyeLocal, Color Shadow, Color Glow)> _passes = new();
+    private ShaderInstance? _shader;
+
+    public override OverlaySpace Space => OverlaySpace.BeforeLighting;
+    public const int ContentZIndex = BeforeLightTargetOverlay.ContentZIndex + 1;
+
+    public StarLightOverlay(
+        IEntityManager entMan,
+        IMapManager mapMan,
+        IPrototypeManager protoMan,
+        IOverlayManager overlayMan,
+        ITileDefinitionManager tileDefMan,
+        IConfigurationManager cfg)
+    {
+        _entMan = entMan;
+        _mapMan = mapMan;
+        _protoMan = protoMan;
+        _overlayMan = overlayMan;
+        _tileDefMan = tileDefMan;
+        _cfg = cfg;
+
+        _mapSystem = entMan.System<SharedMapSystem>();
+        _xformSystem = entMan.System<SharedTransformSystem>();
+        _lookup = entMan.System<EntityLookupSystem>();
+        _occluderQuery = entMan.GetEntityQuery<OccluderComponent>();
+
+        ZIndex = ContentZIndex;
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        return args.Viewport.Eye != null &&
+               _entMan.TryGetComponent<StarLightComponent>(args.MapUid, out var light) &&
+               light.Enabled &&
+               _entMan.TryGetComponent<StarSystemMapComponent>(args.MapUid, out var map) &&
+               map.StarSystem != null;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var eye = args.Viewport.Eye!;
+        var comp = _entMan.GetComponent<StarLightComponent>(args.MapUid);
+        var star = _entMan.GetComponent<StarSystemMapComponent>(args.MapUid).StarSystem!.Star;
+
+        var lightOverlay = _overlayMan.GetOverlay<BeforeLightTargetOverlay>();
+        var target = lightOverlay.GetCachedForViewport(args.Viewport).EnlargedLightTarget;
+        var bounds = lightOverlay.EnlargedBounds;
+        var box = bounds.CalcBoundingBox();
+
+        var viewport = args.Viewport;
+        var lightScale = viewport.LightRenderTarget.Size / (Vector2)viewport.Size;
+        var scale = viewport.RenderScale / (Vector2.One / lightScale);
+        var invMatrix = target.GetWorldToLocalMatrix(eye, scale);
+
+        var mapId = args.MapId;
+        var eyePos = eye.Position.Position;
+
+        var power = MathF.Pow(MathF.Max(0f, star.Luminocity), 0.4f);
+        power = power / (1f + power) * comp.Intensity;
+
+        _shader ??= _protoMan.Index(StarLightShader).InstanceUnique();
+        _shader.SetParameter("starPos", star.Position);
+        _shader.SetParameter("starColor", new Vector3(star.Color.R, star.Color.G, star.Color.B));
+        _shader.SetParameter("starRange", star.Radius * comp.RangeFactor);
+        _shader.SetParameter("starPower", power);
+        _shader.SetParameter("starFalloff", comp.Falloff);
+        _shader.SetParameter("starCurveFactor", comp.CurveFactor);
+        _shader.SetParameter("ambientFloor", new Vector3(comp.AmbientFloor.R, comp.AmbientFloor.G, comp.AmbientFloor.B));
+        _shader.SetParameter("boundsMin", box.BottomLeft);
+        _shader.SetParameter("boundsSize", box.Size);
+
+        var worldHandle = args.WorldHandle;
+
+        worldHandle.RenderInRenderTarget(target,
+            () =>
+            {
+                worldHandle.SetTransform(invMatrix);
+                worldHandle.UseShader(_shader);
+                worldHandle.DrawRect(box, Color.White);
+                worldHandle.UseShader(null);
+
+                DrawGrids(worldHandle, invMatrix, mapId, bounds, eyePos, comp, star);
+
+                worldHandle.SetTransform(Matrix3x2.Identity);
+            }, null);
+    }
+
+    private void DrawGrids(
+        DrawingHandleWorld handle,
+        Matrix3x2 baseMatrix,
+        MapId mapId,
+        Box2Rotated bounds,
+        Vector2 eyeWorld,
+        StarLightComponent comp,
+        Star star)
+    {
+        var shadowLength = comp.ShadowLength;
+
+        _trustRange = _cfg.GetCVar(CVars.NetPvsPriorityRange) / 2f;
+
+        var casterBounds = bounds.Enlarged(shadowLength);
+        var starRadius = star.Radius * comp.RadiusFactor;
+        var range = star.Radius * comp.RangeFactor;
+
+        var power = MathF.Pow(MathF.Max(0f, star.Luminocity), 0.4f);
+        power = power / (1f + power) * comp.Intensity;
+
+        _grids.Clear();
+        _mapMan.FindGridsIntersecting(mapId, casterBounds, ref _grids, approx: true);
+
+        _passes.Clear();
+
+        foreach (var grid in _grids)
+        {
+            var (gridPos, gridRot) = _xformSystem.GetWorldPositionRotation(grid.Owner);
+            var matrix = Matrix3x2.Multiply(_xformSystem.GetWorldMatrix(grid.Owner), baseMatrix);
+
+            var toStar = star.Position - gridPos;
+            var dist = toStar.Length();
+
+            var starLocal = (-gridRot).RotateVec(toStar);
+
+            var shadowAlpha = Math.Clamp(comp.ShadowStrength, 0f, 1f);
+            var lit = Attenuate(dist, range, comp.Falloff, comp.CurveFactor) * power;
+
+            var shadowColor = comp.AmbientFloor.WithAlpha(shadowAlpha);
+
+            var overStar = dist <= starRadius + grid.Comp.LocalAABB.Size.Length();
+
+            var glowColor = overStar
+                ? new Color(star.Color.R * lit, star.Color.G * lit, star.Color.B * lit)
+                : Color.Transparent;
+
+            var eyeLocal = (-gridRot).RotateVec(eyeWorld - gridPos);
+            _passes.Add((grid, matrix, starLocal, eyeLocal, shadowColor, glowColor));
+        }
+
+        foreach (var pass in _passes)
+        {
+            if (pass.Shadow.A <= 0f)
+                continue;
+
+            handle.SetTransform(pass.Matrix);
+            _known = GetRemembered(_entMan.GetNetEntity(pass.Grid.Owner));
+            _eyeLocal = pass.EyeLocal;
+            DrawShadows(handle, pass.Grid, casterBounds, pass.StarLocal, shadowLength, pass.Shadow);
+        }
+
+        foreach (var pass in _passes)
+        {
+            if (pass.Glow.A <= 0f)
+                continue;
+
+            handle.SetTransform(pass.Matrix);
+            DrawGlow(handle, pass.Grid, casterBounds, pass.StarLocal, starRadius, pass.Glow);
+        }
+    }
+
+    private void DrawShadows(
+        DrawingHandleWorld handle,
+        Entity<MapGridComponent> grid,
+        Box2Rotated bounds,
+        Vector2 starLocal,
+        float shadowLength,
+        Color shadowColor)
+    {
+        var tiles = _mapSystem.GetTilesEnumerator(grid.Owner, grid, bounds);
+
+        while (tiles.MoveNext(out var tileRef))
+        {
+            if (!IsOccluding(grid, tileRef.GridIndices))
+                continue;
+
+            var local = _lookup.GetLocalBounds(tileRef, grid.Comp.TileSize);
+
+            var toStar = starLocal - local.Center;
+            var dist = toStar.Length();
+            var dir = dist < 0.001f ? Vector2.UnitX : toStar / dist;
+
+            if (IsHidden(grid, tileRef.GridIndices, -Math.Sign(dir.X), -Math.Sign(dir.Y)))
+                continue;
+
+            var castOffset = -dir * shadowLength;
+            Sweep(local.Enlarged(ShadowBleed), castOffset, _extruded);
+            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, _extruded.AsSpan(0, 6), shadowColor);
+        }
+    }
+
+    private void DrawGlow(
+        DrawingHandleWorld handle,
+        Entity<MapGridComponent> grid,
+        Box2Rotated bounds,
+        Vector2 starLocal,
+        float starRadius,
+        Color glowColor)
+    {
+        var openings = _mapSystem.GetTilesEnumerator(grid.Owner, grid, bounds);
+
+        while (openings.MoveNext(out var tileRef))
+        {
+            if (!IsTransparent(tileRef.Tile))
+                continue;
+
+            var local = _lookup.GetLocalBounds(tileRef, grid.Comp.TileSize);
+
+            var over = DiscCoverage(local, starLocal, starRadius);
+
+            if (over <= 0f)
+                continue;
+
+            handle.DrawRect(local, glowColor.WithAlpha(glowColor.A * over));
+        }
+    }
+
+    private static float DiscCoverage(Box2 tile, Vector2 centre, float radius)
+    {
+        var min = float.MaxValue;
+        var max = float.MinValue;
+
+        for (var i = 0; i < 4; i++)
+        {
+            var dist = (Corner(tile, i) - centre).Length();
+            min = MathF.Min(min, dist);
+            max = MathF.Max(max, dist);
+        }
+
+        if (radius <= min)
+            return 0f;
+
+        if (radius >= max)
+            return 1f;
+
+        return (radius - min) / MathF.Max(max - min, 0.0001f);
+    }
+
+    private bool IsTransparent(Tile tile)
+    {
+        return tile.IsEmpty || ((ContentTileDefinition)_tileDefMan[tile.TypeId]).Transparent;
+    }
+
+    /// <summary>
+    /// CPU copy of the attenuation in star_light.swsl.
+    /// </summary>
+    private static float Attenuate(float dist, float range, float falloff, float curveFactor)
+    {
+        var sd = Math.Clamp(MathF.Sqrt((dist * dist) + 1f) / range, 0f, 1f);
+        var sd2 = sd * sd;
+        var curve = float.Lerp(sd, sd2, Math.Clamp(curveFactor, 0f, 1f));
+
+        return Math.Clamp((1f - sd2) * (1f - sd2) / (1f + (falloff * curve)), 0f, 1f);
+    }
+
+    /// <summary>
+    /// I fucking hate vector math
+    /// </summary>
+    private static void Sweep(Box2 rect, Vector2 offset, Vector2[] output)
+    {
+        var k = offset.X >= 0f
+            ? (offset.Y >= 0f ? 0 : 3)
+            : (offset.Y >= 0f ? 1 : 2);
+
+        output[0] = Corner(rect, k);
+        output[1] = Corner(rect, k + 1);
+        output[2] = output[1] + offset;
+        output[3] = Corner(rect, k + 2) + offset;
+        output[4] = Corner(rect, k + 3) + offset;
+        output[5] = Corner(rect, k + 3);
+    }
+
+    private static Vector2 Corner(Box2 rect, int index)
+    {
+        return (index % 4) switch
+        {
+            0 => rect.BottomLeft,
+            1 => rect.BottomRight,
+            2 => rect.TopRight,
+            _ => rect.TopLeft,
+        };
+    }
+
+    /// <summary>
+    /// A tile stops casting only once every neighbour the shadow could have come from is
+    /// solid. Testing all of them keeps this continuous as the grid rotates, which picking a
+    /// single rounded neighbour did not.
+    /// </summary>
+    private bool IsHidden(Entity<MapGridComponent> grid, Vector2i idx, int sx, int sy)
+    {
+        if (sx != 0 && !IsOccluding(grid, idx + new Vector2i(sx, 0)))
+            return false;
+
+        if (sy != 0 && !IsOccluding(grid, idx + new Vector2i(0, sy)))
+            return false;
+
+        if (sx != 0 && sy != 0 && !IsOccluding(grid, idx + new Vector2i(sx, sy)))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Same test the engine's own lighting uses. Walls and tinted windows carry an enabled
+    /// occluder; plain windows carry none at all, so starlight passes straight through them.
+    /// </summary>
+    private bool IsOccluding(Entity<MapGridComponent> grid, Vector2i idx)
+    {
+        var centre = (idx + new Vector2(0.5f, 0.5f)) * grid.Comp.TileSize;
+
+        // Outside PVS the absence of a wall entity means nothing: the chunk is still
+        // replicated, so an unsent wall looks exactly like an empty room. Only believe what
+        // we see close in, and fall back on what we saw last time further out.
+        if ((centre - _eyeLocal).LengthSquared() > _trustRange * _trustRange)
+            return _known.Contains(idx);
+
+        var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(grid.Owner, grid.Comp, idx);
+
+        while (anchored.MoveNext(out var ent))
+        {
+            if (_occluderQuery.TryGetComponent(ent, out var occluder) && occluder.Enabled)
+            {
+                _known.Add(idx);
+                return true;
+            }
+        }
+
+        _known.Remove(idx);
+        return false;
+    }
+
+    /// <summary>
+    /// Forgets every remembered occluder, for when the map itself changes underneath us.
+    /// </summary>
+    public void ResetMemory()
+    {
+        _remembered.Clear();
+    }
+
+    private HashSet<Vector2i> GetRemembered(NetEntity grid)
+    {
+        if (_remembered.TryGetValue(grid, out var known))
+            return known;
+
+        known = new HashSet<Vector2i>();
+        _remembered[grid] = known;
+        return known;
+    }
+}

--- a/Content.Client/_FarHorizons/StarSystem/StarSystemMapSystem.cs
+++ b/Content.Client/_FarHorizons/StarSystem/StarSystemMapSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._FarHorizons.CCVar;
 using Content.Shared._FarHorizons.StarSystem;
 using Robust.Client.Graphics;
 using Robust.Shared.Configuration;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client._FarHorizons.StarSystem;
@@ -12,9 +13,14 @@ public sealed partial class StarSystemMapSystem : SharedStarSystemMapSystem
     [Dependency] private IOverlayManager _overlayMan = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
 
+    [Dependency] private IMapManager _mapMan = default!;
+    [Dependency] private ITileDefinitionManager _tileDefMan = default!;
+    [Dependency] private IClyde _clyde = default!;
+
     private StarOverlay _starOverlay = default!;
     private PlanetOverlay _planetOverlay = default!;
     private AsteroidBeltOverlay _beltOverlay = default!;
+    private StarLightOverlay _starLightOverlay = default!;
 
     public override void Initialize()
     {
@@ -23,6 +29,7 @@ public sealed partial class StarSystemMapSystem : SharedStarSystemMapSystem
         _starOverlay = new(EntityManager, _protoMan);
         _planetOverlay = new(EntityManager, _protoMan);
         _beltOverlay = new(EntityManager, _protoMan);
+        _starLightOverlay = new(EntityManager, _mapMan, _protoMan, _overlayMan, _tileDefMan, _cfg);
 
         _cfg.OnValueChanged(FHCCVars.RenderStarSystem, EnsureStarSystem, true);
     }
@@ -39,6 +46,9 @@ public sealed partial class StarSystemMapSystem : SharedStarSystemMapSystem
 
             if (!_overlayMan.HasOverlay<AsteroidBeltOverlay>())
                 _overlayMan.AddOverlay(_beltOverlay);
+
+            if (!_overlayMan.HasOverlay<StarLightOverlay>())
+                _overlayMan.AddOverlay(_starLightOverlay);
         }
         else
         {
@@ -50,6 +60,9 @@ public sealed partial class StarSystemMapSystem : SharedStarSystemMapSystem
 
             if (_overlayMan.HasOverlay<AsteroidBeltOverlay>())
                 _overlayMan.RemoveOverlay(_beltOverlay);
+
+            if (_overlayMan.HasOverlay<StarLightOverlay>())
+                _overlayMan.RemoveOverlay(_starLightOverlay);
 
             _starOverlay.ResetShader();
             _planetOverlay.ResetShader();
@@ -63,5 +76,6 @@ public sealed partial class StarSystemMapSystem : SharedStarSystemMapSystem
         _starOverlay.ResetShader();
         _planetOverlay.ResetShader();
         _beltOverlay.ResetShader();
+        _starLightOverlay.ResetMemory();
     }
 }

--- a/Content.Server/_FarHorizons/StarSystem/StarSystemMapSystem.cs
+++ b/Content.Server/_FarHorizons/StarSystem/StarSystemMapSystem.cs
@@ -37,6 +37,8 @@ public sealed partial class StarSystemMapSystem : SharedStarSystemMapSystem
         ent.Comp.StarSystem = BuildPlanetarySystem(system);
         Dirty(ent);
 
+        EnsureComp<StarLightComponent>(ent);
+
         SpawnEntities(ent);
     }
 

--- a/Content.Shared/_FarHorizons/StarSystem/StarLightComponent.cs
+++ b/Content.Shared/_FarHorizons/StarSystem/StarLightComponent.cs
@@ -1,0 +1,44 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._FarHorizons.StarSystem;
+
+/// <summary>
+/// Added to a star system map to paint starlight onto tiles that can see the star.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class StarLightComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
+
+    [DataField, AutoNetworkedField]
+    public float Intensity = 2f;
+
+    /// <summary>
+    /// Floor applied outside the star's reach so deep space isn't pitch black.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Color AmbientFloor = Color.FromHex("#0A0A14");
+
+    /// <summary>
+    /// Light range in world units per solar radius.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float RangeFactor = 30000f;
+
+    [DataField, AutoNetworkedField]
+    public float RadiusFactor = 500f;
+
+    [DataField, AutoNetworkedField]
+    public float Falloff = 2f;
+
+    /// <inheritdoc cref="Robust.Shared.GameObjects.SharedPointLightComponent.CurveFactor"/>
+    [DataField, AutoNetworkedField]
+    public float CurveFactor;
+
+    [DataField, AutoNetworkedField]
+    public float ShadowLength = 48f;
+
+    [DataField, AutoNetworkedField]
+    public float ShadowStrength = 1f;
+}

--- a/Resources/Prototypes/_FarHorizons/Shaders/shaders.yml
+++ b/Resources/Prototypes/_FarHorizons/Shaders/shaders.yml
@@ -10,6 +10,11 @@
     perspectiveStrength: 0.013
 
 - type: shader
+  id: StarLight
+  kind: source
+  path: "/Textures/_FarHorizons/Shaders/StarSystem/star_light.swsl"
+
+- type: shader
   id: GasGiant
   kind: source
   path: "/Textures/_FarHorizons/Shaders/StarSystem/gas_giant.swsl"

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -18,6 +18,7 @@
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
   - PortstrikeAnnounceRuleRandom35To45
+  - StarSystemKyphrus
 
 - type: gamePreset
   id: MonoRogueTSF
@@ -34,6 +35,7 @@
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
   - PortstrikeAnnounceRuleRandom35To45
+  - StarSystemKyphrus
 
 - type: gamePreset
   id: MonoRogueUSSP
@@ -50,6 +52,7 @@
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
   - PortstrikeAnnounceRuleRandom35To45
+  - StarSystemKyphrus
 
 - type: gamePreset
   id: MonoTSFUSSP
@@ -66,6 +69,7 @@
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
   - PortstrikeAnnounceRuleRandom35To45
+  - StarSystemKyphrus
 
 - type: gamePreset
   id: MonoADS
@@ -85,6 +89,7 @@
   #- MonoAsakimSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
   - PortstrikeAnnounceRuleRandom35To45
+  - StarSystemKyphrus
 
 - type: gamePreset
   id: MonoChimera
@@ -102,6 +107,7 @@
   - MonoChimeraSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
   - PortstrikeAnnounceRuleRandom35To45
+  - StarSystemKyphrus
 
 - type: gamePreset
   id: MonoMixed
@@ -111,7 +117,8 @@
   rules:
   - NFAdventure
   - BasicStationEventScheduler
-  - BluespaceEventScheduler
+  - BluespaceEventScheduler  - StarSystemKyphrus
+
   - BluespaceDungeonEventScheduler
   - BluespaceSalvageEventScheduler
   - SmugglingEventScheduler
@@ -122,6 +129,7 @@
   #- MonoAsakimSTCShuttleSpawnerSchedulerSlow
   - MonoMonolithicEventsScheduler
   - PortstrikeAnnounceRuleRandom35To45
+  - StarSystemKyphrus
 
 - type: gamePreset
   id: MonoAllAtOnce
@@ -143,6 +151,7 @@
   - MonoMonolithicEventsScheduler
   - RoundEndRuleHour3
   - PortstrikeAnnounceRuleHour1
+  - StarSystemKyphrus
 
 - type: gamePreset
   id: MonoRogueTSFHyperwar
@@ -155,3 +164,4 @@
   - Hyperwar
   - RoundEndRuleHour3
   - PortstrikeAnnounceRuleHour2
+  - StarSystemKyphrus

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -117,8 +117,8 @@
   rules:
   - NFAdventure
   - BasicStationEventScheduler
-  - BluespaceEventScheduler  - StarSystemKyphrus
-
+  - BluespaceEventScheduler  
+  - StarSystemKyphrus
   - BluespaceDungeonEventScheduler
   - BluespaceSalvageEventScheduler
   - SmugglingEventScheduler

--- a/Resources/Textures/_FarHorizons/Shaders/StarSystem/star_light.swsl
+++ b/Resources/Textures/_FarHorizons/Shaders/StarSystem/star_light.swsl
@@ -1,0 +1,30 @@
+light_mode unshaded;
+
+// Attenuation is lifted from /Shaders/Internal/light_shared.swsl.
+
+uniform highp vec2 starPos;
+uniform highp vec3 starColor;
+uniform highp float starRange;
+uniform highp float starPower;
+uniform highp float starFalloff;
+uniform highp float starCurveFactor;
+
+uniform highp vec3 ambientFloor;
+uniform highp vec2 boundsMin;
+uniform highp vec2 boundsSize;
+
+const highp float LIGHTING_HEIGHT = 1.0;
+
+void fragment() {
+    highp vec2 worldPos = boundsMin + (UV * boundsSize);
+    highp vec2 diff = worldPos - starPos;
+
+    highp float sqrDist = dot(diff, diff) + LIGHTING_HEIGHT;
+    highp float sd = clamp(sqrt(sqrDist) / starRange, 0.0, 1.0);
+    highp float sd2 = sd * sd;
+    highp float curve = mix(sd, sd2, clamp(starCurveFactor, 0.0, 1.0));
+    highp float val = clamp(((1.0 - sd2) * (1.0 - sd2)) / (1.0 + starFalloff * curve), 0.0, 1.0);
+    val *= starPower;
+
+    COLOR = vec4(max(starColor * val, ambientFloor), 1.0);
+}


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Planets have been added to all Monolith gamemodes by default. Also, stars now project light.

This also makes grid fill blend into the nav background. It'll look identical but fill properly on planets. I'll fix the compass and other things not showing up through it anymore in a moment. (it's an easy fix)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

1. Having to run a gamerule every time is annoying
2. Stars not having any sort of light is what we in the industry call Moronic

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="876" height="724" alt="image" src="https://github.com/user-attachments/assets/00617d47-0c9e-4216-9b1a-43f2c2f0983f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
Start a round and move a grid around.

Light projects from the center of a star and also below through Transparent tiles when you're within it's radius.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: In the neverending void of space, the bright glow of Kyphrus lights up it all.
-->
