### PR TITLE
Renamed Standard to Insurgency

### DIFF
--- a/Resources/Locale/en-US/_Mono/gamerules/gamemodes.ftl
+++ b/Resources/Locale/en-US/_Mono/gamerules/gamemodes.ftl
@@ -13,8 +13,8 @@ mono-mixed-description = Native PDV imperials threaten TSF colonial expansion in
 mono-tsfussp-title = Cold War (TSF)
 mono-tsfussp-description = TSF colonization efforts are threatened by USSP expansion. A cold war is in place between the local TSFMC detachment and USSP colonization forces.
 
-mono-standard-title = Standard (TSF|PDV)
-mono-standard-description = Native PDV imperials threaten TSF colonial expansion into the sector.
+mono-standard-title = Insurgency (TSF|PDV)
+mono-standard-description = The Trans-Solarian Federation's efforts to colonise the Colossus sector are put into danger by a theocratic insurgency, with civilians caught in the crossfire.
 
 mono-ads-title = Remnants (TSF|PDV)
 mono-ads-description = Native PD imperials threaten TSF colonial expansion into the sector. A tense cold war between the TSF Marine Corps detachment. Pre-fracture warriors and defense systems threaten their plans.


### PR DESCRIPTION
## About the PR
Changed the name and description of Standard to Insurgency.

## Why / Balance
The people want it. Aura gain.
Also reflects further that Standard is the PDV gamemode, _not_ greenshift. I dislike the perception that Standard is the greenshift mode

## Media
it's a 2 line ftl change i am not building monolith just to get a screenshot of it

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
connect & go to lobby
look in top left

**Changelog**
:cl:
- tweak: Standard has been renamed to Insurgency. Glory to the Sultan.
