### PR TITLE
No More Fissile Nukes

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -157,7 +157,7 @@ namespace Content.Server.Construction
             if (!CheckConditions(uid, edge.Conditions))
                 return HandleResult.False;
 
-            var handle = HandleStep(uid, ev, step, validation, out var user, construction);
+            var handle = HandleStep(uid, ev, step, edge, validation, out var user, construction);
             if (handle is not HandleResult.True)
                 return handle;
 
@@ -195,7 +195,7 @@ namespace Content.Server.Construction
         /// <remarks>When <see cref="validation"/> is true, this method will simply return whether the interaction
         ///          would be handled by the entity or not. It essentially becomes a pure method that modifies nothing.</remarks>
         /// <returns>The result of this interaction with the entity.</returns>
-        private HandleResult HandleStep(EntityUid uid, object ev, ConstructionGraphStep step, bool validation, out EntityUid? user, ConstructionComponent? construction = null)
+        private HandleResult HandleStep(EntityUid uid, object ev, ConstructionGraphStep step, ConstructionGraphEdge edge, bool validation, out EntityUid? user, ConstructionComponent? construction = null)
         {
             user = null;
             if (!Resolve(uid, ref construction))
@@ -203,7 +203,7 @@ namespace Content.Server.Construction
 
             // Let HandleInteraction actually handle the event for this step.
             // We can only perform the rest of our logic if it returns true.
-            var handle = HandleInteraction(uid, ev, step, validation, out user, construction);
+            var handle = HandleInteraction(uid, ev, step, edge, validation, out user, construction);
             if (handle is not HandleResult.True)
                 return handle;
 
@@ -225,7 +225,7 @@ namespace Content.Server.Construction
         /// <remarks>When <see cref="validation"/> is true, this method will simply return whether the interaction
         ///          would be handled by the entity or not. It essentially becomes a pure method that modifies nothing.</remarks>
         /// <returns>The result of this interaction with the entity.</returns>
-        private HandleResult HandleInteraction(EntityUid uid, object ev, ConstructionGraphStep step, bool validation, out EntityUid? user, ConstructionComponent? construction = null)
+        private HandleResult HandleInteraction(EntityUid uid, object ev, ConstructionGraphStep step, ConstructionGraphEdge edge, bool validation, out EntityUid? user, ConstructionComponent? construction = null)
         {
             user = null;
             if (!Resolve(uid, ref construction))
@@ -303,7 +303,7 @@ namespace Content.Server.Construction
                         // Verify that the resulting DoAfter event will be handled by the current construction state.
                         // if it can't what is even the point of raising this DoAfter?
                         doAfterEv.DoAfter = new(default, doAfterEventArgs, default);
-                        var result = HandleInteraction(uid, doAfterEv, step, validation: true, out _, construction);
+                        var result = HandleInteraction(uid, doAfterEv, step, edge, validation: true, out _, construction);
                         DebugTools.Assert(result == HandleResult.Validated);
 #endif
                         return HandleResult.DoAfter;
@@ -364,17 +364,35 @@ namespace Content.Server.Construction
                     if (doAfterState == DoAfterState.Completed)
                         return  HandleResult.True;
 
+                    var durationEvent = new GetConstructionToolUseDurationEvent(
+                        interactUsing.User,
+                        interactUsing.Used,
+                        edge,
+                        toolInsertStep,
+                        TimeSpan.FromSeconds(toolInsertStep.DoAfter));
+                    RaiseLocalEvent(uid, ref durationEvent);
+
                     var result  = _toolSystem.UseTool(
                         interactUsing.Used,
                         interactUsing.User,
                         uid,
-                        TimeSpan.FromSeconds(toolInsertStep.DoAfter),
+                        durationEvent.Duration,
                         new [] { toolInsertStep.Tool },
                         new ConstructionInteractDoAfterEvent(EntityManager, interactUsing),
-                        out var doAfter,
+                        out var doAfterId,
                         toolInsertStep.Fuel);
 
-                    return result && doAfter != null ? HandleResult.DoAfter : HandleResult.False;
+                    if (!result || doAfterId == null)
+                        return HandleResult.False;
+
+                    RaiseLocalEvent(uid, new ConstructionToolUseStartedEvent(
+                        interactUsing.User,
+                        interactUsing.Used,
+                        edge,
+                        toolInsertStep,
+                        doAfterId.Value));
+
+                    return HandleResult.DoAfter;
                 }
 
                 case TemperatureConstructionGraphStep temperatureChangeStep:

--- a/Content.Server/Construction/ConstructionToolUseEvents.cs
+++ b/Content.Server/Construction/ConstructionToolUseEvents.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Construction;
+using Content.Shared.Construction.Steps;
+using Content.Shared.DoAfter;
+
+namespace Content.Server.Construction;
+
+[ByRefEvent]
+public record struct GetConstructionToolUseDurationEvent(
+    EntityUid User,
+    EntityUid Tool,
+    ConstructionGraphEdge Edge,
+    ToolConstructionGraphStep Step,
+    TimeSpan Duration);
+
+public sealed class ConstructionToolUseStartedEvent(
+    EntityUid user,
+    EntityUid tool,
+    ConstructionGraphEdge edge,
+    ToolConstructionGraphStep step,
+    DoAfterId doAfter) : EntityEventArgs
+{
+    public EntityUid User { get; } = user;
+    public EntityUid Tool { get; } = tool;
+    public ConstructionGraphEdge Edge { get; } = edge;
+    public ToolConstructionGraphStep Step { get; } = step;
+    public DoAfterId DoAfter { get; } = doAfter;
+}

--- a/Content.Server/_Mono/Construction/FissileDeconstructionSystem.cs
+++ b/Content.Server/_Mono/Construction/FissileDeconstructionSystem.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Content.Server.Construction;
+using Content.Server.Construction.Completions;
+using Content.Shared.Construction;
+using Content.Shared.Materials;
+using Content.Shared.Popups;
+
+namespace Content.Server._Mono.Construction;
+
+/// <summary>
+/// mald system
+/// </summary>
+public sealed partial class FissileDeconstructionSystem : EntitySystem
+{
+    [Dependency] private SharedMaterialStorageSystem _materialStorage = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+
+    private const string FissileUranium = "UraniumFissile";
+    private const int CriticalMass = 600;
+    private const float TimeMultiplier = 10f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MaterialStorageComponent, GetConstructionToolUseDurationEvent>(OnGetDuration);
+        SubscribeLocalEvent<MaterialStorageComponent, ConstructionToolUseStartedEvent>(OnToolUseStarted);
+    }
+
+    private void OnGetDuration(Entity<MaterialStorageComponent> ent, ref GetConstructionToolUseDurationEvent args)
+    {
+        if (IsHazardous(ent, args.Edge))
+            args.Duration *= TimeMultiplier;
+    }
+
+    private void OnToolUseStarted(Entity<MaterialStorageComponent> ent, ref ConstructionToolUseStartedEvent args)
+    {
+        if (!IsHazardous(ent, args.Edge))
+            return;
+
+        _popup.PopupEntity(Loc.GetString("construction-fissile-deconstruction-warning"),
+            ent,
+            args.User,
+            PopupType.LargeCaution);
+    }
+
+    private bool IsHazardous(Entity<MaterialStorageComponent> ent, ConstructionGraphEdge edge)
+    {
+        return edge.Completed.Any(action => action is RaiseEvent { Event: MachineDeconstructedEvent })
+            && ent.Comp.DropOnDeconstruct
+            && _materialStorage.GetMaterialAmount(ent, FissileUranium, ent.Comp, true) >= CriticalMass;
+    }
+}

--- a/Resources/Locale/en-US/_Mono/construction.ftl
+++ b/Resources/Locale/en-US/_Mono/construction.ftl
@@ -1,0 +1,1 @@
+construction-fissile-deconstruction-warning = You feel your skin begin to burn. This isn't a good idea in the slightest.


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a severe delay to atempting to deconstruct a machine with over-critical Fissile Uranium in it. This is because this happens far too often. I dislike that there wasn't protection against this earlier.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

mald pr

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->
75% AI pr today unfortunately (I properly reviewed it and it's solid, considering Codex is a bit of an idiot at times, but I have morals)

## How to test
Put more then 6 ingots of Fissile Uranium in a silo or some other machine and deconstruct it.

**Changelog**
:cl:
- add: A revision of most machine material storage to save on costs has reduced the lead lining to prevent radiation leaks.
