### PR TITLE
[HOTFIX] Solarian Vault No Longer Gives 100FMC No Matter What

### DIFF
--- a/Content.Server/_NF/StationEvents/Components/BluespaceErrorRuleComponent.cs
+++ b/Content.Server/_NF/StationEvents/Components/BluespaceErrorRuleComponent.cs
@@ -56,6 +56,7 @@ public sealed partial class BluespaceErrorRuleComponent : Component
     [DataField]
     public bool ExtendIfPopulated = true;
 
+    [DataField]
     /// <summary>
     /// How much the grid is appraised at upon entering into existence, set after starting the event
     /// </summary>

--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -127,6 +127,7 @@ public sealed partial class BluespaceErrorRule : StationEventSystem<BluespaceErr
                 EntityManager.AddComponents(spawned, group.AddComponents);
 
                 component.GridsUid.Add(spawned);
+                component.StartingValue += _pricing.AppraiseGrid(spawned);
 
                 if (component.ExtendIfPopulated)
                     _autoExtend.AutoExtend(uid, spawned);


### PR DESCRIPTION
## About the PR
I made the StartingValue field in BluespaceErrorComponent actually get set, so now the game makes sure the vault is worth at least 96% of its initial value instead of at least 96% of 0 when it's checking to see if the TSF deserve their 100FMC

## Why / Balance
my bad for assuming the documentation wasn't fucking lying to my face </3
right now the sol vault will ALWAYS give TSF 100FMC, which is a bug because it turns out the value I was using to determine the starting value of the vault is NEVER SET and will always be ZERO.

## Media
<img width="454" height="57" alt="image" src="https://github.com/user-attachments/assets/21363155-0861-4165-b3de-e562c72bf2a9" />
<img width="351" height="253" alt="image" src="https://github.com/user-attachments/assets/b393c2c7-06da-45c4-a2f4-2b544aecc3c2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
addgamerule BluespaceVaultError
take the diamonds or something
endgamerule <uid>
they don't get fmc


**Changelog**
:cl:
- fix: Solarian Vault no longer always gives FMC no matter how damaged the vault actually is.