### PR TITLE
Civ Progression Block 1

### DIFF
--- a/Resources/Locale/en-US/_Mono/loadout.ftl
+++ b/Resources/Locale/en-US/_Mono/loadout.ftl
@@ -10,3 +10,4 @@ loadout-group-ussp-head = USSP Headgear
 loadout-group-ussp-outerclothing = USSP Outerclothing
 loadout-group-ussp-backpack = USSP Backpack
 loadout-group-chatrank = chat rank
+loadout-group-progression = progression gear

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -161,8 +161,8 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicatePyjamaBundle
-  name: syndicate pyjama duffel bag
-  description: Contains 3 pairs of syndicate pyjamas and 4 plushies for the ultimate sleepover.
+  name: pyjama duffel bag
+  description: Contains 3 pairs of pyjamas and 4 plushies for the ultimate sleepover.
   components:
   - type: Storage
     grid:
@@ -187,7 +187,7 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateC4tBundle
-  name: syndicate C-4 bundle
+  name: C-4 bundle
   description: "Contains a lot of C-4 charges."
   components:
     - type: StorageFill
@@ -217,8 +217,8 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateEVABundle
-  name: syndicate EVA bundle
-  description: "Contains the Syndicate approved EVA suit."
+  name: blood EVA bundle
+  description: "Contains a bloody(?) EVA suit."
   components:
   - type: StorageFill
     contents:
@@ -232,8 +232,8 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateRaidBundle
-  name: syndicate raid suit bundle
-  description: "Contains the Syndicate's durable raid armor suit."
+  name: raid suit bundle
+  description: "Contains a durable raid armor suit."
   components:
   - type: StorageFill
     contents:
@@ -245,8 +245,8 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateHardsuitBundle
-  name: syndicate hardsuit bundle
-  description: "Contains the Syndicate's signature blood red hardsuit."
+  name: blood hardsuit bundle
+  description: "Contains a signature blood red hardsuit."
   components:
   - type: StorageFill
     contents:
@@ -259,8 +259,8 @@
 - type: entity # Mono
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateMedicHardsuitBundle
-  name: syndicate medic hardsuit bundle
-  description: "Contains the Syndicate's blood red medical hardsuit."
+  name: blood medic hardsuit bundle
+  description: "Contains a blood red medical hardsuit."
   components:
   - type: StorageFill
     contents:
@@ -273,8 +273,8 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
-  name: syndicate elite hardsuit bundle
-  description: "Contains the Syndicate's elite hardsuit, which comes with some more stuff in it."
+  name: elite hardsuit bundle
+  description: "Contains a dark colored hardsuit, which comes with some more stuff in it."
   components:
   - type: StorageFill
     contents:
@@ -287,7 +287,7 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateHardsuitExtrasBundle
-  name: syndicate hardsuit extras bundle
+  name: hardsuit extras bundle
   description: "Contains stuff that you will absolutely want to have when purchasing a hardsuit."
   components:
   - type: StorageFill
@@ -300,7 +300,7 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelZombieBundle
-  name: syndicate zombie bundle
+  name: zombie bundle
   description: "An all-in-one kit for unleashing the undead upon a station."
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -1,8 +1,8 @@
 - type: entity
   id: CrateSyndicateSurplusBundle
   parent: [ CrateSyndicate, StorePresetUplink ]
-  name: Syndicate surplus crate
-  description: Contains 250 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
+  name: surplus crate
+  description: Contains 250 telecrystals worth of completely random wayward items. It can be useless junk or really good.
   components:
     - type: SurplusBundle
       totalPrice: 250
@@ -11,7 +11,7 @@
   id: CrateCybersunJuggernautBundle
   suffix: Filled
   parent: CrateSyndicate
-  name: Cybersun juggernaut bundle
+  name: blood juggernaut bundle
   description: Contains everything except a big gun to go postal.
   components:
   - type: StorageFill
@@ -25,8 +25,8 @@
 - type: entity
   id: CrateSyndicateSuperSurplusBundle
   parent: [ CrateSyndicate, StorePresetUplink ]
-  name: Syndicate super surplus crate
-  description: Contains 600 telecrystals worth of completely random Syndicate items.
+  name: super surplus crate
+  description: Contains 600 telecrystals worth of completely random wayward items.
   components:
     - type: SurplusBundle
       totalPrice: 600

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -42,10 +42,10 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      # 4 minutes
-      volume: 0.66
+      # 15+ minutes
+      volume: 2.5
       moles:
-        Oxygen: 0.270782035 # oxygen
+        Oxygen: 1.025689525 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -56,12 +56,11 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      # 4 minutes
-      volume: 0.66
+      # 18+ minutes
+      volume: 2.5
       moles:
-        Nitrogen: 0.270782035 # nitrogen
+        Nitrogen: 1.025689525 # nitrogen
       temperature: 293.15
-
 
 - type: entity
   id: ExtendedEmergencyOxygenTankFilled
@@ -71,10 +70,10 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      # 9 minutes
-      volume: 1.5
+      # 18+ minutes
+      volume: 3
       moles:
-        Oxygen: 0.615413715 # oxygen
+        Oxygen: 1.025689525 # oxygen
       temperature: 293.15
 
 - type: entity
@@ -85,12 +84,11 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      # 9 minutes
-      volume: 1.5
+      # 12+ minutes
+      volume: 3
       moles:
-        Nitrogen: 0.615413715 # nitrogen
+        Nitrogen: 1.025689525 # nitrogen
       temperature: 293.15
-
 
 - type: entity
   id: DoubleEmergencyOxygenTankFilled
@@ -100,8 +98,8 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      # 15 minutes
-      volume: 2.5
+      # 18+ minutes
+      volume: 4
       moles:
         Oxygen: 1.025689525 # oxygen
       temperature: 293.15
@@ -114,8 +112,8 @@
   - type: GasTank
     outputPressure: 21.3
     air:
-      # 15 minutes
-      volume: 2.5
+      # 18+ minutes
+      volume: 4
       moles:
         Nitrogen: 1.025689525 # nitrogen
       temperature: 293.15

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -90,7 +90,7 @@
   parent: GasTankRoundBase
   id: EmergencyOxygenTank
   name: emergency oxygen tank
-  description: An easily portable tank for emergencies. Contains very little oxygen, rated for survival use only. It can hold 0.66 L of gas.
+  description: An easily portable tank for emergencies. Contains oxygen and can fit in your pocket, but doesn't last forever. It can hold 2.5 L of gas.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency.rsi
@@ -99,7 +99,7 @@
     sprite: Objects/Tanks/emergency.rsi
   - type: GasTank
     air:
-      volume: 0.66
+      volume: 2.5
       temperature: 293.15
   - type: Clothing
     sprite: Objects/Tanks/emergency.rsi
@@ -119,7 +119,7 @@
   parent: EmergencyOxygenTank
   id: EmergencyNitrogenTank
   name: emergency nitrogen tank
-  description: An easily portable tank for emergencies. Contains very little nitrogen, rated for survival use only. It can hold 0.66 L of gas.
+  description: An easily portable tank for emergencies. Contains oxygen and can fit in your pocket, but doesn't last forever It can hold 2.5 L of gas.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_red.rsi
@@ -132,7 +132,7 @@
   parent: EmergencyOxygenTank
   id: ExtendedEmergencyOxygenTank
   name: extended-capacity emergency oxygen tank
-  description: An emergency tank with extended capacity. Technically rated for prolonged use. It can hold 1.5 L of gas.
+  description: An emergency tank with extended capacity. Technically rated for prolonged use. It can hold 3 L of gas.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_extended.rsi
@@ -140,7 +140,7 @@
     sprite: Objects/Tanks/emergency_extended.rsi
   - type: GasTank
     air:
-      volume: 1.5
+      volume: 3
       temperature: 293.15
   - type: Clothing
     sprite: Objects/Tanks/emergency_extended.rsi
@@ -149,7 +149,7 @@
   parent: ExtendedEmergencyOxygenTank
   id: ExtendedEmergencyNitrogenTank
   name: extended-capacity emergency nitrogen tank
-  description: An emergency tank with extended capacity. Technically rated for prolonged use. It can hold 1.5 L of gas.
+  description: An emergency tank with extended capacity. Technically rated for prolonged use. It can hold 3 L of gas.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_extended_red.rsi
@@ -162,7 +162,7 @@
   parent: ExtendedEmergencyOxygenTank
   id: DoubleEmergencyOxygenTank
   name: double emergency oxygen tank
-  description: A high-grade dual-tank emergency life support container. It holds a decent amount of oxygen for its small size. It can hold 2.5 L of gas.
+  description: A high-grade dual-tank emergency life support container. It holds a decent amount of oxygen for its small size. It can hold 4 L of gas.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_double.rsi
@@ -170,7 +170,7 @@
     sprite: Objects/Tanks/emergency_double.rsi
   - type: GasTank
     air:
-      volume: 2.5
+      volume: 4
       temperature: 293.15
   - type: Clothing
     sprite: Objects/Tanks/emergency_double.rsi
@@ -184,7 +184,7 @@
   parent: DoubleEmergencyOxygenTank
   id: DoubleEmergencyNitrogenTank
   name: double emergency nitrogen tank
-  description: A high-grade dual-tank emergency life support container. It holds a decent amount of nitrogen for its small size. It can hold 2.5 L of gas.
+  description: A high-grade dual-tank emergency life support container. It holds a decent amount of nitrogen for its small size. It can hold 3 L of gas.
   components:
   - type: Sprite
     sprite: Objects/Tanks/emergency_double_red.rsi

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Backpacks/duffelbag.yml
@@ -28,8 +28,8 @@
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateStealthHardsuitBundle
-  name: cybersun stealthsuit bundle
-  description: "An advanced cybersun stealth hardsuit bundle."
+  name: stealthsuit bundle
+  description: "An advanced stealth hardsuit bundle."
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Boxes/emergency.yml
@@ -7,7 +7,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: DoubleEmergencyOxygenTankFilled
+    - id: EmergencyOxygenTankFilled
     - id: SpaceMedipen
     - id: EmergencyMedipen
     - id: Flare
@@ -46,7 +46,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: DoubleEmergencyOxygenTankFilled
+      - id: EmergencyOxygenTankFilled
       - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare
@@ -62,7 +62,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: DoubleEmergencyNitrogenTankFilled
+      - id: EmergencyNitrogenTankFilled
       - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: Flare

--- a/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/salvmaint_locker.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/Fills/Lockers/salvmaint_locker.yml
@@ -328,9 +328,9 @@
       - !type:GroupSelector
         children:
         - id: OxygenTankFilled
-        - id: DoubleEmergencyOxygenTankFilled
+        - id: EmergencyOxygenTankFilled
         - id: NitrogenTankFilled
-        - id: DoubleEmergencyNitrogenTankFilled
+        - id: EmergencyNitrogenTankFilled
         - id: EmergencyFunnyOxygenTankFilled
           weight: 0.5
       #Mats

--- a/Resources/Prototypes/_Mono/Loadouts/Contractor/progression.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/Contractor/progression.yml
@@ -1,6 +1,7 @@
 - type: loadoutGroup
   id: ContractorProgression
   minLimit: 0
+  maxLimit: 4
   name: loadout-group-progression
   loadouts:
   - ProgressionAmmoBox9x19mmFMJ
@@ -111,7 +112,8 @@
     proto: MonoCiv15Hours
   price: 5000
   storage:
-    back: GeneratorRTGFlatpack
+    back:
+    - GeneratorRTGFlatpack
 
 - type: loadout
   id: ProgressionResearchAndDevelopmentServerFlatpack
@@ -120,7 +122,8 @@
     proto: MonoCiv20Hours
   price: 5000
   storage:
-    back: ResearchAndDevelopmentServerFlatpack
+    back:
+    - ResearchAndDevelopmentServerFlatpack
 
 - type: loadout
   id: ProgressionComputerResearchAndDevelopmentFlatpack
@@ -129,7 +132,8 @@
     proto: MonoCiv20Hours
   price: 5000
   storage:
-    back: ComputerResearchAndDevelopmentFlatpack
+    back:
+    - ComputerResearchAndDevelopmentFlatpack
 
 - type: loadout
   id: ProgressionProtolatheFlatpack
@@ -138,7 +142,8 @@
     proto: MonoCiv20Hours
   price: 5000
   storage:
-    back: ProtolatheFlatpack
+    back:
+    - ProtolatheFlatpack
 
 - type: loadout
   id: ProgressionClothingOuterHardsuitPilot
@@ -147,7 +152,8 @@
     proto: MonoCiv25Hours
   price: 5000
   storage:
-    back: ClothingOuterHardsuitPilot
+    back:
+    - ClothingOuterHardsuitPilot
 
 - type: loadout
   id: ProgressionTelecrystal5
@@ -156,7 +162,8 @@
     proto: MonoCiv30Hours
   price: 5000
   storage:
-    back: Telecrystal5
+    back:
+    - Telecrystal5
 
 - type: loadout
   id: ProgressionRCD
@@ -165,7 +172,8 @@
     proto: MonoCiv40Hours
   price: 5000
   storage:
-    back: RCD
+    back:
+    - RCD
 
 - type: loadout
   id: ProgressionShipRepairDevice
@@ -174,7 +182,8 @@
     proto: MonoCiv40Hours
   price: 5000
   storage:
-    back: ShipRepairDevice
+    back:
+    - ShipRepairDevice
 
 - type: loadout
   id: ProgressionRPD
@@ -183,7 +192,8 @@
     proto: MonoCiv40Hours
   price: 5000
   storage:
-    back: RPD
+    back:
+    - RPD
 
 - type: loadout
   id: ProgressionResearchDisk5000

--- a/Resources/Prototypes/_Mono/Loadouts/Contractor/progression.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/Contractor/progression.yml
@@ -1,0 +1,204 @@
+- type: loadoutGroup
+  id: ContractorProgression
+  minLimit: 0
+  name: loadout-group-progression
+  loadouts:
+  - ProgressionAmmoBox9x19mmFMJ
+  - ProgressionDockFlatpack
+
+- type: loadout
+  id: ProgressionAmmoBox9x19mmFMJ
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv1Hours
+  price: 1000
+  storage:
+    back:
+    - AmmoBox9x19mmFMJ
+
+- type: loadout
+  id: ProgressionDockFlatpack
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv2Hours
+  price: 2000
+  storage:
+    back:
+    - AirlockShuttleFlatpack
+
+- type: loadout
+  id: ProgressionNFPouchContractor
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv4Hours
+  price: 5000
+  storage:
+    back:
+    - NFPouchContractor
+
+- type: loadout
+  id: ProgressionExtendedEmergencyOxygenTankFilled
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv4Hours
+  price: 2000
+  storage:
+    back:
+    - ExtendedEmergencyOxygenTankFilled
+
+- type: loadout
+  id: ProgressionWeaponPistolMk58
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv6Hours
+  price: 3000
+  storage:
+    back:
+    - WeaponPistolMk58
+
+- type: loadout
+  id: ProgressionWeaponPistolViper
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv10Hours
+  price: 6000
+  storage:
+    back:
+    - WeaponPistolViper
+
+- type: loadout
+  id: ProgressionAmmoBox9x19mmBigFMJ
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv10Hours
+  price: 2000
+  storage:
+    back:
+    - AmmoBox9x19mmBigFMJ
+
+- type: loadout
+  id: ProgressionClothingHeadHatBeretCommander
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv15Hours
+  price: 0
+  storage:
+    head:
+    - ClothingHeadHatBeretCommander
+
+- type: loadout
+  id: ProgressionGeneratorRTGFlatpack
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv15Hours
+  price: 5000
+  storage:
+    back: GeneratorRTGFlatpack
+
+- type: loadout
+  id: ProgressionResearchAndDevelopmentServerFlatpack
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv20Hours
+  price: 5000
+  storage:
+    back: ResearchAndDevelopmentServerFlatpack
+
+- type: loadout
+  id: ProgressionComputerResearchAndDevelopmentFlatpack
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv20Hours
+  price: 5000
+  storage:
+    back: ComputerResearchAndDevelopmentFlatpack
+
+- type: loadout
+  id: ProgressionProtolatheFlatpack
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv20Hours
+  price: 5000
+  storage:
+    back: ProtolatheFlatpack
+
+- type: loadout
+  id: ProgressionClothingOuterHardsuitPilot
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv25Hours
+  price: 5000
+  storage:
+    back: ClothingOuterHardsuitPilot
+
+- type: loadout
+  id: ProgressionTelecrystal5
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv30Hours
+  price: 5000
+  storage:
+    back: Telecrystal5
+
+- type: loadout
+  id: ProgressionRCD
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv40Hours
+  price: 5000
+  storage:
+    back: RCD
+
+- type: loadout
+  id: ProgressionShipRepairDevice
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv40Hours
+  price: 5000
+  storage:
+    back: ShipRepairDevice
+
+- type: loadout
+  id: ProgressionRPD
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv40Hours
+  price: 5000
+  storage:
+    back: RPD
+
+- type: loadout
+  id: ProgressionResearchDisk5000
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv50Hours
+  price: 5000
+  storage:
+    back: ResearchDisk5000
+
+- type: loadout
+  id: ProgressionSheetSteel
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv50Hours
+  price: 5000
+  storage:
+    back: SheetSteel
+
+- type: loadout
+  id: ProgressionRCDAmmo
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv50Hours
+  price: 5000
+  storage:
+    back: RCDAmmo
+
+- type: loadout
+  id: Progression
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MonoCiv60Hours
+  price: 5000
+  storage:
+    back: 

--- a/Resources/Prototypes/_Mono/Loadouts/Contractor/progression.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/Contractor/progression.yml
@@ -5,6 +5,24 @@
   loadouts:
   - ProgressionAmmoBox9x19mmFMJ
   - ProgressionDockFlatpack
+  - ProgressionNFPouchContractor
+  - ProgressionExtendedEmergencyOxygenTankFilled
+  - ProgressionWeaponPistolMk58
+  - ProgressionWeaponPistolViper
+  - ProgressionAmmoBox9x19mmBigFMJ
+  - ProgressionClothingHeadHatBeretCommander
+  - ProgressionGeneratorRTGFlatpack
+  - ProgressionResearchAndDevelopmentServerFlatpack
+  - ProgressionComputerResearchAndDevelopmentFlatpack
+  - ProgressionProtolatheFlatpack
+  - ProgressionClothingOuterHardsuitPilot
+  - ProgressionTelecrystal5
+  - ProgressionRCD
+  - ProgressionShipRepairDevice
+  - ProgressionRPD
+  - ProgressionResearchDisk5000
+  - ProgressionSheetSteel
+  - ProgressionRCDAmmo
 
 - type: loadout
   id: ProgressionAmmoBox9x19mmFMJ
@@ -174,7 +192,8 @@
     proto: MonoCiv50Hours
   price: 5000
   storage:
-    back: ResearchDisk5000
+    back:
+    - ResearchDisk5000
 
 - type: loadout
   id: ProgressionSheetSteel
@@ -183,7 +202,8 @@
     proto: MonoCiv50Hours
   price: 5000
   storage:
-    back: SheetSteel
+    back:
+    - SheetSteel
 
 - type: loadout
   id: ProgressionRCDAmmo
@@ -192,13 +212,14 @@
     proto: MonoCiv50Hours
   price: 5000
   storage:
-    back: RCDAmmo
+    back:
+    - RCDAmmo
 
-- type: loadout
-  id: Progression
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: MonoCiv60Hours
-  price: 5000
-  storage:
-    back: 
+#- type: loadout
+#  id: Progression
+#  effects:
+#  - !type:GroupLoadoutEffect
+#    proto: MonoCiv60Hours
+#  price: 5000
+#  storage:
+#    back:

--- a/Resources/Prototypes/_Mono/Loadouts/civilian_playtime_groups.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/civilian_playtime_groups.yml
@@ -51,3 +51,159 @@
       !type:DepartmentTimeRequirement
       department: Civilian
       time: 72000 # 20 hrs - ultimate flex
+
+# progression
+
+- type: loadoutEffectGroup
+  id: MonoCiv1Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 3600 # 1 hour
+
+- type: loadoutEffectGroup
+  id: MonoCiv2Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 7200 # 2 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv4Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 14400 # 4 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv6Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 21600 # 6 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv10Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 36000 # 10 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv15Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 54000 # 15 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv20Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 72000 # 20 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv25Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 90000 # 25 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv30Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 108000 # 30 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv40Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 144000 # 40 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv50Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 180000 # 50 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv60Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 216000 # 60 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv70Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 252000 # 70 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv80Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 288000 # 80 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv90Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 324000 # 90 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv100Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 360000 # 100 hours
+
+- type: loadoutEffectGroup
+  id: MonoCiv200Hours
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 720000 # 200 hours... holy fuck
+

--- a/Resources/Prototypes/_NF/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Boxes/emergency.yml
@@ -41,7 +41,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: DoubleEmergencyOxygenTankFilled
+      - id: EmergencyOxygenTankFilled
       - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE
@@ -58,7 +58,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: DoubleEmergencyNitrogenTankFilled
+      - id: EmergencyNitrogenTankFilled
       - id: SpaceMedipen
       - id: EmergencyMedipen
       - id: MonoMRE # Mono - replace PSB and water bottle w/ MRE

--- a/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
@@ -83,7 +83,6 @@
   - MercenaryClothingHeadHelmetMercenaryBlack
   - MercenaryClothingHeadBandMercenary
   - MercenaryClothingHeadHatBeretMercenary
-  #- MercenaryClothingHeadHatBeretCommander
   - SecurityHelmet
   - SecurityBeret
   subgroups:

--- a/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/mercenary_loadout_groups.yml
@@ -83,7 +83,7 @@
   - MercenaryClothingHeadHelmetMercenaryBlack
   - MercenaryClothingHeadBandMercenary
   - MercenaryClothingHeadHatBeretMercenary
-  - MercenaryClothingHeadHatBeretCommander
+  #- MercenaryClothingHeadHatBeretCommander
   - SecurityHelmet
   - SecurityBeret
   subgroups:

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -47,6 +47,7 @@
   - ContractorMag # Mono
   - CivGunCaseSpecial # Mono
   - ContractorArmorPlates # Mono
+  - ContractorProgression
 
 # Pilot
 - type: roleLoadout


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
adds a progression gear category. Items have scaling civ gameplay requirements.
Buffs pocket oxygen tanks, and switches out starting double o2 tank with a normal one. (Due to buffs it's the same duration.)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
more stuff to work towards
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="560" height="1325" alt="image" src="https://github.com/user-attachments/assets/37cdb328-9b91-44e9-935b-d54a9b6efd29" />
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Onezero0
- add: Added a "progression" category for Vagrants. Unlock nice to haves and unique cosmetics with playtime.
- tweak: Emergency oxygen tanks have buffed capacity.
- tweak: You now start with a regular emergency oxygen tank instead of a double. Due to aforementioned buff though, it has the same capacity as before.
