### PR TITLE
The Great Heist (Solarian Vault Upgrade: Solarian DC Storage Server)

### DIFF
--- a/Content.Server/_Mono/Store/Components/CurrencyInjectionOnBluespaceErrorComponent.cs
+++ b/Content.Server/_Mono/Store/Components/CurrencyInjectionOnBluespaceErrorComponent.cs
@@ -18,4 +18,10 @@ public sealed partial class CurrencyInjectionOnBluespaceErrorComponent : Compone
     /// </summary>
     [DataField]
     public float IntegrityRequirement = 0.96f;
+
+    /// <summary>
+    /// All prototypes that MUST be present on the grid in order for the injection to occur.
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> RequiredEntities = [];
 }

--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -23,6 +23,7 @@ using Content.Server._Mono.StationEvents;
 using Content.Server._Mono.GridClaimer;
 using Content.Server._Mono.Store.Components;
 using Content.Server._Mono.Store;
+using Newtonsoft.Json;
 
 namespace Content.Server._NF.StationEvents.Events;
 
@@ -264,6 +265,30 @@ public sealed partial class BluespaceErrorRule : StationEventSystem<BluespaceErr
                 }
 
                 var gridValue = _pricing.AppraiseGrid(gridUid, null);
+                // Mono: currency injections
+                if (TryComp<CurrencyInjectionOnBluespaceErrorComponent>(uid, out var comp))
+                {
+                    var childQuery = Transform(gridUid).ChildEnumerator;
+                    var requiredEntitiesFound = true;
+                    foreach (var entProtoId in comp.RequiredEntities)
+                    {
+                        requiredEntitiesFound = false;
+                        while (childQuery.MoveNext(out var entity))
+                        {
+                            var metaData = MetaData(entity);
+                            if (metaData.EntityPrototype != null && entProtoId.Equals(metaData.EntityPrototype.ID))
+                            {
+                                requiredEntitiesFound = true;
+                                break;
+                            }
+                        }
+                        if (!requiredEntitiesFound)
+                            break;
+                    }
+                    if (gridValue / component.StartingValue > comp.IntegrityRequirement && requiredEntitiesFound) // good job!
+                        _currencyInjection.InjectCurrency(comp.Company, comp.Amount);
+                }
+                // Mono end
 
                 // Deletion has to happen before grid traversal re-parents players.
                 Del(gridUid);
@@ -278,14 +303,6 @@ public sealed partial class BluespaceErrorRule : StationEventSystem<BluespaceErr
                     var reward = (int)(gridValue * rewardCoeff);
                     _bank.TrySectorDeposit(account, reward, LedgerEntryType.BluespaceReward);
                 }
-
-                // Mono: currency injections
-                if (TryComp<CurrencyInjectionOnBluespaceErrorComponent>(uid, out var comp))
-                {
-                    if (gridValue / component.StartingValue > comp.IntegrityRequirement) // good job!
-                        _currencyInjection.InjectCurrency(comp.Company, comp.Amount);
-                }
-                // Mono end
             }
         }
 

--- a/Resources/Maps/_NF/Bluespace/vault.yml
+++ b/Resources/Maps/_NF/Bluespace/vault.yml
@@ -2226,14 +2226,14 @@ entities:
     - type: Transform
       pos: 9.5,-10.5
       parent: 1
-- proto: BannerNanotrasen
+- proto: DataChitStorageServer
   entities:
   - uid: 1158
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
-- proto: BannerSecurity
+- proto: BannerNGC
   entities:
   - uid: 1159
     components:

--- a/Resources/Prototypes/_Mono/Entities/Structures/Machines/vault_server.yml
+++ b/Resources/Prototypes/_Mono/Entities/Structures/Machines/vault_server.yml
@@ -1,0 +1,70 @@
+- type: entity
+  parent: BaseMachine
+  id: DataChitStorageServer
+  name: solarian data chit storage server
+  description: Contains approximately 500 data chits worth of confiscated data, often found within heavily armoured Solarian vaults. The Phaethon Dynasty would love to reclaim this.
+  suffix: 500 DC
+  components:
+  - type: Sprite # pending a custom sprite
+    sprite: _Mono/Structures/Machines/server.rsi
+    snapCardinals: true
+    layers:
+    - state: server
+    - state: variant-tsf
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerDeviceVisuals.Powered:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { visible: true }
+          False: { visible: false }
+  - type: Appearance
+  - type: AmbientSound
+    volume: -9
+    range: 5
+    sound:
+      path: /Audio/Ambience/Objects/server_fans.ogg
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.4"
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  - type: Anchorable
+    delay: 10 # takes a little bit to unsecure
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1500 # durable
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+  - type: Transform
+    anchored: true
+  - type: Pullable
+  - type: CurrencyInjectionOnSell
+    company: PDV
+    amount:
+      Doubloon: 150 # less than 1/3rd of if it's brought to Helios
+  - type: StaticPrice
+    price: 300000 # too significant a part of the vault for the TSF to try bring to Halcyon. also gives civilians more of a reason to raid the vault
+  - type: Contraband
+    severity: FactionGear3
+    turnInValues:
+      Doubloon: 500 # TSF better not let it get brought to Helios
+    allowedDepartments: [ Security ]
+  - type: RadarBlip
+    radarColor: "#D2B48C"
+    scale: 3
+    shape: hexagon
+    visibleFromOtherGrids: true

--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -82,7 +82,9 @@
   - type: CurrencyInjectionOnBluespaceError # Mono: reward TSF with FMC for defending solarian vault
     company: TSF
     amount:
-      FederationMilitaryCredit: 100
+      FederationMilitaryCredit: 175
+    requiredEntities:
+    - DataChitStorageServer # no cheesing it
 
 - type: entity
   id: BluespaceVaultSmallError
@@ -127,7 +129,7 @@
   - type: CurrencyInjectionOnBluespaceError # Mono: reward TSF with FMC for defending solarian vault
     company: TSF
     amount:
-      FederationMilitaryCredit: 65
+      FederationMilitaryCredit: 100
 
 - type: entity
   id: BluespaceSyndicateFTLInterception


### PR DESCRIPTION
DNM until #4681 gets merged

## About the PR
Added the Solarian Data Chit Storage Server to the Solarian Vault.

It sells for $300,000 and gives the PDV 150 DC if sold at a cargo depot.
If brought to Helios, it can be exchanged for a whopping 500DC!
It does not give anything FMC-wise and is required to be present on the Solarian Vault for the TSF to receive their FMC payout. The FMC payout for the vault has been buffed to 175FMC.
The FMC payout for the small vault has been buffed to 100FMC.
It has a radar blip, making it incredibly risky to transport. The TSFMC must prevent this valuable asset from being taken from their vault.
Removed the NT banner from the Solarian vault (replaced by the server)
Replaced the Security banner with a TSF banner.

## Why / Balance
Solarian Vaults are just lame right now. This gives both civs and PDV a much better reason to raid them _and_ to avoid glassing them. The FMC buff, plus fear of PDV acquiring 500DC, also gives the TSF more of a reason to defend them. This PR aims to create lots more conflict surrounding the Solarian Vault.

## Media
<img width="362" height="197" alt="image" src="https://github.com/user-attachments/assets/c300161e-3af2-4434-9242-5086786fe8e3" />
<img width="400" height="215" alt="image" src="https://github.com/user-attachments/assets/9731bd98-3048-4f40-903a-f817e30ba0ae" />
<img width="958" height="549" alt="image" src="https://github.com/user-attachments/assets/13cb5651-4fcb-48eb-bfad-563f232cd969" />
<img width="626" height="131" alt="image" src="https://github.com/user-attachments/assets/6c3c135c-168b-4595-b33a-7b1bb3250c64" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
addgamerule BluespaceVaultError
cool new server
endgamerule
payout of 175FMC.
addgamerule
delete server
endgamerule
no payout

spawn server on DC exchange pallet
500DC
spawn server on cargo pallet, sell
$300,000, PDV req. station gets 150DC

**Changelog**
:cl:
- add: Added a Solarian Data Chit Storage Server to the Solarian Vault. It's worth $300,000 to civilians who wish to sell it and a whopping 500 DC to the PDV! It has its own radar blip, pull off a heist on the Solarian Vault at your own risk.
- tweak: Buffed FMC payout for defending the vault to 175 FMC. The payout will no longer happen if the server is gone, no matter how much money the vault is worth.
