### PR TITLE
Energy Swords No Longer Cause Fires

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -20,7 +20,7 @@
       malus: 0.6
     - type: Execution
       doAfterDuration: 4.0
-  - type: ItemToggleHot
+# - type: ItemToggleHot # Mono: make eswords not ignite
   - type: ItemToggleSize
     activatedSize: Huge
   - type: ItemTogglePointLight
@@ -71,8 +71,8 @@
       right:
       - state: inhand-right-blade
         shader: unshaded
-  - type: IgnitionSource
-    temperature: 700
+# - type: IgnitionSource # mono: make eswords not ignite
+#   temperature: 700
   - type: Scalpel # Shitmed
     speed: 0.75
   - type: Cautery # Shitmed: you have to be very, very careful to cauterize with it


### PR DESCRIPTION
## About the PR
Energy swords, and by extension all energy melee weapons are no longer an ignition source.

## Why / Balance
ashing in 15 seconds because you dared step in welding fuel while an energy sword was in your hand was such fun gameplay, guys!

tilefires should be set on purpose or be the result of darwin award-level behaviour, dying because you accidentally set one off with an item that NOBODY uses as an ignition source serves as a noobtrap and just plainly ISN'T FUN.

energy swords don't even deal heat on monolith! this doesn't make sense! they're not used as ignition sources, they're used as melee weapons that deal slash. if you want to set off a tilefire, use something that actually creates a FLAME like a welder.

## Media
<img width="351" height="248" alt="image" src="https://github.com/user-attachments/assets/6b74da3b-e08a-4318-831d-af355caa99f6" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
spawn energy sword
spill welding fuel
activate esword and walk on welding fuel
you don't get round removed within 15 seconds

**Changelog**
:cl:
- tweak: Energy swords no longer set off fires.
