### PR TITLE
[BUGFIX] Reverts #3364 "Chimera Drip" (IDENTITY BLOCKING FIX)

### DIFF
--- a/Content.Shared/Inventory/InventoryComponent.cs
+++ b/Content.Shared/Inventory/InventoryComponent.cs
@@ -33,12 +33,6 @@ public sealed partial class InventoryComponent : Component
     /// </summary>
     [DataField]
     public Dictionary<string, DisplacementData> MaleDisplacements = new();
-
-    /// <summary>
-    /// Mono - blocks slots with those names from receiving InventoryRelayEvent-s.
-    /// </summary>
-    [DataField]
-    public List<string> RelayBlockedSlots = new();
 }
 
 /// <summary>

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -38,11 +38,11 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, ElectrocutionAttemptEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SlipAttemptEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshMovementSpeedModifiersEvent>(RelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, BeforeStripEvent>(RelayInventoryEventAlways); // Mono
-        SubscribeLocalEvent<InventoryComponent, SeeIdentityAttemptEvent>(RelayInventoryEventAlways); // Mono
+        SubscribeLocalEvent<InventoryComponent, BeforeStripEvent>(RelayInventoryEvent); // Mono
+        SubscribeLocalEvent<InventoryComponent, SeeIdentityAttemptEvent>(RelayInventoryEvent); // Mono
         SubscribeLocalEvent<InventoryComponent, ModifyChangedTemperatureEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, GetDefaultRadioChannelEvent>(RelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, RefreshNameModifiersEvent>(RelayInventoryEventAlways); // Mono
+        SubscribeLocalEvent<InventoryComponent, RefreshNameModifiersEvent>(RelayInventoryEvent); // Mono
         SubscribeLocalEvent<InventoryComponent, GetFlashbangedEvent>(RelayInventoryEvent); // goob edit
         SubscribeLocalEvent<InventoryComponent, FlashDurationMultiplierEvent>(RelayInventoryEvent); // goob edit
         SubscribeLocalEvent<InventoryComponent, TransformSpeakerNameEvent>(RelayInventoryEvent);
@@ -98,18 +98,7 @@ public partial class InventorySystem
     }
 
     // Mono
-    protected void RefRelayInventoryEventAlways<T>(EntityUid uid, InventoryComponent component, ref T args) where T : IInventoryRelayEvent
-    {
-        RelayEvent((uid, component), ref args, true);
-    }
-
-    // Mono
-    protected void RelayInventoryEventAlways<T>(EntityUid uid, InventoryComponent component, T args) where T : IInventoryRelayEvent
-    {
-        RelayEvent((uid, component), args, true);
-    }
-
-    public void RelayEvent<T>(Entity<InventoryComponent> inventory, ref T args, bool ignoreBlocked = false) where T : IInventoryRelayEvent
+    public void RelayEvent<T>(Entity<InventoryComponent> inventory, ref T args) where T : IInventoryRelayEvent
     {
         if (args.TargetSlots == SlotFlags.NONE)
             return;
@@ -117,27 +106,25 @@ public partial class InventorySystem
         // this copies the by-ref event if it is a struct
         var ev = new InventoryRelayedEvent<T>(args);
         var enumerator = new InventorySlotEnumerator(inventory, args.TargetSlots);
-        while (enumerator.NextItem(out var item, out var slot))
+        while (enumerator.NextItem(out var item))
         {
-            if (!ignoreBlocked && !inventory.Comp.RelayBlockedSlots.Contains(slot.Name)) // Mono
-                RaiseLocalEvent(item, ev);
+            RaiseLocalEvent(item, ev);
         }
 
         // and now we copy it back
         args = ev.Args;
     }
 
-    public void RelayEvent<T>(Entity<InventoryComponent> inventory, T args, bool ignoreBlocked = false) where T : IInventoryRelayEvent
+    public void RelayEvent<T>(Entity<InventoryComponent> inventory, T args) where T : IInventoryRelayEvent
     {
         if (args.TargetSlots == SlotFlags.NONE)
             return;
 
         var ev = new InventoryRelayedEvent<T>(args);
         var enumerator = new InventorySlotEnumerator(inventory, args.TargetSlots);
-        while (enumerator.NextItem(out var item, out var slot))
+        while (enumerator.NextItem(out var item))
         {
-            if (!ignoreBlocked && !inventory.Comp.RelayBlockedSlots.Contains(slot.Name)) // Mono
-                RaiseLocalEvent(item, ev);
+            RaiseLocalEvent(item, ev);
         }
     }
 


### PR DESCRIPTION
## About the PR
Reverted #3364.

## Why / Balance
This PR introduced a bug that has been in the game for half a year now, making people completely unable to hide their identities.

Its stated purpose has been rendered obsolete by the Zethine chimera rework and nothing else has used it so I am reverting it now.

PDV will finally be able to truly infiltrate again.

## Media
<img width="323" height="291" alt="image" src="https://github.com/user-attachments/assets/1dc01688-4e14-491b-b49e-76664c7bb438" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read relevant guidelines/documentation to this PR found on [our devwiki](https://monolith-station.github.io/mono-docs/).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains either no AI-generated content, or AI-generated content that meets our guidelines.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
<!-- When using AI, make sure you are already proficient in creating whatever content you are attempting to generate and that you already have experience contributing to SS14. This means using AI to enhance your preexisting workflow, not vibecoding. -->

**Changelog**
:cl:
- fix: Finally fixed identity blocking being completely non-functional.