### PR TITLE
Remove Special Guns

### DIFF
--- a/Resources/Prototypes/_Mono/Loadouts/ViperGroup/role_loadouts_vipergroup.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/ViperGroup/role_loadouts_vipergroup.yml
@@ -27,7 +27,7 @@
   - ContractorTrinkets
   - ContractorBureaucracy
   - NFSpeciesSpecific
-  - CivGunCaseSpecial # Mono
+# - CivGunCaseSpecial # Mono
   - ContractorArmorPlates # Mono
 
 - type: roleLoadout
@@ -59,7 +59,7 @@
   - ContractorTrinkets
   - ContractorBureaucracy
   - NFSpeciesSpecific
-  - CivGunCaseSpecial # Mono
+# - CivGunCaseSpecial # Mono
   - ContractorArmorPlates # Mono
 
 - type: roleLoadout
@@ -91,5 +91,5 @@
   - ContractorTrinkets
   - ContractorBureaucracy
   - NFSpeciesSpecific
-  - CivGunCaseSpecial # Mono
+# - CivGunCaseSpecial # Mono
   - ContractorArmorPlates # Mono

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -43,7 +43,7 @@
   - NFSpeciesSpecific
   - ContractorFirearm # Mono
   - ContractorMag # Mono
-  - CivGunCaseSpecial # Mono
+# - CivGunCaseSpecial # Mono
   - ContractorArmorPlates # Mono
 
 # Pilot
@@ -75,7 +75,7 @@
   - ContractorArmorPlates # Mono
   - ContractorFirearm # Mono
   - ContractorMag # Mono
-  - CivGunCaseSpecial # Mono
+# - CivGunCaseSpecial # Mono
 
 # Mercenary
 - type: roleLoadout
@@ -107,7 +107,7 @@
   - ContractorTrinkets
   - ContractorBureaucracy
   - NFSpeciesSpecific
-  - CivGunCaseSpecial # Mono
+# - CivGunCaseSpecial # Mono
   - ContractorArmorPlates # Mono
 
 # Frontier


### PR DESCRIPTION
## About the PR
Vagrant, Mercenary, Pilot and the VG roles no longer have the "special gun" tab in their loadout.

## Why / Balance
It was slop. It was filled with tier 2 guns like the MLA-73, WSPR and Annie which means that it broke progression and meant you did not need to contact the TSF or PDV to get an Annie or MLA-73. It encouraged unhealthy hour grinding with the 50 hour requirements, and the five HUNDRED hour requirement for the MLA-179. It also clearly wasn't shown much love -- the Vector was still considered a TSF gun, the abysmally bad .45 ACP Vector was still an option, and the Big Leady and AK-502 are still considered civilian guns despite the USSP being readded. It's better off gone, especially with Pilot dead and Mercenary being on the chopping block. Vagrants don't deserve T2 faction guns for essentially free roundstart.

## Media
<img width="533" height="542" alt="image" src="https://github.com/user-attachments/assets/4706956f-8586-468b-9b5e-f8837603e6f7" />

<img width="525" height="541" alt="image" src="https://github.com/user-attachments/assets/a27b6277-bfb4-4929-b4d7-6aa898978e7c" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
open Vagrant loadout
no special gun
open Mercenary loadout
no special gun
open VG loadouts
no special gun

**Changelog**
:cl:
- remove: Special guns have been removed from civilian loadouts.