### PR TITLE
Soil Behavior Update

### DIFF
--- a/Content.Shared/Construction/SharedFlatpackSystem.cs
+++ b/Content.Shared/Construction/SharedFlatpackSystem.cs
@@ -114,7 +114,7 @@ public abstract partial class SharedFlatpackSystem : EntitySystem
     {
         if (!args.IsInDetailsRange)
             return;
-        args.PushMarkup(Loc.GetString("flatpack-examine"));
+    args.PushMarkup(Loc.GetString("flatpack-examine", ("required-quality", ent.Comp.QualityNeeded))); // Mono: Not all packs use multitool
     }
 
     protected void SetupFlatpack(Entity<FlatpackComponent?> ent, EntProtoId proto, EntityUid board)

--- a/Resources/Locale/en-US/construction/components/flatpack.ftl
+++ b/Resources/Locale/en-US/construction/components/flatpack.ftl
@@ -1,5 +1,5 @@
 flatpack-unpack-no-room = No room to unpack!
-flatpack-examine = Use a [color=yellow]multitool[/color] to unpack this.
+flatpack-examine = Use a tool capable of [color=yellow]{$required-quality}[/color] to unpack this.
 flatpack-entity-name = {$name} flatpack
 flatpack-entity-description = A flatpack used for constructing {INDEFINITE($name)} {$name}.
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -126,6 +126,12 @@
     sprite: Objects/Tools/Hydroponics/spade.rsi
   - type: Shovel
     speedModifier: 0.75 # slower at digging than a full-sized shovel
+  - type: Tool #Mono start: Shovel parity
+    qualities:
+    - Digging
+    speedModifier: 0.5
+    useSound:
+      path: /Audio/Nyanotrasen/Items/shovel_dig.ogg #Mono end
 
 - type: entity
   name: plant bag

--- a/Resources/Prototypes/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/Entities/Structures/soil.yml
@@ -31,6 +31,12 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+      - !type:SpawnEntitiesBehavior # Mono start: stopgap method of deconstructing
+        spawn:
+          HydroponicsSoilEmptyFlatpack:
+            min: 1
+            max: 1
+        amount: 1 #Mono end
   - type: Sprite
     sprite: Structures/Hydroponics/misc.rsi
     state: soil

--- a/Resources/Prototypes/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/Entities/Structures/soil.yml
@@ -35,8 +35,7 @@
         spawn:
           HydroponicsSoilEmptyFlatpack:
             min: 1
-            max: 1
-        amount: 1 #Mono end
+            max: 1 #Mono end
   - type: Sprite
     sprite: Structures/Hydroponics/misc.rsi
     state: soil

--- a/Resources/Prototypes/_NF/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/soil.yml
@@ -7,9 +7,9 @@
   - type: PlantHolder
     waterLevel: 0
     nutritionLevel: 0
-  - type: Construction
-    graph: soil
-    node: HydroponicsSoilEmpty
+#  - type: Construction #Mono out: This has conflicts with the plantholder component
+#    graph: soil
+#    node: HydroponicsSoilEmpty
 
 - type: entity
   parent: hydroponicsSoil
@@ -19,6 +19,6 @@
   - type: PlantHolder
     waterLevel: 0
     nutritionLevel: 100
-  - type: Construction
-    graph: soil
-    node: HydroponicsSoilNutrition
+#  - type: Construction
+#    graph: soil
+#    node: HydroponicsSoilNutrition


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Spades can now unpack soil
Commented out deconstruction graph for soil due to plantholder component interfering with the ability to dig it out. I didn't think touching either the construction system would be a good idea, nor the botany system (we haven't ported the ECS refactor yet, if ever)
Added a simple way of deconstructing the soil by destroying it. This returns a 0 nutrient 0 water flatty.
Fixed the tooltip gaslighting players. The tooltip was hardcoded because nobody ever thought a flatty would use any tool other than a multitool.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It started as a simple cry for help
<img width="555" height="448" alt="image" src="https://github.com/user-attachments/assets/fda4da0e-e2a8-41a7-8b1d-27777474f2eb" />


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="437" height="194" alt="image" src="https://github.com/user-attachments/assets/62d74140-aee2-4b0a-a358-31b284abae7f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

Smash soil
Replace soil with a spade

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

Nothing crazy

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Replaced broken deconstruction method for soil with a stopgap method: Destroy soil to return a flatpack.
- tweak: Spade now counts as a shovel for the purposes of unpacking a soil flatpack
- fix: Soil flatpack tooltip now correctly asks for a shovel
