### PR TITLE
Civ Comms Fix

### DIFF
--- a/Resources/Locale/en-US/_NF/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_NF/guidebook/guides.ftl
@@ -1,5 +1,6 @@
 # Base entries
-guide-entry-nf14 = Frontier Guide
+guide-entry-nf14 = Monolith Basics
+guide-entry-basics = Starting Guide
 guide-entry-bank = Colossus Central Bank
 guide-entry-safety-deposit-box = Safety Deposit Box System
 guide-entry-piloting = Piloting

--- a/Resources/Locale/en-US/_NF/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/_NF/headset/headset-component.ftl
@@ -1,3 +1,3 @@
 chat-radio-traffic = Shortband
 chat-radio-nfsd = NFSD
-chat-radio-ncmc = TSFMC
+chat-radio-ncmc = TSF Comms

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -8,7 +8,7 @@ examine-headset-default-channel = Use {$prefix} for the default channel ([color=
 
 chat-radio-common = Broadband
 chat-radio-centcom = HighComm
-chat-radio-command = TSF Command
+chat-radio-command = TSF Military
 chat-radio-engineering = Engineering
 chat-radio-medical = Medical
 chat-radio-science = Science

--- a/Resources/Prototypes/Guidebook/newplayer.yml
+++ b/Resources/Prototypes/Guidebook/newplayer.yml
@@ -7,6 +7,7 @@
   - Controls
   - CharacterCreation
   - StartingGear # Frontier
+  - BeginnerGuide # Mono
 
 - type: guideEntry
   id: Controls

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Ears/headsets.yml
@@ -1,5 +1,20 @@
 #TSFMC
 - type: entity
+  parent: ClothingHeadset
+  id: ClothingHeadsetTsfCivilian
+  name: TSF radio
+  components:
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/security.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/security.rsi
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+      - EncryptionKeyNfsd
+
+- type: entity
   parent: ClothingHeadsetAlt
   id: ClothingHeadsetAltTsfmc
   name: TSFMC over-ear headset

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Ears/headsets.yml
@@ -43,6 +43,7 @@
       key_slots:
       - EncryptionKeyCommon
       - EncryptionKeyNfsd
+      - EncryptionKeyCommand
 
 - type: entity
   parent: ClothingHeadsetAlt

--- a/Resources/Prototypes/_Mono/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/_Mono/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -110,6 +110,7 @@
     - Common
     - Traffic
     - Nfsd
+    - Command
 
 - type: entity
   id: TSFBorgChassisAssault
@@ -180,7 +181,7 @@
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg
   - type: BorgSwitchableType
-    typeWhitelist: 
+    typeWhitelist:
     - xenoborgheavy
     - xenoborgengineer
     - xenoborgscout
@@ -197,7 +198,7 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellCombat
-    
+
 - type: entity
   id: XenoborgChassisEngineer
   parent: [ BorgChassisSelectableXenoborg, BaseXenoborgTransponder ]

--- a/Resources/Prototypes/_Mono/Guidebook/basics.yml
+++ b/Resources/Prototypes/_Mono/Guidebook/basics.yml
@@ -1,0 +1,5 @@
+- type: guideEntry
+  id: BeginnerGuide
+  name: Beginner's Guide
+  text: "/ServerInfo/_Mono/Guidebook/BeginnerGuide.xml"
+  priority: 2

--- a/Resources/Prototypes/_Mono/Loadouts/PDV/role_loadouts_rogue.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/PDV/role_loadouts_rogue.yml
@@ -153,7 +153,7 @@
   - ContractorFace
   - ContractorGlasses
   - ContractorBelt
-  - ContractorEars
+  # - ContractorEars
   - ContractorEncryptionKey
   - ContractorBoxSurvival
   - ContractorPDA

--- a/Resources/Prototypes/_Mono/Loadouts/TSFMC/role_loadouts_tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/TSFMC/role_loadouts_tsfmc.yml
@@ -240,7 +240,7 @@
   - ContractorFace
   - ContractorGlasses
   - ContractorBelt
-  - ContractorEars
+  #- ContractorEars
   - ContractorEncryptionKey
   - ContractorBoxSurvival
   - ContractorPDA

--- a/Resources/Prototypes/_Mono/Roles/Jobs/PDV/civilian.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/PDV/civilian.yml
@@ -37,3 +37,4 @@
   storage:
     back:
     - NFPouchUtility
+    - ClothingHeadsetAltFreelancer

--- a/Resources/Prototypes/_Mono/Roles/Jobs/TSFMC/civilian.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/TSFMC/civilian.yml
@@ -37,3 +37,4 @@
   storage:
     back:
     - NFPouchUtility
+    - ClothingHeadsetTsfCivilian

--- a/Resources/Prototypes/_Mono/companies.yml
+++ b/Resources/Prototypes/_Mono/companies.yml
@@ -31,7 +31,7 @@
 
 - type: company
   id: PDVCivilian
-  name: Phaeton Dynasty
+  name: Phaethon Dynasty
   color: "#D2B48C"
   disabled: true
   companyUplinkCurrency: Doubloon

--- a/Resources/ServerInfo/_Mono/Guidebook/BeginnerGuide.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/BeginnerGuide.xml
@@ -22,14 +22,55 @@
 
   Almost all loadout items are obtainable in-game, whether through vendors or lathes, so don't stress if you forgot insulated gloves or engineering goggles. Just buy some from a vendor on station.
 
-  ## Bank
+  ### Physical Traits
+
+  Traits are small perks that you can add to your character. While most forks have traits that are largely cosmetic or negative (like accents and disabilities), in Monolith there are "Physical" traits with more gameplay impact.
+  These traits range from small health buffs, to faster do-afters, to bionics. However, you can only take a limited amount of positive buffs before needing to take other negative perks.
+  [bold]Note: Bionic parts are vulnerable to EMP. Watch out for EMP weapons while rocking cool speed legs.[/bold]
+
+  ### Bank
 
   Every character has their own bank account. This is split into two pools: Your regular bank (which can be used to purchase anything) and your savings account (which is prioritized for loadout costs and other meta items, like safety deposit boxes).
+  New characters start with 75k in their regular bank account.
   Credits can be acquired in many ways, usually by selling items on sellpads or by asking for payment from whoever employs you.
   Credit items can then be taken to an ATM (found on most stations), inserted, and then deposited through the ATM UI.
   As your regular bank account fills up, more of your deposits transfer instead to your saving account. This usually softcaps your regular bank from having billions of credits, but you don't usually need more than a million credits to access all in-game content.
 
   ## Spawning In
 
-  
+  When first spawning in (usually as a TSF Contractor, PDV Freeman or MMC Employee), you will likely be faced with a spawnroom. Around the various stations are vendors. Some important pickups include tools and a weapon.
+  After getting your bearings, locate a shipyard console (usually blue colored). [bold]You will not be able to use your faction's shipyard unless you are a military role.[/bold] Use a Scrapyard or regular shipyard instead.
+  You will spawn in with all your loadout items, along with a survival box containing multiple essentials: A pocket oxygen tank, food, a mass scanner, a crowbar, a space and epinephrine pen, and two flares.
+
+  ### Using a Shipyard Console
+
+  To use a shipyard console, take your ID out of your PDA (usually with alt-click) and put it inside the console. Opening the UI, there are multiple available ships; Take whichever one seems best, though if you're unsure a mining ship is always viable.
+  After buying your ship (and optionally renaming it), eject your card, and check your mass scanner for your ship's location. Make your way to the dock, and settle in.
+
+  ### Vessels
+
+  Almost all ships have complimentary space suits inside. If not, just buy one from a vendor on-station. Ships require fuel depending on their generator, so either get ready to mine some or buy spare from a vendor. When you're all geared up, head to the ship's
+  shuttle console, swipe your ID to unlock it, and then prepare for flight.
+  All ships require thrusters and gyroscopes to fly, which also require power; If any get destroyed, you may lose functionality. If you do lose any whether through combat or unfortunate accidents, you can buy replacements, build new ones yourself, or salvage spares from
+  abandoned ships.
+
+  At this point, you should read up on the shuttle piloting section of this guidebook, and optionally the gunnery section as well.
+
+  ### Making a Profit
+
+  Assuming you've bought a mining ship, one surefire way to make some cash is to go out and find asteroids, in asteroid clusters or in the outer reaches of the sector. Mining is simple; Use ship-based mining equipment or destroy asteroid rock yourself with proper equipment,
+  then collect the resulting ores via an ore bag or ship-mounted ore magnet. After getting your first batch of resources, dump them into an ore processor before selling the refined sheets via a sellpad or through arranging a deal with other players.
+
+  Some tips for optimal mining:
+  - Most ore or material related objects have magnets that can automatically collect loose pieces of ore. They can speed up material collection between lathes and storage.
+  - While manual mining is cheaper, watch out for rock golems, crabs and other anomalies that can occasionally appear. Always mine armed.
+  - Ship-based mining is a lot faster than manual mining, but requires more equipment to get started. Ask another miner for advice, or join their crew!
+
+  Using your acquired credits, buy better equipment, mine more, or experiment with other roles!
+
+  ## Round End
+
+  Before entering cryosleep or otherwise disconnecting after a run, make sure to dock your ship to a station with a shipyard console and sell it. This will give back roughly 75% of the value on the ship. Additionally, make sure to deposit all your credits at an ATM
+  so that they aren't lost!
+
 </Document>

--- a/Resources/ServerInfo/_Mono/Guidebook/BeginnerGuide.xml
+++ b/Resources/ServerInfo/_Mono/Guidebook/BeginnerGuide.xml
@@ -1,0 +1,35 @@
+<Document>
+  # Beginner's Guide
+
+  Starting out on Monolith (even with some knowledge of operations on other forks) can be daunting, with all of our unique content.
+  With zero hours, you only have access to a few roles: TSF Contractor, PDV Freeman, and MMC Employee.
+
+  This guide aims to help you through your first shift, get accustomed to Monolith gameplay, and get some more money in your account.
+
+  ## Making your first character
+
+  Making a character is not very different from making a character on any other fork. Choose a species, pick a name, etcetera.
+  However, Monolith has some additional considerations:
+
+  ### Job Loadouts
+  Every job has a large loadout, which can be scary when opening the menu for the first time. However, most of the options available are purely cosmetic; The most important ones to gameplay are:
+  - Your sidearm
+  - PDA cartridges
+  - Implanters
+  - Tools
+  - Glasses
+  - Belt
+
+  Almost all loadout items are obtainable in-game, whether through vendors or lathes, so don't stress if you forgot insulated gloves or engineering goggles. Just buy some from a vendor on station.
+
+  ## Bank
+
+  Every character has their own bank account. This is split into two pools: Your regular bank (which can be used to purchase anything) and your savings account (which is prioritized for loadout costs and other meta items, like safety deposit boxes).
+  Credits can be acquired in many ways, usually by selling items on sellpads or by asking for payment from whoever employs you.
+  Credit items can then be taken to an ATM (found on most stations), inserted, and then deposited through the ATM UI.
+  As your regular bank account fills up, more of your deposits transfer instead to your saving account. This usually softcaps your regular bank from having billions of credits, but you don't usually need more than a million credits to access all in-game content.
+
+  ## Spawning In
+
+  
+</Document>


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Gives TSF and PDV faction comms
TSF command has been renamed to TSF military and is now accessible to all marines
Civs only get the default channel ("TSF radio")

Added a "beginner guide" guidebook entry

PDV/TSF civs lose custom headset but now get tsf/pdv comms always
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
couldn't talk to their factions
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- add: TSF/PDV civilians now get faction comms.
- tweak: TSF command comms have been rebranded as "TSF Military" and should be accessible to all military roles.
- add: There is now a beginner guide guidebook entry.