### PR TITLE
Antimatter Bomb Nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/antimatter_jar.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/antimatter_jar.yml
@@ -4,7 +4,7 @@
   parent: BaseItem
   id: AmeJar
   name: IRE isotopes canister
-  description: A hermetically sealed jar containing volatile isotopes for use in an isotopes reaction engine.
+  description: A hermetically sealed jar containing volatile isotopes for use in an isotopes reaction engine. Do not trigger its release mechanism.
   components:
   - type: Item
     size: Normal
@@ -27,15 +27,29 @@
         !type:DamageTrigger
         damage: 1000
       behaviors:
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 1200
+      behaviors:
       - !type:DoActsBehavior
-        acts: ["Destruction"]
-      - !type:ExplodeBehavior
+        acts: [ "Destruction" ]
   - type: Explosive # Mono
-    explosionType: Default
-    maxIntensity: 50
-    intensitySlope: 2
-    totalIntensity: 375
+    explosionType: Radioactive
+    maxIntensity: 100
+    intensitySlope: 4
+    totalIntensity: 150
   - type: Damageable # Mono
     damageContainer: StructuralInorganic
     damageModifierSet: StructuralMetallicStrong
+  - type: ExplodeOnTrigger
+  - type: OnUseTimerTrigger
+    delay: 30
+    useVerbInstead: true
+    beepSound:
+      path: "/Audio/Effects/beep1.ogg"
+      params:
+        volume: 4
+    initialBeepDelay: 0
+    beepInterval: 5 # 2 beeps total (at 0 and 2)
 # End of modified code

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -29,6 +29,11 @@
         !type:DamageTrigger
         damage: 10
       behaviors:
+      - !type:TimerStartBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 800
+      behaviors:
       - !type:TriggerBehavior
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Nerfs AME jar explosion to be more like a pocket fissile bomb
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
hm yes lets obliterate a station with one bag of 4
Also makes grenades trigger their timer when getting exploded rather than instantly detonate (chain reactions)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
nah
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- tweak: IRE canisters now have a smaller, radioactive explosion.
- tweak: Most grenades now start their timer upon being damaged rather than instantly exploding.
