### PR TITLE
Silly Me (Fix Point Gens)

### DIFF
--- a/Resources/Maps/_Mono/POI/anomalouslab.yml
+++ b/Resources/Maps/_Mono/POI/anomalouslab.yml
@@ -9320,7 +9320,7 @@ entities:
     - type: Transform
       pos: 14.5,23.5
       parent: 1
-- proto: DatafarmResearchFaction
+- proto: DatafarmResearchFaction200
   entities:
   - uid: 1360
     components:

--- a/Resources/Maps/_Mono/POI/pdvhelios_hw.yml
+++ b/Resources/Maps/_Mono/POI/pdvhelios_hw.yml
@@ -25551,7 +25551,7 @@ entities:
     - type: Transform
       pos: -15.5,13.5
       parent: 1
-- proto: DatafarmResearchFaction
+- proto: DatafarmResearchFaction200
   entities:
   - uid: 3892
     components:

--- a/Resources/Maps/_Mono/POI/sevastopol.yml
+++ b/Resources/Maps/_Mono/POI/sevastopol.yml
@@ -10586,7 +10586,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 21.5,-10.5
       parent: 1
-- proto: DatafarmResearchFaction
+- proto: DatafarmResearchFaction200
   entities:
   - uid: 356
     components:

--- a/Resources/Maps/_Mono/POI/tsfmchalcyon_hw.yml
+++ b/Resources/Maps/_Mono/POI/tsfmchalcyon_hw.yml
@@ -30811,7 +30811,7 @@ entities:
     - type: Transform
       pos: 3.5,28.5
       parent: 1
-- proto: DatafarmResearchFaction
+- proto: DatafarmResearchFaction200
   entities:
   - uid: 4851
     components:

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/datafarms.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/datafarms.yml
@@ -103,11 +103,26 @@
   id: DatafarmResearchFaction
   parent: BaseDataFarmIndestructible
   name: bolted data farm (Research)
+  suffix: 35 PPS
   description: A power-hungry server dedicated towards scraping data from... somewhere. This one generates research points at a rate of 200 per second. It seems to be bolted to the floor.
   components:
   - type: ResearchClient
   - type: ResearchPointSource
     pointsPerSecond: 35
+    active: true
+  - type: ApcPowerReceiver
+    powerLoad: 10000
+
+- type: entity
+  id: DatafarmResearchFaction200
+  parent: BaseDataFarmIndestructible
+  name: bolted data farm (Research)
+  suffix: 200 PPS
+  description: A power-hungry server dedicated towards scraping data from... somewhere. This one generates research points at a rate of 200 per second. It seems to be bolted to the floor.
+  components:
+  - type: ResearchClient
+  - type: ResearchPointSource
+    pointsPerSecond: 200
     active: true
   - type: ApcPowerReceiver
     powerLoad: 10000


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes sevas and HW faction bases have 200 point gens again
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fix since other PR made them 35 again
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
nah
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl: Onezero0
- fix: Fixed sevastopol data farms being really weak.
- tweak: Hyperwar faction bases have better point generators.
