### PR TITLE
TSF and PDV Borgs Can Customize Name

### DIFF
--- a/Resources/Prototypes/_Mono/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/role_loadouts.yml
@@ -1,0 +1,9 @@
+- type: roleLoadout
+  id: JobPdvBorg
+  nameDataset: NFNamesBorg
+  canCustomizeName: true
+
+- type: roleLoadout
+  id: JobTsfBorg
+  nameDataset: NFNamesBorg
+  canCustomizeName: true


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
TSF and PDV borgs can customize name

## Why / Balance
Usually borgs can customize name, factions - no. Why?

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
Look to factions borgs loadout

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Pcolik505:
- tweak:  TSF and PDV borgs can customize name
