### PR TITLE
Scuttles the TSFMC Secondary Outpost

### DIFF
--- a/Resources/Prototypes/_Mono/PointsOfInterest/tsfmcsecondary.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/tsfmcsecondary.yml
@@ -14,7 +14,7 @@
   name: 'TSFMC Secondary Outpost'
   minimumDistance: 11000
   maximumDistance: 14000
-  spawnGamePreset: [ NFAdventure, NFPirate, MonoStandard, MonoRogueTSF, MonoTSFUSSP, MonoADS, MonoChimera, MonoMixed, MonoAllAtOnce, MonoChimeraTsf ]
+  spawnGamePreset: []
   spawnGroup: Required
   gridPath: /Maps/_Mono/POI/tsfmcoutpost.yml
   addComponents:

--- a/Resources/Prototypes/_Mono/PointsOfInterest/tsfmcsecondary.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/tsfmcsecondary.yml
@@ -8,45 +8,45 @@
 
 # Notes: Wow.
 #
-- type: pointOfInterest
-  id: TSFMCOutpost
-  parent: [BasePOI, BaseRepairablePOI]
-  name: 'TSFMC Secondary Outpost'
-  minimumDistance: 11000
-  maximumDistance: 14000
-  spawnGamePreset: []
-  spawnGroup: Required
-  gridPath: /Maps/_Mono/POI/tsfmcoutpost.yml
-  addComponents:
-  - type: IFF
-    color: "#047abd"
-    flags: [HideLabel]
-    readOnly: true # mono
+#- type: pointOfInterest
+#  id: TSFMCOutpost
+#  parent: [BasePOI, BaseRepairablePOI]
+#  name: 'TSFMC Secondary Outpost'
+#  minimumDistance: 11000
+#  maximumDistance: 14000
+#  spawnGamePreset: []
+#  spawnGroup: Required
+#  gridPath: /Maps/_Mono/POI/tsfmcoutpost.yml
+#  addComponents:
+#  - type: IFF
+#    color: "#047abd"
+#    flags: [HideLabel]
+#    readOnly: true # mono
 
-- type: gameMap
-  id: TSFMCOutpost
-  mapName: 'TSFMC Secondary Outpost'
-  mapPath: /Maps/_Mono/POI/tsfmcoutpost.yml
-  minPlayers: 0
-  stations:
-    TSFMCOutpost:
-      stationProto: SecurityFrontierOutpost
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: 'TSFMC Secondary Outpost'
-        - type: ExtraStationInformation
-          icon:
-            sprite: _NF/Structures/Decoration/banner.rsi
-            state: nfsd-banner
-          stationSubtext: 'frontier-lobby-tsfmc-secondary-subtext'
-          stationDescription: 'frontier-lobby-tsfmc-secondary-description'
-          lobbySortOrder: 2
-        - type: StationJobs
-          availableJobs:
-            SeniorOfficer: [ 0, 3 ]
-            Brigmedic: [ 0, 1 ]
-            Deputy: [ -1, -1 ]
-          tags:
-          - HeadOfPersonnel
-          - HeadOfSecurity
-        - type: StationDeadDropHintExempt
+#- type: gameMap
+#  id: TSFMCOutpost
+#  mapName: 'TSFMC Secondary Outpost'
+#  mapPath: /Maps/_Mono/POI/tsfmcoutpost.yml
+#  minPlayers: 0
+#  stations:
+#    TSFMCOutpost:
+#      stationProto: SecurityFrontierOutpost
+#      components:
+#        - type: StationNameSetup
+#          mapNameTemplate: 'TSFMC Secondary Outpost'
+#        - type: ExtraStationInformation
+#          icon:
+#            sprite: _NF/Structures/Decoration/banner.rsi
+#            state: nfsd-banner
+#          stationSubtext: 'frontier-lobby-tsfmc-secondary-subtext'
+#          stationDescription: 'frontier-lobby-tsfmc-secondary-description'
+#          lobbySortOrder: 2
+#        - type: StationJobs
+#          availableJobs:
+#            SeniorOfficer: [ 0, 3 ]
+#            Brigmedic: [ 0, 1 ]
+#            Deputy: [ -1, -1 ]
+#          tags:
+#          - HeadOfPersonnel
+#          - HeadOfSecurity
+#        - type: StationDeadDropHintExempt


### PR DESCRIPTION
## About the PR
One line of yml

## Why / Balance
It's only been used as a respawn point for the tsf after halcyon has been destroyed. 

Also: it hasn't been maintained for a while.
<img width="136" height="76" alt="image" src="https://github.com/user-attachments/assets/c620e060-3a63-4889-bb5d-cd610d23b2d9" />


## Media
it no longer exists

## Requirements
- [x] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.

## How to test
build release, start any gamemode. It should no longer spawn

## Breaking changes
none hopefully

**Changelog**
:cl:
- remove: The TSFMC Secondary Outpost has been scuttled from the sector.
