### PR TITLE
Fix IPC Servopumps Not Being Able to Be Reinserted, Fix Liquor Lifeline

### DIFF
--- a/Resources/Locale/en-US/_Shitmed/surgery/surgery-popup.ftl
+++ b/Resources/Locale/en-US/_Shitmed/surgery/surgery-popup.ftl
@@ -48,6 +48,7 @@ surgery-popup-step-SurgeryStepInsertLungs = {$user} is inserting lungs into {$ta
 surgery-popup-step-SurgeryStepInsertLiver = {$user} is inserting a liver into {$target}'s {$part}!
 surgery-popup-step-SurgeryStepInsertEyes = {$user} is inserting eyes into {$target}'s {$part}!
 surgery-popup-step-SurgeryStepInsertHeart = {$user} is inserting a heart into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertPump = {$user} is inserting a pump into {$target}'s {$part}!
 surgery-popup-step-SurgeryStepInsertStomach = {$user} is inserting a stomach into {$target}'s {$part}!
 
 surgery-popup-step-SurgeryStepSealOrganWound = {$user} is sealing the wounds on {$target}'s {$part}.

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -192,21 +192,18 @@
           min: 15
         - !type:OrganType
           type: Dwarf
+        damage:
+          groups:
+            Brute: -1
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
         - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
             Brute: -1
-      - !type:HealthChange # Goobstation - Dwarf buff
-        conditions:
-        - !type:ReagentThreshold
-          min: 3
-        - !type:OrganType
-          type: Dwarf
-        damage:
-          groups:
-            Brute: -1
-            Burn: -1
       - !type:ChemVomit
         probability: 0.04
         conditions:

--- a/Resources/Prototypes/_Mono/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Mono/Entities/Surgery/surgeries.yml
@@ -1,0 +1,18 @@
+- type: entity
+  parent: SurgeryBase
+  id: SurgeryInsertPump
+  name: Insert Pump
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Surgery
+    steps:
+    - SurgeryStepInsertPump
+  - type: SurgeryOrganSlotCondition
+    organSlot: pump
+  - type: SurgeryPartCondition
+    part: Torso
+  - type: SurgeryOrganCondition
+    organ:
+    - type: Heart
+    inverse: true
+    reattaching: true

--- a/Resources/Prototypes/_Mono/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Mono/Entities/Surgery/surgery_steps.yml
@@ -1,0 +1,21 @@
+- type: entity
+  parent: SurgeryStepBase
+  id: SurgeryStepRemoveIPCPart
+  name: Remove IPC part
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryStep
+    tool:
+    - type: Prying
+    duration: 8
+  - type: Sprite
+    sprite: _NF/Objects/Tools/crowbar.rsi
+    state: icon
+  - type: SurgeryRemoveOrganStep
+  - type: SurgeryStepEmoteEffect
+
+- type: entity
+  parent: SurgeryStepInsertOrgan
+  id: SurgeryStepInsertPump
+  name: Add servopump
+  categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_Mono/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Mono/Entities/Surgery/surgery_steps.yml
@@ -1,20 +1,4 @@
 - type: entity
-  parent: SurgeryStepBase
-  id: SurgeryStepRemoveIPCPart
-  name: Remove IPC part
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: SurgeryStep
-    tool:
-    - type: Prying
-    duration: 8
-  - type: Sprite
-    sprite: _NF/Objects/Tools/crowbar.rsi
-    state: icon
-  - type: SurgeryRemoveOrganStep
-  - type: SurgeryStepEmoteEffect
-
-- type: entity
   parent: SurgeryStepInsertOrgan
   id: SurgeryStepInsertPump
   name: Add servopump


### PR DESCRIPTION
## About the PR
closes #4476 
closes #4384 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed IPCs not having a surgery to reinsert their pump (heart).
- fix: Fixed dwarf livers/liquor lifeline not healing damage when drinking ethanol.