### PR TITLE
Edible Limbs

### DIFF
--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -8,6 +8,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Content.Shared.Chemistry.Components.SolutionManager;
 
 namespace Content.Shared.Gibbing.Systems;
 
@@ -140,6 +141,9 @@ public sealed partial class GibbingSystem : EntitySystem
                 {
                     foreach (var ent in container.ContainedEntities)
                     {
+                        // Do not gib solution entities
+                        if (HasComp<ContainedSolutionComponent>(ent))
+                            continue;
                         DropEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
                             ref droppedEntities, launchGibs,
                             launchDirection, launchImpulse, launchImpulseVariance, launchCone);
@@ -154,6 +158,9 @@ public sealed partial class GibbingSystem : EntitySystem
                 {
                     foreach (var ent in container.ContainedEntities)
                     {
+                        // Do not gib solution entities
+                        if (HasComp<ContainedSolutionComponent>(ent))
+                            continue;
                         GibEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
                             ref droppedEntities, launchGibs,
                             launchDirection, launchImpulse, launchImpulseVariance, launchCone);

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -346,15 +346,8 @@
   abstract: true
   components:
   - type: Food
-  - type: Extractable
-    grindableSolutionName: limb
   - type: SolutionContainerManager
     solutions:
-      limb:
-        maxVol: 10
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
       food:
         maxVol: 5
         reagents:
@@ -362,7 +355,7 @@
           Quantity: 5
   - type: FlavorProfile
     flavors:
-      - chicken
+    - chicken # everything kinda tastes like chicken
   - type: Tag
     tags:
     - Meat

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -346,16 +346,9 @@
   abstract: true
   components:
   - type: Food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 5
   - type: FlavorProfile
     flavors:
-    - chicken # everything kinda tastes like chicken
+      - chicken
   - type: Tag
     tags:
     - Meat

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -133,7 +133,7 @@
 
 - type: entity
   abstract: true
-  parent: MajorLimb # Mono
+  parent: [MajorLimb, BaseEdibleLimb] # Mono
   id: BaseLeftArm
   name: "left arm"
   components:
@@ -152,7 +152,7 @@
 
 - type: entity
   abstract: true
-  parent: MajorLimb # Mono
+  parent: [MajorLimb, BaseEdibleLimb] # Mono
   id: BaseRightArm
   name: "right arm"
   components:
@@ -172,7 +172,7 @@
 
 - type: entity
   abstract: true
-  parent: MinorLimb # Mono
+  parent: [MinorLimb, BaseEdibleLimb] # Mono
   id: BaseLeftHand
   name: "left hand"
   components:
@@ -187,7 +187,7 @@
 
 - type: entity
   abstract: true
-  parent: MinorLimb # Mono
+  parent: [MinorLimb, BaseEdibleLimb] # Mono
   id: BaseRightHand
   name: "right hand"
   components:
@@ -202,7 +202,7 @@
 
 - type: entity
   abstract: true
-  parent: MajorLimb # Mono
+  parent: [MajorLimb, BaseEdibleLimb] # Mono
   id: BaseLeftLeg
   name: "left leg"
   components:
@@ -222,7 +222,7 @@
 
 - type: entity
   abstract: true
-  parent: MajorLimb # Mono
+  parent: [MajorLimb, BaseEdibleLimb] # Mono
   id: BaseRightLeg
   name: "right leg"
   components:
@@ -242,7 +242,7 @@
 
 - type: entity
   abstract: true
-  parent: MinorLimb # Mono
+  parent: [MinorLimb, BaseEdibleLimb] # Mono
   id: BaseLeftFoot
   name: "left foot"
   components:
@@ -257,7 +257,7 @@
 
 - type: entity
   abstract: true
-  parent: MinorLimb # Mono
+  parent: [MinorLimb, BaseEdibleLimb] # Mono
   id: BaseRightFoot
   name: "right foot"
   components:
@@ -340,3 +340,29 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MeatLaserImpact
+
+- type: entity
+  id: BaseEdibleLimb
+  abstract: true
+  components:
+  - type: Food
+  - type: Extractable
+    grindableSolutionName: limb
+  - type: SolutionContainerManager
+    solutions:
+      limb:
+        maxVol: 10
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
+  - type: FlavorProfile
+    flavors:
+      - chicken
+  - type: Tag
+    tags:
+    - Meat

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -284,12 +284,16 @@
         damage: 190 # 110->190
       behaviors:
       - !type:GibPartBehavior { }
+      - !type:SpillBehavior
+        solution: limb
     - trigger:
         !type:DamageTypeTrigger
         damageType: Slash
         damage: 210 # 150->210
       behaviors:
       - !type:GibPartBehavior { }
+      - !type:SpillBehavior
+        solution: limb
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat
@@ -301,6 +305,8 @@
           Ash:
             min: 1
             max: 1
+      - !type:SpillBehavior
+        solution: limb
       - !type:BurnBodyBehavior { }
       - !type:PlaySoundBehavior
         sound:
@@ -319,12 +325,16 @@
         damage: 150 # 110->150
       behaviors:
       - !type:GibPartBehavior { }
+      - !type:SpillBehavior
+        solution: limb
     - trigger:
         !type:DamageTypeTrigger
         damageType: Slash
         damage: 180 # 150->180
       behaviors:
       - !type:GibPartBehavior { }
+      - !type:SpillBehavior
+        solution: limb
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat
@@ -336,6 +346,8 @@
           Ash:
             min: 1
             max: 1
+      - !type:SpillBehavior
+        solution: limb
       - !type:BurnBodyBehavior { }
       - !type:PlaySoundBehavior
         sound:
@@ -346,6 +358,20 @@
   abstract: true
   components:
   - type: Food
+  - type: Extractable
+    grindableSolutionName: limb
+  - type: SolutionContainerManager
+    solutions:
+      limb:
+        maxVol: 10
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
   - type: FlavorProfile
     flavors:
       - chicken

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -284,16 +284,12 @@
         damage: 190 # 110->190
       behaviors:
       - !type:GibPartBehavior { }
-      - !type:SpillBehavior
-        solution: limb
     - trigger:
         !type:DamageTypeTrigger
         damageType: Slash
         damage: 210 # 150->210
       behaviors:
       - !type:GibPartBehavior { }
-      - !type:SpillBehavior
-        solution: limb
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat
@@ -305,8 +301,6 @@
           Ash:
             min: 1
             max: 1
-      - !type:SpillBehavior
-        solution: limb
       - !type:BurnBodyBehavior { }
       - !type:PlaySoundBehavior
         sound:
@@ -325,16 +319,12 @@
         damage: 150 # 110->150
       behaviors:
       - !type:GibPartBehavior { }
-      - !type:SpillBehavior
-        solution: limb
     - trigger:
         !type:DamageTypeTrigger
         damageType: Slash
         damage: 180 # 150->180
       behaviors:
       - !type:GibPartBehavior { }
-      - !type:SpillBehavior
-        solution: limb
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat
@@ -346,8 +336,6 @@
           Ash:
             min: 1
             max: 1
-      - !type:SpillBehavior
-        solution: limb
       - !type:BurnBodyBehavior { }
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Body/Parts/silicon.yml
+++ b/Resources/Prototypes/Body/Parts/silicon.yml
@@ -117,15 +117,8 @@
   abstract: true
   components:
   - type: Food
-  - type: Extractable
-    grindableSolutionName: siliconlimb
   - type: SolutionContainerManager
     solutions:
-      siliconlimb:
-        maxVol: 10
-        reagents:
-        - ReagentId: Iron
-          Quantity: 10
       food:
         maxVol: 5
         reagents:
@@ -133,7 +126,7 @@
           Quantity: 5
   - type: FlavorProfile
     flavors:
-      - metallic
+    - metallic # everything kinda tastes like chicken
   - type: Tag
     tags:
     - Meat

--- a/Resources/Prototypes/Body/Parts/silicon.yml
+++ b/Resources/Prototypes/Body/Parts/silicon.yml
@@ -25,7 +25,7 @@
     - Robotics
 
 - type: entity
-  parent: [ PartSiliconBase, BaseLeftArm ]
+  parent: [ PartSiliconBase, BaseEdibleSiliconLimb, BaseLeftArm ]
   id: LeftArmBorg
   name: cyborg left arm
   components:
@@ -40,7 +40,7 @@
     - BorgLArm
 
 - type: entity
-  parent: [ PartSiliconBase, BaseRightArm ]
+  parent: [ PartSiliconBase, BaseEdibleSiliconLimb, BaseRightArm ]
   id: RightArmBorg
   name: cyborg right arm
   components:
@@ -55,7 +55,7 @@
     - BorgRArm
 
 - type: entity
-  parent: [ PartSiliconBase, BaseLeftLeg ]
+  parent: [ PartSiliconBase, BaseEdibleSiliconLimb, BaseLeftLeg ]
   id: LeftLegBorg
   name: cyborg left leg
   components:
@@ -70,7 +70,7 @@
     - BorgLLeg
 
 - type: entity
-  parent: [ PartSiliconBase, BaseRightLeg ]
+  parent: [ PartSiliconBase, BaseEdibleSiliconLimb, BaseRightLeg ]
   id: RightLegBorg
   name: cyborg right leg
   components:
@@ -111,3 +111,29 @@
     tags:
     - Trash
     - BorgTorso
+
+- type: entity
+  id: BaseEdibleSiliconLimb
+  abstract: true
+  components:
+  - type: Food
+  - type: Extractable
+    grindableSolutionName: siliconlimb
+  - type: SolutionContainerManager
+    solutions:
+      siliconlimb:
+        maxVol: 10
+        reagents:
+        - ReagentId: Iron
+          Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
+  - type: FlavorProfile
+    flavors:
+      - metallic
+  - type: Tag
+    tags:
+    - Meat

--- a/Resources/Prototypes/Body/Parts/silicon.yml
+++ b/Resources/Prototypes/Body/Parts/silicon.yml
@@ -117,16 +117,9 @@
   abstract: true
   components:
   - type: Food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 5
   - type: FlavorProfile
     flavors:
-    - metallic # everything kinda tastes like chicken
+      - metallic
   - type: Tag
     tags:
     - Meat

--- a/Resources/Prototypes/Body/Parts/silicon.yml
+++ b/Resources/Prototypes/Body/Parts/silicon.yml
@@ -117,6 +117,20 @@
   abstract: true
   components:
   - type: Food
+  - type: Extractable
+    grindableSolutionName: limb
+  - type: SolutionContainerManager
+    solutions:
+      limb:
+        maxVol: 10
+        reagents:
+        - ReagentId: Iron
+          Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
   - type: FlavorProfile
     flavors:
       - metallic

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -180,15 +180,8 @@
   abstract: true
   components:
   - type: Food
-  - type: Extractable
-    grindableSolutionName: cyberneticlimb
   - type: SolutionContainerManager
     solutions:
-      cyberneticlimb:
-        maxVol: 10
-        reagents:
-        - ReagentId: Iron
-          Quantity: 10
       food:
         maxVol: 5
         reagents:
@@ -196,7 +189,7 @@
           Quantity: 5
   - type: FlavorProfile
     flavors:
-      - metallic
+    - metallic # everything kinda tastes like chicken
   - type: Tag
     tags:
     - Meat

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -15,7 +15,7 @@
 
 - type: entity
   abstract: true
-  parent: [ CyberneticPartBase, BaseLeftArm ]
+  parent: [ CyberneticPartBase, BaseEdibleCyberneticLimb, BaseLeftArm ]
   id: LeftArmCyberneticBase
   components:
   - type: Sprite
@@ -29,7 +29,7 @@
 
 - type: entity
   abstract: true
-  parent: [ CyberneticPartBase, BaseRightArm ]
+  parent: [ CyberneticPartBase, BaseEdibleCyberneticLimb, BaseRightArm ]
   id: RightArmCyberneticBase
   components:
   - type: Sprite
@@ -43,7 +43,7 @@
 
 - type: entity
   abstract: true
-  parent: [ CyberneticPartBase, BaseLeftLeg ]
+  parent: [ CyberneticPartBase, BaseEdibleCyberneticLimb, BaseLeftLeg ]
   id: LeftLegCyberneticBase
   components:
   - type: Sprite
@@ -57,7 +57,7 @@
 
 - type: entity
   abstract: true
-  parent: [ CyberneticPartBase, BaseRightLeg ]
+  parent: [ CyberneticPartBase, BaseEdibleCyberneticLimb, BaseRightLeg ]
   id: RightLegCyberneticBase
   components:
   - type: Sprite
@@ -70,7 +70,7 @@
     id: RightFootCybernetic
 
 - type: entity
-  parent: [ CyberneticPartBase, BaseLeftHand ]
+  parent: [ CyberneticPartBase, BaseEdibleCyberneticLimb, BaseLeftHand ]
   id: LeftHandCybernetic
   name: cybernetic left hand
   components:
@@ -78,7 +78,7 @@
     baseLayerId: MobCyberneticBishopLHand
 
 - type: entity
-  parent: [ CyberneticPartBase, BaseRightHand ]
+  parent: [ CyberneticPartBase, BaseEdibleCyberneticLimb, BaseRightHand ]
   id: RightHandCybernetic
   name: cybernetic right hand
   components:
@@ -86,7 +86,7 @@
     baseLayerId: MobCyberneticBishopRHand
 
 - type: entity
-  parent: [ CyberneticPartBase, BaseLeftFoot ]
+  parent: [ CyberneticPartBase, BaseEdibleCyberneticLimb, BaseLeftFoot ]
   id: LeftFootCybernetic
   name: cybernetic left foot
   components:
@@ -94,7 +94,7 @@
     baseLayerId: MobCyberneticBishopLFoot
 
 - type: entity
-  parent: [ CyberneticPartBase, BaseRightFoot ]
+  parent: [ CyberneticPartBase, BaseEdibleCyberneticLimb, BaseRightFoot ]
   id: RightFootCybernetic
   name: cybernetic right foot
   components:
@@ -174,3 +174,29 @@
   components:
   - type: DoAfterDelayMultiplier
     multiplier: 0.8
+
+- type: entity
+  id: BaseEdibleCyberneticLimb
+  abstract: true
+  components:
+  - type: Food
+  - type: Extractable
+    grindableSolutionName: cyberneticlimb
+  - type: SolutionContainerManager
+    solutions:
+      cyberneticlimb:
+        maxVol: 10
+        reagents:
+        - ReagentId: Iron
+          Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
+  - type: FlavorProfile
+    flavors:
+      - metallic
+  - type: Tag
+    tags:
+    - Meat

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -180,6 +180,20 @@
   abstract: true
   components:
   - type: Food
+  - type: Extractable
+    grindableSolutionName: limb
+  - type: SolutionContainerManager
+    solutions:
+      limb:
+        maxVol: 10
+        reagents:
+        - ReagentId: Iron
+          Quantity: 10
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
   - type: FlavorProfile
     flavors:
       - metallic

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -180,16 +180,9 @@
   abstract: true
   components:
   - type: Food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 5
   - type: FlavorProfile
     flavors:
-    - metallic # everything kinda tastes like chicken
+      - metallic
   - type: Tag
     tags:
     - Meat


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
All Limbs except heads are now edible
limbs can be placed in reagent grinder for:
- organic limbs 10 Nutriment
- cybernetic/silicon 10 Iron

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
loose limbs are clogging up medical and operating rooms from limb upgrades and more.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
<!-- Describe the way it can be tested -->
spawn limb, eat limb
spawn head, cant eat head

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Loose Limbs are now edible!

