### PR TITLE
PDV Tweaks IV (Shipyard Refactor)

### DIFF
--- a/Resources/Locale/en-US/_Mono/store/pdv-uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Mono/store/pdv-uplink-catalog.ftl
@@ -291,6 +291,15 @@ uplink-pirate-syndisupersurplus-desc = Contains a huge amount of imported good f
 uplink-pdv-t0-voucher-name = PDV Tier 0 Ship Voucher
 uplink-pdv-t0-voucher-desc = A single-use voucher for any small ship.
 
+uplink-pdv-t1-voucher-name = PDV Tier 1 Ship Voucher
+uplink-pdv-t1-voucher-desc = A small card that will allow you to procure any tier-1 PDV ship from the Dynasty's reserves.
+
+uplink-pdv-t2-voucher-name = PDV Tier 2 Ship Voucher
+uplink-pdv-t2-voucher-desc = A small card that will allow you to procure any tier-2 PDV ship from the Dynasty's reserves.
+
+uplink-pdv-t3-voucher-name = PDV Tier 3 Ship Voucher
+uplink-pdv-t3-voucher-desc = A small card that will allow you to procure any tier-3 PDV ship from the Dynasty's reserves.
+
 uplink-pdv-t1-hourglass-voucher-name = PDV Hourglass LPC [T1]
 uplink-pdv-t1-hourglass-voucher-desc = A small card that contains the data for the procurement of an Hourglass-class escort from the flagship's reserves.
 

--- a/Resources/Prototypes/_Mono/Catalogs/pdv_uplink_catalog.yml
+++ b/Resources/Prototypes/_Mono/Catalogs/pdv_uplink_catalog.yml
@@ -1396,6 +1396,66 @@
     whitelist:
       tags:
       - FactionStaticUplinkPdv
+
+- type: listing
+  id: UplinkPDVT1Voucher
+  name:  uplink-pdv-t1-voucher-name
+  description: uplink-pdv-t1-voucher-desc
+  productEntity: ShipVoucherPdvT1
+  cost:
+    Doubloon: 150
+  categories:
+  - UplinkPdvVouchers
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - FactionStaticUplinkPdv
+
+- type: listing
+  id: UplinkPDVT2Voucher
+  name:  uplink-pdv-t2-voucher-name
+  description: uplink-pdv-t2-voucher-desc
+  productEntity: ShipVoucherPdvT2
+  cost:
+    Doubloon: 275
+  categories:
+  - UplinkPdvVouchers
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - FactionStaticUplinkPdv
+
+- type: listing
+  id: UplinkPDVT3Voucher
+  name:  uplink-pdv-t3-voucher-name
+  description: uplink-pdv-t3-voucher-desc
+  productEntity: ShipVoucherPdvT3
+  cost:
+    Doubloon: 600
+  categories:
+  - UplinkPdvVouchers
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - FactionStaticUplinkPdv
+
+- type: listing
+  id: UplinkPirateT4VoucherSaturn
+  name:  uplink-pdv-t4-saturn-voucher-name
+  description: uplink-pdv-t4-saturn-voucher-desc
+  productEntity: ShipVoucherSaturn
+  cost:
+    Doubloon: 1150
+  categories:
+  - UplinkPdvVouchers
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - FactionStaticUplinkPdv
       
 # MARK: Materials
 

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
@@ -253,7 +253,7 @@
       shader: unshaded
   - type: ShipyardVoucher
     destroyOnEmpty: false
-    cooldown: 7200 # one hour
+    cooldown: 3600 # one hour
     consoleType: BlackMarket
     companyName: PDV
     vessels:
@@ -277,7 +277,7 @@
       shader: unshaded
   - type: ShipyardVoucher
     destroyOnEmpty: false
-    cooldown: 7200 # one hour
+    cooldown: 3600 # one hour
     consoleType: BlackMarket
     companyName: PDV
     vessels:
@@ -302,7 +302,7 @@
       shader: unshaded
   - type: ShipyardVoucher
     destroyOnEmpty: false
-    cooldown: 7200 # one hour
+    cooldown: 5400 # 1.5 hours
     consoleType: BlackMarket
     companyName: PDV
     vessels:

--- a/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Devices/ship_vouchers.yml
@@ -240,6 +240,7 @@
   parent: ShipVoucherPdvT0
   id: ShipVoucherPdvT1
   name: PDV T1 ship voucher
+  description: Allows for one medium PDV ship purchase. Destroyed on sale.
   components:
   - type: Sprite
     sprite: _Mono/Objects/Misc/lpcnew.rsi
@@ -263,6 +264,7 @@
   parent: ShipVoucherPdvT0
   id: ShipVoucherPdvT2
   name: PDV T2 ship voucher
+  description: Allows for one medium to large PDV ship purchase. Destroyed on sale.
   components:
   - type: Sprite
     sprite: _Mono/Objects/Misc/lpcnew.rsi
@@ -282,6 +284,30 @@
     - MotleyAnne
     - Neptune
     - Osa
+
+- type: entity
+  parent: ShipVoucherPdvT0
+  id: ShipVoucherPdvT3
+  name: PDV T3 ship voucher
+  description: Allows for one large PDV ship purchase. Destroyed on sale.
+  components:
+  - type: Sprite
+    sprite: _Mono/Objects/Misc/lpcnew.rsi
+    layers:
+    - state: icon
+    - state: screen
+      color: "#1eff00"
+    - state: screen7
+      color: "#1eff00"
+      shader: unshaded
+  - type: ShipyardVoucher
+    destroyOnEmpty: false
+    cooldown: 7200 # one hour
+    consoleType: BlackMarket
+    companyName: PDV
+    vessels:
+    - KortikR
+    - Europa
 
 - type: entity
   parent: BaseShipLPCRenewable

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/Computers/shipyard.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/Computers/shipyard.yml
@@ -173,5 +173,4 @@
   - type: CompanyAccessReader
     requiredCompanies:
     - TSF
-    - PDV
     inverted: true

--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/Computers/computers_shipyard.yml
@@ -53,7 +53,6 @@
   - type: CompanyAccessReader
     requiredCompanies:
     - TSF
-    - PDV
     inverted: true
 
 - type: entity
@@ -198,7 +197,6 @@
   - type: CompanyAccessReader
     requiredCompanies:
     - TSF
-    - PDV
     inverted: true
 
 - type: entity
@@ -227,7 +225,6 @@
   - type: CompanyAccessReader
     requiredCompanies:
     - TSF
-    - PDV
     inverted: true
 
 - type: entity
@@ -256,7 +253,6 @@
   - type: CompanyAccessReader
     requiredCompanies:
     - TSF
-    - PDV
     inverted: true
 
 - type: entity


### PR DESCRIPTION
## About the PR
Allowed PDV to use civilian shipyard consoles again.
Added uplink entries for PDV ship vouchers -- 150DC for T1, 275DC for T2, 600DC for T3. Also added one for the Saturn at a whopping 1150DC.

## Why / Balance
Changes originating from PDV Tweaks III, and also PDV should be able to hide as civilians again. The shipyard refactor will prevent them from getting anything too powerful, I hope.

## Media
<img width="281" height="396" alt="image" src="https://github.com/user-attachments/assets/98535623-a517-4b59-a864-895d2928a80f" />
<img width="943" height="512" alt="image" src="https://github.com/user-attachments/assets/0054684e-d8e1-4225-80d5-745740d7a8ac" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
spawn as PDV
check uplink
new vouchers!
go to civ shipyard refactor, the biolock is gone

**Changelog**
:cl:
- add: Added PDV vouchers to the uplink for rather steep prices.
- tweak: The PDV can use civilian shipyards again.