### PR TITLE
Deposit Boxes Changes

### DIFF
--- a/Content.Server/_WF/SafetyDepositBox/SafetyDepositBoxSystem.cs
+++ b/Content.Server/_WF/SafetyDepositBox/SafetyDepositBoxSystem.cs
@@ -528,6 +528,13 @@ public sealed partial class SafetyDepositBoxSystem : EntitySystem
             return;
         }
 
+        if (box.LastWithdrawn != null) // Check to make sure it isn't already deposited.
+        {
+            ConsolePopup(player, "Box already withdrawn in world.");
+            PlayDenySound(consoleUid, component);
+            return;
+        }
+
         Log.Info($"WithdrawBoxAsync: Retrieved box {boxId} with {box.Items.Count} items from database");
 
         // Verify ownership

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -711,6 +711,7 @@
     tags:
     - Trash
     - Document
+    - Unstashable # Mono - deposit box currency bypass
   #- type: Appearance, hide stamp marks until we have some kind of displacement
   - type: Flammable
     fireSpread: true

--- a/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
+++ b/Resources/Prototypes/_Mono/Entities/Materials/materials.yml
@@ -79,6 +79,7 @@
   - type: Tag
     tags:
     - Sheet
+    - Unstashable
   - type: Item
     sprite: _Mono/Objects/Materials/iridite.rsi
     heldPrefix: iridite

--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/loot.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/loot.yml
@@ -39,6 +39,9 @@
     damage:
       types:
         Blunt: 50
+  - type: Tag
+    tags:
+    - Unstashable
 
 - type: entity
   name: medium monolithic crystal
@@ -82,6 +85,9 @@
     damage:
       types:
         Blunt: 50
+  - type: Tag
+    tags:
+    - Unstashable
 
 - type: entity
   name: large monolithic crystal
@@ -127,5 +133,8 @@
     damage:
       types:
         Blunt: 50
+  - type: Tag
+    tags:
+    - Unstashable
 
 

--- a/Resources/Prototypes/_WF/Entities/Structures/Machines/safety_deposit_box.yml
+++ b/Resources/Prototypes/_WF/Entities/Structures/Machines/safety_deposit_box.yml
@@ -15,14 +15,21 @@
   - type: Storage
     blacklist:
       components:
-      - IdCard
-      - Currency
-      - Store
-      - EncryptionKey
-      - Implant
-      - Storage
-      - SafetyDepositBox
-      - ShipyardVoucher
+      - IdCard # Fuckery, abusable
+      - Currency # Balance
+      - Store # Balance
+      - EncryptionKey # Balance
+      - Implant # Prevent recursion
+      - Storage # Prevent recursion
+      - SafetyDepositBox # Prevent recursion
+      - ShipyardVoucher # Mfw 6 T4 vouchers in one box
+      - SecretStash # WL bypass
+      - Implanter # WL bypass
+      - OverwatchConsole # Requested by staff
+      - GhostRoleMobSpawner # Reinforcement radios
+      - DoorRemote # Requested by staff
+      - SolutionContainerManager # Requested by staff + lets you do crazy crazy shit that shouldn't be allowed gameplay wise (such as storing 6ku of letoferol)
+      - NukeDisk # Might be abusable in some way, who knows.
       tags:
       - Unstashable
   - type: SafetyDepositBox

--- a/Resources/ServerInfo/_NF/Guidebook/SafetyDepositBox.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/SafetyDepositBox.xml
@@ -94,6 +94,6 @@ The following items are explicitly blacklisted (not an extensive list!):
   - Overwatch Consoles
   - Ghostrole spawners (such as reinforcement radios)
   - Anything with secret storage (such as plushies)
-  - Reagent storages (such as beakers)
+  - Reagent storages (such as beakers); note that seeds are excluded!
   - Iridite & Monolithic Crystals <!--NOTE - I don't mind if someone adds a way to store Iridite, perhaps in a compressed form w/ much lower stack size.-->
 </Document>

--- a/Resources/ServerInfo/_NF/Guidebook/SafetyDepositBox.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/SafetyDepositBox.xml
@@ -83,7 +83,7 @@ The safety deposit system preserves:
   - [bold]Stack counts[/bold] - The exact number of items in stacks
   - [bold]Box nicknames[/bold] - Custom labels on the boxes themselves
 
-The following items are explicitly blacklisted (not an extensive list!):
+[italic][color=gold]The following items are explicitly blacklisted (not an extensive list!):[/color][/italic]
   - [bold]ID Cards[/bold]
   - [bold]LPCs[/bold]
   - [bold]Uplinks[/bold]

--- a/Resources/ServerInfo/_NF/Guidebook/SafetyDepositBox.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/SafetyDepositBox.xml
@@ -8,10 +8,10 @@ The [color=#44cc00]Safety Deposit Box System[/color] allows you to securely stor
     <GuideEntityEmbed Entity="SafetyDepositConsole"/>
   </Box>
   The [color=#44cc00]Safety Deposit Console[/color] is your interface for managing your deposit boxes. Located at Camelot, Zvezda, and Caelestinius Central's shipyards, it allows you to:
-- [bold]Purchase[/bold] new safety deposit boxes
-- [bold]Deposit[/bold] boxes to store items in the database
-- [bold]Withdraw[/bold] stored boxes to retrieve your items
-- [bold]Reclaim[/bold] lost boxes that were never returned
+  - [bold]Purchase[/bold] new safety deposit boxes
+  - [bold]Deposit[/bold] boxes to store items in the database
+  - [bold]Withdraw[/bold] stored boxes to retrieve your items
+  - [bold]Reclaim[/bold] lost boxes that were never returned
 
 ## Box Sizes and Pricing
   <Box>
@@ -20,9 +20,9 @@ The [color=#44cc00]Safety Deposit Box System[/color] allows you to securely stor
     <GuideEntityEmbed Entity="SafetyDepositBoxLarge"/>
   </Box>
   Three box sizes are available, each with different storage capacity:
-- [bold]Small (2x2)[/bold] - $2,000,000
-- [bold]Medium (2x4)[/bold] - $3,500,000
-- [bold]Large (2x6)[/bold] - $5,000,000
+  - [bold]Small (2x2)[/bold] - $2,000,000
+  - [bold]Medium (2x4)[/bold] - $3,500,000
+  - [bold]Large (2x6)[/bold] - $5,000,000
 
 The cost is deducted from your [color=#44cc00]bank account[/color] when you purchase a box.
 
@@ -53,9 +53,9 @@ The physical box will be consumed when deposited, but your items are now protect
 ## Box Status Indicators
 
 Your boxes can have several status indicators:
-- [color=#00ff00][bold]Stored[/bold][/color] - Box has items safely stored in the database
-- [color=#ffff00][bold]In World[/bold][/color] - Box was withdrawn recently (less than 7 days ago)
-- [color=#ff0000][bold]Lost (Empty)[/bold][/color] - Box was withdrawn over 7 days ago and never returned
+  - [color=#00ff00][bold]Stored[/bold][/color] - Box has items safely stored in the database
+  - [color=#ffff00][bold]In World[/bold][/color] - Box was withdrawn recently (less than 7 days ago)
+  - [color=#ff0000][bold]Lost (Empty)[/bold][/color] - Box was withdrawn over 7 days ago and never returned
 
 ## Reclaiming Lost Boxes
 
@@ -69,19 +69,31 @@ If you lost a box after withdrawing it (disconnected, round ended, etc.), and it
 
 ## Tips and Best Practices
 
-- [bold]Label your boxes[/bold] - Use a hand labeler to give your boxes nicknames for easy identification
-- [bold]Deposit before leaving[/bold] - Always re-deposit your boxes before ending your shift
-- [bold]Keep valuables safe[/bold] - Store important documents, rare items, or valuable equipment
-- [bold]Multiple boxes[/bold] - You can own multiple boxes to organize different types of items
-- [bold]ID cards can't be stored[/bold] - The system won't allow ID cards to be deposited for security reasons
+  - [bold]Label your boxes[/bold] - Use a hand labeler to give your boxes nicknames for easy identification
+  - [bold]Deposit before leaving[/bold] - Always re-deposit your boxes before ending your shift
+  - [bold]Keep valuables safe[/bold] - Store important documents, rare items, or valuable equipment
+  - [bold]Multiple boxes[/bold] - You can own multiple boxes to organize different types of items
+  - [bold]ID cards can't be stored[/bold] - The system won't allow ID cards to be deposited for security reasons
 
 ## Item Preservation
 
 The safety deposit system preserves:
-- [bold]Paper content[/bold] - Written documents, stamps, and signatures
-- [bold]Labels[/bold] - Custom names you've applied to items
-- [bold]Stack counts[/bold] - The exact number of items in stacks
-- [bold]Box nicknames[/bold] - Custom labels on the boxes themselves
+  - [bold]Paper content[/bold] - Written documents, stamps, and signatures
+  - [bold]Labels[/bold] - Custom names you've applied to items
+  - [bold]Stack counts[/bold] - The exact number of items in stacks
+  - [bold]Box nicknames[/bold] - Custom labels on the boxes themselves
 
-Most items can be stored, but some sensitive items (like ID cards) are blacklisted for security reasons.
+The following items are explicitly blacklisted (not an extensive list!):
+  - ID Cards
+  - LPCs
+  - Uplinks
+  - Currency (such as FMC/DC or just normal cash)
+  - Encryption Keys
+  - Implanters
+  - Anything with storage
+  - Overwatch Consoles
+  - Ghostrole spawners (such as reinforcement radios)
+  - Anything with secret storage (such as plushies)
+  - Reagent storages (such as beakers)
+  - Iridite & Monolithic Crystals <!--NOTE - I don't mind if someone adds a way to store Iridite, perhaps in a compressed form w/ much lower stack size.-->
 </Document>

--- a/Resources/ServerInfo/_NF/Guidebook/SafetyDepositBox.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/SafetyDepositBox.xml
@@ -84,16 +84,17 @@ The safety deposit system preserves:
   - [bold]Box nicknames[/bold] - Custom labels on the boxes themselves
 
 The following items are explicitly blacklisted (not an extensive list!):
-  - ID Cards
-  - LPCs
-  - Uplinks
-  - Currency (such as FMC/DC or just normal cash)
-  - Encryption Keys
-  - Implanters
-  - Anything with storage
-  - Overwatch Consoles
-  - Ghostrole spawners (such as reinforcement radios)
-  - Anything with secret storage (such as plushies)
-  - Reagent storages (such as beakers); note that seeds are excluded!
-  - Iridite & Monolithic Crystals <!--NOTE - I don't mind if someone adds a way to store Iridite, perhaps in a compressed form w/ much lower stack size.-->
+  - [bold]ID Cards[/bold]
+  - [bold]LPCs[/bold]
+  - [bold]Uplinks[/bold]
+  - [bold]Currency[/bold]
+  - [bold]Encryption Keys[/bold]
+  - [bold]Implanters[/bold]
+  - [bold]Anything with storage[/bold]
+  - [bold]Overwatch Consoles[/bold]
+  - [bold]Ghostrole spawners (such as reinforcement radios)[/bold]
+  - [bold]Anything with secret storage (such as plushies)[/bold]
+  - [bold]Reagent storages (such as beakers)[/bold]
+  - [bold]Iridite[/bold] <!--NOTE - I don't mind if someone adds a way to store Iridite, perhaps in a compressed form w/ much lower stack size?-->
+  - [bold]Monolithic Crystals[/bold]
 </Document>


### PR DESCRIPTION
fixes withdraw being able to dupe boxes and their contents (i dont care enough to fix reclaiming, you cant abuse shit with that anyways) when spammed w/ lag

adds item blacklist requested by staff (and balance):
- no more secretstash (plushies)
- no more implanters (can be withdrawn to abuse it for persistent uplink/storage)
- no more overwatch consoles, no more ghostrole spawners
- no more door remote
- no more reagent storage (didn't want to do this but there's no system for whitelist based off reagents. Nothing is worth the tradeoff of 6ku of letoferol being able to be stored between rounds). Seeds purposely excluded, I don't care about omnizine and I think it's cool if you manage to gamble ichor gene and sell it or whatever.
- no more iridite sheets
- no more monolithic crystals

:cl:
- tweak: Expanded the safety deposit box blacklist for entities. No more 6ku of persistent letoferol guys. It's over.
- fix: Fixed safety deposit box withdrawing being able to duplicate boxes.