### PR TITLE
Disable PDV Freeman & Remove Sol Common From TSF Contractors

### DIFF
--- a/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
@@ -48,7 +48,7 @@
           stationDescription: 'frontier-lobby-pirate-description'
         - type: StationJobs
           availableJobs:
-            PdvCivilian: [ -1, -1 ]
+            # PdvCivilian: [ -1, -1 ]
             PirateCaptain: [ 1, 1 ]
             PirateFirstMate: [ 1, 1 ]
             PDVDenasvar: [ 3, 3 ]

--- a/Resources/Prototypes/_Mono/Roles/Jobs/Medical/medic.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/Medical/medic.yml
@@ -19,7 +19,7 @@
   - Medical
   special:
   - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, TrackingImplant ]
+    implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
       - type: NpcFactionMember

--- a/Resources/Prototypes/_Mono/Roles/Jobs/PDV/HighCommand/ambassador.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/PDV/HighCommand/ambassador.yml
@@ -10,7 +10,7 @@
   displayWeight: 0
   assignedCompany: PDV
   canBeAntag: false
-  setPreference: true
+  setPreference: false
   access:
   - Pirate
   - GrandVizier

--- a/Resources/Prototypes/_Mono/Roles/Jobs/PDV/HighCommand/prince.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/PDV/HighCommand/prince.yml
@@ -10,7 +10,7 @@
   displayWeight: 0
   assignedCompany: PDV
   canBeAntag: false
-  setPreference: true
+  setPreference: false
   access:
   - Pirate
   - GrandVizier

--- a/Resources/Prototypes/_Mono/Roles/Jobs/PDV/civilian.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/PDV/civilian.yml
@@ -11,7 +11,7 @@
   displayWeight: 0
   assignedCompany: PDVCivilian
   canBeAntag: true
-  setPreference: true
+  setPreference: false # disabled with Helios IFF hiding
   accessGroups:
   - GeneralAccess
   special:

--- a/Resources/Prototypes/_Mono/Roles/Jobs/TSFMC/civilian.yml
+++ b/Resources/Prototypes/_Mono/Roles/Jobs/TSFMC/civilian.yml
@@ -20,11 +20,11 @@
     - type: NpcFactionMember
       factions:
       - TSFMC
-  - !type:AddLanguageSpecial
-    languagesSpoken:
-    - SolCommon
-    languagesUnderstood:
-    - SolCommon
+# - !type:AddLanguageSpecial # UNCOMMENT WHEN THIS DOESN'T MAKE IMPERSONATING TSF CIVS IMPOSSIBLE FOR PDV
+#   languagesSpoken:
+#   - SolCommon
+#   languagesUnderstood:
+#   - SolCommon
   - !type:GiveItemOnHolidaySpecial
     holiday: FrontierBirthday
     prototype: FrontierBirthdayGift


### PR DESCRIPTION
## About the PR
PDV Freemen no longer spawn on Helios

PDV Freemen can no longer be selected in loadout

TSF Contractors no longer understand Sol Common

Oh yeah also I removed TSF trackers from ERs because they make no sense

## Why / Balance
Doesn't make sense with the ASRification of the PDV. The TSF has established a shaky control over Colossus and pushed the PDV back, they all probably got conscripted or something

As for the TSF civ change, it's honestly just a gameplay concession. Is it stupid that TSF citizens don't know their native language? Yes, but we can't let PDV have the chance to understand Sol Common or else 1 comms key being lost ruins the TSF, and TSF Contractors are impossible for PDV to impersonate if they speak Sol Common. I really want this to work somehow but this is the best solution gameplay wise. Please, someone, figure out a solution and PR it so TSF civs can understand Sol again.

ERs are not TSFMC

## Media
very small change that's hard to show visually

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
check loadout
no pdv civ
start round
look at helios
no pdv civ slot
spawn as tsf civ
no sol common
kill an ER
no deathrattle

**Changelog**
:cl:
- remove: PDV Freemen no longer spawn on Helios and can no longer be selected in the loadout.
- tweak: TSF Contractors no longer understand Sol Common to make them possible to impersonate.
- remove: Emergency Responders no longer spawn with TSFMC tracking implants.
- fix: You can no longer select loadouts for PDV Ambassadors or the Prince.
