### PR TITLE
PDV Helios Opsec Buff (Deathrattle + Overwatch Jamming)

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._Mono.Deathrattle.Components;
 using Content.Server._Mono.Planets;
 using Content.Server.Administration.Logs;
 using Content.Server.Body.Systems;
@@ -256,6 +257,11 @@ namespace Content.Server.Explosion.EntitySystems
             // Frontier: Gets station location of the implant
             var grid = ownerXform.GridUid;
             var gridText = grid is null ? "" : MetaData(grid.Value).EntityName;
+
+            // Mono: Check if this place is actively jamming deathrattles.
+            var implantProto = MetaData(uid).EntityPrototype;
+            if (TryComp<JamDeathrattlesComponent>(grid, out var jamComp) && implantProto != null && !jamComp.Exclusions.Contains(implantProto.ID))
+                return;
 
             if (HasComp<MapComponent>(grid) && !HasComp<PlanetMapComponent>(grid))
                 gridText = "";

--- a/Content.Server/_Mono/Deathrattle/Components/JamDeathrattlesComponent.cs
+++ b/Content.Server/_Mono/Deathrattle/Components/JamDeathrattlesComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Mono.Deathrattle.Components;
+
+[RegisterComponent]
+public sealed partial class JamDeathrattlesComponent : Component
+{
+    /// <summary>
+    /// A list of implant prototypes that will be unaffected by this component.
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> Exclusions = [];
+}

--- a/Content.Server/_Mono/Overwatch/Components/JamOverwatchComponent.cs
+++ b/Content.Server/_Mono/Overwatch/Components/JamOverwatchComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared._Mono.Company;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Mono.Overwatch.Components;
+
+[RegisterComponent]
+public sealed partial class JamOverwatchComponent : Component
+{
+    /// <summary>
+    /// The list of factions whose overwatch consoles are not affected by the jamming.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<CompanyPrototype>> ExcludedFactions = [];
+}

--- a/Content.Server/_Rat/Overwatch/OverwatchSystem.cs
+++ b/Content.Server/_Rat/Overwatch/OverwatchSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.UserInterface;
 using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Content.Server._Mono.Overwatch.Components;
 
 namespace Content.Server._Rat.Overwatch;
 
@@ -95,6 +96,9 @@ public sealed class OverwatchSystem : EntitySystem
         SubscribeLocalEvent<CompanyComponent, ComponentShutdown>(OnFactionComponentShutdown);
         SubscribeLocalEvent<SquadComponent, ComponentInit>(OnSquadComponentInit);
         SubscribeLocalEvent<SquadComponent, ComponentShutdown>(OnSquadComponentShutdown);
+
+        // Mono: overwatch jamming
+        SubscribeLocalEvent<CompanyComponent, GridUidChangedEvent>(OnGridUidChanged);
 
         Subs.BuiEvents<OverwatchConsoleComponent>(OverwatchUiKey.Key, subs =>
         {
@@ -638,6 +642,15 @@ public sealed class OverwatchSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    /// Mono: This is so that overwatch console jamming components on grids can function as intended.
+    /// </summary> 
+    private void OnGridUidChanged(Entity<CompanyComponent> ent, ref GridUidChangedEvent args)
+    {
+        if (_factionMembersCache.Keys.Contains(ent.Comp.CompanyName))
+            _factionMembersCache.Remove(ent.Comp.CompanyName); // clear cache to allow overwatch jamming to function
+    }
+
     /// <inheritdoc/>
     public override void Update(float frameTime)
     {
@@ -689,6 +702,8 @@ public sealed class OverwatchSystem : EntitySystem
         var query = EntityQueryEnumerator<CompanyComponent>();
         while (query.MoveNext(out var uid, out var factionComp))
         {
+            if (Transform(uid).GridUid != null && TryComp<JamOverwatchComponent>(Transform(uid).GridUid, out var jamComp) && !jamComp.ExcludedFactions.Contains(faction)) // Mono: grids can jam the overwatch console to prevent coordinates leaks.
+                continue;
             if (factionComp.CompanyName == faction && !HasComp<ShuttleComponent>(uid))
                 members.Add(uid);
         }

--- a/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
+++ b/Resources/Prototypes/_Mono/PointsOfInterest/pdvhelios.yml
@@ -39,6 +39,12 @@
       gridComponents:
       - type: VesselInfo
         description: "An oppressive imperial aura lurks here. Glory to the Sultan."
+      - type: JamDeathrattles
+        exclusions:
+        - FreelanceTrackingImplant
+      - type: JamOverwatch
+        excludedFactions:
+        - PDV
       components:
         - type: StationNameSetup
           mapNameTemplate: 'PDV Helio Fortress'


### PR DESCRIPTION
## About the PR
Non-PDV deathrattle implants no longer function while on board Helios.

Non-PDV overwatch consoles will no longer detect members of their faction who are on board Helios. 

## Why / Balance
There were a few major noobtraps regarding keeping Helios's location a secret: deathrattle implants and overwatch consoles.

Deathrattle implants were, for the most part, avoidable? Radio jammers blocked them and they were removeable, so planned executions could work around them if they were smart. Not every death that happens on Helios is going to be planned though -- in the first round alone, some random civilian managed to find Helios and die on it, announcing its coords to the entire Medical channel. That is unacceptable and feels awful from a PDV perspective.

Overwatch consoles, on the other hand, had absolutely no recourse. Any rahkshan who brought a dead marine, ER, judge, viper, rifleman or employee to Helios was doxxing its location usually without even thinking about the possibility. 

This PR aims to remove these noobtraps to help make keeping Helios' identity secret less difficult.

## Media
can't really show via screenshot? there just. isn't a deathrattle on Helios.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

## How to test
spawn as pdv rahkshan
take med + tsf tracking implants, add those encryption keys to your headset
buy viper, right click execute
only the PDV implant goes off

spawn as pdv rahkshan
VV your company component to say TSF
spawn TSFMC handheld overwatch console
you don't show up!
walk off of helios
you show up now
walk back on
you vanish

**Changelog**
:cl:
- add: Helios has been installed with a faraday cage that blocks any deathrattles that occur on board and prevent overwatch consoles from detecting anybody on board. PDV deathrattles and the PDV overwatch console are exempt.
