### PR TITLE
Made the Durability of Firelocks and TSF Holographic Forcefields More Sane

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -22,7 +22,7 @@
     - type: InteractionOutline
     - type: Damageable
       damageContainer: StructuralInorganic
-      damageModifierSet: StructuralMetallicStrong
+      damageModifierSet: StrongMetallic # mono: made equivalent to an airlock
     - type: RCDDeconstructable
       cost: 4
       delay: 6

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -156,3 +156,5 @@
         behaviors:
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
+  - type: Damageable
+    damageContainer: StructuralInorganic


### PR DESCRIPTION
## About the PR
Firelocks no longer have a 75% resistance to structural damage. They are now on par with airlocks.

Holographic forcefields can now take structural damage.

The only real impact is that these are now destroyed in one Hristov shot.

## Why / Balance
Firelocks are already annoying as shit and should not be able to survive one full Hristov shot. Their durability is now identical to that of an airlock.

TSF holographic forcefields are spammable, replaceable and stackable and should not be able to survive TWO full Hristov shots.

Plus, holographic forcefields not taking structural was just odd, making even specialised breaching tools ineffective against them.

## Media
<img width="424" height="338" alt="image" src="https://github.com/user-attachments/assets/64088434-1c2e-4c63-9e6a-7c619e334a3b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
spawn firelock
spawn TSF holographic forcefield
spawn Hristov
shoot each once
they are destroyed in one hit

**Changelog**
:cl:
- tweak: Firelocks and TSF holographic forcefields are now more susceptible to structural damage. The most notable difference is that they can now be destroyed by the Hristov in one shot.
