### PR TITLE
Vagrant Drip

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -42,6 +42,7 @@
   - ContractorTrinkets
   - ContractorBureaucracy
   - NFSpeciesSpecific
+  - MercenaryBalaclava # Mono
   - ContractorFirearm # Mono
   - ContractorMag # Mono
 # - CivGunCaseSpecial # Mono

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -16,20 +16,21 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Contractor
+# mono: give vagrants mercenary loadout options
 - type: roleLoadout
   id: JobContractor
   groups:
-  - ContractorHead
+  - MercenaryHead
   - ContractorNeck
-  - ContractorJumpsuit
-  - ContractorGloves
-  - ContractorBackpack
+  - MercenaryJumpsuit
+  - MercenaryGloves
+  - MercenaryBackpack
   - ContractorOuterClothing
-  - ContractorShoes
-  - ContractorFace
-  - ContractorGlasses
-  - ContractorBelt
-  - ContractorEars
+  - MercenaryShoes
+  - MercenaryFace
+  - MercenaryGlasses
+  - MercenaryBelt
+  - MercenaryEars
   - ContractorEncryptionKey
   - ContractorBoxSurvival
   - ContractorPDA


### PR DESCRIPTION
## About the PR
Vagrants now have the mercenary loadout options for clothing.

This does NOT include: outer clothing, firearm or PDA. However, yes, it does include large chest rigs.

## Why / Balance
People wanted their drip

## Media
<img width="538" height="520" alt="image" src="https://github.com/user-attachments/assets/755b9488-65d9-4ce5-8846-98bdca372013" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
go to lobby
open Vagrant loadout
mercenary items

**Changelog**
:cl:
- add: You can now, for the most part, equip your old Mercenary drip as a Vagrant!
