### PR TITLE
Cinquedea, the TSF Laser Brawler

### DIFF
--- a/Resources/Locale/en-US/_Mono/store/tsfmc-uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Mono/store/tsfmc-uplink-catalog.ftl
@@ -106,6 +106,9 @@ uplink-security-t1-aldebaran-voucher-desc = A small card that contains the data 
 uplink-security-t2-andromeda-voucher-name = TSFMC Andromeda LPC [T2]
 uplink-security-t2-andromeda-voucher-desc = A small card that contains the data for the procurement of an Andromeda-class cruiser from the flagship's reserves.
 
+uplink-security-t2-cinquedea-voucher-name = TSFMC Cinquedea LPC [T2]
+uplink-security-t2-cinquedea-voucher-desc = A small card that contains the data for the procurement of an Cinquedea-class corvette from the flagship's reserves.
+
 uplink-security-t2-spekter-voucher-name = TSFMC Spekter LPC [T2]
 uplink-security-t2-spekter-voucher-desc = A small card that contains the data for the procurement of an Spekter-class corvette from the flagship's reserves.
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
@@ -127,6 +127,7 @@
     - Fujian
     - Mercury
     - Spekter
+    - Cinquedea
 
 # TSF Fujian Fighters
 

--- a/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
+++ b/Resources/Prototypes/_Mono/Entities/SpaceArtillery/SpaceArtillery/Energy/launcher.yml
@@ -565,7 +565,7 @@
     startingCharge: 50000
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 500
+    autoRechargeRate: 4002
   - type: ExaminableBattery
   - type: WirelessNetworkConnection
     range: 500

--- a/Resources/Prototypes/_Mono/Shipyard/TSF/cinquedea.yml
+++ b/Resources/Prototypes/_Mono/Shipyard/TSF/cinquedea.yml
@@ -1,0 +1,40 @@
+#original concept by kasature90 (github)/_starch_ (discord)
+#internals refit by harrow/waphun
+- type: vessel
+  id: Cinquedea
+  parent: BaseVesselIFFDisabled
+  name: TSF-ELF Cinquedea
+  description: Moderately armed and heavily armored multipurpose corvette. Armed with 6 Prometheus laser cannons and 2 L-1 Phalanxes for Point Defence. Quick and Agile, perfect for pursuing and finishing off damaged enemy vessels.
+  price: 250000 #242609 baseline. Marked up to an even 250k for being a millitary vessel.
+  purchasable: false # voucher only - T2
+  category: Medium
+  group: Security
+  access: Security
+  shuttlePath: /SharedMaps/_Mono/Shuttles/TSF/cinquedea.yml
+  guidebookPage: Null
+  class:
+  - Pursuit
+  - Brawler
+  - Corvette
+  engine:
+  - Plasma
+
+- type: gameMap
+  id: Cinquedea
+  mapName: 'Cinquedea'
+  mapPath: /SharedMaps/_Mono/Shuttles/TSF/cinquedea.yml
+  minPlayers: 0
+  stations:
+    Cinquedea:
+      stationProto: StandardFrontierSecurityVessel
+      components:
+      - type: StationNameSetup
+        mapNameTemplate: 'Cinquedea TSF{1}'
+        nameGenerator:
+          !type:NanotrasenNameGenerator
+          prefixCreator: '14'
+      - type: StationJobs
+        availableJobs:
+          Deputy: [ 0, 0 ]
+          TsfBorg: [ 0, 0 ]
+

--- a/Resources/SharedMaps/_Mono/Shuttles/TSF/cinquedea.yml
+++ b/Resources/SharedMaps/_Mono/Shuttles/TSF/cinquedea.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/28/2026 20:55:41
+  time: 08/29/2026 22:21:02
   entityCount: 960
 maps: []
 grids:
@@ -697,10 +697,10 @@ entities:
             125: -11,-14
     - type: SpreaderGrid
       spreadQueues:
-        Kudzu: []
         Smoke: []
         MetalFoam: []
         Puddle: []
+        Kudzu: []
     - type: GridAtmosphere
       version: 2
       data:
@@ -3494,7 +3494,7 @@ entities:
       parent: 1
 - proto: HardpointEnergyLight
   entities:
-  - uid: 953
+  - uid: 408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3502,7 +3502,7 @@ entities:
       parent: 1
     - type: Physics
       canCollide: False
-  - uid: 956
+  - uid: 409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3512,162 +3512,168 @@ entities:
       canCollide: False
 - proto: HardpointEnergyMedium
   entities:
-  - uid: 942
+  - uid: 410
     components:
     - type: Transform
-      pos: -6.5,-4.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-  - uid: 945
-    components:
-    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -2.5,8.5
       parent: 1
     - type: Physics
       canCollide: False
-  - uid: 946
+  - uid: 412
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 1.5,8.5
       parent: 1
     - type: Physics
       canCollide: False
-  - uid: 947
+  - uid: 413
     components:
     - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-  - uid: 948
-    components:
-    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 4.5,1.5
       parent: 1
     - type: Physics
       canCollide: False
-  - uid: 949
+  - uid: 414
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -5.5,1.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 956
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-4.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 959
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
       parent: 1
     - type: Physics
       canCollide: False
 - proto: LargeAPC
   entities:
-  - uid: 408
+  - uid: 415
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 1
-  - uid: 409
+  - uid: 416
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 410
+  - uid: 417
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 411
+  - uid: 418
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 412
+  - uid: 419
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
 - proto: LightBulbCrystalBlue
   entities:
-  - uid: 414
+  - uid: 421
     components:
     - type: Transform
-      parent: 413
+      parent: 420
     - type: Physics
       canCollide: False
-  - uid: 416
+  - uid: 423
     components:
     - type: Transform
-      parent: 415
+      parent: 422
     - type: Physics
       canCollide: False
 - proto: LightBulbCrystalGreen
   entities:
-  - uid: 418
+  - uid: 425
     components:
     - type: Transform
-      parent: 417
+      parent: 424
     - type: Physics
       canCollide: False
 - proto: LightBulbCrystalPink
   entities:
-  - uid: 420
+  - uid: 427
     components:
     - type: Transform
-      parent: 419
+      parent: 426
     - type: Physics
       canCollide: False
 - proto: LockableButtonTSFMC
   entities:
-  - uid: 421
+  - uid: 428
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        641:
+        650:
         - - Pressed
           - Toggle
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 422
+  - uid: 429
     components:
     - type: Transform
       pos: -2.7699358,-9.433822
       parent: 1
 - proto: LockerMedicineFilled
   entities:
-  - uid: 423
+  - uid: 430
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
 - proto: MachineFTLDrive
   entities:
-  - uid: 424
+  - uid: 431
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
 - proto: MedicalBed
   entities:
-  - uid: 425
+  - uid: 432
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
 - proto: MedTekCartridge
   entities:
-  - uid: 426
+  - uid: 433
     components:
     - type: Transform
       pos: -2.622004,0.66841817
       parent: 1
 - proto: NFHolopadShip
   entities:
-  - uid: 427
+  - uid: 434
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 428
+  - uid: 435
     components:
     - type: Transform
       anchored: True
@@ -3677,7 +3683,7 @@ entities:
       bodyType: Static
 - proto: OxygenCanister
   entities:
-  - uid: 429
+  - uid: 436
     components:
     - type: Transform
       anchored: True
@@ -3687,7 +3693,7 @@ entities:
       bodyType: Static
 - proto: PaperBin20
   entities:
-  - uid: 430
+  - uid: 437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3695,7 +3701,7 @@ entities:
       parent: 1
 - proto: PaperOffice
   entities:
-  - uid: 431
+  - uid: 438
     components:
     - type: Transform
       pos: -0.42452556,-12.795266
@@ -3723,7 +3729,7 @@ entities:
         Have a safe flight marine.
 - proto: Pen
   entities:
-  - uid: 432
+  - uid: 439
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3731,13 +3737,13 @@ entities:
       parent: 1
 - proto: PlasturaniumWindowRadProof
   entities:
-  - uid: 433
+  - uid: 440
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-7.5
       parent: 1
-  - uid: 434
+  - uid: 441
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3745,21 +3751,21 @@ entities:
       parent: 1
 - proto: PlushieCatTabby
   entities:
-  - uid: 435
+  - uid: 442
     components:
     - type: Transform
       pos: 1.6589265,-13.564506
       parent: 1
 - proto: PowerCellMedium
   entities:
-  - uid: 436
+  - uid: 443
     components:
     - type: Transform
       pos: -2.302477,0.42926902
       parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 437
+  - uid: 444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3767,7 +3773,7 @@ entities:
       parent: 1
 - proto: PoweredlightBlue
   entities:
-  - uid: 438
+  - uid: 445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3775,7 +3781,7 @@ entities:
       parent: 1
 - proto: PoweredlightCyan
   entities:
-  - uid: 439
+  - uid: 446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3783,7 +3789,7 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 440
+  - uid: 447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3791,7 +3797,7 @@ entities:
       parent: 1
 - proto: PoweredlightSodium
   entities:
-  - uid: 441
+  - uid: 448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3799,7 +3805,7 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 442
+  - uid: 449
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3807,7 +3813,7 @@ entities:
       parent: 1
 - proto: PoweredSmallLightEmpty
   entities:
-  - uid: 413
+  - uid: 420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3818,12 +3824,12 @@ entities:
         light_bulb: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 414
+          ent: 421
     - type: ApcPowerReceiver
       powerLoad: 60
     - type: DamageOnInteract
       isDamageActive: False
-  - uid: 415
+  - uid: 422
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3834,12 +3840,12 @@ entities:
         light_bulb: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 416
+          ent: 423
     - type: ApcPowerReceiver
       powerLoad: 60
     - type: DamageOnInteract
       isDamageActive: False
-  - uid: 417
+  - uid: 424
     components:
     - type: Transform
       pos: 1.5,-5.5
@@ -3849,12 +3855,12 @@ entities:
         light_bulb: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 418
+          ent: 425
     - type: ApcPowerReceiver
       powerLoad: 60
     - type: DamageOnInteract
       isDamageActive: False
-  - uid: 419
+  - uid: 426
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3865,20 +3871,20 @@ entities:
         light_bulb: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 420
+          ent: 427
     - type: ApcPowerReceiver
       powerLoad: 60
     - type: DamageOnInteract
       isDamageActive: False
 - proto: PoweredStrobeBlueEnabled
   entities:
-  - uid: 443
+  - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-19.5
       parent: 1
-  - uid: 444
+  - uid: 451
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3886,49 +3892,49 @@ entities:
       parent: 1
 - proto: PoweredStrobeSodiumEnabled
   entities:
-  - uid: 445
+  - uid: 452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
-  - uid: 446
+  - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-4.5
       parent: 1
-  - uid: 447
+  - uid: 454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 448
+  - uid: 455
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,8.5
       parent: 1
-  - uid: 449
+  - uid: 456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 450
+  - uid: 457
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 1
-  - uid: 451
+  - uid: 458
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-13.5
       parent: 1
-  - uid: 452
+  - uid: 459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3936,44 +3942,44 @@ entities:
       parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 453
+  - uid: 460
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-10.5
       parent: 1
-  - uid: 454
+  - uid: 461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 455
+  - uid: 462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-14.5
       parent: 1
-  - uid: 456
+  - uid: 463
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-19.5
       parent: 1
-  - uid: 457
+  - uid: 464
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
 - proto: Rack
   entities:
-  - uid: 458
+  - uid: 465
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-10.5
       parent: 1
-  - uid: 459
+  - uid: 466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3981,297 +3987,297 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerDiagonal
   entities:
-  - uid: 460
+  - uid: 467
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-5.5
       parent: 1
-  - uid: 461
+  - uid: 468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-14.5
       parent: 1
-  - uid: 462
+  - uid: 469
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 1
-  - uid: 463
+  - uid: 470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 464
+  - uid: 471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 465
+  - uid: 472
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,7.5
       parent: 1
-  - uid: 466
+  - uid: 473
     components:
     - type: Transform
       pos: -2.5,-19.5
       parent: 1
-  - uid: 467
+  - uid: 474
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-20.5
       parent: 1
-  - uid: 468
+  - uid: 475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 469
+  - uid: 476
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-20.5
       parent: 1
-  - uid: 470
+  - uid: 477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-20.5
       parent: 1
-  - uid: 471
+  - uid: 478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-5.5
       parent: 1
-  - uid: 472
+  - uid: 479
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-14.5
       parent: 1
-  - uid: 473
+  - uid: 480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-12.5
       parent: 1
-  - uid: 474
+  - uid: 481
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-19.5
       parent: 1
-  - uid: 475
+  - uid: 482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-20.5
       parent: 1
-  - uid: 476
+  - uid: 483
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 477
+  - uid: 484
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
-  - uid: 478
+  - uid: 485
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-10.5
       parent: 1
-  - uid: 479
+  - uid: 486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 480
+  - uid: 487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-15.5
       parent: 1
-  - uid: 481
+  - uid: 488
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-15.5
       parent: 1
-  - uid: 482
+  - uid: 489
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 1
-  - uid: 483
+  - uid: 490
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 484
+  - uid: 491
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 485
+  - uid: 492
     components:
     - type: Transform
       pos: -4.5,-15.5
       parent: 1
-  - uid: 486
+  - uid: 493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 487
+  - uid: 494
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 488
+  - uid: 495
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 489
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 490
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-8.5
-      parent: 1
-  - uid: 491
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 492
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 493
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,0.5
-      parent: 1
-  - uid: 494
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 495
-    components:
-    - type: Transform
-      pos: -2.5,-14.5
-      parent: 1
   - uid: 496
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-17.5
+      pos: -2.5,-2.5
       parent: 1
   - uid: 497
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-14.5
+      pos: 0.5,-8.5
       parent: 1
   - uid: 498
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-17.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-17.5
       parent: 1
-  - uid: 499
+  - uid: 506
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 500
-    components:
-    - type: Transform
-      pos: -5.5,-4.5
-      parent: 1
-  - uid: 501
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-16.5
-      parent: 1
-  - uid: 502
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-5.5
-      parent: 1
-  - uid: 503
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
-      parent: 1
-  - uid: 504
-    components:
-    - type: Transform
-      pos: -3.5,-16.5
-      parent: 1
-  - uid: 505
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-17.5
-      parent: 1
-  - uid: 506
-    components:
-    - type: Transform
-      pos: 6.5,-14.5
-      parent: 1
   - uid: 507
     components:
     - type: Transform
-      pos: 7.5,-14.5
+      pos: -5.5,-4.5
       parent: 1
   - uid: 508
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,-14.5
+      pos: 2.5,-16.5
       parent: 1
   - uid: 509
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-17.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 516
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-14.5
       parent: 1
-  - uid: 951
+  - uid: 517
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-14.5
       parent: 1
-  - uid: 952
+  - uid: 518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4279,13 +4285,13 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerHalftiltLeft
   entities:
-  - uid: 511
+  - uid: 519
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,3.5
       parent: 1
-  - uid: 512
+  - uid: 520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4293,13 +4299,13 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerHalftiltRight
   entities:
-  - uid: 514
+  - uid: 521
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 515
+  - uid: 522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4307,586 +4313,586 @@ entities:
       parent: 1
 - proto: RadarEdgeMarkerStraight
   entities:
-  - uid: 510
+  - uid: 523
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 513
+  - uid: 524
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 516
+  - uid: 525
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 1
-  - uid: 517
+  - uid: 526
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 518
+  - uid: 527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-3.5
       parent: 1
-  - uid: 519
+  - uid: 528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-4.5
       parent: 1
-  - uid: 520
+  - uid: 529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-20.5
       parent: 1
-  - uid: 521
+  - uid: 530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-20.5
       parent: 1
-  - uid: 522
+  - uid: 531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,9.5
       parent: 1
-  - uid: 523
+  - uid: 532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-19.5
       parent: 1
-  - uid: 524
-    components:
-    - type: Transform
-      pos: 8.5,-13.5
-      parent: 1
-  - uid: 525
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-19.5
-      parent: 1
-  - uid: 526
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 1
-  - uid: 527
-    components:
-    - type: Transform
-      pos: -3.5,5.5
-      parent: 1
-  - uid: 528
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,1.5
-      parent: 1
-  - uid: 529
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,2.5
-      parent: 1
-  - uid: 530
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,3.5
-      parent: 1
-  - uid: 531
-    components:
-    - type: Transform
-      pos: -5.5,3.5
-      parent: 1
-  - uid: 532
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-19.5
-      parent: 1
   - uid: 533
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-20.5
+      pos: 8.5,-13.5
       parent: 1
   - uid: 534
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-19.5
+      pos: -3.5,-19.5
       parent: 1
   - uid: 535
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,8.5
+      pos: -2.5,-20.5
       parent: 1
   - uid: 536
     components:
     - type: Transform
-      pos: -3.5,8.5
+      pos: -3.5,5.5
       parent: 1
   - uid: 537
     components:
     - type: Transform
-      pos: -5.5,2.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
       parent: 1
   - uid: 538
     components:
     - type: Transform
-      pos: -5.5,1.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
       parent: 1
   - uid: 539
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -9.5,-13.5
+      pos: 4.5,3.5
       parent: 1
   - uid: 540
     components:
     - type: Transform
-      pos: -3.5,6.5
+      pos: -5.5,3.5
       parent: 1
   - uid: 541
     components:
     - type: Transform
-      pos: -3.5,9.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,-19.5
       parent: 1
   - uid: 542
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-20.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-19.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-13.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 543
+  - uid: 552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 544
+  - uid: 553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 1
-  - uid: 545
+  - uid: 554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 546
+  - uid: 555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-14.5
       parent: 1
-  - uid: 547
+  - uid: 556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-14.5
       parent: 1
-  - uid: 548
+  - uid: 557
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 1
-  - uid: 549
+  - uid: 558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-14.5
       parent: 1
-  - uid: 550
+  - uid: 559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-10.5
       parent: 1
-  - uid: 551
+  - uid: 560
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 552
+  - uid: 561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 1
-  - uid: 553
+  - uid: 562
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 554
+  - uid: 563
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
-  - uid: 555
+  - uid: 564
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 556
+  - uid: 565
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 557
+  - uid: 566
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 558
+  - uid: 567
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 559
+  - uid: 568
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 560
+  - uid: 569
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 561
+  - uid: 570
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 562
+  - uid: 571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-15.5
       parent: 1
-  - uid: 563
+  - uid: 572
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-15.5
       parent: 1
-  - uid: 564
+  - uid: 573
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-15.5
       parent: 1
-  - uid: 565
+  - uid: 574
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 566
+  - uid: 575
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 567
+  - uid: 576
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 568
+  - uid: 577
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 569
+  - uid: 578
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 570
+  - uid: 579
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 571
+  - uid: 580
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 572
+  - uid: 581
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-  - uid: 573
+  - uid: 582
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 574
+  - uid: 583
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 575
+  - uid: 584
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 576
+  - uid: 585
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 577
+  - uid: 586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 1
-  - uid: 578
+  - uid: 587
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 579
+  - uid: 588
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 580
+  - uid: 589
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 581
+  - uid: 590
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 582
+  - uid: 591
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 583
+  - uid: 592
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 1
-  - uid: 584
+  - uid: 593
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 585
+  - uid: 594
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 586
+  - uid: 595
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 587
+  - uid: 596
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 588
+  - uid: 597
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
-  - uid: 589
+  - uid: 598
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 590
+  - uid: 599
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 591
+  - uid: 600
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 592
+  - uid: 601
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 593
+  - uid: 602
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 594
+  - uid: 603
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 595
+  - uid: 604
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 596
+  - uid: 605
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 597
+  - uid: 606
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 598
+  - uid: 607
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 599
+  - uid: 608
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 600
+  - uid: 609
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 601
+  - uid: 610
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 602
+  - uid: 611
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 603
+  - uid: 612
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 1
-  - uid: 604
-    components:
-    - type: Transform
-      pos: -3.5,4.5
-      parent: 1
-  - uid: 605
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,5.5
-      parent: 1
-  - uid: 606
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,6.5
-      parent: 1
-  - uid: 607
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,7.5
-      parent: 1
-  - uid: 608
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,1.5
-      parent: 1
-  - uid: 609
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 610
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 611
-    components:
-    - type: Transform
-      pos: 0.5,-15.5
-      parent: 1
-  - uid: 612
-    components:
-    - type: Transform
-      pos: 0.5,-16.5
-      parent: 1
   - uid: 613
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-15.5
+      pos: -3.5,4.5
       parent: 1
   - uid: 614
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,-16.5
+      pos: 2.5,5.5
       parent: 1
   - uid: 615
     components:
     - type: Transform
-      pos: -3.5,-16.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
       parent: 1
   - uid: 616
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-17.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
       parent: 1
   - uid: 617
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-11.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
       parent: 1
   - uid: 618
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-20.5
+      pos: 3.5,2.5
       parent: 1
   - uid: 619
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 1
+  - uid: 622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-15.5
+      parent: 1
+  - uid: 623
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 1
+  - uid: 624
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 1
+  - uid: 625
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-17.5
+      parent: 1
+  - uid: 626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 627
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-20.5
+      parent: 1
+  - uid: 628
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-18.5
       parent: 1
-  - uid: 620
+  - uid: 629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-17.5
       parent: 1
-  - uid: 621
+  - uid: 630
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4894,85 +4900,85 @@ entities:
       parent: 1
 - proto: Railing
   entities:
-  - uid: 622
+  - uid: 631
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-14.5
       parent: 1
-  - uid: 623
+  - uid: 632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-13.5
       parent: 1
-  - uid: 624
+  - uid: 633
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-13.5
       parent: 1
-  - uid: 625
+  - uid: 634
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-12.5
       parent: 1
-  - uid: 626
+  - uid: 635
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-10.5
       parent: 1
-  - uid: 627
+  - uid: 636
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 628
+  - uid: 637
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 1
-  - uid: 629
+  - uid: 638
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 1
-  - uid: 630
+  - uid: 639
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 631
+  - uid: 640
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 632
+  - uid: 641
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-16.5
       parent: 1
-  - uid: 633
+  - uid: 642
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-17.5
       parent: 1
-  - uid: 634
+  - uid: 643
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 635
+  - uid: 644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4980,40 +4986,40 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 636
+  - uid: 645
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: ShieldGeneratorSmall
   entities:
-  - uid: 637
+  - uid: 646
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
 - proto: ShipRepairDevice
   entities:
-  - uid: 638
+  - uid: 647
     components:
     - type: Transform
       pos: -0.5283375,-10.381769
       parent: 1
 - proto: ShipRepairDeviceAmmo
   entities:
-  - uid: 639
+  - uid: 648
     components:
     - type: Transform
       pos: 0.20668983,-10.5598755
       parent: 1
-  - uid: 640
+  - uid: 649
     components:
     - type: Transform
       pos: 0.4806118,-10.251793
       parent: 1
 - proto: ShuttersRadiation
   entities:
-  - uid: 641
+  - uid: 650
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5021,7 +5027,7 @@ entities:
       parent: 1
 - proto: SinkWide
   entities:
-  - uid: 642
+  - uid: 651
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5029,75 +5035,75 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 643
+  - uid: 652
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 644
+  - uid: 653
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 645
+  - uid: 654
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 646
+  - uid: 655
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
 - proto: StairDark
   entities:
-  - uid: 647
+  - uid: 656
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-13.5
       parent: 1
-  - uid: 648
+  - uid: 657
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
 - proto: SuitStorageM82c
   entities:
-  - uid: 649
+  - uid: 658
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 650
+  - uid: 659
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-14.5
       parent: 1
-  - uid: 651
+  - uid: 660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-14.5
       parent: 1
-  - uid: 652
+  - uid: 661
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-  - uid: 653
+  - uid: 662
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 654
+  - uid: 663
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5105,25 +5111,25 @@ entities:
       parent: 1
 - proto: ThrusterLargeNfsd
   entities:
-  - uid: 655
+  - uid: 664
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-14.5
       parent: 1
-  - uid: 656
+  - uid: 665
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-20.5
       parent: 1
-  - uid: 657
+  - uid: 666
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-14.5
       parent: 1
-  - uid: 658
+  - uid: 667
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5131,19 +5137,19 @@ entities:
       parent: 1
 - proto: ThrusterNfsd
   entities:
-  - uid: 659
+  - uid: 668
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 1
-  - uid: 660
+  - uid: 669
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
-  - uid: 661
+  - uid: 670
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5151,96 +5157,96 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 662
+  - uid: 671
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-17.5
       parent: 1
-  - uid: 663
+  - uid: 672
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-17.5
       parent: 1
-  - uid: 664
+  - uid: 673
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 665
+  - uid: 674
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 666
+  - uid: 675
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 667
+  - uid: 676
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-15.5
       parent: 1
-  - uid: 668
+  - uid: 677
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-15.5
       parent: 1
-  - uid: 669
+  - uid: 678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 670
+  - uid: 679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-1.5
       parent: 1
-  - uid: 671
+  - uid: 680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 672
+  - uid: 681
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 1
-  - uid: 673
+  - uid: 682
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 1
-  - uid: 674
+  - uid: 683
     components:
     - type: Transform
       pos: -6.5,-11.5
       parent: 1
-  - uid: 675
+  - uid: 684
     components:
     - type: Transform
       pos: -7.5,-11.5
       parent: 1
-  - uid: 676
+  - uid: 685
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 677
+  - uid: 686
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
-  - uid: 678
+  - uid: 687
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5248,19 +5254,19 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 1
-  - uid: 679
+  - uid: 688
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 1
-  - uid: 680
+  - uid: 689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 1
-  - uid: 681
+  - uid: 690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5268,115 +5274,115 @@ entities:
       parent: 1
 - proto: TurboItemRecharger
   entities:
-  - uid: 682
+  - uid: 691
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 683
+  - uid: 692
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 1
 - proto: WallArmorAddonSolid
   entities:
-  - uid: 684
+  - uid: 693
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 685
+  - uid: 694
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 686
+  - uid: 695
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 1
-  - uid: 687
+  - uid: 696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 1
-  - uid: 688
+  - uid: 697
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 1
-  - uid: 689
+  - uid: 698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 690
+  - uid: 699
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 1
-  - uid: 691
+  - uid: 700
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
-  - uid: 692
+  - uid: 701
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 693
+  - uid: 702
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 695
+  - uid: 703
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 696
+  - uid: 704
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 697
+  - uid: 705
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 1
-  - uid: 699
+  - uid: 706
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 700
+  - uid: 707
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 702
+  - uid: 708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,9.5
       parent: 1
-  - uid: 707
+  - uid: 709
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5388,56 +5394,56 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 712
+  - uid: 711
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: WallArmorAddonSolidBrokenCornerR
   entities:
-  - uid: 701
+  - uid: 712
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-10.5
       parent: 1
-  - uid: 703
+  - uid: 713
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,10.5
       parent: 1
-  - uid: 704
+  - uid: 714
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
-  - uid: 705
+  - uid: 715
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,7.5
       parent: 1
-  - uid: 706
+  - uid: 716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-  - uid: 708
+  - uid: 717
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
-  - uid: 711
+  - uid: 718
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 717
+  - uid: 719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5450,71 +5456,22 @@ entities:
       parent: 1
 - proto: WallArmorAddonSolidCornerL
   entities:
-  - uid: 694
+  - uid: 721
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 1
-  - uid: 698
+  - uid: 722
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 709
+  - uid: 723
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-10.5
-      parent: 1
-  - uid: 713
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-5.5
-      parent: 1
-  - uid: 714
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,7.5
-      parent: 1
-  - uid: 715
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,3.5
-      parent: 1
-  - uid: 716
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,0.5
-      parent: 1
-  - uid: 718
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,10.5
-      parent: 1
-  - uid: 719
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-2.5
-      parent: 1
-- proto: WallPlastitanium
-  entities:
-  - uid: 722
-    components:
-    - type: Transform
-      pos: -4.5,-4.5
-      parent: 1
-  - uid: 723
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-6.5
       parent: 1
   - uid: 724
     components:
@@ -5525,88 +5482,137 @@ entities:
   - uid: 725
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,-5.5
+      pos: 3.5,3.5
       parent: 1
   - uid: 727
     components:
     - type: Transform
-      pos: -2.5,3.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
       parent: 1
   - uid: 728
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -5.5,-4.5
+      pos: -3.5,10.5
       parent: 1
   - uid: 729
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-9.5
+      pos: 4.5,-2.5
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
       parent: 1
   - uid: 731
     components:
     - type: Transform
-      pos: 3.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-5.5
       parent: 1
   - uid: 733
     components:
     - type: Transform
-      pos: 1.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
       parent: 1
   - uid: 734
     components:
     - type: Transform
-      pos: -3.5,3.5
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-4.5
       parent: 1
   - uid: 736
     components:
     - type: Transform
-      pos: 2.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-9.5
       parent: 1
   - uid: 737
     components:
     - type: Transform
-      pos: 2.5,4.5
+      pos: 3.5,-16.5
       parent: 1
   - uid: 738
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: 1.5,3.5
       parent: 1
   - uid: 739
     components:
     - type: Transform
-      pos: 0.5,-19.5
+      pos: -3.5,3.5
       parent: 1
   - uid: 740
     components:
     - type: Transform
-      pos: -1.5,3.5
+      pos: 2.5,-16.5
       parent: 1
   - uid: 741
     components:
     - type: Transform
-      pos: 0.5,3.5
+      pos: 2.5,4.5
       parent: 1
   - uid: 742
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 744
+  - uid: 747
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 746
+  - uid: 748
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 748
+  - uid: 749
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5689,446 +5695,446 @@ entities:
     - type: Transform
       pos: -1.5,-19.5
       parent: 1
-  - uid: 765
+  - uid: 764
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 1
-  - uid: 766
+  - uid: 765
     components:
     - type: Transform
       pos: -8.5,-12.5
       parent: 1
-  - uid: 767
+  - uid: 766
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-20.5
       parent: 1
-  - uid: 768
+  - uid: 767
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,4.5
       parent: 1
-  - uid: 769
+  - uid: 768
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 772
+  - uid: 769
     components:
     - type: Transform
       pos: -4.5,-16.5
       parent: 1
-  - uid: 773
+  - uid: 770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 774
+  - uid: 771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-9.5
       parent: 1
-  - uid: 776
+  - uid: 772
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-11.5
       parent: 1
-  - uid: 777
+  - uid: 773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 778
+  - uid: 774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-10.5
       parent: 1
-  - uid: 779
+  - uid: 775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-12.5
       parent: 1
-  - uid: 781
+  - uid: 776
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-6.5
       parent: 1
-  - uid: 782
+  - uid: 777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-5.5
       parent: 1
-  - uid: 783
+  - uid: 778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 1
-  - uid: 785
+  - uid: 779
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 1
-  - uid: 788
+  - uid: 780
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-18.5
       parent: 1
-  - uid: 789
+  - uid: 781
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-20.5
       parent: 1
-  - uid: 790
+  - uid: 782
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-18.5
       parent: 1
-  - uid: 791
+  - uid: 783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-10.5
       parent: 1
-  - uid: 793
+  - uid: 784
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 794
+  - uid: 785
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 795
+  - uid: 786
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 796
+  - uid: 787
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 797
+  - uid: 788
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 1
-  - uid: 798
+  - uid: 789
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 1
-  - uid: 799
+  - uid: 790
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 1
-  - uid: 800
+  - uid: 791
     components:
     - type: Transform
       pos: 5.5,-14.5
       parent: 1
-  - uid: 801
+  - uid: 792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-19.5
       parent: 1
-  - uid: 803
+  - uid: 793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-19.5
       parent: 1
-  - uid: 804
+  - uid: 794
     components:
     - type: Transform
       pos: -6.5,-14.5
       parent: 1
-  - uid: 805
+  - uid: 795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-15.5
       parent: 1
-  - uid: 806
+  - uid: 796
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 807
+  - uid: 797
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 808
+  - uid: 798
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 809
+  - uid: 799
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 810
+  - uid: 800
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 811
+  - uid: 801
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 812
+  - uid: 802
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 813
+  - uid: 803
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 814
+  - uid: 804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 815
+  - uid: 805
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 816
+  - uid: 806
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 1
-  - uid: 817
+  - uid: 807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,9.5
       parent: 1
-  - uid: 818
+  - uid: 808
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 819
+  - uid: 809
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 820
+  - uid: 810
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 821
+  - uid: 811
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 822
+  - uid: 812
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 823
+  - uid: 813
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 824
+  - uid: 814
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 1
-  - uid: 827
+  - uid: 815
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 828
+  - uid: 816
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 829
+  - uid: 817
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 830
+  - uid: 818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-12.5
       parent: 1
-  - uid: 831
+  - uid: 819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-18.5
       parent: 1
-  - uid: 832
+  - uid: 820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-18.5
       parent: 1
-  - uid: 833
+  - uid: 821
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,4.5
       parent: 1
-  - uid: 834
+  - uid: 822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-21.5
       parent: 1
-  - uid: 836
+  - uid: 823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-18.5
       parent: 1
-  - uid: 837
+  - uid: 824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-18.5
       parent: 1
-  - uid: 838
+  - uid: 825
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-18.5
       parent: 1
-  - uid: 839
+  - uid: 826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-8.5
       parent: 1
-  - uid: 840
+  - uid: 827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-17.5
       parent: 1
-  - uid: 842
+  - uid: 828
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,5.5
       parent: 1
-  - uid: 847
+  - uid: 829
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 1
-  - uid: 850
+  - uid: 830
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 1
-  - uid: 851
+  - uid: 831
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 863
+  - uid: 832
     components:
     - type: Transform
       pos: -9.5,-12.5
       parent: 1
-  - uid: 864
+  - uid: 833
     components:
     - type: Transform
       pos: -8.5,-11.5
       parent: 1
-  - uid: 865
+  - uid: 834
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-12.5
       parent: 1
-  - uid: 866
+  - uid: 835
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-14.5
       parent: 1
-  - uid: 867
+  - uid: 836
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-14.5
       parent: 1
-  - uid: 868
+  - uid: 837
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-15.5
       parent: 1
-  - uid: 870
+  - uid: 838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-20.5
       parent: 1
-  - uid: 871
+  - uid: 839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-11.5
       parent: 1
-  - uid: 872
+  - uid: 840
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 1
-  - uid: 873
+  - uid: 841
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 874
+  - uid: 842
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-20.5
       parent: 1
-  - uid: 875
+  - uid: 843
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6136,580 +6142,580 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 721
+  - uid: 844
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 726
+  - uid: 845
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 730
+  - uid: 846
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 1
-  - uid: 732
+  - uid: 847
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 735
+  - uid: 848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,7.5
       parent: 1
-  - uid: 743
+  - uid: 849
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
-  - uid: 745
+  - uid: 850
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 747
+  - uid: 851
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 1
-  - uid: 749
+  - uid: 852
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 764
+  - uid: 853
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 1
-  - uid: 770
+  - uid: 854
     components:
     - type: Transform
       pos: -6.5,-12.5
       parent: 1
-  - uid: 771
+  - uid: 855
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 1
-  - uid: 775
+  - uid: 856
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 780
+  - uid: 857
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 784
+  - uid: 858
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,6.5
       parent: 1
-  - uid: 786
+  - uid: 859
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
-  - uid: 787
+  - uid: 860
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 792
+  - uid: 861
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,7.5
       parent: 1
-  - uid: 802
+  - uid: 862
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 1
-  - uid: 825
+  - uid: 863
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 1
-  - uid: 826
+  - uid: 864
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 1
-  - uid: 835
+  - uid: 865
     components:
     - type: Transform
       pos: -6.5,-13.5
       parent: 1
-  - uid: 841
+  - uid: 866
     components:
     - type: Transform
       pos: -5.5,-13.5
       parent: 1
-  - uid: 843
+  - uid: 867
     components:
     - type: Transform
       pos: 4.5,-14.5
       parent: 1
-  - uid: 844
+  - uid: 868
     components:
     - type: Transform
       pos: -5.5,-14.5
       parent: 1
-  - uid: 845
+  - uid: 869
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
-  - uid: 846
+  - uid: 870
     components:
     - type: Transform
       pos: -4.5,-14.5
       parent: 1
-  - uid: 848
+  - uid: 871
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-  - uid: 849
+  - uid: 872
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-  - uid: 852
+  - uid: 873
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,2.5
       parent: 1
-  - uid: 853
+  - uid: 874
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 1
-  - uid: 854
+  - uid: 875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 1
-  - uid: 855
+  - uid: 876
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 878
+  - uid: 877
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 879
+  - uid: 878
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 880
+  - uid: 879
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 881
+  - uid: 880
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 882
+  - uid: 881
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 883
+  - uid: 882
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
-  - uid: 884
+  - uid: 883
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 885
+  - uid: 884
     components:
     - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 886
+  - uid: 885
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 887
+  - uid: 886
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 888
+  - uid: 887
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 889
+  - uid: 888
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-15.5
       parent: 1
-  - uid: 890
+  - uid: 889
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 1
-  - uid: 891
+  - uid: 890
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 892
+  - uid: 891
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-11.5
       parent: 1
-  - uid: 893
+  - uid: 892
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-11.5
       parent: 1
-  - uid: 894
+  - uid: 893
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 895
+  - uid: 894
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 896
+  - uid: 895
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
-  - uid: 897
+  - uid: 896
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 898
+  - uid: 897
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 899
+  - uid: 898
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 900
+  - uid: 899
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 1
-  - uid: 901
+  - uid: 900
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 902
+  - uid: 901
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 903
+  - uid: 902
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 904
+  - uid: 903
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 1
-  - uid: 905
+  - uid: 904
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 906
+  - uid: 905
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 1
-  - uid: 907
+  - uid: 906
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 908
+  - uid: 907
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-11.5
       parent: 1
-  - uid: 909
+  - uid: 908
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 910
+  - uid: 909
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 911
+  - uid: 910
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 912
+  - uid: 911
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 913
+  - uid: 912
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 914
+  - uid: 913
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 915
+  - uid: 914
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 916
+  - uid: 915
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 917
+  - uid: 916
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-8.5
       parent: 1
-  - uid: 918
+  - uid: 917
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 919
+  - uid: 918
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 920
+  - uid: 919
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 921
+  - uid: 920
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 922
+  - uid: 921
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 923
+  - uid: 922
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-5.5
       parent: 1
-  - uid: 924
+  - uid: 923
     components:
     - type: Transform
       pos: -4.5,-13.5
       parent: 1
-  - uid: 925
+  - uid: 924
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 926
+  - uid: 925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 927
+  - uid: 926
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 928
+  - uid: 927
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 929
+  - uid: 928
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
-  - uid: 930
+  - uid: 929
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 1
-  - uid: 931
+  - uid: 930
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 932
+  - uid: 931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-15.5
       parent: 1
-  - uid: 933
+  - uid: 932
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-15.5
       parent: 1
-  - uid: 934
+  - uid: 933
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 1
-  - uid: 935
+  - uid: 934
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 936
+  - uid: 935
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-  - uid: 937
+  - uid: 936
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 938
+  - uid: 937
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 856
+  - uid: 938
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 857
+  - uid: 939
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 1
-  - uid: 858
+  - uid: 940
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-7.5
       parent: 1
-  - uid: 859
+  - uid: 941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 1
-  - uid: 860
+  - uid: 942
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 1
-  - uid: 861
+  - uid: 943
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 862
+  - uid: 944
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,10.5
       parent: 1
-  - uid: 869
+  - uid: 945
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 876
+  - uid: 946
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 1
-  - uid: 877
+  - uid: 947
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
 - proto: WarpPoint
   entities:
-  - uid: 939
+  - uid: 948
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 1
 - proto: WeaponEnergyGun
   entities:
-  - uid: 940
+  - uid: 949
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6725,7 +6731,7 @@ entities:
       heldPrefix: disabler
 - proto: WeaponLaserPistolNF
   entities:
-  - uid: 941
+  - uid: 950
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6733,13 +6739,13 @@ entities:
       parent: 1
 - proto: WeaponLaserTurretL1Phalanx
   entities:
-  - uid: 954
+  - uid: 951
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-13.5
       parent: 1
-  - uid: 955
+  - uid: 952
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6747,45 +6753,45 @@ entities:
       parent: 1
 - proto: WeaponLaserTurretPrometheus
   entities:
-  - uid: 943
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-4.5
-      parent: 1
-  - uid: 944
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,1.5
-      parent: 1
-  - uid: 957
+  - uid: 411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 958
+  - uid: 953
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -6.5,-4.5
+      pos: 4.5,1.5
       parent: 1
-  - uid: 959
+  - uid: 954
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,8.5
       parent: 1
-  - uid: 960
+  - uid: 955
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,1.5
       parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 960
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-4.5
+      parent: 1
 - proto: WindoorSecureUranium
   entities:
-  - uid: 950
+  - uid: 958
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/SharedMaps/_Mono/Shuttles/TSF/cinquedea.yml
+++ b/Resources/SharedMaps/_Mono/Shuttles/TSF/cinquedea.yml
@@ -1,0 +1,6796 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 277.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 08/28/2026 20:55:41
+  entityCount: 960
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  8: FloorDark
+  45: FloorDarkAlt
+  3: FloorDarkMono
+  42: FloorDarkMonoAlt
+  6: FloorDarkPavement
+  11: FloorDarkPavementVertical
+  44: FloorDarkPlastic
+  43: FloorDarkSquiggly
+  47: FloorElevatorShaft
+  7: FloorHullReinforced
+  13: FloorMetalDiamond
+  89: FloorSteel
+  4: FloorTechMaint3
+  5: FloorTechMaintAlt
+  49: FloorTechMaintDark
+  48: FloorTileCatwalkVertical
+  10: FloorWhite
+  9: FloorWhiteMono
+  46: FloorWhitePlastic
+  12: FloorWoodLarge
+  2: Lattice
+  38: LatticeCornerNE
+  41: LatticeCornerNW
+  16: LatticeCornerSE
+  19: LatticeCornerSW
+  35: LatticeHalfTiltNESLower
+  34: LatticeHalfTiltNESUpper
+  31: LatticeHalfTiltNWSLower
+  30: LatticeHalfTiltNWSUpper
+  20: LatticeHalfTiltSENLower
+  21: LatticeHalfTiltSENUpper
+  24: LatticeHalfTiltSWNLower
+  25: LatticeHalfTiltSWNUpper
+  1: Plating
+  14: PlatingCornerNE
+  17: PlatingCornerNW
+  15: PlatingCornerSE
+  18: PlatingCornerSW
+  33: PlatingHalfTiltNESLower
+  32: PlatingHalfTiltNESUpper
+  37: PlatingHalfTiltNEWLower
+  36: PlatingHalfTiltNEWUpper
+  39: PlatingHalfTiltNWELower
+  40: PlatingHalfTiltNWEUpper
+  29: PlatingHalfTiltNWSLower
+  28: PlatingHalfTiltNWSUpper
+  22: PlatingHalfTiltSENLower
+  23: PlatingHalfTiltSENUpper
+  26: PlatingHalfTiltSWNLower
+  27: PlatingHalfTiltSWNUpper
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Calypso
+    - type: Transform
+      pos: 0.5,0.5
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAACUAAAAAAAAHAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAACoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAABAAAAAAAABwAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAqAAAAAAAAAQAAAAAAACsAAAAAAAMsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAACsAAAAAAAMDAAAAAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAAAABwAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAsAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAQAAAAAAAAEAAAAAAAAqAAAAAAAAAQAAAAAAAAEAAAAAAAAqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAACoAAAAAAAABAAAAAAAALAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAALAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAKgAAAAAAAAEAAAAAAAAtAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAACoAAAAAAAABAAAAAAAALQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAqAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAtAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAACoAAAAAAAAsAAAAAAAALQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAALAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAACQAAAAAAAC4AAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAkAAAAAAAAuAAAAAAAAAQAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAARAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoAAAAAAAAqAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAHAAAAAAAAJwAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAALAAAAAAAACoAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAABwAAAAAAAAEAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKgAAAAAAACoAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAcAAAAAAAASAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAAAAAAAALAAAAAAAACoAAAAAAAABAAAAAAAAAQAAAAAAABMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALAAAAAAAACwAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAsAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAAAAAAAAKgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAABEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAAACoAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAqAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALAAAAAAAACoAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAKgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALAAAAAAAACoAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAkAAAAAAAAJAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAATAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAAAAABAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAAAQAAAAAAABMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,0:
+          ind: 0,0
+          tiles: KgAAAAAAACoAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAEAAAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAABAAAAAAAAGwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,-2:
+          ind: 0,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0AAAAAAAAAAAAAAAAAIgAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAABwAAAAAAAAcAAAAAAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAcAAAAAAAAHAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAAAHAAAAAAAAKQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,-2:
+          ind: -1,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAAB4AAAAAAAAAAAAAAAAAIQAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACEAAAAAAAAHAAAAAAAABwAAAAAAAAEAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAABwAAAAAAAAcAAAAAAAABAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgAAAAAAAAcAAAAAAAABAAAAAAAAAwAAAAAAAAgAAAAAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAAIAAAAAAAAMQAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: BecomesStation
+      id: Calypso
+    - type: OccluderTree
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            zIndex: 1
+            angle: 3.141592653589793 rad
+            color: '#467799FF'
+            id: ArrowsGreyscale
+          decals:
+            128: 0,-4
+        - node:
+            zIndex: 1
+            angle: 3.141592653589793 rad
+            color: '#51B3E9CC'
+            id: ArrowsGreyscale
+          decals:
+            126: -2,-4
+        - node:
+            color: '#5FA1E7FF'
+            id: BotGreyscale
+          decals:
+            36: 1,-17
+        - node:
+            color: '#DE3A3A96'
+            id: BotGreyscale
+          decals:
+            187: -2,-13
+        - node:
+            zIndex: 2
+            color: '#DE3A3A96'
+            id: BotGreyscale
+          decals:
+            172: -4,-11
+            173: 2,-11
+            174: 2,-14
+            175: -4,-14
+            176: -3,-8
+            177: -3,-6
+        - node:
+            zIndex: 1
+            color: '#EFB34196'
+            id: BotGreyscale
+          decals:
+            59: -1,-15
+            60: -3,-10
+            61: -3,-7
+            62: 1,-4
+            63: -3,-4
+            64: 0,0
+            65: -3,-17
+        - node:
+            color: '#F96363FF'
+            id: BotGreyscale
+          decals:
+            38: 1,-18
+        - node:
+            color: '#FFFFFFFF'
+            id: BotGreyscale
+          decals:
+            37: 0,-17
+            43: -3,-18
+        - node:
+            color: '#345973B5'
+            id: BoxGreyscale
+          decals:
+            188: -1,-14
+        - node:
+            color: '#2C2C2CFF'
+            id: BrickLineOverlayW
+          decals:
+            239: -1,-19
+        - node:
+            color: '#26374996'
+            id: BrickTileWhiteLineS
+          decals:
+            243: -1,-13
+            244: 0,-13
+            245: 1,-13
+        - node:
+            zIndex: 2
+            color: '#EFB34196'
+            id: CautionGreyscale
+          decals:
+            226: 1,-10
+        - node:
+            zIndex: 1
+            color: '#D4D4D496'
+            id: HalfTileOverlayGreyscale
+          decals:
+            165: -3,0
+        - node:
+            color: '#D4D4D496'
+            id: ShiptestAltHalfTileOverlayGreyscale
+          decals:
+            169: -2,0
+            170: -3,0
+        - node:
+            zIndex: 2
+            color: '#355A7396'
+            id: ShiptestOverlayTrimlineNorth
+          decals:
+            233: -1.0007716,-5.2199764
+        - node:
+            zIndex: 1
+            color: '#52B4E996'
+            id: ShiptestOverlayTrimlineNorthWest
+          decals:
+            151: -2,-1
+        - node:
+            zIndex: 1
+            angle: 3.141592653589793 rad
+            color: '#355A7396'
+            id: ShiptestOverlayTrimlineSouthWest
+          decals:
+            132: 0,-1
+        - node:
+            zIndex: 1
+            angle: 3.141592653589793 rad
+            color: '#355A7396'
+            id: ShiptestOverlayTrimlineWest
+          decals:
+            129: 0,-4
+            130: 0,-3
+            131: 0,-2
+        - node:
+            zIndex: 1
+            color: '#52B4E996'
+            id: ShiptestOverlayTrimlineWest
+          decals:
+            152: -2,-2
+            153: -2,-3
+            154: -2,-4
+        - node:
+            zIndex: 1
+            color: '#345973FF'
+            id: ShiptestSplineEast
+          decals:
+            135: -2,-3
+            136: -2,-2
+            137: -2,-1
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: ShiptestSplineEast
+          decals:
+            27: -1,-21
+            270: -2,-18
+            271: -2,-17
+            272: -2,-16
+        - node:
+            zIndex: 2
+            color: '#355A7396'
+            id: ShiptestSplineEast
+          decals:
+            208: -1,-20
+        - node:
+            zIndex: 1
+            color: '#467799FF'
+            id: ShiptestSplineEast
+          decals:
+            168: -2,0
+        - node:
+            zIndex: 1
+            color: '#51B3E9B5'
+            id: ShiptestSplineEast
+          decals:
+            163: -3,-1
+        - node:
+            zIndex: 1
+            color: '#51B3E9B6'
+            id: ShiptestSplineEast
+          decals:
+            161: -3,-2
+        - node:
+            zIndex: 1
+            color: '#EFB34196'
+            id: ShiptestSplineEast
+          decals:
+            88: 1,-7
+        - node:
+            zIndex: 1
+            color: '#345973FF'
+            id: ShiptestSplineNorth
+          decals:
+            143: -1,-4
+        - node:
+            zIndex: 1
+            color: '#626166FF'
+            id: ShiptestSplineNorth
+          decals:
+            274: -2,-16
+        - node:
+            zIndex: 1
+            color: '#345973FF'
+            id: ShiptestSplineNorthEastCorner
+          decals:
+            134: -2,-4
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: ShiptestSplineNorthEastCorner
+          decals:
+            21: -1,-22
+        - node:
+            zIndex: 1
+            color: '#EFB34196'
+            id: ShiptestSplineNorthEnd
+          decals:
+            85: 1,-6
+        - node:
+            zIndex: 1
+            color: '#345973FF'
+            id: ShiptestSplineNorthWestCorner
+          decals:
+            133: 0,-4
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: ShiptestSplineNorthWestCorner
+          decals:
+            22: -1,-22
+            273: -1,-19
+        - node:
+            zIndex: 2
+            color: '#51B3E9B5'
+            id: ShiptestSplineSouth
+          decals:
+            171: -2,0
+        - node:
+            color: '#355A7396'
+            id: ShiptestSplineSouthEastCorner
+          decals:
+            217: -1,-19
+        - node:
+            zIndex: 2
+            color: '#355A7396'
+            id: ShiptestSplineSouthEastCorner
+          decals:
+            220: -1,-19
+        - node:
+            zIndex: 1
+            color: '#51B3E9B6'
+            id: ShiptestSplineSouthEastCorner
+          decals:
+            158: -3,0
+        - node:
+            zIndex: 1
+            color: '#EFB34196'
+            id: ShiptestSplineSouthEnd
+          decals:
+            86: 1,-8
+        - node:
+            color: '#355A7396'
+            id: ShiptestSplineSouthWestCorner
+          decals:
+            218: -1,-19
+        - node:
+            zIndex: 2
+            color: '#355A7396'
+            id: ShiptestSplineSouthWestCorner
+          decals:
+            219: -1,-19
+        - node:
+            zIndex: 1
+            color: '#345973FF'
+            id: ShiptestSplineWest
+          decals:
+            139: 0,-3
+            140: 0,-2
+            141: 0,-1
+            142: 0,0
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: ShiptestSplineWest
+          decals:
+            26: -1,-21
+            268: -1,-17
+            269: -1,-18
+        - node:
+            zIndex: 2
+            color: '#355A7396'
+            id: ShiptestSplineWest
+          decals:
+            207: -1,-20
+        - node:
+            zIndex: 1
+            color: '#EFB34196'
+            id: ShiptestSplineWest
+          decals:
+            87: 1,-7
+        - node:
+            zIndex: 1
+            color: '#5189AFC0'
+            id: TechCornerE
+          decals:
+            255: 0,-14
+            258: 0,-15
+        - node:
+            zIndex: 1
+            color: '#5189AFC0'
+            id: TechCornerN
+          decals:
+            254: 1,-14
+            259: 1,-15
+        - node:
+            zIndex: 1
+            color: '#FFFFFFFF'
+            id: TechCornerN
+          decals:
+            90: -2,-11
+        - node:
+            zIndex: 1
+            color: '#5189AFC0'
+            id: TechCornerS
+          decals:
+            257: 0,-14
+        - node:
+            zIndex: 1
+            color: '#5189AFC0'
+            id: TechCornerW
+          decals:
+            256: 1,-14
+        - node:
+            zIndex: 1
+            color: '#FFFFFFFF'
+            id: TechCornerW
+          decals:
+            89: -2,-15
+        - node:
+            color: '#FFFFFFFF'
+            id: TechE
+          decals:
+            184: 1,-4
+            185: 2,-11
+            186: 2,-14
+        - node:
+            zIndex: 1
+            color: '#FFFFFFFF'
+            id: TechE
+          decals:
+            144: 1,-2
+            145: 1,-1
+            146: 1,0
+            260: 1,-14
+        - node:
+            zIndex: 1
+            color: '#EBF4F3FF'
+            id: TechN
+          decals:
+            206: -1.000697,-19.471016
+        - node:
+            color: '#FFFFFFFF'
+            id: TechN
+          decals:
+            80: -1,-6
+        - node:
+            zIndex: 1
+            color: '#FFFFFFFF'
+            id: TechN
+          decals:
+            246: -1,-13
+            247: 0,-13
+        - node:
+            zIndex: 1
+            color: '#FFFFFFFF'
+            id: TechNE
+          decals:
+            248: 1,-13
+        - node:
+            color: '#FFFFFFFF'
+            id: TechNW
+          decals:
+            73: -3,-11
+            79: -2,-6
+        - node:
+            color: '#EBF4F3FF'
+            id: TechS
+          decals:
+            18: -0.9980985,-21.529652
+        - node:
+            color: '#FFFFFFFF'
+            id: TechS
+          decals:
+            57: 0,-15
+            58: -1,-15
+        - node:
+            zIndex: 2
+            color: '#FFFFFFFF'
+            id: TechS
+          decals:
+            232: -1,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: TechSE
+          decals:
+            56: 1,-15
+        - node:
+            color: '#FFFFFFFF'
+            id: TechSW
+          decals:
+            70: -3,-15
+        - node:
+            color: '#FFFFFFFF'
+            id: TechW
+          decals:
+            71: -3,-14
+            72: -3,-12
+            74: -2,-10
+            76: -2,-9
+            77: -2,-8
+            78: -2,-7
+            178: -4,-14
+            179: -4,-11
+            180: -3,-8
+            181: -3,-7
+            182: -3,-6
+            183: -3,-4
+        - node:
+            zIndex: 1
+            color: '#FFFFFFFF'
+            id: TechW
+          decals:
+            265: -2,-18
+            266: -2,-17
+            267: -2,-16
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimWarnEast
+          decals:
+            81: -0.84708905,-6.9944277
+            82: -0.8480185,-7.9984446
+            83: -0.8432849,-5.9965944
+            262: -0.6901659,-18.000858
+        - node:
+            zIndex: 1
+            color: '#EFA74A96'
+            id: TrimWarnNorth
+          decals:
+            97: 1.0010495,-9.802611
+        - node:
+            color: '#355A7396'
+            id: TrimWarnSouth
+          decals:
+            19: -0.99132454,-21.844025
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimWarnSouth
+          decals:
+            264: -1.0007501,-18.655512
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimWarnWest
+          decals:
+            263: -0.34472388,-18.00005
+        - node:
+            zIndex: 2
+            color: '#355A7396'
+            id: TrimWarnWest
+          decals:
+            224: -0.3445462,-16.999132
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimlineCcwEast
+          decals:
+            98: -2,-7
+            104: -2,-10
+            108: -3,-14
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimlineEast
+          decals:
+            99: -2,-8
+            102: -2,-9
+            106: -3,-12
+            107: -3,-13
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimlineNorthEast
+          decals:
+            110: -2,-15
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimlineNorthEastCorner
+          decals:
+            109: -3,-15
+        - node:
+            zIndex: 2
+            color: '#355A7396'
+            id: TrimlineNorthEastCorner
+          decals:
+            275: -2,-16
+        - node:
+            zIndex: 2
+            color: '#EFB34196'
+            id: TrimlineSouth
+          decals:
+            228: 0,-10
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimlineSouthEast
+          decals:
+            101: -1,-6
+            103: -2,-11
+        - node:
+            zIndex: 2
+            color: '#EFB34196'
+            id: TrimlineSouthEast
+          decals:
+            230: 0.50427854,-11.003683
+        - node:
+            zIndex: 1
+            color: '#355A7396'
+            id: TrimlineSouthEastCorner
+          decals:
+            100: -2,-6
+            105: -3,-11
+        - node:
+            zIndex: 2
+            color: '#EFB34196'
+            id: TrimlineSouthEastCorner
+          decals:
+            227: -1,-10
+        - node:
+            zIndex: 2
+            color: '#EFB34196'
+            id: TrimlineSouthWest
+          decals:
+            231: -0.5010805,-10.997787
+        - node:
+            zIndex: 2
+            color: '#EFB34196'
+            id: TrimlineSouthWestCorner
+          decals:
+            229: 1,-10
+        - node:
+            zIndex: 2
+            angle: 1.5707963267948966 rad
+            color: '#34597367'
+            id: WarnCornerSmallGreyscaleSE
+          decals:
+            225: -0.966141,-19.000484
+        - node:
+            zIndex: 1
+            angle: 1.5707963267948966 rad
+            color: '#EFB34196'
+            id: WarnCornerSmallGreyscaleSE
+          decals:
+            95: -0.03202045,-9.924829
+        - node:
+            zIndex: 1
+            color: '#518AB1FF'
+            id: WarnFullGreyscale
+          decals:
+            112: 9,-14
+            113: 4,1
+            114: 4,0
+            115: 5,-5
+            116: 5,-6
+            117: 1,8
+            118: 1,7
+            119: -3,8
+            120: -3,7
+            121: -6,1
+            122: -6,0
+            123: -7,-5
+            124: -7,-6
+            125: -11,-14
+    - type: SpreaderGrid
+      spreadQueues:
+        Kudzu: []
+        Smoke: []
+        MetalFoam: []
+        Puddle: []
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -3,-4:
+            0: 8288
+            1: 19072
+          -2,-4:
+            1: 276
+            0: 2
+          -3,-3:
+            0: 8
+          -2,-3:
+            1: 17411
+            0: 32
+          -2,-2:
+            0: 2
+            1: 8704
+          -2,-1:
+            0: 2
+            1: 1088
+          -2,-5:
+            0: 17408
+            1: 2048
+          -2,0:
+            1: 68
+            0: 17408
+          -1,-4:
+            2: 61412
+          -1,-3:
+            2: 20210
+          -1,-2:
+            2: 36590
+          -1,-1:
+            2: 26190
+          -1,-5:
+            2: 61064
+            1: 3
+          -1,0:
+            2: 6
+          0,-4:
+            2: 14128
+          0,-3:
+            2: 880
+          0,-1:
+            2: 13075
+          0,-5:
+            2: 13056
+            1: 2054
+          0,-2:
+            2: 546
+          0,0:
+            2: 3
+          1,-4:
+            1: 3265
+            0: 2
+          1,-3:
+            1: 4358
+            0: 40
+          1,-1:
+            1: 272
+            0: 2
+          1,-5:
+            0: 4352
+          1,-2:
+            0: 2
+            1: 8704
+          1,0:
+            1: 17
+            0: 4352
+          2,-4:
+            0: 8240
+            1: 4608
+          -2,1:
+            1: 136
+          -2,2:
+            0: 136
+          -1,1:
+            1: 8384
+            0: 1024
+          -1,2:
+            1: 2
+            0: 288
+          0,1:
+            1: 8344
+            0: 256
+          0,2:
+            1: 2
+            0: 1192
+          0,-6:
+            0: 36096
+            1: 24576
+          -1,-6:
+            2: 34816
+            0: 1280
+            1: 12288
+          -2,-6:
+            0: 34816
+        uniqueMixes:
+        - volume: 2500
+          immutable: True
+          moles: {}
+        - volume: 2500
+          temperature: 293.15
+          moles: {}
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ShipGridLock
+      locked: False
+    - type: Roof
+      data:
+        0,1: 4
+        0,0: 434041075834752783
+        -1,0: 3472328608833927416
+        -1,1: 16
+        -1,-1: 18229723555229007612
+        0,-1: 2242545358519353119
+        -1,-2: 18229723568130752510
+        0,-2: 2242545774070071103
+        -2,-2: 3772833792
+        1,-2: 50529024
+        -1,-3: 18373838743202695168
+        0,-3: 4548388366924318720
+    - type: ThermalSignature
+    - type: ExplosionAirtightGrid
+- proto: AirAlarm
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-18.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 376
+      - 387
+      - 304
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 306
+      - 383
+      - 378
+      - 384
+      - 379
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 307
+      - 385
+      - 381
+      - 386
+      - 380
+      - 382
+      - 389
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-12.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 305
+      - 388
+      - 377
+- proto: AirlockExternalGlassNfsdLocked
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-18.5
+      parent: 1
+- proto: AirlockNfsdGlassLocked
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-8.5
+      parent: 1
+- proto: AirlockNfsdLocked
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+- proto: AirlockShuttleNfsdLocked
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -0.5,-21.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -0.5,-21.5
+      parent: 1
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-17.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-17.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-16.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-19.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-19.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-21.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-20.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-21.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-15.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-19.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-20.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-19.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-20.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-21.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-21.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-20.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-17.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-16.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-13.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-14.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-14.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-14.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-12.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-11.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-11.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-13.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-14.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-13.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-14.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-12.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-14.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-14.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-13.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-20.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -8.5,-13.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 7.5,-13.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 6.5,-13.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 3.5,-16.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -1.5,-19.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -0.5,-19.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -0.5,-17.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -0.5,-16.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -0.5,-18.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -0.5,-20.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-6.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-19.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-20.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-14.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-15.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-17.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-19.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-13.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-13.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-13.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-14.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-14.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-20.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-20.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-19.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-20.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-19.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-8.5
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 1.5456178,-13.601127
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-13.5
+      parent: 1
+- proto: ClosetRadiationSuitFilled
+  entities:
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -2.318975,-9.436629
+      parent: 1
+- proto: ComputerGunneryConsole
+  entities:
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerIFF
+  entities:
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerShuttleTSFNVWS
+  entities:
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        13:
+        - - device-button-1
+          - DoorBolt
+        9:
+        - - device-button-2
+          - DoorBolt
+        6:
+        - - device-button-3
+          - DoorBolt
+        8:
+        - - device-button-3
+          - DoorBolt
+        10:
+        - - device-button-3
+          - DoorBolt
+        11:
+        - - device-button-3
+          - DoorBolt
+        12:
+        - - device-button-3
+          - DoorBolt
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerWallmountStationRecords
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-14.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: DarkCatwalkMono
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-13.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-14.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 296
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 1
+- proto: DrinkMugMoebius
+  entities:
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 1.0298302,-14.549682
+      parent: 1
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 298
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-9.5
+      parent: 1
+- proto: FaxMachineShip
+  entities:
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 1
+- proto: FireAlarm
+  entities:
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-18.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 304
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-15.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 305
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-8.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 306
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 307
+- proto: FirelockGlass
+  entities:
+  - uid: 304
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-18.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 300
+      - 2
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-15.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 301
+      - 5
+  - uid: 306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 302
+      - 3
+  - uid: 307
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 303
+      - 4
+- proto: FloorDrain
+  entities:
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FuelPlasma
+  entities:
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 0.68133235,-10.665262
+      parent: 1
+- proto: GasMixerOnFlipped
+  entities:
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-16.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.75
+      inletOneConcentration: 0.25
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-19.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -0.5,-17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#9955CCFF'
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-19.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#9955CCFF'
+- proto: GasPipeBend
+  entities:
+  - uid: 315
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 316
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 317
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 318
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 319
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 321
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 322
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 324
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 328
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 330
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 332
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 333
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 335
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#9955CCFF'
+  - uid: 336
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 340
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 342
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 366
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 367
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunctionAlt2
+  entities:
+  - uid: 368
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 370
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 372
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 374
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 375
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-17.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 377
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-14.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 380
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 381
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 382
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubberAlt2
+  entities:
+  - uid: 383
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 387
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-16.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 388
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 389
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorCRPinchShuttle
+  entities:
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-7.5
+      parent: 1
+    - type: FuelGenerator
+      targetPower: 120000
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 391
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -5.5,-16.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-16.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 396
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-17.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-17.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+- proto: GunneryServerHigh
+  entities:
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+    - type: Battery
+      startingCharge: 0
+    - type: ApcPowerReceiver
+      powerLoad: 20
+- proto: GyroscopeNfsd
+  entities:
+  - uid: 403
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-10.5
+      parent: 1
+- proto: Handrail
+  entities:
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-17.5
+      parent: 1
+- proto: HardpointEnergyLight
+  entities:
+  - uid: 953
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-13.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 956
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-13.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+- proto: HardpointEnergyMedium
+  entities:
+  - uid: 942
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 945
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 946
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 947
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 948
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+  - uid: 949
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+    - type: Physics
+      canCollide: False
+- proto: LargeAPC
+  entities:
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+- proto: LightBulbCrystalBlue
+  entities:
+  - uid: 414
+    components:
+    - type: Transform
+      parent: 413
+    - type: Physics
+      canCollide: False
+  - uid: 416
+    components:
+    - type: Transform
+      parent: 415
+    - type: Physics
+      canCollide: False
+- proto: LightBulbCrystalGreen
+  entities:
+  - uid: 418
+    components:
+    - type: Transform
+      parent: 417
+    - type: Physics
+      canCollide: False
+- proto: LightBulbCrystalPink
+  entities:
+  - uid: 420
+    components:
+    - type: Transform
+      parent: 419
+    - type: Physics
+      canCollide: False
+- proto: LockableButtonTSFMC
+  entities:
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        641:
+        - - Pressed
+          - Toggle
+- proto: LockerEngineerFilledHardsuit
+  entities:
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -2.7699358,-9.433822
+      parent: 1
+- proto: LockerMedicineFilled
+  entities:
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+- proto: MachineFTLDrive
+  entities:
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+- proto: MedTekCartridge
+  entities:
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -2.622004,0.66841817
+      parent: 1
+- proto: NFHolopadShip
+  entities:
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 1
+- proto: NitrogenCanister
+  entities:
+  - uid: 428
+    components:
+    - type: Transform
+      anchored: True
+      pos: 1.5,-17.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: OxygenCanister
+  entities:
+  - uid: 429
+    components:
+    - type: Transform
+      anchored: True
+      pos: 1.5,-16.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: PaperBin20
+  entities:
+  - uid: 430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.6975255,-14.58206
+      parent: 1
+- proto: PaperOffice
+  entities:
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -0.42452556,-12.795266
+      parent: 1
+    - type: Paper
+      stampState: paper_stamp-mono-solstice
+      stampedBy:
+      - reapply: False
+        stampType: RubberStamp
+        stampedColor: '#008CE3FF'
+        stampedName: stamp-component-stamped-name-winter-solstice
+      content: >-
+        In an effort to reduce unecessary pilot deaths, this shuttle has been equipped with manual anti-boarding measures.
+
+        The shuttle console's programmable buttons are linked with the bolt controls of all present airlocks.
+
+
+        Button 1 bolts the external airlock used for docking.
+
+        Button 2 bolts the two airlocks leading in, and out of the cockpit.
+
+        Button 3 bolts the rest of the airlocks.
+
+
+        Have a safe flight marine.
+- proto: Pen
+  entities:
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.2527103,-14.335779
+      parent: 1
+- proto: PlasturaniumWindowRadProof
+  entities:
+  - uid: 433
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+- proto: PlushieCatTabby
+  entities:
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 1.6589265,-13.564506
+      parent: 1
+- proto: PowerCellMedium
+  entities:
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -2.302477,0.42926902
+      parent: 1
+- proto: PoweredDimSmallLight
+  entities:
+  - uid: 437
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+- proto: PoweredlightBlue
+  entities:
+  - uid: 438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-13.5
+      parent: 1
+- proto: PoweredlightCyan
+  entities:
+  - uid: 439
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-13.5
+      parent: 1
+- proto: PoweredlightLED
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+- proto: PoweredlightSodium
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+- proto: PoweredSmallLightEmpty
+  entities:
+  - uid: 413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        light_bulb: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 414
+    - type: ApcPowerReceiver
+      powerLoad: 60
+    - type: DamageOnInteract
+      isDamageActive: False
+  - uid: 415
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-17.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        light_bulb: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 416
+    - type: ApcPowerReceiver
+      powerLoad: 60
+    - type: DamageOnInteract
+      isDamageActive: False
+  - uid: 417
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        light_bulb: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 418
+    - type: ApcPowerReceiver
+      powerLoad: 60
+    - type: DamageOnInteract
+      isDamageActive: False
+  - uid: 419
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-17.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        light_bulb: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 420
+    - type: ApcPowerReceiver
+      powerLoad: 60
+    - type: DamageOnInteract
+      isDamageActive: False
+- proto: PoweredStrobeBlueEnabled
+  entities:
+  - uid: 443
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-19.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-19.5
+      parent: 1
+- proto: PoweredStrobeSodiumEnabled
+  entities:
+  - uid: 445
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-13.5
+      parent: 1
+- proto: PoweredWarmSmallLight
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-19.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 458
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-10.5
+      parent: 1
+- proto: RadarEdgeMarkerDiagonal
+  entities:
+  - uid: 460
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-14.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -2.5,-19.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-20.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-20.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-20.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-14.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-19.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-20.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 2.5,-17.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-15.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-15.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      pos: -3.5,-15.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -4.5,-15.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-17.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-17.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-16.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-17.5
+      parent: 1
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 1
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-14.5
+      parent: 1
+  - uid: 951
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 952
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-14.5
+      parent: 1
+- proto: RadarEdgeMarkerHalftiltLeft
+  entities:
+  - uid: 511
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+- proto: RadarEdgeMarkerHalftiltRight
+  entities:
+  - uid: 514
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+- proto: RadarEdgeMarkerStraight
+  entities:
+  - uid: 510
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-20.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-20.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-19.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 8.5,-13.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-19.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: -2.5,-20.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-19.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-20.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-19.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 538
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 539
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-13.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-14.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-14.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-15.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-15.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 569
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 603
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-15.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-16.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-17.5
+      parent: 1
+  - uid: 617
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 618
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-20.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-18.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-21.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 622
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 623
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 624
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 625
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 627
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 628
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 629
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 630
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 631
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 632
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-16.5
+      parent: 1
+  - uid: 633
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-17.5
+      parent: 1
+  - uid: 634
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+- proto: RailingCorner
+  entities:
+  - uid: 636
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: ShieldGeneratorSmall
+  entities:
+  - uid: 637
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+- proto: ShipRepairDevice
+  entities:
+  - uid: 638
+    components:
+    - type: Transform
+      pos: -0.5283375,-10.381769
+      parent: 1
+- proto: ShipRepairDeviceAmmo
+  entities:
+  - uid: 639
+    components:
+    - type: Transform
+      pos: 0.20668983,-10.5598755
+      parent: 1
+  - uid: 640
+    components:
+    - type: Transform
+      pos: 0.4806118,-10.251793
+      parent: 1
+- proto: ShuttersRadiation
+  entities:
+  - uid: 641
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-8.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 642
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 643
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 644
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      pos: -0.5,-17.5
+      parent: 1
+  - uid: 646
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+- proto: StairDark
+  entities:
+  - uid: 647
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-13.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 1
+- proto: SuitStorageM82c
+  entities:
+  - uid: 649
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 650
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-14.5
+      parent: 1
+  - uid: 651
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 654
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+- proto: ThrusterLargeNfsd
+  entities:
+  - uid: 655
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-20.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-14.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-20.5
+      parent: 1
+- proto: ThrusterNfsd
+  entities:
+  - uid: 659
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 1
+  - uid: 662
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-17.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 667
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 668
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-15.5
+      parent: 1
+  - uid: 669
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 670
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 671
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 672
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 673
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 674
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 675
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 1
+  - uid: 676
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 677
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 678
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 1
+  - uid: 679
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 680
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 681
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+- proto: TurboItemRecharger
+  entities:
+  - uid: 682
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -2.5,-17.5
+      parent: 1
+- proto: WallArmorAddonSolid
+  entities:
+  - uid: 684
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 685
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 686
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 687
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 689
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 690
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-8.5
+      parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 692
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 695
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 696
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 699
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 700
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 702
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 712
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: WallArmorAddonSolidBrokenCornerR
+  entities:
+  - uid: 701
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 703
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 706
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 711
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 717
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 720
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: WallArmorAddonSolidCornerL
+  entities:
+  - uid: 694
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 698
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 709
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 713
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 715
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 716
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 718
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 719
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 722
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 727
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 728
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 731
+    components:
+    - type: Transform
+      pos: 3.5,-16.5
+      parent: 1
+  - uid: 733
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 739
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 742
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 746
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 748
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 751
+    components:
+    - type: Transform
+      pos: -7.5,-12.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-18.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 755
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 756
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-21.5
+      parent: 1
+  - uid: 758
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-15.5
+      parent: 1
+  - uid: 759
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 760
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 761
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 762
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 763
+    components:
+    - type: Transform
+      pos: -1.5,-19.5
+      parent: 1
+  - uid: 765
+    components:
+    - type: Transform
+      pos: 8.5,-13.5
+      parent: 1
+  - uid: 766
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 1
+  - uid: 767
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-20.5
+      parent: 1
+  - uid: 768
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 769
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 772
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 1
+  - uid: 773
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 774
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 776
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 779
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-12.5
+      parent: 1
+  - uid: 781
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 782
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 783
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 785
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 1
+  - uid: 788
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-18.5
+      parent: 1
+  - uid: 789
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-20.5
+      parent: 1
+  - uid: 790
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-18.5
+      parent: 1
+  - uid: 791
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 793
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 794
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 795
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 796
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 797
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 1
+  - uid: 798
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 799
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 800
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 1
+  - uid: 801
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-19.5
+      parent: 1
+  - uid: 803
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-19.5
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      pos: -6.5,-14.5
+      parent: 1
+  - uid: 805
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-15.5
+      parent: 1
+  - uid: 806
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 807
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 810
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 811
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 812
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 813
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 814
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 815
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 816
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 817
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 818
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 819
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 820
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 821
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 822
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 823
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 824
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 827
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 828
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 829
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 830
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-12.5
+      parent: 1
+  - uid: 831
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-18.5
+      parent: 1
+  - uid: 832
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-18.5
+      parent: 1
+  - uid: 833
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 834
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-21.5
+      parent: 1
+  - uid: 836
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-18.5
+      parent: 1
+  - uid: 837
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-18.5
+      parent: 1
+  - uid: 838
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-18.5
+      parent: 1
+  - uid: 839
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-8.5
+      parent: 1
+  - uid: 840
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-17.5
+      parent: 1
+  - uid: 842
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 847
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 850
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 1
+  - uid: 851
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 863
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 1
+  - uid: 864
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 1
+  - uid: 865
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 1
+  - uid: 866
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-14.5
+      parent: 1
+  - uid: 867
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-14.5
+      parent: 1
+  - uid: 868
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-15.5
+      parent: 1
+  - uid: 870
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-20.5
+      parent: 1
+  - uid: 871
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 872
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 874
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-20.5
+      parent: 1
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-15.5
+      parent: 1
+- proto: WallReinforced
+  entities:
+  - uid: 721
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 747
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 770
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 771
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 775
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 780
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 784
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 786
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 792
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 802
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 1
+  - uid: 825
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 1
+  - uid: 826
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 1
+  - uid: 835
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 1
+  - uid: 841
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 843
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 1
+  - uid: 844
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 1
+  - uid: 845
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 1
+  - uid: 848
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 849
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 852
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 853
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 854
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 855
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 882
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 883
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 884
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 1
+  - uid: 886
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 887
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 888
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 889
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-15.5
+      parent: 1
+  - uid: 890
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 891
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 893
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 894
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 1
+  - uid: 896
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 897
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 898
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 899
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 902
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 903
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 1
+  - uid: 905
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 907
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 910
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 911
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 913
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 914
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 917
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 918
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 919
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 920
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 921
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 922
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 923
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 924
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 925
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 926
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 927
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 928
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 929
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 1
+  - uid: 930
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 931
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 932
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-15.5
+      parent: 1
+  - uid: 933
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-15.5
+      parent: 1
+  - uid: 934
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 935
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 936
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 937
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 938
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+- proto: WallReinforcedDiagonal
+  entities:
+  - uid: 856
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 857
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 858
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 859
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 860
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 861
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 862
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 869
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 876
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 877
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 939
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+- proto: WeaponEnergyGun
+  entities:
+  - uid: 940
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.693708,0.40042138
+      parent: 1
+    - type: EnergyGun
+      currentFireMode:
+        state: disabler
+        name: disable
+        fireCost: 45
+        proto: BulletDisabler
+    - type: Item
+      heldPrefix: disabler
+- proto: WeaponLaserPistolNF
+  entities:
+  - uid: 941
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.3215462,0.22981346
+      parent: 1
+- proto: WeaponLaserTurretL1Phalanx
+  entities:
+  - uid: 954
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-13.5
+      parent: 1
+  - uid: 955
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-13.5
+      parent: 1
+- proto: WeaponLaserTurretPrometheus
+  entities:
+  - uid: 943
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 944
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 958
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 960
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,1.5
+      parent: 1
+- proto: WindoorSecureUranium
+  entities:
+  - uid: 950
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-8.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+...


### PR DESCRIPTION
## About the PR
1. Added a new T2 ship for the TSF shipyards. 6 prometheuses and a dream
2. Adjusts the recharge rate of the Prometheus to be able to sustain its buffed fire-rate
## Why / Balance
I've laid my reasons for its addition out in #4591. The stuff about about the Calypso being outdated is not relevant anymore.

I have also significantly reduced its armour on all sides by replacing much of the plastitanium on it with reinforced walls as requested.

## Media
<img width="672" height="1056" alt="cinquedea-0" src="https://github.com/user-attachments/assets/8a333abb-8c2e-4f5c-be04-88018426c733" /><br>
The ship.
<img width="301" height="432" alt="Screenshot_20260828_024320" src="https://github.com/user-attachments/assets/6367961f-6e9a-4da4-b4ab-5cf5e1f455b4" /><br>
Radar edge marks.

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
Redeem a T2 voucher for this then enjoy the buffed Prometheuses.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added the Cinquedea, a T2 laser-based pursuit ship to the TSF shipyards.
- fix: Tweaked the Prometheus' (shipgun) recharge-rate so it can sustain its buffed fire rate.
