### PR TITLE
Deprecated Mixed

### DIFF
--- a/Resources/Prototypes/_Mono/game_presets.yml
+++ b/Resources/Prototypes/_Mono/game_presets.yml
@@ -114,7 +114,7 @@
   id: MonoMixed
   name: mono-mixed-title
   description: mono-mixed-description
-  showInVote: true
+  showInVote: false # deprecated alongside remnants
   rules:
   - NFAdventure
   - BasicStationEventScheduler


### PR DESCRIPTION
## About the PR
Deprecated Mixed as a gamemode.

## Why / Balance
Mixed is just diluted Biothreat with a diluted version of the deprecated Remnants on top. Keeping it makes no sense if Remnants isn't being kept.

## Media
1 line change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
golobby
no option to vote mixed

**Changelog**
:cl:
- remove: The Mixed gamemode has been deprecated similarly to Remnants.