### PR TITLE
Minor Oversights Whatever Lalalalalalaaa

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -278,10 +278,6 @@
   - type: LaserPointer
     targetedColor: "#ff0037"
     defaultColor: "#03c2fc"
-  - type: WieldDelay
-    baseDelay: 0.5
-    modifiedDelay: 0.5
-    preventFiring: true
   - type: MeleeRequiresWield
   - type: MeleeWeapon
     attackRate: 0.6

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -278,3 +278,20 @@
   - type: LaserPointer
     targetedColor: "#ff0037"
     defaultColor: "#03c2fc"
+  - type: WieldDelay
+    baseDelay: 0.5
+    modifiedDelay: 0.5
+    preventFiring: true
+  - type: MeleeRequiresWield
+  - type: MeleeWeapon
+    attackRate: 0.6
+    damage:
+      types:
+        Blunt: 24
+    angle: 0
+    wideAnimationRotation: 45
+    animation: WeaponArcThrust
+    soundHit:
+      collection: MetalThud
+  - type: AltFireMelee
+    attackType: Light

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/pdv.yml
@@ -25,8 +25,8 @@
     capacity: 3
     proto: Cartridge145x114mm
   - type: SpeedModifiedOnWield
-    walkModifier: 0.6
-    sprintModifier: 0.6
+    walkModifier: 0.4
+    sprintModifier: 0.4
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 7

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/pdv.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/pdv.yml
@@ -36,3 +36,20 @@
   - type: LaserPointer
     targetedColor: "#8cfc03"
     defaultColor: "#fc0324"
+  - type: WieldDelay
+    baseDelay: 0.5
+    modifiedDelay: 0.5
+    preventFiring: true
+  - type: MeleeRequiresWield
+  - type: MeleeWeapon
+    attackRate: 0.6
+    damage:
+      types:
+        Blunt: 24
+    angle: 0
+    wideAnimationRotation: 45
+    animation: WeaponArcThrust
+    soundHit:
+      collection: MetalThud
+  - type: AltFireMelee
+    attackType: Light

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/tsfmc.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Snipers/tsfmc.yml
@@ -86,6 +86,10 @@
       collection: MetalThud
   - type: AltFireMelee
     attackType: Light
+  - type: WieldDelay
+    baseDelay: 0.5
+    modifiedDelay: 0.5
+    preventFiring: true
 
 - type: entity
   name: VFD QBU-243 Xian DMR (8x65mm SKR)


### PR DESCRIPTION
## About the PR
minor wielddelays for shenzhen/anubis/hristov
anubis & hristov get same alt attack melee damage as shenzhen now
hristov slowdown nerfed (40% -> 60%) (shenzhen 70% for comparison)

## Why / Balance
all are heavy long-arms like grizzly
sniper pushing bad bad bad
nazzie-poo forgot to account for making the hristov do all the same heavy weapon stuff as shenzhen when he gigabuffed the round

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wield delays for hristov/shenzhen/anubis, all 3 share the same melee alt-attack damage now (24 blunt), hristov slowdown increased.
