### PR TITLE
PDV Tweaks II (Oversight Correction)

### DIFF
--- a/Resources/Locale/en-US/_Mono/store/pdv-uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Mono/store/pdv-uplink-catalog.ftl
@@ -101,6 +101,9 @@ uplink-pirate-chameleon-pda-desc = A PDA with integrated chameleon technology, a
 uplink-pirate-chameleon-headset-name = Chameleon Headset
 uplink-pirate-chameleon-headset-desc = A headset with integrated chameleon technology, allowing you to hide your true allegiance.
 
+uplink-pirate-chameleon-backpack-name = Chameleon Backpack
+uplink-pirate-chameleon-backpack-desc = A backpack with integrated chameleon technology, allowing you to hide your true allegiance. Does not come with anything inside.
+
 uplink-pirate-dna-scrambler-name = DNA Scrambler Implanter
 uplink-pirate-dna-scrambler-desc = A relatively rare implant that allows you to completely change your identity once.
 

--- a/Resources/Locale/en-US/_Mono/store/pdv-uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Mono/store/pdv-uplink-catalog.ftl
@@ -95,6 +95,12 @@ uplink-pirate-voicemask-desc = A voicemask to engage in some subterfuge and tomf
 uplink-pirate-blank-id-name = Blank ID Card 
 uplink-pirate-blank-id-desc = A blank vagrant ID card with no identifying features. Can be customised to your heart's content at Helios' ID card console.
 
+uplink-pirate-chameleon-pda-name = Chameleon PDA
+uplink-pirate-chameleon-pda-desc = A PDA with integrated chameleon technology, allowing you to hide your true allegiance.
+
+uplink-pirate-chameleon-headset-name = Chameleon Headset
+uplink-pirate-chameleon-headset-desc = A headset with integrated chameleon technology, allowing you to hide your true allegiance.
+
 uplink-pirate-dna-scrambler-name = DNA Scrambler Implanter
 uplink-pirate-dna-scrambler-desc = A relatively rare implant that allows you to completely change your identity once.
 

--- a/Resources/Prototypes/_Mono/Catalogs/pdv_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/pdv_uplink_catalog.yml
@@ -360,6 +360,21 @@
       - PirateUplink
 
 - type: listing
+  id: UplinkPirateBackpackChameleon
+  name: uplink-pirate-chameleon-backpack-name
+  description: uplink-pirate-chameleon-backpack-desc
+  productEntity: ClothingBackpackChameleon
+  cost:
+    Doubloon: 5
+  categories:
+  - UplinkPirateUtility
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - PirateUplink
+
+- type: listing
   id: UplinkPirateVoicemask
   name: uplink-pirate-voicemask-name
   description: uplink-pirate-voicemask-desc

--- a/Resources/Prototypes/_Mono/Catalogs/pdv_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/pdv_uplink_catalog.yml
@@ -315,6 +315,51 @@
       - PirateUplink
 
 - type: listing
+  id: UplinkPiratePdaChameleon
+  name: uplink-pirate-chameleon-pda-name
+  description: uplink-pirate-chameleon-pda-desc
+  productEntity: ChameleonPDA
+  cost:
+    Doubloon: 5
+  categories:
+  - UplinkPirateUtility
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - PirateUplink
+
+- type: listing
+  id: UplinkPiratePdaChameleon
+  name: uplink-pirate-chameleon-pda-name
+  description: uplink-pirate-chameleon-pda-desc
+  productEntity: ChameleonPDA
+  cost:
+    Doubloon: 5
+  categories:
+  - UplinkPirateUtility
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - PirateUplink
+
+- type: listing
+  id: UplinkPirateHeadsetChameleon
+  name: uplink-pirate-chameleon-headset-name
+  description: uplink-pirate-chameleon-headset-desc
+  productEntity: ClothingHeadsetChameleon
+  cost:
+    Doubloon: 5
+  categories:
+  - UplinkPirateUtility
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - PirateUplink
+
+- type: listing
   id: UplinkPirateVoicemask
   name: uplink-pirate-voicemask-name
   description: uplink-pirate-voicemask-desc

--- a/Resources/Prototypes/_Mono/Catalogs/pdv_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/pdv_uplink_catalog.yml
@@ -330,21 +330,6 @@
       - PirateUplink
 
 - type: listing
-  id: UplinkPiratePdaChameleon
-  name: uplink-pirate-chameleon-pda-name
-  description: uplink-pirate-chameleon-pda-desc
-  productEntity: ChameleonPDA
-  cost:
-    Doubloon: 5
-  categories:
-  - UplinkPirateUtility
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - PirateUplink
-
-- type: listing
   id: UplinkPirateHeadsetChameleon
   name: uplink-pirate-chameleon-headset-name
   description: uplink-pirate-chameleon-headset-desc


### PR DESCRIPTION
## About the PR
Added chameleon headsets, backpacks and PDAs to the PDV uplink.

## Why / Balance
The headsets, bags and PDAs PDV spawn with out them as PDV, and they have no easy way to obtain PDAs, bags or headsets that _don't_. Even if Helios had an AstroVend, Plus, there's like 20 different headsets, bags and PDAs that civs can choose to spawn with, so giving a straight chameleon option for both of them is the only real way to prevent metagaming.

Robbing a civilian is still an option if you're stingy about your DC, and chameleon on Monolith is... dodgy at best so it may still end up being the superior option.


## Media
<img width="274" height="85" alt="image" src="https://github.com/user-attachments/assets/b1af276b-b2f8-47bd-a578-34e5856399e8" />
<img width="279" height="192" alt="image" src="https://github.com/user-attachments/assets/eac58f1c-ee64-4c99-a164-3876510109a7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
spawn as PDV
check uplink Utility tab
chameleon pda, backpack and headset

**Changelog**
:cl:
- add: Chameleon PDAs, backpacks and headsets have been added to the PDV uplink.
