### PR TITLE
TSF & PDV War Declarators (Replaces Automated Portstrike)

### DIFF
--- a/Content.Server/_Mono/WarDeclarator/FactionWarDeclaratorComponent.cs
+++ b/Content.Server/_Mono/WarDeclarator/FactionWarDeclaratorComponent.cs
@@ -1,0 +1,32 @@
+using Content.Shared._Mono.Company;
+using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Mono.WarDeclarator;
+
+[RegisterComponent]
+public sealed partial class FactionWarDeclaratorComponent : Component
+{
+    /// <summary>
+    /// Which faction this declarator belongs to.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<CompanyPrototype> Faction;
+
+    /// <summary>
+    /// Which channel to announce that this device has been used over.
+    /// </summary>
+    [DataField]
+    public ProtoId<RadioChannelPrototype> Channel = "Common";
+
+    /// <summary>
+    /// The message to announce over the radio when the war declarator is used.
+    /// </summary>
+    [DataField(required: true)]
+    public LocId WarDeclarationMessage;
+
+    /// <summary>
+    /// The message to tell the user when the war declarator is used by the wrong faction.
+    /// </summary>
+    public LocId WarDeclarationFailedMessage = "war-declarator-failed-invalid-biometrics";
+}

--- a/Content.Server/_Mono/WarDeclarator/ManualPortstrikeRuleComponent.cs
+++ b/Content.Server/_Mono/WarDeclarator/ManualPortstrikeRuleComponent.cs
@@ -1,0 +1,21 @@
+using Content.Shared._Mono.Company;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Mono.WarDeclarator;
+
+[RegisterComponent]
+public sealed partial class ManualPortstrikeRuleComponent : Component
+{
+    /// <summary>
+    /// Which factions are involved in portstrike and whether or not they have declared hostilities.
+    /// Must be defined in the YAML definition of the gamerule.
+    /// </summary>
+    [DataField(required: true)]
+    public Dictionary<ProtoId<CompanyPrototype>, bool> SectorStatus;
+
+    /// <summary>
+    /// War level to set it to once all sides declare war. True for HOT, false for COLD.
+    /// </summary>
+    [DataField]
+    public bool WarLevel = true;
+}

--- a/Content.Server/_Mono/WarDeclarator/ManualPortstrikeRuleSystem.cs
+++ b/Content.Server/_Mono/WarDeclarator/ManualPortstrikeRuleSystem.cs
@@ -1,0 +1,62 @@
+using Content.Server.GameTicking.Rules;
+using Content.Server._Mono.Company;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
+using Content.Shared.Radio;
+using Content.Server._Mono.AlertLevel;
+using Content.Shared._Mono.Company;
+using Content.Server.GameTicking;
+using Robust.Shared.Prototypes;
+using Content.Server.Radio.EntitySystems;
+
+namespace Content.Server._Mono.WarDeclarator;
+
+public sealed partial class ManualPortstrikeRuleSystem : GameRuleSystem<ManualPortstrikeRuleComponent>
+{
+    [Dependency] private CompanyManager _companyManager = default!;
+    [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private IPrototypeManager _prototypeManager = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private RadioSystem _radio = default!;
+    [Dependency] private WarLevelSystem _warLevelSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FactionWarDeclaratorComponent, UseInHandEvent>(OnWarDeclaratorUsed);
+    }
+
+    private void OnWarDeclaratorUsed(Entity<FactionWarDeclaratorComponent> ent, ref UseInHandEvent args)
+    {
+        if (!TryComp<CompanyComponent>(args.User, out var userCompany) || ent.Comp.Faction != userCompany.CompanyName)
+        {
+            _popup.PopupEntity(Loc.GetString(ent.Comp.WarDeclarationFailedMessage), ent, args.User);
+            return;
+        }
+
+        var query = EntityQueryEnumerator<ManualPortstrikeRuleComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (!comp.SectorStatus.TryGetValue(ent.Comp.Faction, out var warAlreadyDeclared) || warAlreadyDeclared)
+                continue;
+
+            comp.SectorStatus[ent.Comp.Faction] = true;
+
+            var channel = _prototypeManager.Index(ent.Comp.Channel);
+            _radio.SendRadioMessage(ent, Loc.GetString(ent.Comp.WarDeclarationMessage), channel, ent);
+
+            var factionYetToDeclare = false;
+            foreach (var factionDeclaredWar in comp.SectorStatus.Values)
+            {
+                if (!factionDeclaredWar)
+                {
+                    factionYetToDeclare = true;
+                    break;
+                }
+            }
+            if (!factionYetToDeclare)
+                _warLevelSystem.SetLevel(comp.WarLevel);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Mono/war-declarator/war-declarator.ftl
+++ b/Resources/Locale/en-US/_Mono/war-declarator/war-declarator.ftl
@@ -1,0 +1,4 @@
+war-declaration-tsfmc = Attention! The Trans-Solarian Federation Marine Corps have declared hostilities and an intention to go to war.
+war-declaration-pdv = Attention! The Phaethon Dynasty Imperial Vanguard have declared hostilities and an intention to go to war.
+
+war-declarator-failed-invalid-biometrics = War declaration failed: Invalid company biometrics

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/Misc/faction_war_declarator.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/Misc/faction_war_declarator.yml
@@ -1,0 +1,33 @@
+- type: entity
+  parent: BaseItem
+  abstract: true
+  id: BaseFactionWarDeclarator
+  name: war declarator
+  description: A device used to declare hostilities within the sector. If both sides activate it, total war will be declared.
+  components:
+    - type: Sprite
+      sprite: Objects/Devices/declaration_of_war.rsi
+      layers:
+        - state: declarator
+    - type: Item
+    - type: UseDelay
+      delay: 0.5
+    - type: FactionWarDeclarator
+
+- type: entity
+  parent: BaseFactionWarDeclarator
+  id: WarDeclaratorTsf
+  name: TSFMC war declarator
+  components:
+  - type: FactionWarDeclarator
+    faction: TSF
+    warDeclarationMessage: war-declaration-tsfmc
+
+- type: entity
+  parent: BaseFactionWarDeclarator
+  id: WarDeclaratorPdv
+  name: PDV war declarator
+  components:
+  - type: FactionWarDeclarator
+    faction: PDV
+    warDeclarationMessage: war-declaration-pdv

--- a/Resources/Prototypes/_Mono/GameRules/timings.yml
+++ b/Resources/Prototypes/_Mono/GameRules/timings.yml
@@ -59,3 +59,12 @@
     delay:
       min: 5
       max: 5
+
+- type: entity
+  id: ManualPortstrikeTsfPdv
+  parent: BaseGameRule
+  components:
+  - type: ManualPortstrikeRule
+    sectorStatus: 
+      TSF: false
+      PDV: false

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -17,6 +17,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
+  - ManualPortstrikeTsfPdv
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -33,6 +34,7 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
+  - ManualPortstrikeTsfPdv
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -84,6 +86,7 @@
   - MonoAISTCShuttleSpawnerSchedulerTier2
   #- MonoAsakimSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
+  - ManualPortstrikeTsfPdv
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -102,6 +105,7 @@
   - FrontierRoundstartVariation
   - MonoChimeraSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
+  - ManualPortstrikeTsfPdv
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -123,6 +127,7 @@
   - MonoAISTCShuttleSpawnerSchedulerTier2Slow
   #- MonoAsakimSTCShuttleSpawnerSchedulerSlow
   - MonoMonolithicEventsScheduler
+  - ManualPortstrikeTsfPdv
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -144,7 +149,7 @@
   #- MonoAsakimSTCShuttleSpawnerSchedulerApocalypse
   - MonoMonolithicEventsScheduler
   - RoundEndRuleHour3
-  - PortstrikeAnnounceRuleHour1
+  - ManualPortstrikeTsfPdv
   - StarSystemKyphrus
 
 - type: gamePreset

--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -17,7 +17,6 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom35To45
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -34,7 +33,6 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom35To45
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -51,7 +49,6 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom35To45
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -68,7 +65,6 @@
   - SmugglingEventScheduler
   - FrontierRoundstartVariation
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom35To45
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -88,7 +84,6 @@
   - MonoAISTCShuttleSpawnerSchedulerTier2
   #- MonoAsakimSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom35To45
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -107,7 +102,6 @@
   - FrontierRoundstartVariation
   - MonoChimeraSTCShuttleSpawnerScheduler
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom35To45
   - StarSystemKyphrus
 
 - type: gamePreset
@@ -129,7 +123,6 @@
   - MonoAISTCShuttleSpawnerSchedulerTier2Slow
   #- MonoAsakimSTCShuttleSpawnerSchedulerSlow
   - MonoMonolithicEventsScheduler
-  - PortstrikeAnnounceRuleRandom35To45
   - StarSystemKyphrus
 
 - type: gamePreset

--- a/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Nfsd/sheriff.yml
@@ -65,3 +65,4 @@
     - RubberStampTSFColonel #Mono. Look, it had comments on the Bailiff/Captain file.
     - TSFHandheldOverwatchConsole
     - BookTSFSOP
+    - WarDeclaratorTsf

--- a/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
+++ b/Resources/Prototypes/_NF/Roles/Jobs/Pirates/pirate_captain.yml
@@ -59,4 +59,4 @@
     - PDVHandheldOverwatchConsole
     - RubberStampPDVVizier # mono
     - PhoneInstrumentHigh
-    
+    - WarDeclaratorPdv


### PR DESCRIPTION
## About the PR
Removed the automated portstrike announcement entirely from every gamemode except Hyperwar and Apocalypse.
It has been replaced with TSF & PDV war declarators, given to the Colonel and Vizier when they spawn. Using the declarator requires you to be a member of the faction, and once you do it announces your intentions over Broadband. Once both sides have used their declarator, total war is declared.

## Why / Balance
A guaranteed portstrike every round has turned faction culture into pure TDM slop. You can't lay back and try to roleplay or you will get violated the moment the total war hits.

Helios has been hidden. This is a good change BUT if auto-portstrike remains, it'll force TSF to basically basesit during the whole total war. I think it'll be a lot healthier without the guaranteed portstrike.

The war declarators allow portstrike to remain as a feature of Monolith, but only with both FLs' consent.


## Media
<img width="270" height="713" alt="image" src="https://github.com/user-attachments/assets/c9171247-ab9e-4e18-a45d-c95d7ad6feb2" />
<img width="546" height="619" alt="image" src="https://github.com/user-attachments/assets/507dbce5-bfda-4dc2-b022-7834b8a0a4da" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
load Standard
wait 4.5 hours
no portstrike announcement still?
spawn as TSFMC Colonel
cool new TSF war declarator
use it, it talks over broadband
spawn in PDV war declarator
Colonel can't use it
respawn as PDV Grand Vizier
cool new PDV war declarator
use it, it talks over broadband and total war is declared

**Changelog**
:cl:
- remove: Portstrike is no longer guaranteed to be automatically called between 3.5-4.5 hours in the round. You can rest easy now.
- add: The Colonel and Grand Vizier now spawn with war declarators. Once both leaders use their war declarators, total war is declared and portstrike begins.
