### PR TITLE
Powergamers Begone

### DIFF
--- a/Content.Shared/_Mono/BlackFlash/BlackFlashArmedComponent.cs
+++ b/Content.Shared/_Mono/BlackFlash/BlackFlashArmedComponent.cs
@@ -7,7 +7,4 @@ public sealed partial class BlackFlashArmedComponent : Component
 {
     [DataField, AutoNetworkedField]
     public EntityUid User;
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan ExpiresAt;
 }

--- a/Content.Shared/_Mono/BlackFlash/BlackFlashComponent.cs
+++ b/Content.Shared/_Mono/BlackFlash/BlackFlashComponent.cs
@@ -11,45 +11,48 @@ namespace Content.Shared._Mono.BlackFlash;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class BlackFlashComponent : Component
 {
+    [DataField, AutoNetworkedField]
+    public bool EmptyHandedOnly = false;
+
     [DataField]
     public EntProtoId Action = "ActionBlackFlash";
 
     [DataField, AutoNetworkedField]
     public EntityUid? ActionEntity;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public TimeSpan HitCooldown = TimeSpan.FromMinutes(1);
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public TimeSpan MissCooldown = TimeSpan.FromSeconds(10);
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float DamageMultiplier = 2.5f;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float StaminaCost = 30f;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public TimeSpan Hitstop = TimeSpan.FromSeconds(0.2);
 
-    [DataField]
-    public TimeSpan StunTime = TimeSpan.FromSeconds(4);
+    [DataField, AutoNetworkedField]
+    public TimeSpan StunTime = TimeSpan.FromSeconds(1);
 
-    [DataField]
-    public float ThrowDistance = 14f;
+    [DataField, AutoNetworkedField]
+    public float ThrowDistance = 15f;
 
-    [DataField]
-    public float ThrowSpeed = 28f;
+    [DataField, AutoNetworkedField]
+    public float ThrowSpeed = 25f;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntProtoId HitEffect = "EffectBlackFlash";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntProtoId MissEffect = "EffectBlackFlashWhiff";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public SoundSpecifier? HitSound = new SoundPathSpecifier("/Audio/_Mono/Items/black_flash.ogg");
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public SoundSpecifier? MissSound = new SoundPathSpecifier("/Audio/_Mono/Items/black_flash_fumble.ogg");
 }

--- a/Content.Shared/_Mono/BlackFlash/BlackFlashSystem.cs
+++ b/Content.Shared/_Mono/BlackFlash/BlackFlashSystem.cs
@@ -162,6 +162,9 @@ public sealed partial class BlackFlashSystem : EntitySystem
         if (!_blackFlashQuery.TryComp(args.User, out var flash))
             return;
 
+        if (flash.EmptyHandedOnly && args.Weapon != args.User)
+            return;
+
         if (args.HitEntities.Count == 0)
         {
             Lapse(weapon, weapon.Comp, args.Direction);
@@ -252,7 +255,7 @@ public sealed partial class BlackFlashSystem : EntitySystem
         var armed = EntityQueryEnumerator<BlackFlashArmedComponent>();
         while (armed.MoveNext(out var uid, out var comp))
         {
-            if (!_blackFlashQuery.HasComp(comp.User))
+            if (!_blackFlashQuery.TryComp(comp.User, out var flash))
             {
                 RemCompDeferred<BlackFlashArmedComponent>(uid);
                 continue;
@@ -262,9 +265,7 @@ public sealed partial class BlackFlashSystem : EntitySystem
                 continue;
 
             RemCompDeferred<BlackFlashArmedComponent>(uid);
-            var moved = EnsureComp<BlackFlashArmedComponent>(current);
-            moved.User = comp.User;
-            Dirty(current, moved);
+            _actions.SetToggled(flash.ActionEntity, false);
         }
 
         var frames = EntityQueryEnumerator<BlackFlashImpactFramesComponent>();

--- a/Resources/Prototypes/_Mono/Body/Organs/cybernetics.yml
+++ b/Resources/Prototypes/_Mono/Body/Organs/cybernetics.yml
@@ -129,3 +129,4 @@
   - type: Organ
     onAdd:
     - type: BlackFlash
+      emptyHandedOnly: true # you did this to yourself


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The Black Flash implant has been nerfed. You can only do it with an empty hand and the default stun time has been reduced to 1 second.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

No more powergaming. Admins can revert to old behaviour easily.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

98% human made PR today (i had codex do a review on the systems change but that was it)

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: MMC's replacement heart implant has been weakened for commercial use due to repeated incidents of abuse by factions.
