### PR TITLE
Lower Job Requirement Times

### DIFF
--- a/Resources/Prototypes/_Mono/Roles/Jobs/Medical/medic.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/Medical/medic.yml
@@ -5,7 +5,7 @@
   playTimeTracker: MdMedic
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 54000 # 15 hrs
+      time: 14400 # 4 hours. It's a paramedic role dude.
   startingGear: MdMedicGear
   alwaysUseSpawner: true
   icon: "JobIconMedicalDoctor"

--- a/Resources/Prototypes/_NF/Roles/Jobs/Civilian/contractor.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Civilian/contractor.yml
@@ -3,9 +3,9 @@
   name: job-name-contractor
   description: job-description-contractor
   playTimeTracker: JobPassenger
-  requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 43200 # 12 hours
+#  requirements: # If a new player decides the role named vagrant is better for guidance than employee/citizen it's their fault
+#  - !type:OverallPlaytimeRequirement
+#    time: 43200 # 12 hours
   icon: "JobIconContractor"
   supervisors: job-supervisors-nobody
   displayWeight: 40 # Top

--- a/Resources/Prototypes/_NF/Roles/Jobs/Frontier/security_guard.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Frontier/security_guard.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobSecurityGuard
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 36000 # Frontier - 10 hrs
+      time: 14400 # 4 hours. I don't expect new players to play almost 2 full rounds before they get bored, and it's mostly a raider check.
   startingGear: SecurityGuardGear
   alwaysUseSpawner: true
   icon: "JobIconSecurityGuard"

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/deputy.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/deputy.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobSecurityOfficer
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 36000 # 10 hours
+      time: 14400 # 4 hours. I don't expect new players to play almost 2 full rounds before they get bored, and it's mostly a raider check.
   startingGear: DeputyGear
   icon: JobIconDeputy
   supervisors: job-supervisors-sergeant

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobPirate
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 36000 # 10 hrs - mono
+      time: 14400 # 4 hours. I don't expect new players to play almost 2 full rounds before they get bored, and it's mostly a raider check.
   startingGear: PirateNFGear
   alwaysUseSpawner: true
   hideConsoleVisibility: true


### PR DESCRIPTION
## About the PR
lowers required times for ERs, rahks, marines, & judges to 4hrs
removes vagrant timelock

## Why / Balance
If a new player wants to play ER or factions, they're not going to grind 2 full rounds of a (pretty boring and empty right now) shipfork, they're just going to leave.
If a new player decides Vagrant is more guidance than something named MMC Employee or TSF Citizen, that's on them. Plus, other people use this role when they're introducing friends/having new players play with them.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: ER, Judge, Rahk and Marine timelocks lowered to 4 hours.
- remove: Removed timelocks for Vagrants.