### PR TITLE
Remove Mercenary

### DIFF
--- a/Resources/Prototypes/_Mono/Outpost/caelestinus.yml
+++ b/Resources/Prototypes/_Mono/Outpost/caelestinus.yml
@@ -41,7 +41,7 @@
           availableJobs:
             Contractor: [ -1, -1 ]
             # Pilot: [ -1, -1 ]
-            Mercenary: [ -1, -1 ]
+            # Mercenary: [ -1, -1 ]
             Borg: [ -1, -1 ]
             StationRepresentative: [ 1, 1 ]
             StationTrafficController: [ 2, 2 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/arkansaw.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/arkansaw.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             ## Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            ## Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/comet.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/comet.yml
@@ -33,4 +33,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/duran.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/duran.yml
@@ -35,4 +35,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             ## Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            ## Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/fortunate.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/fortunate.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/judiciary.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/judiciary.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/littora.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/littora.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/magus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/magus.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/padval.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/padval.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/picses.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/picses.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/sabinemk2.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/sabinemk2.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/sagittarius.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/sagittarius.yml
@@ -35,4 +35,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/siebel.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/siebel.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/sirius.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/sirius.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Expedition/twilightmk2.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Expedition/twilightmk2.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/betelgeuse.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/betelgeuse.yml
@@ -32,4 +32,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/horsefly.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/horsefly.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/mite.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/mite.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/mudskipper.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/mudskipper.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/scallywag.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/scallywag.yml
@@ -40,4 +40,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/serkesh.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/serkesh.yml
@@ -40,4 +40,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/skelraak.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/skelraak.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/tick.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/tick.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Scrap/vrikaash.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Scrap/vrikaash.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Sr/ravager.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Sr/ravager.yml
@@ -36,6 +36,6 @@
       - type: StationJobs
         availableJobs:
           Contractor: [ 0, 0 ]
-          Mercenary: [ 0, 0 ]
+          # Mercenary: [ 0, 0 ]
           Borg: [ 0, 0 ]
           SecurityGuard: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/Valkyrie.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/Valkyrie.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/archer.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/archer.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/argent.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/argent.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/arribane.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/arribane.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/artemis.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/artemis.yml
@@ -38,4 +38,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/autumn.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/autumn.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/baeg.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/baeg.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/balor.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/balor.yml
@@ -33,4 +33,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/borer.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/borer.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/bratan.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/bratan.yml
@@ -49,4 +49,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/brute.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/brute.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/canister.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/canister.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/caracara.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/caracara.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/claymore.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/claymore.yml
@@ -40,4 +40,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/dervi.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/dervi.yml
@@ -35,4 +35,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/ethereal.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/ethereal.yml
@@ -41,4 +41,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/femur.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/femur.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/framework.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/framework.yml
@@ -42,4 +42,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/hammerhead.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/hammerhead.yml
@@ -43,4 +43,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/iapetus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/iapetus.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/intermission.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/intermission.yml
@@ -43,4 +43,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/jitterbug.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/jitterbug.yml
@@ -40,4 +40,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/kestrel.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/kestrel.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/kuldi.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/kuldi.yml
@@ -41,4 +41,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/kunai.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/kunai.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/leaf.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/leaf.yml
@@ -39,4 +39,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/mcchicken.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/mcchicken.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/mcchilly.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/mcchilly.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/mclass.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/mclass.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/medicus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/medicus.yml
@@ -41,4 +41,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/noble.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/noble.yml
@@ -36,4 +36,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/notch.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/notch.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/odenta.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/odenta.yml
@@ -41,4 +41,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/olympus.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/olympus.yml
@@ -36,4 +36,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/peregrine.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/peregrine.yml
@@ -36,4 +36,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/phaeron.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/phaeron.yml
@@ -40,4 +40,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/phantom.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/phantom.yml
@@ -40,4 +40,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/pillbox.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/pillbox.yml
@@ -31,4 +31,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/piva.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/piva.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/plutomkii.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/plutomkii.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/praetorian.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/praetorian.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/promise.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/promise.yml
@@ -39,4 +39,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/rig.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/rig.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/rosetta.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/rosetta.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/ruby.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/ruby.yml
@@ -37,4 +37,4 @@
 #          availableJobs:
 #            Contractor: [ 0, 0 ]
 #            # Pilot: [ 0, 0 ]
-#            Mercenary: [ 0, 0 ]
+#            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/sakuratsu.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/sakuratsu.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/sellsword.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/sellsword.yml
@@ -39,4 +39,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/shareholder.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/shareholder.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/spessbite.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/spessbite.yml
@@ -41,4 +41,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/spyglass.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/spyglass.yml
@@ -32,5 +32,5 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]
 

--- a/Resources/Prototypes/_Mono/Shipyard/stubby.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/stubby.yml
@@ -39,4 +39,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/takeaway.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/takeaway.yml
@@ -44,4 +44,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/tanuki.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/tanuki.yml
@@ -38,4 +38,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/tiger.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/tiger.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/tokarev.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/tokarev.yml
@@ -39,4 +39,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/triage.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/triage.yml
@@ -38,4 +38,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/twilight.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/twilight.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/tzipora.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/tzipora.yml
@@ -39,4 +39,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/vaquita.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/vaquita.yml
@@ -37,4 +37,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/velios.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/velios.yml
@@ -39,4 +39,4 @@
             Contractor: [ 0, 0 ]
             MdMedic: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/victoria.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/victoria.yml
@@ -41,4 +41,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/windreign.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/windreign.yml
@@ -33,4 +33,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_Mono/Shipyard/zeros.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/zeros.yml
@@ -40,4 +40,4 @@
           availableJobs:
             Contractor: [ 0, 0 ]
             # Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+            # Mercenary: [ 0, 0 ]

--- a/Resources/Prototypes/_NF/Maps/debug.yml
+++ b/Resources/Prototypes/_NF/Maps/debug.yml
@@ -31,7 +31,7 @@
           availableJobs:
             Contractor: [ -1, -1 ]
             # Pilot: [ -1, -1 ]
-            Mercenary: [ -1, -1 ]
+            # Mercenary: [ -1, -1 ]
             Borg: [ -1, -1]
             StationRepresentative: [ -1, -1 ]
             StationTrafficController: [ -1, -1 ]

--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/mercenary.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/mercenary.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-hire
   weight: 3 # Prioritize station & department jobs
   displayWeight: 20 # Second from the bottom
-  setPreference: true
+  setPreference: false # Mono: unselectable
   access:
   - Mercenary
   accessGroups: # Frontier

--- a/Resources/ServerInfo/_Mono/Guidebook/Factions/minor_factions.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/Factions/minor_factions.xml
@@ -7,5 +7,5 @@
 
   > The [color=red]Viper Group[/color] are a band of professional operatives resembling the Gorlex Marauders of the corporate era, selling their services to whoever can meet their price.
 
-  These groups do not engage either the [color=cyan]TSFMC[/color] or [color=gold]PDV[/color] on sight, and find themselves acting on the same level as the many [color=green]Mercs[/color] of the sector.
+  These groups do not engage either the [color=cyan]TSFMC[/color] or [color=gold]PDV[/color] on sight, and find themselves acting on the same level as the many [color=green]vagrants[/color] of the sector.
 </Document>


### PR DESCRIPTION
## About the PR
Mercenary is no longer selectable.

## Why / Balance
Vestigial role a la Pilot. There is nothing a Mercenary can do that a Vagrant can't. The role's existence also muddies the waters about the transition to Vagrants and raises questions about their validity.

## Media
<img width="593" height="133" alt="image" src="https://github.com/user-attachments/assets/2421c332-9a26-40f7-82ba-b852df19f36b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
join lobby
hit Customize
no option to ready up as Mercenary

**Changelog**
:cl:
- remove: Mercenaries have been removed. Play as a Vagrant if you want to be a lone wolf fending for yourself.