### PR TITLE
ADMIN: Add a Horrible Hack

### DIFF
--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -144,6 +144,14 @@
   - loadprototype
   - uploadfolder
 
+- Flags: HEADMIN
+  Commands:
+  - tip
+  
+- Flags: SENIORMIN
+  Commands:
+  - tippy
+
 - Commands:
   - "|"
   - oldhelp


### PR DESCRIPTION
## About the PR
This is honestly a disgrace.
It adds 2 new flags for the permissions panel that give 1 irrelevant command

## WHY???
The permissions system uses a "WHO HAS MORE FLAGS" hierarchy. AKA: if you have more flags, you're the higher rank, if you have less flags, you're the lower rank. This adds 2 new flags, so that it can be given to seniormins (SO THEY CANT HAVE THEIR RANK REMOVED BY NORMAL ADMINS) and headmins (SO THEY CANT HAVE THEIR RANK REMOVED BY SENIORMINS AND BELOW)

It would be better if someone reworked the permissions system so this wouldn't have to happen, but that's never happening lol

**Changelog**
No player facing changes.
