### PR TITLE
Derotate Jupiter

### DIFF
--- a/Resources/Prototypes/_Mono/PointsOfInterest/Supercapitals/jupiter.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/Supercapitals/jupiter.yml
@@ -14,7 +14,7 @@
   name: 'PDV Jupiter Class Carrier'
   minimumDistance: 17000
   maximumDistance: 19000
-  spawnGamePreset: [ NFAdventure, NFPirate, MonoStandard, MonoRogueTSF, MonoRogueUSSP, MonoADS, MonoChimera, MonoMixed, MonoAllAtOnce, MonoChimeraPdv ]
+  spawnGamePreset: []
   spawnGroup: Required
   gridPath: /Maps/_Mono/Supercapitals/jupiter.yml
   addComponents:


### PR DESCRIPTION
## About the PR
Jupiter no longer spawns in any gamemode.

(Hyperwar-Jupiter still spawns in Hyperwar)

## Why / Balance
PDV, who are meant to struggle to field combat ships, get a supercapital that starts with 183GP and has a station gunnery + an LM-212 Vanguard capital shield roundstart. Doesn't make much sense and it's also a glorified lootbox. Docking it to Helios is a noobtrap nowadays too.

It also enables an infinite FMC/DC glitch where you dock Jupiter to the Secondary Outpost, buy an M82c with a TSF uplink for 10FMC on Jupiter's exchange pallet, take the 30DC, buy a SCAF suit with a PDV uplink for 15DC on the outpost's exchange pallet, take the 30FMC and repeat. At least Helios and Halcyon are both far away and usually populated.

## Media
can't really show that there's no jupiter

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
start MonoStandard
observe
no jupiter

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: PDV Jupiter has been shot down and no longer spawns.
